### PR TITLE
Implement notcurses_refresh() #150

### DIFF
--- a/README.md
+++ b/README.md
@@ -1749,6 +1749,7 @@ acquired using the `notcurses_stats()` function. This function cannot fail.
 ```c
 typedef struct ncstats {
   uint64_t renders;          // number of notcurses_render() runs
+  uint64_t failed_renders;   // number of aborted renders, should be 0
   uint64_t render_bytes;     // bytes emitted to ttyfp
   uint64_t render_max_bytes; // max bytes emitted for a frame
   uint64_t render_min_bytes; // min bytes emitted for a frame

--- a/README.md
+++ b/README.md
@@ -379,12 +379,11 @@ corresponding to a bare NCURSES `WINDOW`.
 // of the resized ncplane. Finally, 'ylen' and 'xlen' are the dimensions of the
 // ncplane after resizing. 'ylen' must be greater than or equal to 'keepleny',
 // and 'xlen' must be greater than or equal to 'keeplenx'. It is an error to
-// attempt to resize the standard plane. If either of 'keepy' or 'keepx' is
-// non-zero, both must be non-zero.
+// attempt to resize the standard plane. If either of 'keepleny' or 'keeplenx'
+// is non-zero, both must be non-zero.
 //
 // Essentially, the kept material does not move. It serves to anchor the
-// resized plane. If there is no kept material, the plane can move freely:
-// it is possible to implement ncplane_move() in terms of ncplane_resize().
+// resized plane. If there is no kept material, the plane can move freely.
 int ncplane_resize(struct ncplane* n, int keepy, int keepx, int keepleny,
                        int keeplenx, int yoff, int xoff, int ylen, int xlen);
 

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -282,7 +282,8 @@ API unsigned notcurses_supported_styles(const struct notcurses* nc);
 API int notcurses_palette_size(const struct notcurses* nc);
 
 typedef struct ncstats {
-  uint64_t renders;          // number of notcurses_render() runs
+  uint64_t renders;          // number of successful notcurses_render() runs
+  uint64_t failed_renders;   // number of aborted renders, should be 0
   uint64_t render_bytes;     // bytes emitted to ttyfp
   int64_t render_max_bytes;  // max bytes emitted for a frame
   int64_t render_min_bytes;  // min bytes emitted for a frame
@@ -312,12 +313,11 @@ API void notcurses_stats(const struct notcurses* nc, ncstats* stats);
 // of the resized ncplane. Finally, 'ylen' and 'xlen' are the dimensions of the
 // ncplane after resizing. 'ylen' must be greater than or equal to 'keepleny',
 // and 'xlen' must be greater than or equal to 'keeplenx'. It is an error to
-// attempt to resize the standard plane. If either of 'keepy' or 'keepx' is
-// non-zero, both must be non-zero.
+// attempt to resize the standard plane. If either of 'keepleny' or 'keeplenx'
+// is non-zero, both must be non-zero.
 //
 // Essentially, the kept material does not move. It serves to anchor the
-// resized plane. If there is no kept material, the plane can move freely:
-// it is possible to implement ncplane_move() in terms of ncplane_resize().
+// resized plane. If there is no kept material, the plane can move freely.
 API int ncplane_resize(struct ncplane* n, int keepy, int keepx, int keepleny,
                        int keeplenx, int yoff, int xoff, int ylen, int xlen);
 

--- a/src/demo/boxdemo.c
+++ b/src/demo/boxdemo.c
@@ -49,24 +49,22 @@ int box_demo(struct notcurses* nc){
   if(ncplane_putstr_aligned(n, ytargbase++, "┗━━┻━━┛", NCALIGN_CENTER) < 0){
     return -1;
   }
-  ncplane_set_fg_rgb(n, 255, 255, 255);
-  ncplane_set_bg_rgb(n, 180, 40, 180);
   do{
     int y = 0, x = 0;
     ncplane_dim_yx(n, &ylen, &xlen);
     while(ylen - y >= targy && xlen - x >= targx){
       cell_set_fg_rgb(&ul, 107 - (y * 2), zbonus, 107 + (y * 2));
-      cell_set_bg_rgb(&ul, zbonus, 20 + y, 20 + y);
+      cell_set_bg_rgb(&ul, 20, zbonus, 20);
       cell_set_fg_rgb(&ur, 107 - (y * 2), zbonus, 107 + (y * 2));
-      cell_set_bg_rgb(&ur, zbonus, 20 + y, 20 + y);
+      cell_set_bg_rgb(&ur, 20, zbonus, 20);
       cell_set_fg_rgb(&hl, 107 - (y * 2), zbonus, 107 + (y * 2));
       cell_set_bg_rgb(&hl, 20, zbonus, 20);
       cell_set_fg_rgb(&ll, 107 - (y * 2), zbonus, 107 + (y * 2));
-      cell_set_bg_rgb(&ll, zbonus, 20 + y, 20 + y);
+      cell_set_bg_rgb(&ll, 20, zbonus, 20);
       cell_set_fg_rgb(&lr, 107 - (y * 2), zbonus, 107 + (y * 2));
-      cell_set_bg_rgb(&lr, zbonus, 20 + y, 20 + y);
-      cell_set_fg_rgb(&vl, 20, zbonus, 20);
-      cell_set_bg_rgb(&vl, 107 - (y * 2), zbonus, 107 + (y * 2));
+      cell_set_bg_rgb(&lr, 20, zbonus, 20);
+      cell_set_fg_rgb(&vl, 107 - (y * 2), zbonus, 107 + (y * 2));
+      cell_set_bg_rgb(&vl, 20, zbonus, 20);
       if(ncplane_cursor_move_yx(n, y, x)){
         return -1;
       }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -89,6 +89,7 @@ typedef struct notcurses {
   // We verify that some terminfo capabilities exist. These needn't be checked
   // before further use; just use tiparm() directly.
   char* cup;      // move cursor
+  bool RGBflag;   // terminfo-reported "RGB" flag for 24bpc directcolor
   char* civis;    // hide cursor
   // These might be NULL, and we can more or less work without them. Check!
   char* clearscr; // erase screen and home cursor
@@ -112,9 +113,10 @@ typedef struct notcurses {
   char* italoff;  // CELL_STYLE_ITALIC (disable)
   char* smkx;     // enter keypad transmit mode (keypad_xmit)
   char* rmkx;     // leave keypad transmit mode (keypad_local)
-
+  cell* shadowbuf;// last rendered frame
+  int shadowy;    // dimensions of shadowbuf
+  int shadowx;    // dimensions of shadowbuf
   struct termios tpreserved; // terminal state upon entry
-  bool RGBflag;   // terminfo-reported "RGB" flag for 24bpc directcolor
   bool CCCflag;   // terminfo-reported "CCC" flag for palette set capability
   ncplane* top;   // the contents of our topmost plane (initially entire screen)
   ncplane* stdscr;// aliases some plane from the z-buffer, covers screen

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -84,6 +84,9 @@ typedef struct notcurses {
   FILE* ttyfp;    // FILE* for controlling tty, from opts->ttyfp
   FILE* ttyinfp;  // FILE* for processing input
   unsigned char* damage;   // damage map (row granularity)
+  char* mstream;  // buffer for rendering memstream, see open_memstream(3)
+  FILE* mstreamfp;// FILE* for rendering memstream
+  size_t mstrsize;// size of rendering memstream
   int colors;     // number of colors usable for this screen
   ncstats stats;  // some statistics across the lifetime of the notcurses ctx
   // We verify that some terminfo capabilities exist. These needn't be checked
@@ -113,9 +116,6 @@ typedef struct notcurses {
   char* italoff;  // CELL_STYLE_ITALIC (disable)
   char* smkx;     // enter keypad transmit mode (keypad_xmit)
   char* rmkx;     // leave keypad transmit mode (keypad_local)
-  cell* shadowbuf;// last rendered frame
-  int shadowy;    // dimensions of shadowbuf
-  int shadowx;    // dimensions of shadowbuf
   struct termios tpreserved; // terminal state upon entry
   bool CCCflag;   // terminfo-reported "CCC" flag for palette set capability
   ncplane* top;   // the contents of our topmost plane (initially entire screen)


### PR DESCRIPTION
Clean up colors in boxdemo. Recycle memstream across render runs. Use said memstream to implement extremely fast `notcurses_refresh()` (just dump it right back out to the screen).