### PR TITLE
Transparency via alpha channels

### DIFF
--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -1003,6 +1003,7 @@ typedef struct panelreel_options {
   unsigned tabletmask; // bitfield; same as bordermask but for tablet borders
   cell tabletattr;     // attributes used for tablet borders
   cell focusedattr;    // attributes used for focused tablet borders, no color!
+  uint64_t bgchannel;  // background colors
 } panelreel_options;
 
 struct tablet;

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -702,6 +702,16 @@ notcurses_bg_set_alpha(uint64_t* channels, int alpha){
 }
 
 static inline int
+notcurses_fg_alpha(uint64_t channels){
+  return (channels & CELL_BGALPHA_MASK) >> 60u;
+}
+
+static inline int
+notcurses_bg_alpha(uint64_t channels){
+  return (channels & CELL_BGALPHA_MASK) >> 28u;
+}
+
+static inline int
 notcurses_fg_prep(uint64_t* channels, int r, int g, int b){
   return notcurses_channel_prep(channels, CELL_FG_MASK, 32, r, g, b, CELL_FGDEFAULT_MASK);
 }
@@ -761,6 +771,17 @@ cell_fg_default_p(const cell* c){
 static inline void
 cell_bg_default(cell* c){
   notcurses_bg_default_prep(&c->channels);
+}
+
+// is the cell using the terminal's default foreground color for its foreground?
+static inline bool
+notcurses_fg_default_p(uint64_t channels){
+  return !(channels & CELL_FGDEFAULT_MASK);
+}
+
+static inline bool
+notcurses_bg_default_p(uint64_t channels){
+  return !(channels & CELL_BGDEFAULT_MASK);
 }
 
 // is the cell using the terminal's default background color for its background?

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -581,7 +581,6 @@ API void cell_release(struct ncplane* n, cell* c);
 
 #define CELL_STYLE_SHIFT     16u
 #define CELL_STYLE_MASK      0xffff0000ul
-#define CELL_ALPHA_MASK      0x000000fful
 // these are used for the style bitfield *after* it is shifted
 #define CELL_STYLE_STANDOUT  0x0001u
 #define CELL_STYLE_UNDERLINE 0x0002u

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -773,7 +773,6 @@ cell_bg_default(cell* c){
   notcurses_bg_default_prep(&c->channels);
 }
 
-// is the cell using the terminal's default foreground color for its foreground?
 static inline bool
 notcurses_fg_default_p(uint64_t channels){
   return !(channels & CELL_FGDEFAULT_MASK);
@@ -788,6 +787,26 @@ notcurses_bg_default_p(uint64_t channels){
 static inline bool
 cell_bg_default_p(const cell* c){
   return !(c->channels & CELL_BGDEFAULT_MASK);
+}
+
+static inline int
+cell_fg_set_alpha(cell* c, int alpha){
+  return notcurses_fg_set_alpha(&c->channels, alpha);
+}
+
+static inline int
+cell_bg_set_alpha(cell *c, int alpha){
+  return notcurses_bg_set_alpha(&c->channels, alpha);
+}
+
+static inline int
+cell_fg_alpha(const cell* c){
+  return notcurses_fg_alpha(c->channels);
+}
+
+static inline int
+cell_bg_alpha(const cell* c){
+  return notcurses_bg_alpha(c->channels);
 }
 
 // does the cell contain an East Asian Wide codepoint?

--- a/src/demo/boxdemo.c
+++ b/src/demo/boxdemo.c
@@ -4,6 +4,15 @@
 
 #define ITERATIONS 10
 
+// throw this in the middle with transparent background FIXME
+/* ┏━━┳━━┓ 
+   ┃┌─╂─┐┃ 
+   ┃│╲╿╱│┃ 
+   ┣┿╾╳╼┿┫ 
+   ┃│╱╽╲│┃ 
+   ┃└─╂─┘┃ 
+   ┗━━┻━━┛ */
+
 int box_demo(struct notcurses* nc){
   const int64_t totalns = timespec_to_ns(&demodelay);
   struct timespec iterdelay;

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -69,7 +69,7 @@ outro_message(struct notcurses* nc, int rows, int cols){
   ncplane_dim_yx(on, &rows, &cols);
   int ybase = 0;
   // bevel the upper corners
-  if(ncplane_cursor_move_yx(on, ybase, 0) || ncplane_putsimple(on, '\0', 0, 0) < 0){
+  if(ncplane_cursor_move_yx(on, ybase, 0) || ncplane_putsimple(on, ' ', 0, 0) < 0){
     return -1;
   }
   if(ncplane_cursor_move_yx(on, ybase, cols - 1) || ncplane_putsimple(on, ' ', 0, 0) < 0){

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -69,17 +69,21 @@ outro_message(struct notcurses* nc, int rows, int cols){
   ncplane_dim_yx(on, &rows, &cols);
   int ybase = 0;
   // bevel the upper corners
-  if(ncplane_cursor_move_yx(on, ybase, 0) || ncplane_putsimple(on, ' ', 0, 0) < 0){
+  uint64_t channel = 0;
+  if(notcurses_bg_set_alpha(&channel, 3)){
     return -1;
   }
-  if(ncplane_cursor_move_yx(on, ybase, cols - 1) || ncplane_putsimple(on, ' ', 0, 0) < 0){
+  if(ncplane_cursor_move_yx(on, ybase, 0) || ncplane_putsimple(on, ' ', 0, channel) < 0){
+    return -1;
+  }
+  if(ncplane_cursor_move_yx(on, ybase, cols - 1) || ncplane_putsimple(on, ' ', 0, channel) < 0){
     return -1;
   }
   // ...and now the lower corners
-  if(ncplane_cursor_move_yx(on, rows - 1, 0) || ncplane_putsimple(on, ' ', 0, 0) < 0){
+  if(ncplane_cursor_move_yx(on, rows - 1, 0) || ncplane_putsimple(on, ' ', 0, channel) < 0){
     return -1;
   }
-  if(ncplane_cursor_move_yx(on, rows - 1, cols - 1) || ncplane_putsimple(on, ' ', 0, 0) < 0){
+  if(ncplane_cursor_move_yx(on, rows - 1, cols - 1) || ncplane_putsimple(on, ' ', 0, channel) < 0){
     return -1;
   }
   if(ncplane_set_fg_rgb(on, 0, 0, 0)){

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -56,10 +56,10 @@ usage(const char* exe, int status){
 static int
 outro_message(struct notcurses* nc, int rows, int cols){
   const char str0[] = " ATL, baby! ATL! ";
-  const char str1[] = "much, much more is coming";
+  const char str1[] = " much, much more is coming ";
   const char str2[] = " hack on! —dank❤ ";
-  struct ncplane* on = notcurses_newplane(nc, 5, strlen(str1) + 6, rows - 6,
-                                         (cols - (strlen(str1) + 6)) / 2, NULL);
+  struct ncplane* on = notcurses_newplane(nc, 5, strlen(str1) + 4, rows - 6,
+                                         (cols - (strlen(str1) + 4)) / 2, NULL);
   if(on == NULL){
     return -1;
   }
@@ -68,6 +68,20 @@ outro_message(struct notcurses* nc, int rows, int cols){
   ncplane_set_background(on, &bgcell);
   ncplane_dim_yx(on, &rows, &cols);
   int ybase = 0;
+  // bevel the upper corners
+  if(ncplane_cursor_move_yx(on, ybase, 0) || ncplane_putsimple(on, '\0', 0, 0) < 0){
+    return -1;
+  }
+  if(ncplane_cursor_move_yx(on, ybase, cols - 1) || ncplane_putsimple(on, ' ', 0, 0) < 0){
+    return -1;
+  }
+  // ...and now the lower corners
+  if(ncplane_cursor_move_yx(on, rows - 1, 0) || ncplane_putsimple(on, ' ', 0, 0) < 0){
+    return -1;
+  }
+  if(ncplane_cursor_move_yx(on, rows - 1, cols - 1) || ncplane_putsimple(on, ' ', 0, 0) < 0){
+    return -1;
+  }
   if(ncplane_set_fg_rgb(on, 0, 0, 0)){
     return -1;
   }

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -73,17 +73,29 @@ outro_message(struct notcurses* nc, int rows, int cols){
   if(notcurses_bg_set_alpha(&channel, 3)){
     return -1;
   }
-  if(ncplane_cursor_move_yx(on, ybase, 0) || ncplane_putsimple(on, ' ', 0, channel) < 0){
+  if(ncplane_cursor_move_yx(on, ybase, 0)){
     return -1;
   }
-  if(ncplane_cursor_move_yx(on, ybase, cols - 1) || ncplane_putsimple(on, ' ', 0, channel) < 0){
+  if(ncplane_putsimple(on, ' ', 0, channel) < 0 || ncplane_putsimple(on, ' ', 0, channel) < 0){
+    return -1;
+  }
+  if(ncplane_cursor_move_yx(on, ybase, cols - 2)){
+    return -1;
+  }
+  if(ncplane_putsimple(on, ' ', 0, channel) < 0 || ncplane_putsimple(on, ' ', 0, channel) < 0){
     return -1;
   }
   // ...and now the lower corners
-  if(ncplane_cursor_move_yx(on, rows - 1, 0) || ncplane_putsimple(on, ' ', 0, channel) < 0){
+  if(ncplane_cursor_move_yx(on, rows - 1, 0)){
     return -1;
   }
-  if(ncplane_cursor_move_yx(on, rows - 1, cols - 1) || ncplane_putsimple(on, ' ', 0, channel) < 0){
+  if(ncplane_putsimple(on, ' ', 0, channel) < 0 || ncplane_putsimple(on, ' ', 0, channel) < 0){
+    return -1;
+  }
+  if(ncplane_cursor_move_yx(on, rows - 1, cols - 2)){
+    return -1;
+  }
+  if(ncplane_putsimple(on, ' ', 0, channel) < 0 || ncplane_putsimple(on, ' ', 0, channel) < 0){
     return -1;
   }
   if(ncplane_set_fg_rgb(on, 0, 0, 0)){

--- a/src/demo/panelreel.c
+++ b/src/demo/panelreel.c
@@ -255,12 +255,16 @@ panelreel_demo_core(struct notcurses* nc, int efd, tabletctx** tctxs){
     .loff = x,
     .roff = x,
     .boff = y,
+    .bgchannel = 0,
   };
   cell_set_fg(&popts.focusedattr, 58, 150, 221);
   cell_set_bg(&popts.focusedattr, 97, 214, 214);
   cell_set_fg(&popts.tabletattr, 19, 161, 14);
   cell_set_fg(&popts.borderattr, 136, 23, 152);
   cell_set_bg(&popts.borderattr, 0, 0, 0);
+  if(notcurses_bg_set_alpha(&popts.bgchannel, 3)){
+    return NULL;
+  }
   struct ncplane* w = notcurses_stdplane(nc);
   struct panelreel* pr = panelreel_create(w, &popts, efd);
   if(pr == NULL){

--- a/src/demo/widecolor.c
+++ b/src/demo/widecolor.c
@@ -7,6 +7,17 @@
 #include <pthread.h>
 #include "demo.h"
 
+// FIXME throw this in there somehow
+//   ∮ E⋅da = Q,  n → ∞, ∑ f(i) = ∏ g(i),     ⎧⎡⎛┌─────┐⎞⎤⎫
+//                                            ⎪⎢⎜│a²+b³ ⎟⎥⎪
+//  ∀x∈ℝ: ⌈x⌉ = −⌊−x⌋, α ∧ ¬β = ¬(¬α ∨ β),    ⎪⎢⎜│───── ⎟⎥⎪
+//                                            ⎪⎢⎜⎷ c₈   ⎟⎥⎪
+//  ℕ ⊆ ℕ₀ ⊂ ℤ ⊂ ℚ ⊂ ℝ ⊂ ℂ (z̄ = ℜ(z)−ℑ(z)⋅𝑖), ⎨⎢⎜       ⎟⎥⎬
+//                                            ⎪⎢⎜ ∞     ⎟⎥⎪
+//  ⊥ < a ≠ b ≡ c ≤ d ≪ ⊤ ⇒ (⟦A⟧ ⇔ ⟪B⟫),      ⎪⎢⎜ ⎲     ⎟⎥⎪
+//                                            ⎪⎢⎜ ⎳aⁱ-bⁱ⎟⎥⎪
+//  2H₂ + O₂ ⇌ 2H₂O, R = 4.7 kΩ, ⌀ 200 µm     ⎩⎣⎝i=1    ⎠⎦⎭
+
 // get the (up to) eight surrounding cells. they run clockwise, starting from
 // the upper left: 012
 //                 7 3

--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -41,8 +41,8 @@ egcpool_grow(egcpool* pool, size_t len){
   while(len > newsize - pool->poolsize){ // ensure we make enough space
     newsize *= 2;
   }
-  // offsets only have 24 bits available...
-  if(newsize >= 1u << 24u){
+  // offsets only have 25 bits available...
+  if(newsize >= 1u << 25u){
     return -1;
   }
   // nasty cast here because c++ source might include this header :/
@@ -106,7 +106,7 @@ egcpool_alloc_justified(const egcpool* pool, int len){
 
 // stash away the provided UTF8, NUL-terminated grapheme cluster. the cluster
 // should not be less than 2 bytes (such a cluster should be directly stored in
-// the cell). returns -1 on error, and otherwise a non-negative 24-bit offset.
+// the cell). returns -1 on error, and otherwise a non-negative 25-bit offset.
 // 'ulen' must be the number of bytes to lift from egc (utf8_egc_len()).
 static inline int
 egcpool_stash(egcpool* pool, const char* egc, size_t ulen){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -923,9 +923,6 @@ term_setstyle(FILE* out, unsigned cur, unsigned targ, unsigned stylebit,
 // write any escape sequences necessary to set the desired style
 static int
 term_setstyles(const notcurses* nc, FILE* out, uint32_t* curattr, const cell* c){
-  if(cell_inherits_style(c)){
-    return 0; // change nothing
-  }
   uint32_t cellattr = cell_styles(c);
   if(cellattr == *curattr){
     return 0; // happy agreement, change nothing
@@ -955,8 +952,8 @@ visible_cell(int y, int x, ncplane** retp){
       if(poffx < p->lenx && poffx >= 0){
         *retp = p;
         const cell* vis = &p->fb[fbcellidx(p, poffy, poffx)];
-        // if we never actually loaded the cell, use the background, if one
-        // is defined.
+        // if we never loaded any content into the cell (or obliterated it by
+        // writing in a zero), use the plane's background cell.
         if(vis->gcluster == 0){
           vis = &p->background;
         }
@@ -1086,7 +1083,7 @@ notcurses_render_internal(notcurses* nc){
   }
   // no need to write a clearscreen, since we update everything that's been
   // changed. we explicitly move the cursor at the beginning of each line
-  // (to work around broken prior lines), do no need to home it here, either.
+  // (to work around broken prior lines), so no need to home it expliticly.
   prep_optimized_palette(nc, out); // FIXME do what on failure?
   uint32_t curattr = 0; // current attributes set (does not include colors)
   // FIXME as of at least gcc 9.2.1, we get a false -Wmaybe-uninitialized below

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -957,9 +957,8 @@ visible_cell(int y, int x, ncplane** retp){
         if(vis->gcluster == 0){
           vis = &p->background;
         }
-        // if it's using the terminal default, chase further down
-        // FIXME should probably be based off alpha channel
-        if(cell_fg_default_p(vis) && cell_bg_default_p(vis) && vis->gcluster == 0){
+        // FIXME do this more rigorously, PoC
+        if(cell_fg_alpha(vis) || cell_bg_alpha(vis)){
           *retp = p->z;
           const cell* trans = visible_cell(y, x, retp);
           if(trans){

--- a/src/lib/panelreel.c
+++ b/src/lib/panelreel.c
@@ -593,6 +593,10 @@ panelreel* panelreel_create(ncplane* w, const panelreel_options* popts, int efd)
     free(pr);
     return NULL;
   }
+  cell bgc = CELL_TRIVIAL_INITIALIZER;
+  bgc.channels = popts->bgchannel;
+  ncplane_set_background(pr->p, &bgc);
+  cell_release(pr->p, &bgc);
   if(panelreel_redraw(pr)){
     ncplane_destroy(pr->p);
     free(pr);

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -76,3 +76,27 @@ TEST_F(CellTest, SetStyles) {
   ASSERT_EQ(6, ulen);
   // FIXME
 }*/
+
+TEST_F(CellTest, CellSetFGAlpha){
+  cell c = CELL_TRIVIAL_INITIALIZER;
+  EXPECT_GT(0, cell_fg_set_alpha(&c, -1));
+  EXPECT_GT(0, cell_fg_set_alpha(&c, 4));
+  EXPECT_EQ(0, cell_fg_set_alpha(&c, 0));
+  EXPECT_EQ(0, cell_fg_alpha(&c));
+  EXPECT_EQ(0, cell_fg_set_alpha(&c, 3));
+  EXPECT_EQ(3, cell_fg_alpha(&c));
+  EXPECT_TRUE(cell_fg_default_p(&c));
+  EXPECT_TRUE(cell_bg_default_p(&c));
+}
+
+TEST_F(CellTest, CellSetBGAlpha){
+  cell c = CELL_TRIVIAL_INITIALIZER;
+  EXPECT_GT(0, cell_bg_set_alpha(&c, -1));
+  EXPECT_GT(0, cell_bg_set_alpha(&c, 4));
+  EXPECT_EQ(0, cell_bg_set_alpha(&c, 0));
+  EXPECT_EQ(0, cell_bg_alpha(&c));
+  EXPECT_EQ(0, cell_bg_set_alpha(&c, 3));
+  EXPECT_EQ(3, cell_bg_alpha(&c));
+  EXPECT_TRUE(cell_fg_default_p(&c));
+  EXPECT_TRUE(cell_bg_default_p(&c));
+}

--- a/tests/notcurses.cpp
+++ b/tests/notcurses.cpp
@@ -110,7 +110,11 @@ TEST_F(NotcursesTest, ChannelSetFGAlpha){
   EXPECT_GT(0, notcurses_fg_set_alpha(&channel, -1));
   EXPECT_GT(0, notcurses_fg_set_alpha(&channel, 4));
   EXPECT_EQ(0, notcurses_fg_set_alpha(&channel, 0));
+  EXPECT_EQ(0, notcurses_fg_alpha(channel));
   EXPECT_EQ(0, notcurses_fg_set_alpha(&channel, 3));
+  EXPECT_EQ(3, notcurses_fg_alpha(channel));
+  EXPECT_TRUE(notcurses_fg_default_p(channel));
+  EXPECT_TRUE(notcurses_bg_default_p(channel));
 }
 
 TEST_F(NotcursesTest, ChannelSetBGAlpha){
@@ -118,5 +122,9 @@ TEST_F(NotcursesTest, ChannelSetBGAlpha){
   EXPECT_GT(0, notcurses_bg_set_alpha(&channel, -1));
   EXPECT_GT(0, notcurses_bg_set_alpha(&channel, 4));
   EXPECT_EQ(0, notcurses_bg_set_alpha(&channel, 0));
+  EXPECT_EQ(0, notcurses_bg_alpha(channel));
   EXPECT_EQ(0, notcurses_bg_set_alpha(&channel, 3));
+  EXPECT_EQ(3, notcurses_bg_alpha(channel));
+  EXPECT_TRUE(notcurses_fg_default_p(channel));
+  EXPECT_TRUE(notcurses_bg_default_p(channel));
 }

--- a/tests/notcurses.cpp
+++ b/tests/notcurses.cpp
@@ -104,3 +104,19 @@ TEST_F(NotcursesTest, TileScreenWithPlanes) {
   delete[] planes;
   ASSERT_EQ(0, notcurses_render(nc_));
 }
+
+TEST_F(NotcursesTest, ChannelSetFGAlpha){
+  uint64_t channel = 0;
+  EXPECT_GT(0, notcurses_fg_set_alpha(&channel, -1));
+  EXPECT_GT(0, notcurses_fg_set_alpha(&channel, 4));
+  EXPECT_EQ(0, notcurses_fg_set_alpha(&channel, 0));
+  EXPECT_EQ(0, notcurses_fg_set_alpha(&channel, 3));
+}
+
+TEST_F(NotcursesTest, ChannelSetBGAlpha){
+  uint64_t channel = 0;
+  EXPECT_GT(0, notcurses_bg_set_alpha(&channel, -1));
+  EXPECT_GT(0, notcurses_bg_set_alpha(&channel, 4));
+  EXPECT_EQ(0, notcurses_bg_set_alpha(&channel, 0));
+  EXPECT_EQ(0, notcurses_bg_set_alpha(&channel, 3));
+}

--- a/tests/panelreel.cpp
+++ b/tests/panelreel.cpp
@@ -231,3 +231,11 @@ TEST_F(PanelReelTest, SubwinNoOffsetGeom) {
   EXPECT_EQ(OK, delwin(basew));
 }
 */
+
+TEST_F(PanelReelTest, TransparentBackground) {
+  panelreel_options p{};
+  notcurses_bg_set_alpha(&p.bgchannel, 3);
+  struct panelreel* pr = panelreel_create(n_, &p, -1);
+  ASSERT_NE(nullptr, pr);
+  // FIXME
+}


### PR DESCRIPTION
* Reduce alpha channels to 2 bits for both of fg and bg
* Move alpha channels into channels, out of attrword
* Bevel the outro plane's corners with transparency
* Add a background channel to panelreel, honor it in `panelreel_create()`