### PR TITLE
Mouse support #165

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,40 +1,40 @@
 ---
-kind: pipeline:
+kind: pipeline
 type: docker
 name: debianunstable
-  prep:
-    image: dankamongmen/unstable_builder
-    docker:
-      tty: true
-    commands:
-      - apt-get update
-      - apt-get -y remove man-db
-      - apt-get -y install devscripts git-buildpackage locales
-      - echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
-      - locale-gen
-      - mk-build-deps --install -t'apt-get -y'
-      - mkdir build
-      - cd build
-      - cmake ..
-      - make
-      - LANG="en_US.UTF-8" ./notcurses-tester
+steps:
+- name: prep
+  image: dankamongmen/unstable_builder
+  commands:
+  - apt-get update
+  - apt-get -y remove man-db
+  - apt-get -y install devscripts git-buildpackage locales
+  - echo 'en_US.UTF-8 UTF-8' &gt; /etc/locale.gen
+  - locale-gen
+  - mk-build-deps --install -t'apt-get -y'
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make
+  - LANG="en_US.UTF-8" ./notcurses-tester
 ---
-kind: pipeline:
+kind: pipeline
 type: docker
 name: debianstable
-  prep:
-    image: library/debian:unstable
-    docker:
-      tty: true
-    commands:
-      - apt-get update
-      - apt-get -y remove man-db
-      - apt-get -y install devscripts git-buildpackage locales
-      - echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
-      - locale-gen
-      - mk-build-deps --install -t'apt-get -y'
-      - mkdir build
-      - cd build
-      - cmake ..
-      - make
-      - LANG="en_US.UTF-8" ./notcurses-tester
+steps:
+  name: prep
+  image: library/debian:unstable
+  docker:
+    tty: true
+  commands:
+    - apt-get update
+    - apt-get -y remove man-db
+    - apt-get -y install devscripts git-buildpackage locales
+    - echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
+    - locale-gen
+    - mk-build-deps --install -t'apt-get -y'
+    - mkdir build
+    - cd build
+    - cmake ..
+    - make
+    - LANG="en_US.UTF-8" ./notcurses-tester

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,27 @@
 ---
-pipeline:
+kind: pipeline:
+type: docker
+name: debianunstable
+  prep:
+    image: dankamongmen/unstable_builder
+    docker:
+      tty: true
+    commands:
+      - apt-get update
+      - apt-get -y remove man-db
+      - apt-get -y install devscripts git-buildpackage locales
+      - echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
+      - locale-gen
+      - mk-build-deps --install -t'apt-get -y'
+      - mkdir build
+      - cd build
+      - cmake ..
+      - make
+      - LANG="en_US.UTF-8" ./notcurses-tester
+---
+kind: pipeline:
+type: docker
+name: debianstable
   prep:
     image: library/debian:unstable
     docker:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,40 +1,18 @@
 ---
-kind: pipeline
-type: docker
-name: debianunstable
-steps:
-- name: prep
-  image: dankamongmen/unstable_builder
-  commands:
-  - apt-get update
-  - apt-get -y remove man-db
-  - apt-get -y install devscripts git-buildpackage locales
-  - echo 'en_US.UTF-8 UTF-8' &gt; /etc/locale.gen
-  - locale-gen
-  - mk-build-deps --install -t'apt-get -y'
-  - mkdir build
-  - cd build
-  - cmake ..
-  - make
-  - LANG="en_US.UTF-8" ./notcurses-tester
----
-kind: pipeline
-type: docker
-name: debianstable
-steps:
-  name: prep
-  image: library/debian:unstable
-  docker:
-    tty: true
-  commands:
-    - apt-get update
-    - apt-get -y remove man-db
-    - apt-get -y install devscripts git-buildpackage locales
-    - echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
-    - locale-gen
-    - mk-build-deps --install -t'apt-get -y'
-    - mkdir build
-    - cd build
-    - cmake ..
-    - make
-    - LANG="en_US.UTF-8" ./notcurses-tester
+pipeline:
+  prep:
+    image: library/debian:unstable
+    docker:
+      tty: true
+    commands:
+      - apt-get update
+      - apt-get -y remove man-db
+      - apt-get -y install devscripts git-buildpackage locales
+      - echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen
+      - locale-gen
+      - mk-build-deps --install -t'apt-get -y'
+      - mkdir build
+      - cd build
+      - cmake ..
+      - make
+      - LANG="en_US.UTF-8" ./notcurses-tester

--- a/README.md
+++ b/README.md
@@ -288,12 +288,6 @@ must be readable without delay for it to be interpreted as such.
 // returned to indicate that no input was available, but only by
 // notcurses_getc(). Otherwise (including on EOF) (char32_t)-1 is returned.
 
-// is this wide character a Supplementary Private Use Area-B codepoint?
-static inline bool
-wchar_supppuab_p(char32_t w){
-  return w >= 0x100000 && w <= 0x10fffd;
-}
-
 #define suppuabize(w) ((w) + 0x100000)
 
 // Special composed key defintions. These values are added to 0x100000.
@@ -321,6 +315,26 @@ wchar_supppuab_p(char32_t w){
 #define NCKEY_F08     suppuabize(28)
 #define NCKEY_F09     suppuabize(29)
 #define NCKEY_F10     suppuabize(30)
+#define NCKEY_F11     suppuabize(31)
+#define NCKEY_F12     suppuabize(32)
+#define NCKEY_F13     suppuabize(33)
+#define NCKEY_F14     suppuabize(34)
+#define NCKEY_F15     suppuabize(35)
+#define NCKEY_F16     suppuabize(36)
+#define NCKEY_F17     suppuabize(37)
+#define NCKEY_F18     suppuabize(38)
+#define NCKEY_F19     suppuabize(39)
+#define NCKEY_F20     suppuabize(40)
+#define NCKEY_F21     suppuabize(41)
+#define NCKEY_F22     suppuabize(42)
+#define NCKEY_F23     suppuabize(43)
+#define NCKEY_F24     suppuabize(44)
+#define NCKEY_F25     suppuabize(45)
+#define NCKEY_F26     suppuabize(46)
+#define NCKEY_F27     suppuabize(47)
+#define NCKEY_F28     suppuabize(48)
+#define NCKEY_F29     suppuabize(49)
+#define NCKEY_F30     suppuabize(50)
 // ... leave room for up to 100 function keys, egads
 #define NCKEY_ENTER   suppuabize(121)
 #define NCKEY_CLS     suppuabize(122) // "clear-screen or erase"
@@ -338,10 +352,32 @@ wchar_supppuab_p(char32_t w){
 #define NCKEY_PRINT   suppuabize(134)
 #define NCKEY_REFRESH suppuabize(135)
 // Mouse events. We try to encode some details into the char32_t (i.e. which
-// button was pressed), but some is embedded in the ncinput event.
-#define NCKEY_MOUSEB1 suppuabize(201)
-#define NCKEY_MOUSEB2 suppuabize(202)
-#define NCKEY_MOUSEB3 suppuabize(203)
+// button was pressed), but some is embedded in the ncinput event. The release
+// event is generic across buttons; callers must maintain state, if they care.
+#define NCKEY_BUTTON1  suppuabize(201)
+#define NCKEY_BUTTON2  suppuabize(202)
+#define NCKEY_BUTTON3  suppuabize(203)
+#define NCKEY_BUTTON4  suppuabize(204)
+#define NCKEY_BUTTON5  suppuabize(205)
+#define NCKEY_BUTTON6  suppuabize(206)
+#define NCKEY_BUTTON7  suppuabize(207)
+#define NCKEY_BUTTON8  suppuabize(208)
+#define NCKEY_BUTTON9  suppuabize(209)
+#define NCKEY_BUTTON10 suppuabize(210)
+#define NCKEY_BUTTON11 suppuabize(211)
+#define NCKEY_RELEASE  suppuabize(212)
+
+// Is this char32_t a Supplementary Private Use Area-B codepoint?
+static inline bool
+wchar_supppuab_p(char32_t w){
+  return w >= 0x100000 && w <= 0x10fffd;
+}
+
+// Is the event a synthesized mouse event?
+static inline bool
+nckey_mouse_p(char32_t r){
+  return r >= NCKEY_BUTTON1 && r <= NCKEY_RELEASE;
+}
 
 // An input event. Cell coordinates are currently defined only for mouse events.
 typedef struct ncinput {

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -228,6 +228,7 @@ wchar_supppuab_p(char32_t w){
 #define NCKEY_EXIT    suppuabize(133)
 #define NCKEY_PRINT   suppuabize(134)
 #define NCKEY_REFRESH suppuabize(135)
+#define NCKEY_MOUSEEVENT suppuabize(200)
 
 // See ppoll(2) for more detail. Provide a NULL 'ts' to block at length, a 'ts'
 // of 0 for non-blocking operation, and otherwise a timespec to bound blocking.

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -161,12 +161,6 @@ API struct ncplane* notcurses_top(struct notcurses* n);
 
 #define suppuabize(w) ((w) + 0x100000)
 
-// is this wide character a Supplementary Private Use Area-B codepoint?
-static inline bool
-wchar_supppuab_p(char32_t w){
-  return w >= 0x100000 && w <= 0x10fffd;
-}
-
 // Special composed key defintions. These values are added to 0x100000.
 #define NCKEY_INVALID suppuabize(0)
 #define NCKEY_RESIZE  suppuabize(1) // generated interally in response to SIGWINCH
@@ -228,29 +222,69 @@ wchar_supppuab_p(char32_t w){
 #define NCKEY_EXIT    suppuabize(133)
 #define NCKEY_PRINT   suppuabize(134)
 #define NCKEY_REFRESH suppuabize(135)
-#define NCKEY_MOUSEEVENT suppuabize(200)
+// Mouse events. We try to encode some details into the char32_t (i.e. which
+// button was pressed), but some is embedded in the ncinput event. The release
+// event is generic across buttons; callers must maintain state, if they care.
+#define NCKEY_BUTTON1  suppuabize(201)
+#define NCKEY_BUTTON2  suppuabize(202)
+#define NCKEY_BUTTON3  suppuabize(203)
+#define NCKEY_BUTTON4  suppuabize(204)
+#define NCKEY_BUTTON5  suppuabize(205)
+#define NCKEY_BUTTON6  suppuabize(206)
+#define NCKEY_BUTTON7  suppuabize(207)
+#define NCKEY_BUTTON8  suppuabize(208)
+#define NCKEY_BUTTON9  suppuabize(209)
+#define NCKEY_BUTTON10 suppuabize(210)
+#define NCKEY_BUTTON11 suppuabize(211)
+#define NCKEY_RELEASE  suppuabize(212)
+
+// Is this char32_t a Supplementary Private Use Area-B codepoint?
+static inline bool
+wchar_supppuab_p(char32_t w){
+  return w >= 0x100000 && w <= 0x10fffd;
+}
+
+// Is the event a synthesized mouse event?
+static inline bool
+nckey_mouse_p(char32_t r){
+  return r >= NCKEY_BUTTON1 && r <= NCKEY_RELEASE;
+}
+
+// An input event. Cell coordinates are currently defined only for mouse events.
+typedef struct ncinput {
+  char32_t id;     // identifier. Unicode codepoint or synthesized NCKEY event
+  int y;           // y cell coordinate of event, -1 for undefined
+  int x;           // x cell coordinate of event, -1 for undefined
+  // FIXME modifiers (alt, etc?)
+} ncinput;
 
 // See ppoll(2) for more detail. Provide a NULL 'ts' to block at length, a 'ts'
 // of 0 for non-blocking operation, and otherwise a timespec to bound blocking.
 // Signals in sigmask (less several we handle internally) will be atomically
 // masked and unmasked per ppoll(2). It should generally contain all signals.
 // Returns a single Unicode code point, or (char32_t)-1 on error. 'sigmask' may
-// be NULL.
-API char32_t notcurses_getc(struct notcurses* n, const struct timespec* ts, sigset_t* sigmask);
+// be NULL. Returns 0 on a timeout. If an event is processed, the return value
+// is the 'id' field from that event. 'ni' may be NULL.
+API char32_t notcurses_getc(struct notcurses* n, const struct timespec* ts,
+                            sigset_t* sigmask, ncinput* ni);
 
+// 'ni' may be NULL if the caller is uninterested in event details. If no event
+// is ready, returns 0.
 static inline char32_t
-notcurses_getc_nblock(struct notcurses* n){
+notcurses_getc_nblock(struct notcurses* n, ncinput* ni){
   sigset_t sigmask;
   sigfillset(&sigmask);
   struct timespec ts = { .tv_sec = 0, .tv_nsec = 0 };
-  return notcurses_getc(n, &ts, &sigmask);
+  return notcurses_getc(n, &ts, &sigmask, ni);
 }
 
+// 'ni' may be NULL if the caller is uninterested in event details. Blocks
+// until an event is processed or a signal is received.
 static inline char32_t
-notcurses_getc_blocking(struct notcurses* n){
+notcurses_getc_blocking(struct notcurses* n, ncinput* ni){
   sigset_t sigmask;
   sigemptyset(&sigmask);
-  return notcurses_getc(n, NULL, &sigmask);
+  return notcurses_getc(n, NULL, &sigmask, ni);
 }
 
 // Enable the mouse in "button-event tracking" mode with focus detection and

--- a/src/demo/panelreel.c
+++ b/src/demo/panelreel.c
@@ -231,7 +231,7 @@ handle_input(struct notcurses* nc, struct panelreel* pr, int efd,
       return (wchar_t)-1;
     }else{
       if(fds[0].revents & POLLIN){
-        key = notcurses_getc_blocking(nc);
+        key = notcurses_getc_blocking(nc, NULL);
         if(key < 0){
           return -1;
         }

--- a/src/demo/view.c
+++ b/src/demo/view.c
@@ -5,7 +5,7 @@ static int
 watch_for_keystroke(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused))){
   wchar_t w;
   // we don't want a keypress, but should handle NCKEY_RESIZE
-  if((w = notcurses_getc_nblock(nc)) != (wchar_t)-1){
+  if((w = notcurses_getc_nblock(nc, NULL)) != (wchar_t)-1){
     if(w == NCKEY_RESIZE){
       // FIXME resize that sumbitch
     }else{

--- a/src/demo/witherworm.c
+++ b/src/demo/witherworm.c
@@ -673,7 +673,7 @@ int witherworm_demo(struct notcurses* nc){
         struct timespec left, cur;
         clock_gettime(CLOCK_MONOTONIC, &cur);
         timespec_subtract(&left, &screenend, &cur);
-        key = notcurses_getc(nc, &left, NULL);
+        key = notcurses_getc(nc, &left, NULL, NULL);
         clock_gettime(CLOCK_MONOTONIC, &cur);
         int64_t ns = timespec_subtract_ns(&cur, &screenend);
         if(ns > 0){

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -135,12 +135,12 @@ int main(void){
   notcurses_term_dim_yx(nc, &dimy, &dimx);
   ncplane_set_fg(n, 0);
   ncplane_set_bg(n, 0xbb64bb);
-  ncplane_styles_set(n, CELL_STYLE_UNDERLINE);
+  ncplane_styles_on(n, CELL_STYLE_UNDERLINE);
   if(ncplane_putstr_aligned(n, 0, "mash some keys, yo. give that mouse some waggle!", NCALIGN_CENTER) <= 0){
     notcurses_stop(nc);
     return EXIT_FAILURE;
   }
-  ncplane_styles_off(n, CELL_STYLE_UNDERLINE);
+  ncplane_styles_set(n, 0);
   ncplane_set_bg_default(n);
   notcurses_render(nc);
   int y = 2;

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -73,6 +73,7 @@ const char* nckeystr(wchar_t spkey){
     case NCKEY_EXIT:    return "exit";
     case NCKEY_PRINT:   return "print";
     case NCKEY_REFRESH: return "refresh";
+    case NCKEY_MOUSEEVENT: return "mouseevent";
     default:            return "unknown";
   }
 }

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -112,11 +112,10 @@ handle_getc(notcurses* nc, int kpress){
     return -1;
   }
   if(kpress == ESC){
-    // FIXME delay a little waiting for more?
     const esctrie* esc = nc->inputescapes;
     while(esc && esc->special == NCKEY_INVALID && nc->inputbuf_occupied){
       int candidate = pop_input_keypress(nc);
-//fprintf(stderr, "CANDIDATE: %c\n", candidate);
+fprintf(stderr, "CANDIDATE: 0x%02x %d '%c'\n", candidate, candidate, candidate);
       if(esc->trie == NULL){
         esc = NULL;
       }else if(candidate >= 0x80 || candidate < 0){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1558,6 +1558,8 @@ int notcurses_mouse_enable(notcurses* n){
                    n->ttyfp, true);
 }
 
+// this seems to work (note difference in suffix, 'l' vs 'h'), but what about
+// the sequences 1000 etc?
 int notcurses_mouse_disable(notcurses* n){
   return term_emit("mouse", ESC "[?" SET_BTN_EVENT_MOUSE ";"
                    SET_FOCUS_EVENT_MOUSE ";" SET_SGR_MODE_MOUSE "l",

--- a/src/planereel/main.cpp
+++ b/src/planereel/main.cpp
@@ -64,7 +64,7 @@ int main(void){
   }
   PR = pr; // FIXME eliminate
   char32_t key;
-  while((key = notcurses_getc_blocking(nc)) != (char32_t)-1){
+  while((key = notcurses_getc_blocking(nc, nullptr)) != (char32_t)-1){
     switch(key){
       case 'q':
         return notcurses_stop(nc) ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -37,7 +37,7 @@ int ncview(struct notcurses* nc, struct ncvisual* ncv, int* averr){
       .tv_sec = start.tv_sec + (long)(ns / 1000000000),
       .tv_nsec = start.tv_nsec + (long)(ns % 1000000000),
     };
-    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &interval, NULL);
+    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &interval, nullptr);
   }
   if(*averr == AVERROR_EOF){
     return 0;
@@ -78,7 +78,7 @@ int main(int argc, char** argv){
       std::cerr << "Error decoding " << argv[i] << ": " << errbuf.data() << std::endl;
       return EXIT_FAILURE;
     }
-    notcurses_getc_blocking(nc);
+    notcurses_getc_blocking(nc, nullptr);
     ncvisual_destroy(ncv);
   }
   if(notcurses_stop(nc)){


### PR DESCRIPTION
Request and parse up mouse messages. We handle up to 11 mouse
buttons, 3 modifiers (currently thrown away), motion while
holding down a button, and loss/gain of focus. I've added twelve
new NCKEYs: one for each button, and one for release. In addition,
I've introduced the 'ncinput' struct, which encodes the nckey plus
extra data. The only extra data thus far is coordinates for mouse
events. It is not necessary to provide a ncinput to all input
functions; NULL can be provided if the caller doesn't care about
details. All demos are updated. notcurses-input has been updated
to decode full information of returned ncinputs.

The primary resource for this work was Dickey at al's "XTerm Control
Sequences", https://invisible-island.net/xterm/ctlseqs/ctlseqs.html.
Some assistance and provocation was provided by @klamonte.