### PR TITLE
Improve chances of DirectColor terminal detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ by [nick black](https://nick-black.com/dankwiki/index.php/Hack_on) (<nickblack@l
   * [Features missing relative to NCURSES](#features-missing-relative-to-ncurses)
   * [Adapting NCURSES programs](#adapting-ncurses-programs)
 * [Environment notes](#environment-notes)
+  * [DirectColor detection](#DirectColor-detection)
   * [Fonts](#fonts)
 * [Supplemental material](#supplemental-material)
   * [Useful links](#useful-links)
@@ -1909,6 +1910,18 @@ These are pretty obvious, implementation-wise.
 
 * The unit tests assume dimensions of at least 80x25. They might work in a
   smaller terminal. They might not. Don't file bugs on it.
+
+### DirectColor detection
+
+ncurses aims to use only information found in the terminal's terminfo entry to detect capabilities, DirectColor
+being one of them. Support for this is indicated by terminfo having a flag, added in NCURSES 6.1, named `RGB` set
+to `true`. However, as of today there are few and far between terminfo entries which have the capability in their
+database entry and so DirectColor won't be used in most cases. Terminal emulators have had for years a kludge to
+work around this limitation of terminfo in the form of the `COLORTERM` environment variable which, if set to either
+`truecolor` or `24bit` does the job of indicating the capability of sending the escapes 48 and 38 together with a
+tripartite RGB (0 <= c <= 255 for all three components) to specify fore- and background colors.
+Checking for `COLORTERM` admittedly goes against the goal stated at the top of this section but, for all practical
+purposes, makes the detection work quite well **today**.
 
 ### Fonts
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -582,6 +582,21 @@ interrogate_terminfo(notcurses* nc, const notcurses_options* opts){
   char* longname_term = longname();
   fprintf(stderr, "Term: %s\n", longname_term ? longname_term : "?");
   nc->RGBflag = tigetflag("RGB") == 1;
+  if (nc->RGBflag == 0) {
+    // RGB terminfo capability being a new thing (as of ncurses 6.1), it's not commonly found in
+    // terminal entries today. COLORTERM, however, is a de-facto (if imperfect/kludgy) standard way
+    // of indicating DirectColor support for a terminal. The variable takes one of two case-sensitive
+    // values:
+    //
+    //   truecolor
+    //   24bit
+    //
+    // https://gist.github.com/XVilka/8346728#true-color-detection gives some more information about
+    // the topic
+    //
+    const char* cterm = getenv("COLORTERM");
+    nc->RGBflag = cterm && (strcmp(cterm, "truecolor") == 0 || strcmp(cterm, "24bit") == 0);
+  }
   nc->CCCflag = tigetflag("ccc") == 1;
   if((nc->colors = tigetnum("colors")) <= 0){
     fprintf(stderr, "This terminal doesn't appear to support colors\n");


### PR DESCRIPTION
While ncurses 6.1 adds the `RGB` capability to terminfo, the flag is not
commonly used in terminfo entries as of now. The `COLORTERM` environment
variable is, otoh, commonly present and set to either `truecolor` or
`24bit` value by terminal emulators which support direct color.

Add a check for this if `RGB` is false (or absent)

With this check in I was able to properly appreciate the awesomeness of
notcurses demos :)