### PR TITLE
Default colors, massive speedups

### DIFF
--- a/src/bin/unicodeblocks.c
+++ b/src/bin/unicodeblocks.c
@@ -112,9 +112,9 @@ int unicodeblocks_demo(struct notcurses* nc){
         }
       }
       cell_release(n, &c);
-      if(notcurses_render(nc)){
-        return -1;
-      }
+    }
+    if(notcurses_render(nc)){
+      return -1;
     }
     usleep(10000);
     // for a 32-bit wchar_t, we would want up through 24 bits of block ID. but

--- a/src/bin/unicodeblocks.c
+++ b/src/bin/unicodeblocks.c
@@ -116,7 +116,7 @@ int unicodeblocks_demo(struct notcurses* nc){
     if(notcurses_render(nc)){
       return -1;
     }
-    usleep(10000);
+    usleep(100000);
     // for a 32-bit wchar_t, we would want up through 24 bits of block ID. but
     // really, the vast majority of space is unused. cap at 0x3000.
     blockstart += BLOCKSIZE;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -576,7 +576,7 @@ int notcurses_render(notcurses* nc){
   int y, x;
   char* buf = NULL;
   size_t buflen = 0;
-  FILE* out = open_memstream(&buf, &buflen);
+  FILE* out = open_memstream(&buf, &buflen); // worth keeping around?
   if(out == NULL){
     return -1;
   }
@@ -600,7 +600,7 @@ int notcurses_render(notcurses* nc){
     }
   }
   ret |= fclose(out);
-  printf("%.*s", (int)buflen, buf);
+  printf("%s", buf);
   clock_gettime(CLOCK_MONOTONIC, &done);
   free(buf);
   update_render_stats(&done, &start, &nc->stats);


### PR DESCRIPTION
* Get default colors working via `op` terminfo capability (#31)
* Stop performing hundreds of unnecessary renders in uniblock demo (#41)
* Reduce rendering to a single system call (#41)

Between these latter two, we get a ~130 speedup on our worst case :D.