### PR TITLE
Use halfblocks to double vertical resolution of media

### DIFF
--- a/src/lib/libav.c
+++ b/src/lib/libav.c
@@ -29,7 +29,7 @@ void ncvisual_destroy(ncvisual* ncv){
   }
 }
 
-static void
+/* static void
 print_frame_summary(const AVCodecContext* cctx, const AVFrame* f){
   char pfmt[128];
   av_get_pix_fmt_string(pfmt, sizeof(pfmt), f->format);
@@ -65,7 +65,7 @@ print_frame_summary(const AVCodecContext* cctx, const AVFrame* f){
           f->best_effort_timestamp,
           f->key_frame ? "" : "non-",
           f->quality);
-}
+}*/
 
 AVFrame* ncvisual_decode(struct ncvisual* nc, int* averr){
   bool have_frame = false;
@@ -151,6 +151,10 @@ ncvisual* ncplane_visual_open(struct ncplane* nc, const char* filename, int* ave
   memset(ncv, 0, sizeof(*ncv));
   ncv->ncp = nc;
   ncplane_dim_yx(nc, &ncv->dstheight, &ncv->dstwidth);
+  // FIXME we only want to do this if we're not already large enough to
+  // faithfully reproduce the image, methinks?
+  //ncv->dstwidth *= 2;
+  ncv->dstheight *= 2;
   *averr = avformat_open_input(&ncv->fmtctx, filename, NULL, NULL);
   if(*averr < 0){
     fprintf(stderr, "Couldn't open %s (%s)\n", filename, av_err2str(*averr));

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1553,12 +1553,6 @@ int ncvisual_render(const ncvisual* ncv){
   ncplane_cursor_move_yx(ncv->ncp, 0, 0);
   const int linesize = f->linesize[0];
   const unsigned char* data = f->data[0];
-  if(f->height != dimy * 2){
-    return -1;
-  }
-  /*if(f->width != dimx * 2){
-    return -1;
-  }*/
   for(y = 0 ; y < f->height / 2 && y < dimy ; ++y){
     for(x = 0 ; x < f->width && x < dimx ; ++x){
       int bpp = av_get_bits_per_pixel(av_pix_fmt_desc_get(f->format));


### PR DESCRIPTION
Pretty simple -- use unicode upper and lower drawing characters to effectively double our rendering resolution. Effects are drastic -- see #88. w00t!