### PR TITLE
Z-axis damage

### DIFF
--- a/src/demo/luigi.c
+++ b/src/demo/luigi.c
@@ -159,26 +159,27 @@ int luigi_demo(struct notcurses* nc){
   int yoff = rows * 4 / 5 - height + 1; // tuned
   struct ncplane* lns[3];
   int i;
+  struct ncplane* lastseen = NULL;
   for(i = 0 ; i < 3 ; ++i){
-    lns[i] = notcurses_newplane(nc, height, 16, yoff, -16, NULL);
+    lns[i] = notcurses_newplane(nc, height, 16, yoff, 0, NULL);
     if(lns[i] == NULL){
       while(--i){
         ncplane_destroy(lns[i]);
       }
       return -1;
     }
+    lastseen = lns[i];
+    ncplane_move_bottom(lastseen); // all start hidden underneath stdplane
   }
   draw_luigi(lns[0], luigi1);
   draw_luigi(lns[1], luigi2);
   draw_luigi(lns[2], luigi3);
-  struct ncplane* lastseen = NULL;
   struct timespec stepdelay;
   ns_to_timespec(timespec_to_ns(&demodelay) / (cols - 16 - 1), &stepdelay);
   for(i = 0 ; i < cols - 16 - 1 ; ++i){
-    if(lastseen){ // hide the previous sprite
-      ncplane_move_yx(lastseen, yoff, -16);
-    }
+    ncplane_move_bottom(lastseen); // hide the previous sprite
     lastseen = lns[i % 3];
+    ncplane_move_top(lastseen);
     ncplane_move_yx(lastseen, yoff, i);
     notcurses_render(nc);
     nanosleep(&stepdelay, NULL);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1200,6 +1200,7 @@ int ncplane_move_above_unsafe(ncplane* restrict n, ncplane* restrict above){
   *an = n->z; // splice n out
   n->z = above; // attach above below n
   *aa = n; // spline n in above
+  ncplane_updamage(n); // conservative (we might not actually be visible)
   return 0;
 }
 
@@ -1212,6 +1213,7 @@ int ncplane_move_below_unsafe(ncplane* restrict n, ncplane* restrict below){
   *an = n->z; // splice n out
   n->z = below->z; // reattach subbelow list to n
   below->z = n; // splice n in below
+  ncplane_updamage(n); // conservative (we might not actually be visible)
   return 0;
 }
 
@@ -1223,6 +1225,7 @@ int ncplane_move_top(ncplane* n){
   *an = n->z; // splice n out
   n->z = n->nc->top;
   n->nc->top = n;
+  ncplane_updamage(n);
   return 0;
 }
 
@@ -1238,6 +1241,7 @@ int ncplane_move_bottom(ncplane* n){
   }
   *an = n;
   n->z = NULL;
+  ncplane_updamage(n);
   return 0;
 }
 


### PR DESCRIPTION
When changing a plane's zaxis position, pass up damage for its breadth. This can lead to false positives if the plane wasn't visible and still isn't visible, but the alternative is kinda dicey. #146