### PR TITLE
Boxes and colors

### DIFF
--- a/src/bin/boxdemo.c
+++ b/src/bin/boxdemo.c
@@ -15,12 +15,9 @@ int box_demo(struct notcurses* nc){
   cell_init(&lr);
   cell_init(&hl);
   cell_init(&vl);
-  cell_load(n, &ul, "╭");
-  cell_load(n, &ur, "╮");
-  cell_load(n, &ll, "╰");
-  cell_load(n, &lr, "╯");
-  cell_load(n, &vl, "│");
-  cell_load(n, &hl, "─");
+  if(ncplane_rounded_box_cells(n, &ul, &ur, &ll, &lr, &hl, &vl)){
+    return -1;
+  }
   cell_set_fg(&ul, 107, 40, 107);
   cell_set_bg(&ul, 20, 20, 20);
   cell_set_fg(&ur, 107, 40, 107);
@@ -38,7 +35,8 @@ int box_demo(struct notcurses* nc){
     if(ncplane_cursor_move_yx(n, y, x)){
       return -1;
     }
-    if(ncplane_box(n, &ul, &ur, &ll, &lr, &hl, &vl, ymax, xmax)){
+    if(ncplane_box_sized(n, &ul, &ur, &ll, &lr, &hl, &vl, ymax, xmax)){
+fprintf(stderr, "failed at %d/%d + %d/%d\n", y, x, ymax, xmax);
       return -1;
     }
     ymax -= 2;

--- a/src/bin/demo.c
+++ b/src/bin/demo.c
@@ -103,13 +103,7 @@ int main(int argc, char** argv){
   cell lr = CELL_TRIVIAL_INITIALIZER;
   cell vl = CELL_TRIVIAL_INITIALIZER;
   cell hl = CELL_TRIVIAL_INITIALIZER;
-  cell_load(ncp, &ul, "╭");
-  cell_load(ncp, &ur, "╮");
-  cell_load(ncp, &ll, "╰");
-  cell_load(ncp, &lr, "╯");
-  cell_load(ncp, &vl, "│");
-  cell_load(ncp, &hl, "─");
-  if(ncplane_cursor_move_yx(ncp, 1, 1)){
+  if(ncplane_rounded_box_cells(ncp, &ul, &ur, &ll, &lr, &hl, &vl)){
     goto err;
   }
   cell_set_fg(&ul, 90, 0, 90);
@@ -124,7 +118,10 @@ int main(int argc, char** argv){
   cell_set_bg(&lr, 0, 0, 180);
   cell_set_bg(&vl, 0, 0, 180);
   cell_set_bg(&hl, 0, 0, 180);
-  if(ncplane_box(ncp, &ul, &ur, &ll, &lr, &hl, &vl, rows - 1, cols - 2)){
+  if(ncplane_cursor_move_yx(ncp, 1, 1)){
+    goto err;
+  }
+  if(ncplane_box(ncp, &ul, &ur, &ll, &lr, &hl, &vl, rows - 2, cols - 2)){
     goto err;
   }
   if(notcurses_render(nc)){

--- a/src/bin/maxcolor.c
+++ b/src/bin/maxcolor.c
@@ -39,12 +39,9 @@ int maxcolor_demo(struct notcurses* nc){
   cell ur = CELL_TRIVIAL_INITIALIZER;
   cell hl = CELL_TRIVIAL_INITIALIZER;
   cell vl = CELL_TRIVIAL_INITIALIZER;
-  cell_load(n, &ul, "╭");
-  cell_load(n, &ur, "╮");
-  cell_load(n, &ll, "╰");
-  cell_load(n, &lr, "╯");
-  cell_load(n, &vl, "│");
-  cell_load(n, &hl, "─");
+  if(ncplane_rounded_box_cells(n, &ul, &ur, &ll, &lr, &hl, &vl)){
+    return -1;
+  }
   cell_set_fg(&ul, 0, 128, 128);
   cell_set_fg(&ur, 0, 128, 128);
   cell_set_fg(&ll, 0, 128, 128);
@@ -59,7 +56,7 @@ int maxcolor_demo(struct notcurses* nc){
   cell_set_bg(&hl, 90, 0, 90);
   int y = 0, x = 0;
   ncplane_cursor_move_yx(n, y, x);
-  if(ncplane_box(n, &ul, &ur, &ll, &lr, &hl, &vl, maxy, maxx)){
+  if(ncplane_box_sized(n, &ul, &ur, &ll, &lr, &hl, &vl, maxy, maxx)){
     return -1;
   }
   uint32_t rgb = 0;

--- a/src/bin/unicodeblocks.c
+++ b/src/bin/unicodeblocks.c
@@ -123,6 +123,7 @@ int unicodeblocks_demo(struct notcurses* nc){
       }
       cell_release(n, &c);
     }
+    ncplane_fg_rgb8(n, 0x40, 0xc0, 0x40);
     if(ncplane_cursor_move_yx(n, 6 + BLOCKSIZE / CHUNKSIZE, 3)){
       return -1;
     }

--- a/src/bin/unicodeblocks.c
+++ b/src/bin/unicodeblocks.c
@@ -57,25 +57,35 @@ int unicodeblocks_demo(struct notcurses* nc){
   };
   size_t sindex;
   ncplane_erase(n);
+  cell ul = CELL_TRIVIAL_INITIALIZER;
+  cell ur = CELL_TRIVIAL_INITIALIZER;
+  cell ll = CELL_TRIVIAL_INITIALIZER;
+  cell lr = CELL_TRIVIAL_INITIALIZER;
+  cell vl = CELL_TRIVIAL_INITIALIZER;
+  cell hl = CELL_TRIVIAL_INITIALIZER;
+  if(ncplane_rounded_box_cells(n, &ul, &ur, &ll, &lr, &hl, &vl)){
+    return -1;
+  }
   for(sindex = 0 ; sindex < sizeof(blocks) / sizeof(*blocks) ; ++sindex){
     uint32_t blockstart = blocks[sindex].start;
     const char* description = blocks[sindex].name;
     int chunk;
-    if(ncplane_cursor_move_yx(n, 2, 4)){
+    if(ncplane_cursor_move_yx(n, 1, 4)){
       return -1;
     }
     ncplane_fg_rgb8(n, 0xad, 0xd8, 0xe6);
     if(ncplane_printf(n, "Unicode points %04x–%04x", blockstart, blockstart + BLOCKSIZE) <= 0){
       return -1;
     }
-    if(ncplane_cursor_move_yx(n, 3, 3)){
+    if(ncplane_cursor_move_yx(n, 3, 4)){
       return -1;
     }
-    if(ncplane_printf(n, "%-*.*s", maxx - 3, maxx - 3, description) <= 0){
+    if(ncplane_box_sized(n, &ul, &ur, &ll, &lr, &hl, &vl,
+                         BLOCKSIZE / CHUNKSIZE + 2, CHUNKSIZE + 2)){
       return -1;
     }
     for(chunk = 0 ; chunk < BLOCKSIZE / CHUNKSIZE ; ++chunk){
-      if(ncplane_cursor_move_yx(n, 5 + chunk, 5)){
+      if(ncplane_cursor_move_yx(n, 4 + chunk, 5)){
         return -1;
       }
       int z;
@@ -112,6 +122,12 @@ int unicodeblocks_demo(struct notcurses* nc){
         }
       }
       cell_release(n, &c);
+    }
+    if(ncplane_cursor_move_yx(n, 6 + BLOCKSIZE / CHUNKSIZE, 3)){
+      return -1;
+    }
+    if(ncplane_printf(n, "%-*.*s", maxx - 3, maxx - 3, description) <= 0){
+      return -1;
     }
     if(notcurses_render(nc)){
       return -1;

--- a/src/lib/libav.c
+++ b/src/lib/libav.c
@@ -2,7 +2,8 @@
 #include <libavformat/avformat.h>
 #include "notcurses.h"
 
-int notcurses_visual_open(struct notcurses* nc, const char* filename){
+int notcurses_visual_open(struct notcurses* nc __attribute__ ((unused)),
+                          const char* filename){
   AVFormatContext* ps = NULL;
   int ret = avformat_open_input(&ps, filename, NULL, NULL);
   if(ret < 0){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -719,10 +719,8 @@ int ncplane_putstr(ncplane* n, const char* gcluster){
   while(*gcluster){
     cell c;
     memset(&c, 0, sizeof(c));
-    uint32_t rgb = cell_fg_rgb(n->channels);
-    cell_set_fg(&c, cell_rgb_red(rgb), cell_rgb_green(rgb), cell_rgb_blue(rgb));
-    uint32_t rgbbg = cell_bg_rgb(n->channels);
-    cell_set_bg(&c, cell_rgb_red(rgbbg), cell_rgb_green(rgbbg), cell_rgb_blue(rgbbg));
+    c.channels = n->channels;
+    c.attrword = n->attrword;
     int wcs = cell_load(n, &c, gcluster);
     if(wcs < 0){
       return -ret;
@@ -883,6 +881,8 @@ void ncplane_erase(ncplane* n){
   memset(n->fb, 0, sizeof(*n->fb) * n->lenx * n->leny);
   egcpool_dump(&n->pool);
   egcpool_init(&n->pool);
+  n->channels = 0;
+  n->attrword = 0;
 }
 
 int ncplane_rounded_box_cells(ncplane* n, cell* ul, cell* ur, cell* ll,

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -589,14 +589,19 @@ int notcurses_render(notcurses* nc){
       unsigned r, g, b, br, bg, bb;
       // FIXME z-culling!
       const cell* c = &nc->stdscr->fb[fbcellidx(nc->stdscr, y, x)];
-      // FIXME we allow these to be set distinctly, but terminfo only
-      // supports using them both via the 'op' capability
+      // we allow these to be set distinctly, but terminfo only supports using
+      // them both via the 'op' capability. unless we want to generate the 'op'
+      // escapes ourselves, if either is set to default, we first send op, and
+      // then a turnon for whichever aren't default.
       if(cell_fg_default_p(c) || cell_bg_default_p(c)){
         term_emit(nc->op, out);
-      }else{
+      }
+      if(!cell_fg_default_p(c)){
         cell_get_fg(c, &r, &g, &b);
-        cell_get_bg(c, &br, &bg, &bb);
         term_fg_rgb8(nc, out, r, g, b);
+      }
+      if(!cell_bg_default_p(c)){
+        cell_get_bg(c, &br, &bg, &bb);
         term_bg_rgb8(nc, out, br, bg, bb);
       }
       term_putc(out, nc->stdscr, c);

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -165,13 +165,10 @@ TEST_F(NcplaneTest, VerticalLines) {
 TEST_F(NcplaneTest, BadlyPlacedBoxen) {
   int x, y;
   ncplane_dimyx(n_, &y, &x);
+  ASSERT_LT(2, y);
+  ASSERT_LT(2, x);
   cell ul{}, ll{}, lr{}, ur{}, hl{}, vl{};
-  cell_load(n_, &ul, "╭");
-  cell_load(n_, &ur, "╮");
-  cell_load(n_, &ll, "╰");
-  cell_load(n_, &lr, "╯");
-  cell_load(n_, &vl, "│");
-  cell_load(n_, &hl, "─");
+  ASSERT_EQ(0, ncplane_rounded_box_cells(n_, &ul, &ur, &ll, &lr, &hl, &vl));
   EXPECT_GT(0, ncplane_box(n_, &ul, &ur, &ll, &lr, &hl, &vl, y + 1, x + 1));
   EXPECT_EQ(0, ncplane_cursor_move_yx(n_, 1, 0));
   EXPECT_GT(0, ncplane_box(n_, &ul, &ur, &ll, &lr, &hl, &vl, y, x));
@@ -188,16 +185,11 @@ TEST_F(NcplaneTest, BadlyPlacedBoxen) {
 TEST_F(NcplaneTest, PerimeterBox) {
   int x, y;
   ncplane_dimyx(n_, &y, &x);
-  ASSERT_LT(0, y);
-  ASSERT_LT(0, x);
+  ASSERT_LT(2, y);
+  ASSERT_LT(2, x);
   cell ul{}, ll{}, lr{}, ur{}, hl{}, vl{};
-  cell_load(n_, &ul, "╭");
-  cell_load(n_, &ur, "╮");
-  cell_load(n_, &ll, "╰");
-  cell_load(n_, &lr, "╯");
-  cell_load(n_, &vl, "│");
-  cell_load(n_, &hl, "─");
-  EXPECT_EQ(0, ncplane_box(n_, &ul, &ur, &ll, &lr, &hl, &vl, y, x));
+  ASSERT_EQ(0, ncplane_rounded_box_cells(n_, &ul, &ur, &ll, &lr, &hl, &vl));
+  EXPECT_EQ(0, ncplane_box(n_, &ul, &ur, &ll, &lr, &hl, &vl, y - 1, x - 1));
   cell_release(n_, &vl);
   cell_release(n_, &hl);
   cell_release(n_, &ul);
@@ -206,6 +198,21 @@ TEST_F(NcplaneTest, PerimeterBox) {
   cell_release(n_, &lr);
 }
 
+TEST_F(NcplaneTest, PerimeterBoxSized) {
+  int x, y;
+  ncplane_dimyx(n_, &y, &x);
+  ASSERT_LT(2, y);
+  ASSERT_LT(2, x);
+  cell ul{}, ll{}, lr{}, ur{}, hl{}, vl{};
+  ASSERT_EQ(0, ncplane_rounded_box_cells(n_, &ul, &ur, &ll, &lr, &hl, &vl));
+  EXPECT_EQ(0, ncplane_box_sized(n_, &ul, &ur, &ll, &lr, &hl, &vl, y, x));
+  cell_release(n_, &vl);
+  cell_release(n_, &hl);
+  cell_release(n_, &ul);
+  cell_release(n_, &ll);
+  cell_release(n_, &ur);
+  cell_release(n_, &lr);
+}
 TEST_F(NcplaneTest, EraseScreen) {
   ncplane_erase(n_);
 }


### PR DESCRIPTION
* Get default colors working when only one or the other of fg/bg are default (#48)
* Replace lots of boilerplate with `ncplane_rounded_box_cells()`
* Put a box around the uniblock in uniblocks demo
* Add `ncplane_box_sized()` to use relative rather than absolute coordinates