### PR TITLE
Input escape sequences #78

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,8 +783,6 @@ to implement".
 * There is no concept of subwindows which share memory with their parents.
 * There is no tracing functionality ala `trace(3NCURSES)`. Superior external
   tracing solutions exist, such as `bpftrace`.
-* There is no timeout functionality for input (`timeout()`, `halfdelay()`, etc.).
-  Roll your own with any of the four thousand ways to do it.
 
 ## Environment notes
 

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -154,7 +154,11 @@ typedef enum {
   NCKEY_RIGHT,
   NCKEY_DOWN,
   NCKEY_LEFT,
-  NCKEY_DC,       // delete
+  NCKEY_DEL,
+  NCKEY_PGDOWN,
+  NCKEY_PGUP,
+  NCKEY_HOME,
+  NCKEY_END,
   // FIXME...
 } ncspecial_key;
 
@@ -179,6 +183,11 @@ notcurses_getc_blocking(struct notcurses* n, cell* c, ncspecial_key* nkey){
   sigemptyset(&sigmask);
   return notcurses_getc(n, c, nkey, NULL, &sigmask);
 }
+
+// Add this escape sequence to the trie, resolving to the specified specialkey.
+// Exported mainly for the benefit of unit tests.
+API int notcurses_add_input_escape(struct notcurses* nc, const char* esc,
+                                   ncspecial_key special);
 
 // Refresh our idea of the terminal's dimensions, reshaping the standard plane
 // if necessary. Without a call to this function following a terminal resize

--- a/src/demo/panelreel.c
+++ b/src/demo/panelreel.c
@@ -315,7 +315,7 @@ panelreel_demo_core(struct notcurses* nc, int efd, tabletctx** tctxs){
           case NCKEY_RIGHT: ++x; if(panelreel_move(pr, x, y)){ --x; } break;
           case NCKEY_UP: panelreel_prev(pr); break;
           case NCKEY_DOWN: panelreel_next(pr); break;
-          case NCKEY_DC: kill_active_tablet(pr, tctxs); break;
+          case NCKEY_DEL: kill_active_tablet(pr, tctxs); break;
           default:
                     ncplane_cursor_move_yx(w, 3, 2);
                     ncplane_printf(w, "Unknown special (%d)\n", special);

--- a/src/demo/panelreel.c
+++ b/src/demo/panelreel.c
@@ -219,7 +219,7 @@ handle_input(struct notcurses* nc, struct panelreel* pr, int efd,
       fprintf(stderr, "Error polling on stdin/eventfd (%s)\n", strerror(errno));
     }else{
       if(fds[0].revents & POLLIN){
-        key = notcurses_getc(nc, c, special);
+        key = notcurses_getc_blocking(nc, c, special);
         if(key < 0){
           return -1;
         }

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -23,6 +23,14 @@ const char* nckeystr(ncspecial_key key){
   }
 }
 
+// print the utf8 Control Pictures for otherwise unprintable chars
+wchar_t printutf8(int kp){
+  if(kp <= 27 && kp >= 0){
+    return 0x2400 + kp;
+  }
+  return kp;
+}
+
 int main(void){
   if(setlocale(LC_ALL, "") == nullptr){
     return EXIT_FAILURE;
@@ -57,7 +65,8 @@ int main(void){
                           special, special, nckeystr(special)) < 0){
           break;
         }
-      }else if(ncplane_printf(n, "Got UTF-8: [0x%04x (%04d)] '%c'\n", kp, kp, kp) < 0){
+      }else if(ncplane_printf(n, "Got ASCII: [0x%02x (%03d)] '%lc'\n",
+                              kp, kp, isprint(kp) ? kp : printutf8(kp)) < 0){
         break;
       }
     }else{

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -1,0 +1,71 @@
+#include <sys/poll.h>
+#include "internal.h"
+
+sig_atomic_t resize_seen = 0;
+
+static int
+handle_getc(const notcurses* nc __attribute__ ((unused)), cell* c, int kpress,
+            ncspecial_key* special){
+// fprintf(stderr, "KEYPRESS: %d\n", kpress);
+  if(kpress < 0){
+    return -1;
+  }
+  *special = 0;
+  if(kpress == 0x04){ // ctrl-d
+    return -1;
+  }
+  // FIXME look for keypad
+  if(kpress < 0x80){
+    c->gcluster = kpress;
+  }else{
+    // FIXME
+  }
+  return 1;
+}
+
+int notcurses_getc(const notcurses* nc, cell* c, ncspecial_key* special){
+  if(resize_seen){
+    resize_seen = 0;
+    c->gcluster = 0;
+    *special = NCKEY_RESIZE;
+    return 1;
+  }
+  int r = getc(nc->ttyinfp);
+  if(r < 0){
+    return r;
+  }
+  return handle_getc(nc, c, r, special);
+}
+
+// we set our infd to non-blocking on entry, so to do a blocking call (without
+// burning cpu) we'll need to set up a poll().
+int notcurses_getc_blocking(const notcurses* nc, cell* c, ncspecial_key* special){
+  struct pollfd pfd = {
+    .fd = fileno(nc->ttyinfp),
+    .events = POLLIN | POLLRDHUP,
+    .revents = 0,
+  };
+  int pret, r;
+  sigset_t smask;
+  sigfillset(&smask);
+  sigdelset(&smask, SIGWINCH);
+  while((pret = ppoll(&pfd, 1, NULL, &smask)) >= 0){
+    if(pret == 0){
+      continue;
+    }
+    r = getc(nc->ttyinfp);
+    if(r < 0){
+      break; // want EINTR handling below
+    }
+    return handle_getc(nc, c, r, special);
+  }
+  if(errno == EINTR){
+    if(resize_seen){
+      resize_seen = 0;
+      c->gcluster = 0;
+      *special = NCKEY_RESIZE;
+      return 1;
+    }
+  }
+  return -1;
+}

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -1,79 +1,110 @@
 #include <sys/poll.h>
 #include "internal.h"
 
+static const unsigned char ESC = 0x1b; // 27
+
 sig_atomic_t resize_seen = 0;
+
+static inline int
+pop_input_keypress(notcurses* nc){
+  int candidate = nc->inputbuf[nc->inputbuf_valid_starts];
+fprintf(stderr, "DEOCCUPY: %u@%u read: %d\n", nc->inputbuf_occupied, nc->inputbuf_valid_starts, nc->inputbuf[nc->inputbuf_valid_starts]);
+  if(++nc->inputbuf_valid_starts == sizeof(nc->inputbuf) / sizeof(*nc->inputbuf)){
+    nc->inputbuf_valid_starts = 0;
+  }
+  --nc->inputbuf_occupied;
+  return candidate;
+}
 
 // add the keypress we just read to our input queue (assuming there is room).
 // if there is a full UTF8 codepoint or keystroke (composed or otherwise),
 // return it, and pop it from the queue.
 static int
-handle_getc(const notcurses* nc __attribute__ ((unused)), cell* c, int kpress,
-            ncspecial_key* special){
+handle_getc(notcurses* nc, cell* c, int kpress, ncspecial_key* special){
 fprintf(stderr, "KEYPRESS: %d\n", kpress);
   if(kpress < 0){
     return -1;
   }
-  // FIXME add it to the queue, then consult queue
+  if(kpress == ESC){
+fprintf(stderr, "ESCAPE OH SHIT\n");
+    // FIXME delay a little waiting for more?
+    while(nc->inputbuf_occupied){
+      int candidate = pop_input_keypress(nc);
+      // FIXME walk trie via candidate, exiting (and ungetc()ing) on failure
+fprintf(stderr, "CANDIDATE: %c\n", candidate);
+    }
+  }
   *special = 0;
-  if(kpress == 0x04){ // ctrl-d
+  if(kpress == 0x04){ // ctrl-d, treated as EOF
     return -1;
   }
-  // FIXME look for keypad
   if(kpress < 0x80){
     c->gcluster = kpress;
   }else{
-    // FIXME
+    // FIXME load up zee utf8
   }
   return 1;
 }
 
-int notcurses_getc(const notcurses* nc, cell* c, ncspecial_key* special){
-  if(resize_seen){
-    resize_seen = 0;
-    c->gcluster = 0;
-    *special = NCKEY_RESIZE;
-    return 1;
-  }
-  // FIXME check queue
-  int r = getc(nc->ttyinfp);
-  if(r < 0){
-    return r;
-  }
-  return handle_getc(nc, c, r, special);
-}
-
-// we set our infd to non-blocking on entry, so to do a blocking call (without
-// burning cpu) we'll need to set up a poll().
-int notcurses_getc_blocking(const notcurses* nc, cell* c, ncspecial_key* special){
+// blocks up through ts (infinite with NULL ts), returning number of events
+// (0 on timeout) or -1 on error/interruption.
+static int
+block_on_input(FILE* fp, const struct timespec* ts, sigset_t* sigmask){
   struct pollfd pfd = {
-    .fd = fileno(nc->ttyinfp),
+    .fd = fileno(fp),
     .events = POLLIN | POLLRDHUP,
     .revents = 0,
   };
-  int pret, r;
-  sigset_t smask;
-  sigfillset(&smask);
-  sigdelset(&smask, SIGWINCH);
-  sigdelset(&smask, SIGINT);
-  sigdelset(&smask, SIGQUIT);
-  sigdelset(&smask, SIGSEGV);
-  while((pret = ppoll(&pfd, 1, NULL, &smask)) >= 0){
-    if(pret == 0){
-      continue;
+  sigdelset(sigmask, SIGWINCH);
+  sigdelset(sigmask, SIGINT);
+  sigdelset(sigmask, SIGQUIT);
+  sigdelset(sigmask, SIGSEGV);
+  return ppoll(&pfd, 1, ts, sigmask);
+}
+
+static bool
+input_queue_full(const notcurses* nc){
+  return nc->inputbuf_occupied == sizeof(nc->inputbuf) / sizeof(*nc->inputbuf);
+}
+
+static int
+handle_input(notcurses* nc, cell* c, ncspecial_key* special){
+  int r;
+  c->gcluster = 0;
+  // getc() returns unsigned chars cast to ints
+  while(!input_queue_full(nc) && (r = getc(nc->ttyinfp)) >= 0){
+    nc->inputbuf[nc->inputbuf_write_at] = (unsigned char)r;
+fprintf(stderr, "OCCUPY: %u@%u read: %d\n", nc->inputbuf_occupied, nc->inputbuf_write_at, nc->inputbuf[nc->inputbuf_write_at]);
+    if(++nc->inputbuf_write_at == sizeof(nc->inputbuf) / sizeof(*nc->inputbuf)){
+      nc->inputbuf_write_at = 0;
     }
-    r = notcurses_getc(nc, c, special);
-    if(r < 0){
-      break; // want EINTR handling below
-    }
+    ++nc->inputbuf_occupied;
+  }
+  // highest priority is resize notifications, since they don't queue
+  if(resize_seen){
+    resize_seen = 0;
+    *special = NCKEY_RESIZE;
+    return 1;
+  }
+  // if there was some error in getc(), we still dole out the existing queue
+  if(nc->inputbuf_occupied == 0){
+    return -1;
+  }
+  r = pop_input_keypress(nc);
+  return handle_getc(nc, c, r, special);
+}
+
+// infp has always been set non-blocking
+int notcurses_getc(notcurses* nc, cell* c, ncspecial_key* special,
+                   const struct timespec *ts, sigset_t* sigmask){
+  errno = 0;
+  int r = handle_input(nc, c, special);
+  if(r > 0){
     return r;
   }
-  if(errno == EINTR){
-    if(resize_seen){
-      resize_seen = 0;
-      c->gcluster = 0;
-      *special = NCKEY_RESIZE;
-      return 1;
-    }
+  if(errno == EAGAIN || errno == EWOULDBLOCK){
+    block_on_input(nc->ttyinfp, ts, sigmask);
+    r = handle_input(nc, c, special);
   }
-  return -1;
+  return r;
 }

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -3,13 +3,17 @@
 
 sig_atomic_t resize_seen = 0;
 
+// add the keypress we just read to our input queue (assuming there is room).
+// if there is a full UTF8 codepoint or keystroke (composed or otherwise),
+// return it, and pop it from the queue.
 static int
 handle_getc(const notcurses* nc __attribute__ ((unused)), cell* c, int kpress,
             ncspecial_key* special){
-// fprintf(stderr, "KEYPRESS: %d\n", kpress);
+fprintf(stderr, "KEYPRESS: %d\n", kpress);
   if(kpress < 0){
     return -1;
   }
+  // FIXME add it to the queue, then consult queue
   *special = 0;
   if(kpress == 0x04){ // ctrl-d
     return -1;
@@ -30,6 +34,7 @@ int notcurses_getc(const notcurses* nc, cell* c, ncspecial_key* special){
     *special = NCKEY_RESIZE;
     return 1;
   }
+  // FIXME check queue
   int r = getc(nc->ttyinfp);
   if(r < 0){
     return r;
@@ -49,15 +54,18 @@ int notcurses_getc_blocking(const notcurses* nc, cell* c, ncspecial_key* special
   sigset_t smask;
   sigfillset(&smask);
   sigdelset(&smask, SIGWINCH);
+  sigdelset(&smask, SIGINT);
+  sigdelset(&smask, SIGQUIT);
+  sigdelset(&smask, SIGSEGV);
   while((pret = ppoll(&pfd, 1, NULL, &smask)) >= 0){
     if(pret == 0){
       continue;
     }
-    r = getc(nc->ttyinfp);
+    r = notcurses_getc(nc, c, special);
     if(r < 0){
       break; // want EINTR handling below
     }
-    return handle_getc(nc, c, r, special);
+    return r;
   }
   if(errno == EINTR){
     if(resize_seen){

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -8,7 +8,7 @@ sig_atomic_t resize_seen = 0;
 static inline int
 pop_input_keypress(notcurses* nc){
   int candidate = nc->inputbuf[nc->inputbuf_valid_starts];
-fprintf(stderr, "DEOCCUPY: %u@%u read: %d\n", nc->inputbuf_occupied, nc->inputbuf_valid_starts, nc->inputbuf[nc->inputbuf_valid_starts]);
+// fprintf(stderr, "DEOCCUPY: %u@%u read: %d\n", nc->inputbuf_occupied, nc->inputbuf_valid_starts, nc->inputbuf[nc->inputbuf_valid_starts]);
   if(++nc->inputbuf_valid_starts == sizeof(nc->inputbuf) / sizeof(*nc->inputbuf)){
     nc->inputbuf_valid_starts = 0;
   }
@@ -16,17 +16,83 @@ fprintf(stderr, "DEOCCUPY: %u@%u read: %d\n", nc->inputbuf_occupied, nc->inputbu
   return candidate;
 }
 
+// we assumed escapes can only be composed of 7-bit chars
+typedef struct esctrie {
+  ncspecial_key special; // escape terminating here
+  struct esctrie** trie;  // if non-NULL, next level of radix-128 trie
+} esctrie;
+
+static esctrie*
+create_esctrie_node(ncspecial_key special){
+  esctrie* e = malloc(sizeof(*e));
+  if(e){
+    e->special = special;
+    e->trie = NULL;
+  }
+  return e;
+}
+
+void input_free_esctrie(esctrie** eptr){
+  esctrie* e;
+  if( (e = *eptr) ){
+    if(e->trie){
+      int z;
+      for(z = 0 ; z < 0x80 ; ++z){
+        if(e->trie[z]){
+          input_free_esctrie(&e->trie[z]);
+        }
+      }
+      free(e->trie);
+    }
+    free(e);
+  }
+}
+
+int input_add_escape(notcurses* nc, const char* esc, ncspecial_key special){
+  esctrie** cur;
+  fprintf(stderr, "ADDING: %s for %d\n", esc, special);
+  if(esc[0] != ESC || strlen(esc) < 2){ // assume ESC prefix + content
+    return -1;
+  }
+  do{
+    ++esc;
+    int validate = *esc;
+    if(validate < 0 || validate >= 0x80){
+      return -1;
+    }
+    if(nc->inputescapes == NULL){
+      cur = &nc->inputescapes;
+    }else if(validate){
+      if((*cur)->trie == NULL){
+        const size_t tsize = sizeof((*cur)->trie) * 0x80;
+        (*cur)->trie = malloc(tsize);
+        memset((*cur)->trie, 0, tsize);
+      }
+      cur = &(*cur)->trie[validate];
+    }
+    if(*cur == NULL){
+      if((*cur = create_esctrie_node(NCKEY_INVALID)) == NULL){
+        return -1;
+      }
+    }
+  }while(*esc);
+  if((*cur)->special){ // already had one here!
+    return -1;
+  }
+  (*cur)->special = special;
+  return 0;
+}
+
 // add the keypress we just read to our input queue (assuming there is room).
 // if there is a full UTF8 codepoint or keystroke (composed or otherwise),
 // return it, and pop it from the queue.
 static int
 handle_getc(notcurses* nc, cell* c, int kpress, ncspecial_key* special){
-fprintf(stderr, "KEYPRESS: %d\n", kpress);
+// fprintf(stderr, "KEYPRESS: %d\n", kpress);
   if(kpress < 0){
     return -1;
   }
   if(kpress == ESC){
-fprintf(stderr, "ESCAPE OH SHIT\n");
     // FIXME delay a little waiting for more?
     while(nc->inputbuf_occupied){
       int candidate = pop_input_keypress(nc);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -104,6 +104,8 @@ typedef struct notcurses {
   char* right; // kcuf1
   char* up;    // kcuu1
   char* down;  // kcud1
+  char* del;   // delete
+  char* home;  // home
   char* npage; // knp
   char* ppage; // kpp
 
@@ -126,9 +128,6 @@ typedef struct notcurses {
 } notcurses;
 
 extern sig_atomic_t resize_seen;
-
-// add this escape sequence to the trie, resolving to the specified specialkey
-int input_add_escape(notcurses* nc, const char* esc, ncspecial_key special);
 
 // free up the input escapes trie
 void input_free_esctrie(struct esctrie** trie);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -6,8 +6,10 @@
 #include <stdint.h>
 #include <stdarg.h>
 #include <string.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <pthread.h>
+#include "notcurses.h"
 #include "egcpool.h"
 
 #ifdef __cplusplus
@@ -120,6 +122,8 @@ typedef struct notcurses {
   unsigned inputbuf_valid_starts;
   unsigned inputbuf_write_at;
 } notcurses;
+
+extern sig_atomic_t resize_seen;
 
 #ifdef __cplusplus
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -112,7 +112,7 @@ typedef struct notcurses {
   ncplane* top;   // the contents of our topmost plane (initially entire screen)
   ncplane* stdscr;// aliases some plane from the z-buffer, covers screen
   FILE* renderfp; // debugging FILE* to which renderings are written
-  char inputbuf[BUFSIZ];
+  unsigned char inputbuf[BUFSIZ];
   // we keep a wee ringbuffer of input queued up for delivery. if
   // inputbuf_occupied == sizeof(inputbuf), there is no room. otherwise, data
   // can be read to inputbuf_write_at until we fill up. the first datum

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -23,6 +23,7 @@ struct AVCodec;
 struct AVCodecParameters;
 struct AVPacket;
 struct SwsContext;
+struct esctrie;
 
 // A plane is memory for some rectilinear virtual window, plus current cursor
 // state for that window. A notcurses context describes a single terminal, and
@@ -121,9 +122,16 @@ typedef struct notcurses {
   unsigned inputbuf_occupied;
   unsigned inputbuf_valid_starts;
   unsigned inputbuf_write_at;
+  struct esctrie* inputescapes; // trie of input escapes -> ncspecial_keys
 } notcurses;
 
 extern sig_atomic_t resize_seen;
+
+// add this escape sequence to the trie, resolving to the specified specialkey
+int input_add_escape(notcurses* nc, const char* esc, ncspecial_key special);
+
+// free up the input escapes trie
+void input_free_esctrie(struct esctrie** trie);
 
 #ifdef __cplusplus
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -110,6 +110,15 @@ typedef struct notcurses {
   ncplane* top;   // the contents of our topmost plane (initially entire screen)
   ncplane* stdscr;// aliases some plane from the z-buffer, covers screen
   FILE* renderfp; // debugging FILE* to which renderings are written
+  char inputbuf[BUFSIZ];
+  // we keep a wee ringbuffer of input queued up for delivery. if
+  // inputbuf_occupied == sizeof(inputbuf), there is no room. otherwise, data
+  // can be read to inputbuf_write_at until we fill up. the first datum
+  // available for the app is at inputbuf_valid_starts iff inputbuf_occupied is
+  // not 0. the main purpose is working around bad predictions of escapes.
+  unsigned inputbuf_occupied;
+  unsigned inputbuf_valid_starts;
+  unsigned inputbuf_write_at;
 } notcurses;
 
 #ifdef __cplusplus

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -613,6 +613,9 @@ notcurses* notcurses_init(const notcurses_options* opts){
     free(ret);
     return NULL;
   }
+  ret->inputbuf_occupied = 0;
+  ret->inputbuf_valid_starts = 0;
+  ret->inputbuf_write_at = 0;
   if((ret->ttyfd = fileno(ret->ttyfp)) < 0){
     fprintf(stderr, "No file descriptor was available in opts->outfp\n");
     free(ret);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -40,7 +40,6 @@ ncplane_unlock(const ncplane* n){
 
 // only one notcurses object can be the target of signal handlers, due to their
 // process-wide nature.
-static sig_atomic_t resize_seen;
 static notcurses* _Atomic signal_nc = ATOMIC_VAR_INIT(NULL); // ugh
 static void (*signal_sa_handler)(int); // stashed signal handler we replaced
 
@@ -1666,73 +1665,6 @@ void ncplane_erase(ncplane* n){
   cell_load(n, &n->background, egc);
   free(egc);
   ncplane_unlock(n);
-}
-
-static int
-handle_getc(const notcurses* nc __attribute__ ((unused)), cell* c, int kpress,
-            ncspecial_key* special){
-// fprintf(stderr, "KEYPRESS: %d\n", kpress);
-  if(kpress < 0){
-    return -1;
-  }
-  *special = 0;
-  if(kpress == 0x04){ // ctrl-d
-    return -1;
-  }
-  // FIXME look for keypad
-  if(kpress < 0x80){
-    c->gcluster = kpress;
-  }else{
-    // FIXME
-  }
-  return 1;
-}
-
-int notcurses_getc(const notcurses* nc, cell* c, ncspecial_key* special){
-  if(resize_seen){
-    resize_seen = 0;
-    c->gcluster = 0;
-    *special = NCKEY_RESIZE;
-    return 1;
-  }
-  int r = getc(nc->ttyinfp);
-  if(r < 0){
-    return r;
-  }
-  return handle_getc(nc, c, r, special);
-}
-
-// we set our infd to non-blocking on entry, so to do a blocking call (without
-// burning cpu) we'll need to set up a poll().
-int notcurses_getc_blocking(const notcurses* nc, cell* c, ncspecial_key* special){
-  struct pollfd pfd = {
-    .fd = fileno(nc->ttyinfp),
-    .events = POLLIN | POLLRDHUP,
-    .revents = 0,
-  };
-  int pret, r;
-  sigset_t smask;
-  sigfillset(&smask);
-  sigdelset(&smask, SIGWINCH);
-  while((pret = ppoll(&pfd, 1, NULL, &smask)) >= 0){
-    if(pret == 0){
-      continue;
-    }
-    r = getc(nc->ttyinfp);
-    if(r < 0){
-      break; // want EINTR handling below
-    }
-    return handle_getc(nc, c, r, special);
-  }
-  if(errno == EINTR){
-    if(resize_seen){
-      resize_seen = 0;
-      c->gcluster = 0;
-      *special = NCKEY_RESIZE;
-      return 1;
-    }
-  }
-  return -1;
 }
 
 int ncvisual_render(const ncvisual* ncv){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -607,6 +607,7 @@ notcurses* notcurses_init(const notcurses_options* opts){
   ret->stats.render_min_bytes = ~0UL;
   ret->ttyfp = opts->outfp;
   ret->renderfp = opts->renderfp;
+  ret->inputescapes = NULL;
   ret->ttyinfp = stdin; // FIXME
   if(make_nonblocking(ret->ttyinfp)){
     free(ret);
@@ -729,6 +730,7 @@ int notcurses_stop(notcurses* nc){
       nc->top = p->z;
       free_plane(p);
     }
+    input_free_esctrie(&nc->inputescapes);
     ret |= pthread_mutex_destroy(&nc->lock);
     free(nc);
   }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -520,12 +520,33 @@ interrogate_terminfo(notcurses* nc, const notcurses_options* opts){
   term_verify_seq(&nc->italoff, "ritm");
   term_verify_seq(&nc->op, "op");
   term_verify_seq(&nc->clear, "clear");
-  term_verify_seq(&nc->left, "kcub1");
-  term_verify_seq(&nc->right, "kcuf1");
-  term_verify_seq(&nc->up, "kcuu1");
-  term_verify_seq(&nc->down, "kcud1");
-  term_verify_seq(&nc->npage, "knp");
-  term_verify_seq(&nc->ppage, "kpp");
+  if(term_verify_seq(&nc->left, "kcub1") == 0){
+    notcurses_add_input_escape(nc, nc->left, NCKEY_LEFT);
+  }
+  if(term_verify_seq(&nc->right, "kcuf1") == 0){
+    notcurses_add_input_escape(nc, nc->right, NCKEY_RIGHT);
+  }
+  if(term_verify_seq(&nc->up, "kcuu1") == 0){
+    notcurses_add_input_escape(nc, nc->up, NCKEY_UP);
+  }
+  if(term_verify_seq(&nc->down, "kcud1") == 0){
+    notcurses_add_input_escape(nc, nc->down, NCKEY_DOWN);
+  }
+  if(term_verify_seq(&nc->del, "kdch1") == 0){
+    notcurses_add_input_escape(nc, nc->down, NCKEY_DEL);
+  }
+  if(term_verify_seq(&nc->home, "kend") == 0){
+    notcurses_add_input_escape(nc, nc->down, NCKEY_END);
+  }
+  if(term_verify_seq(&nc->home, "khome") == 0){
+    notcurses_add_input_escape(nc, nc->down, NCKEY_HOME);
+  }
+  if(term_verify_seq(&nc->npage, "knp") == 0){
+    notcurses_add_input_escape(nc, nc->down, NCKEY_PGDOWN);
+  }
+  if(term_verify_seq(&nc->ppage, "kpp") == 0){
+    notcurses_add_input_escape(nc, nc->down, NCKEY_PGUP);
+  }
   // Some terminals cannot combine certain styles with colors. Don't advertise
   // support for the style in that case.
   int nocolor_stylemask = tigetnum("ncv");

--- a/tests/notcurses.cpp
+++ b/tests/notcurses.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <cstdlib>
 #include <notcurses.h>
+#include "internal.h"
 #include "main.h"
 
 class NotcursesTest : public :: testing::Test {
@@ -102,4 +103,11 @@ TEST_F(NotcursesTest, TileScreenWithPlanes) {
   delete[] planesecrets;
   delete[] planes;
   ASSERT_EQ(0, notcurses_render(nc_));
+}
+
+// build a trie up from terminfo(5)-style escape sequences
+TEST_F(NotcursesTest, InputEscapesTrie) {
+  const char* khome = "\x1bOH";
+  ASSERT_EQ(0, notcurses_add_input_escape(nc_, khome, NCKEY_HOME));
+  // FIXME need be able to lookup
 }


### PR DESCRIPTION
* Decode several keyboard input escape sequences #78 
* Build up trie of sequences from terminfo(5) at startup
* Destroy trie at shutdown
* Iterate over trie when processing input
* Update `notcurses-input` to print Unicode Control glyphs rather than blank spaces