### PR TITLE
input: use SPUA-B for special keys #118

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ input queue per `struct notcurses`.
 
 Like NCURSES, notcurses will watch for escape sequences, check them against the
 terminfo database, and return them as special keys. Unlike NCURSES, the
-fundamental unit of input is the UTF8-encoded Unicode codepoint.
+fundamental unit of input is the UTF8-encoded Unicode codepoint. Note, however,
+that only one codepoint is returned at a time (as opposed to an entire EGC).
 
 ```c
 // All input is currently taken from stdin, though this will likely change. We
@@ -183,19 +184,15 @@ fundamental unit of input is the UTF8-encoded Unicode codepoint.
 // Extended Grapheme Cluster (despite use of the cell object, which encodes an
 // entire EGC). It is also possible that we will read a special keypress, i.e.
 // anything that doesn't correspond to a Unicode codepoint (e.g. arrow keys,
-// function keys, screen resize events, etc.). On return, 'special' is a valid
-// special key if and only if c.gcluster is 0 AND the return value is positive.
+// function keys, screen resize events, etc.). These are mapped into Unicode's
+// Private Use Area.
 //
-// Many special keys arrive as an escape sequence. It can thus be necessary for
-// notcurses_getc() to wait a short time following receipt of an escape. If no
-// further input is received, it is assumed that the actual Escape key was
-// pressed. Otherwise, the input will be checked against the terminfo database
-// to see if it indicates a special key. In all other cases, notcurses_getc()
-// is non-blocking. notcurses_getc_blocking() blocks until a codepoint or
-// special key is read (though it can be interrupted by a signal).
+// notcurses_getc() and notcurses_getc_nblock() are both nonblocking.
+// notcurses_getc_blocking() blocks until a codepoint or special key is read,
+// or until interrupted by a signal.
 //
 // In the case of a valid read, a positive value is returned corresponding to
-// the number of bytes in the UTF-8 character, or '1' for all specials keys.
+// the number of bytes in the UTF-8 character, or '1' for all special keys.
 // 0 is returned to indicate that no input was available, but only by
 // notcurses_getc(). Otherwise (including on EOF) -1 is returned.
 typedef enum {
@@ -968,7 +965,6 @@ The worst case input frame (in terms of output size) is one whose colors change
 from coordinate to coordinate, uses multiple combining characters within each
 grapheme cluster, and has a large geometry. Peculiarities of the terminal
 make it impossible to comment more meaningfully regarding delay.
-
 
 ## Included tools
 

--- a/src/demo/widecolor.c
+++ b/src/demo/widecolor.c
@@ -580,7 +580,7 @@ int widecolor_demo(struct notcurses* nc){
   const size_t screens = sizeof(steps) / sizeof(*steps);
   ncplane_erase(n);
   for(i = 0 ; i < screens ; ++i){
-    ncspecial_key special;
+    wchar_t key = NCKEY_INVALID;
     cell c;
     do{ // (re)draw a screen
       const int start = starts[i];
@@ -591,7 +591,6 @@ int widecolor_demo(struct notcurses* nc){
       int dimy, dimx;
       notcurses_resize(nc, &dimy, &dimx);
       cell_init(&c);
-      special = NCKEY_INVALID;
       int y, x, maxy, maxx;
       ncplane_dim_yx(n, &maxy, &maxx);
       int rgb = start;
@@ -676,13 +675,12 @@ int widecolor_demo(struct notcurses* nc){
       }
       pthread_t tid;
       pthread_create(&tid, NULL, snake_thread, nc);
-      int key;
       do{
-        key = notcurses_getc_blocking(nc, &c, &special);
+        key = notcurses_getc_blocking(nc);
       }while(key < 0);
       pthread_cancel(tid);
       pthread_join(tid, NULL);
-    }while(c.gcluster == 0 && special == NCKEY_RESIZE);
+    }while(c.gcluster == 0 && key == NCKEY_RESIZE);
   }
   return 0;
 }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -79,10 +79,7 @@ int main(int argc, char** argv){
       std::cerr << "Error decoding " << argv[i] << ": " << errbuf.data() << std::endl;
       return EXIT_FAILURE;
     }
-    ncspecial_key special;
-    cell c = CELL_TRIVIAL_INITIALIZER;
-    notcurses_getc_blocking(nc, &c, &special);
-    cell_release(ncp, &c);
+    notcurses_getc_blocking(nc);
     ncvisual_destroy(ncv);
   }
   if(notcurses_stop(nc)){


### PR DESCRIPTION
It's annoying to have to handle two return values from input. Instead, stick our special keys into the Supplementary Private Use Area-B of Unicode (#118).