### PR TITLE
Observe correct `char32_t` signedness

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -10,7 +10,7 @@ static int dimy, dimx;
 static struct notcurses* nc;
 
 // return the string version of a special composed key
-const char* nckeystr(wchar_t spkey){
+const char* nckeystr(char32_t spkey){
   switch(spkey){ // FIXME
     case NCKEY_RESIZE:
       notcurses_resize(nc, &dimy, &dimx);
@@ -78,8 +78,8 @@ const char* nckeystr(wchar_t spkey){
 }
 
 // Print the utf8 Control Pictures for otherwise unprintable ASCII
-wchar_t printutf8(wchar_t kp){
-  if(kp <= 27 && kp >= 0){
+char32_t printutf8(char32_t kp){
+  if(kp <= 27 && kp < UINT_LEAST32_MAX){
     return 0x2400 + kp;
   }
   return kp;
@@ -144,13 +144,13 @@ int main(void){
   ncplane_set_bg_default(n);
   notcurses_render(nc);
   int y = 2;
-  std::deque<wchar_t> cells;
-  wchar_t r;
+  std::deque<char32_t> cells;
+  char32_t r;
   if(notcurses_mouse_enable(nc)){
     notcurses_stop(nc);
     return EXIT_FAILURE;
   }
-  while(errno = 0, (r = notcurses_getc_blocking(nc)) >= 0){
+  while(errno = 0, (r = notcurses_getc_blocking(nc)) < UINT_LEAST32_MAX){
     if(r == 0){ // interrupted by signal
       continue;
     }
@@ -192,7 +192,7 @@ int main(void){
   int e = errno;
   notcurses_mouse_disable(nc);
   notcurses_stop(nc);
-  if(r < 0 && e){
+  if(r == UINT_LEAST32_MAX && e){
     std::cerr << "Error reading from terminal (" << strerror(e) << "?)\n";
   }
   return EXIT_FAILURE;

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -202,7 +202,7 @@ handle_input(notcurses* nc){
   }
   // if there was some error in getc(), we still dole out the existing queue
   if(nc->inputbuf_occupied == 0){
-    return -1;
+    return UINT_LEAST32_MAX;
   }
   r = pop_input_keypress(nc);
   return handle_getc(nc, r);
@@ -212,7 +212,7 @@ handle_input(notcurses* nc){
 char32_t notcurses_getc(notcurses* nc, const struct timespec *ts, sigset_t* sigmask){
   errno = 0;
   char32_t r = handle_input(nc);
-  if(r == (char32_t)-1){
+  if(r == UINT_LEAST32_MAX){
     if(errno == EAGAIN || errno == EWOULDBLOCK){
       block_on_input(nc->ttyinfp, ts, sigmask);
       return handle_input(nc);


### PR DESCRIPTION
The `char32_t` type (in C11 and C++11) is defined to be an unsigned
32-bit type. To be exact, it's defined as a typedef for the
`uint_least32_t` type. Therefore, using `-1` albeit being a typing
shortcut is not completely correct. `-1` will be equal to value of the
`UINT_LEAST32_MAX` macro defined in `stdint.h` (or `cstdint` in C++) so
let's use it in place of `-1`