### PR TITLE
Support building without ffmpeg #153

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,46 +9,66 @@ set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-configure_file(tools/version.h.in include/version.h)
-
 include(GNUInstallDirs)
+
+option(DISABLE_FFMPEG "Disable FFmpeg image/video support" OFF)
+
+configure_file(tools/version.h.in include/version.h)
 
 find_package(PkgConfig REQUIRED)
 find_package(Threads REQUIRED)
 pkg_check_modules(TERMINFO REQUIRED tinfo>=6.1)
+if(NOT "${DISABLE_FFMPEG}")
 pkg_check_modules(AVUTIL REQUIRED libavutil>=56.0)
 pkg_check_modules(AVFORMAT REQUIRED libavformat>=57.0)
 pkg_check_modules(SWSCALE REQUIRED libswscale>=5.0)
+endif()
 find_library(LIBRT rt)
 
 file(GLOB LIBSRCS CONFIGURE_DEPENDS src/lib/*.c)
 add_library(notcurses SHARED ${LIBSRCS})
-target_include_directories(notcurses
-  PRIVATE
-    include
-    "${PROJECT_BINARY_DIR}/include"
-    "${TERMINFO_INCLUDE_DIR}"
-    "${AVFORMAT_INCLUDE_DIR}"
-    "${SWSCALE_INCLUDE_DIR}"
-)
-target_link_libraries(notcurses
-  PRIVATE
-    "${TERMINFO_LIBRARIES}"
-    "${AVFORMAT_LIBRARIES}"
-    "${SWSCALE_LIBRARIES}"
-    "${LIBRT}"
-)
-target_link_directories(notcurses
-  PRIVATE
-    "${TERMINFO_LIBRARY_DIRS}"
-    "${AVFORMAT_LIBRARY_DIRS}"
-    "${SWSCALE_LIBRARY_DIRS}"
-)
 set_target_properties(notcurses PROPERTIES
   PUBLIC_HEADER "include/notcurses.h"
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR}
 )
+target_include_directories(notcurses
+  PRIVATE
+    include
+    "${PROJECT_BINARY_DIR}/include"
+    "${TERMINFO_INCLUDE_DIR}"
+)
+target_link_libraries(notcurses
+  PRIVATE
+    "${TERMINFO_LIBRARIES}"
+    "${LIBRT}"
+)
+target_link_directories(notcurses
+  PRIVATE
+    "${TERMINFO_LIBRARY_DIRS}"
+)
+
+if(NOT "${DISABLE_FFMPEG}")
+target_include_directories(notcurses
+  PRIVATE
+    "${AVFORMAT_INCLUDE_DIR}"
+    "${SWSCALE_INCLUDE_DIR}"
+)
+endif()
+if(NOT "${DISABLE_FFMPEG}")
+target_link_libraries(notcurses
+  PRIVATE
+    "${AVFORMAT_LIBRARIES}"
+    "${SWSCALE_LIBRARIES}"
+)
+endif()
+if(NOT "${DISABLE_FFMPEG}")
+target_link_directories(notcurses
+  PRIVATE
+    "${AVFORMAT_LIBRARY_DIRS}"
+    "${SWSCALE_LIBRARY_DIRS}"
+)
+endif()
 
 target_compile_options(notcurses
   PRIVATE
@@ -135,7 +155,9 @@ target_compile_definitions(notcurses-planereel
 )
 
 file(GLOB VIEWSRCS CONFIGURE_DEPENDS src/view/*.cpp)
+if(NOT "${DISABLE_FFMPEG}")
 add_executable(notcurses-view ${VIEWSRCS})
+endif()
 target_include_directories(notcurses-view
   PRIVATE
     include
@@ -151,6 +173,8 @@ target_link_libraries(notcurses-view
     notcurses
   PRIVATE
     "${AVUTIL_LIBRARIES}"
+    "${AVFORMAT_LIBRARIES}"
+    "${SWSCALE_LIBRARIES}"
 )
 target_compile_options(notcurses-view
   PRIVATE
@@ -167,6 +191,7 @@ find_package(GTest 1.9 REQUIRED)
 target_include_directories(notcurses-tester
   PRIVATE
     include
+    "${PROJECT_BINARY_DIR}/include"
     src/lib
 )
 target_link_libraries(notcurses-tester
@@ -230,7 +255,9 @@ install(FILES
 )
 
 install(TARGETS notcurses-demo DESTINATION bin)
+if(NOT "${DISABLE_FFMPEG}")
 install(TARGETS notcurses-view DESTINATION bin)
+endif()
 install(TARGETS notcurses-input DESTINATION bin)
 install(TARGETS notcurses-planereel DESTINATION bin)
 install(TARGETS notcurses

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -15,9 +15,6 @@
 #ifdef __cplusplus
 extern "C" {
 #define RESTRICT
-#include <libavutil/pixdesc.h>
-#include <libavutil/avconfig.h>
-#include <libavcodec/avcodec.h> // ffmpeg doesn't reliably "C"-guard itself
 #else
 #define RESTRICT restrict
 #endif

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -10,7 +10,17 @@
 #include <stdbool.h>
 #include <pthread.h>
 #include "notcurses.h"
+#include "version.h"
 #include "egcpool.h"
+
+#ifndef DISABLE_FFMPEG
+#include <libavutil/error.h>
+#include <libavutil/frame.h>
+#include <libavutil/pixdesc.h>
+#include <libavutil/version.h>
+#include <libswscale/version.h>
+#include <libavformat/version.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -773,11 +773,12 @@ notcurses* notcurses_init(const notcurses_options* opts, FILE* outfp){
           ret->colors, ret->RGBflag ? "direct" : "palette",
           __VERSION__, curses_version());
 #ifndef DISABLE_FFMPEG
-    fprintf(ret->ttyfp, " avformat %u.%u.%u\navutil %u.%u.%u\nswscale %u.%u.%u\n",
+    fprintf(ret->ttyfp, " avformat %u.%u.%u\n avutil %u.%u.%u\n swscale %u.%u.%u\n",
           LIBAVFORMAT_VERSION_MAJOR, LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO,
           LIBAVUTIL_VERSION_MAJOR, LIBAVUTIL_VERSION_MINOR, LIBAVUTIL_VERSION_MICRO,
           LIBSWSCALE_VERSION_MAJOR, LIBSWSCALE_VERSION_MINOR, LIBSWSCALE_VERSION_MICRO);
 #else
+    putp(tiparm(ret->setaf, 3));
     fprintf(ret->ttyfp, " warning: built without ffmpeg support\n");
 #endif
     if(!ret->RGBflag){ // FIXME

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <stdio.h>
+#include <limits.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -12,12 +13,6 @@
 #include <sys/poll.h>
 #include <stdatomic.h>
 #include <sys/ioctl.h>
-#include <libavutil/error.h>
-#include <libavutil/frame.h>
-#include <libavutil/pixdesc.h>
-#include <libavutil/version.h>
-#include <libswscale/version.h>
-#include <libavformat/version.h>
 #include "notcurses.h"
 #include "internal.h"
 #include "version.h"
@@ -769,20 +764,22 @@ notcurses* notcurses_init(const notcurses_options* opts, FILE* outfp){
     char prefixbuf[BPREFIXSTRLEN + 1];
     fprintf(ret->ttyfp, "\n"
           " notcurses %s by nick black\n"
+          " %d rows, %d columns (%sB), %d colors (%s)\n"
           " compiled with gcc-%s\n"
-          " terminfo from %s\n"
-          " avformat %u.%u.%u\n"
-          " avutil %u.%u.%u\n"
-          " swscale %u.%u.%u\n"
-          " %d rows, %d columns (%sB), %d colors (%s)\n",
-          notcurses_version(), __VERSION__,
-          curses_version(), LIBAVFORMAT_VERSION_MAJOR,
-          LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO,
-          LIBAVUTIL_VERSION_MAJOR, LIBAVUTIL_VERSION_MINOR, LIBAVUTIL_VERSION_MICRO,
-          LIBSWSCALE_VERSION_MAJOR, LIBSWSCALE_VERSION_MINOR, LIBSWSCALE_VERSION_MICRO,
+          " terminfo from %s\n",
+          notcurses_version(),
           ret->stdscr->leny, ret->stdscr->lenx,
           bprefix(ret->stats.fbbytes, 1, prefixbuf, 0),
-          ret->colors, ret->RGBflag ? "direct" : "palette");
+          ret->colors, ret->RGBflag ? "direct" : "palette",
+          __VERSION__, curses_version());
+#ifndef DISABLE_FFMPEG
+    fprintf(ret->ttyfp, " avformat %u.%u.%u\navutil %u.%u.%u\nswscale %u.%u.%u\n",
+          LIBAVFORMAT_VERSION_MAJOR, LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO,
+          LIBAVUTIL_VERSION_MAJOR, LIBAVUTIL_VERSION_MINOR, LIBAVUTIL_VERSION_MICRO,
+          LIBSWSCALE_VERSION_MAJOR, LIBSWSCALE_VERSION_MINOR, LIBSWSCALE_VERSION_MICRO);
+#else
+    fprintf(ret->ttyfp, " warning: built without ffmpeg support\n");
+#endif
     if(!ret->RGBflag){ // FIXME
       if(ret->colors >= 16){
         putp(tiparm(ret->setaf, 207));

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -6,6 +6,12 @@
 #include <iostream>
 #include "notcurses.h"
 
+extern "C" {
+#include <libavutil/pixdesc.h>
+#include <libavutil/avconfig.h>
+#include <libavcodec/avcodec.h> // ffmpeg doesn't reliably "C"-guard itself
+}
+
 static void usage(std::ostream& os, const char* name, int exitcode)
   __attribute__ ((noreturn));
 

--- a/tests/internal.cpp
+++ b/tests/internal.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <cstdlib>
 #include <clocale>
+#include "internal.h"
 #include "main.h"
 
 class InternalsTest : public :: testing::Test {

--- a/tests/libav.cpp
+++ b/tests/libav.cpp
@@ -1,6 +1,11 @@
 #include <notcurses.h>
+#include "version.h"
 #include "main.h"
 
+#ifndef DISABLE_FFMPEG
+#include <libavutil/pixdesc.h>
+#include <libavutil/avconfig.h>
+#include <libavcodec/avcodec.h> // ffmpeg doesn't reliably "C"-guard itself
 class LibavTest : public :: testing::Test {
  protected:
   void SetUp() override {
@@ -87,3 +92,4 @@ TEST_F(LibavTest, LoadVideoCreatePlane) {
   EXPECT_EQ(0, notcurses_render(nc_));
   ncvisual_destroy(ncv);
 }
+#endif

--- a/tests/main.h
+++ b/tests/main.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 #include <notcurses.h>
 #include <curses.h>
-#include "internal.h"
 
 // GTEST_SKIP only came along in GoogleTest 1.9
 #ifndef GTEST_SKIP

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <notcurses.h>
+#include "internal.h"
 #include "main.h"
 
 class NcplaneTest : public :: testing::Test {

--- a/tools/version.h.in
+++ b/tools/version.h.in
@@ -1,3 +1,4 @@
 #define notcurses_VERSION_MAJOR "@notcurses_VERSION_MAJOR@"
 #define notcurses_VERSION_MINOR "@notcurses_VERSION_MINOR@"
 #define notcurses_VERSION_PATCH "@notcurses_VERSION_PATCH@"
+#cmakedefine DISABLE_FFMPEG


### PR DESCRIPTION
Introduces new CMake variable, `DISABLE_FFMPEG`, defaulting to OFF. If set to true, DISABLE_FFMPEG is written to `version.h`, `notcurses-view` is not built, and FFmpeg options are not added to binaries/libraries.

Code-wise, we don't build libav unit tests, and all our libav functions get stubbed out to simply return errors. The intro banner prints a warning rather than the versions of ffmpeg libraries.