### PR TITLE
Handle resizes gracefully

### DIFF
--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -189,7 +189,6 @@ intro(struct notcurses* nc){
 
 static int
 ext_demos(struct notcurses* nc, const char* demos){
-  int dimy, dimx;
   while(*demos){
     int ret = 0;
     switch(*demos){
@@ -209,7 +208,6 @@ ext_demos(struct notcurses* nc, const char* demos){
       return ret;
     }
     ++demos;
-    notcurses_resize(nc, &dimy, &dimx);
   }
   return 0;
 }


### PR DESCRIPTION
* Check for a resize at the start of `notcurses_render()`, forcing a reallocation of the framebuffer and standard plane #105 .
* Check for a resize in each iteration of fadein/fadeout, since they both keep a shadow framebuffer