### PR TITLE
Elide color commands based off glyph

### DIFF
--- a/README.md
+++ b/README.md
@@ -2153,13 +2153,7 @@ and style specifications, and moving the cursor over large unchanged areas.
 
 Using the "default color" as only one of the foreground or background requires
 emitting the `op` escape followed by the appropriate escape for changing the
-fore- or background (since `op` changes both at once). If you're printing full
-block characters, it's for this reason better to give them all the same
-meaningless background color than to leave the background on the default. If
-you're printing spaces, you likewise want a meaningless foreground color. For
-a long string of such cells, eliding these ops can be a nice savings. See
-[Issue #131](https://github.com/dankamongmen/notcurses/issues/131), though;
-I'll likely natively handle this within `notcurses_render()` soon.
+fore- or background (since `op` changes both at once).
 
 ## Included tools
 

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -1339,7 +1339,7 @@ API const char* cell_extended_gcluster(const struct ncplane* n, const cell* c);
 // FIXME do this at cell prep time and set a bit in the channels
 static inline bool
 cell_noforeground_p(const cell* c){
-  return cell_simple_p(c) || isspace(c->gcluster);
+  return cell_simple_p(c) && isspace(c->gcluster);
 }
 
 // True if the cell does not generate background pixels. Only the FULL BLOCK

--- a/src/demo/eagle.c
+++ b/src/demo/eagle.c
@@ -121,8 +121,6 @@ draw_eagle(struct ncplane* n, const char* sprite){
   size_t s;
   int sbytes;
   uint64_t channels = 0;
-  // optimization so we can elide more color changes, see README's "#perf"
-  channels_set_bg_rgb(&channels, 0x00, 0x00, 0x00);
   ncplane_cursor_move_yx(n, 0, 0);
   for(s = 0 ; sprite[s] ; ++s){
     switch(sprite[s]){

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -540,7 +540,6 @@ notcurses_render_internal(notcurses* nc){
       //  * we are a no-foreground glyph, and the previous was default background, or
       //  * we are a no-background glyph, and the previous was default foreground
 
-      // FIXME move these into the cell bits
       bool noforeground = cell_noforeground_p(&c);
       bool nobackground = cell_nobackground_p(p, &c);
       if((!noforeground && cell_fg_default_p(&c)) || (!nobackground && cell_bg_default_p(&c))){
@@ -560,29 +559,37 @@ notcurses_render_internal(notcurses* nc){
       // foreground set iff either:
       //  * the previous was non-default, and matches what we have now, or
       //  * we are a no-foreground glyph (iswspace() is true)
-      if(/*!noforeground &&*/ !cell_fg_default_p(&c)){
-        cell_get_fg_rgb(&c, &r, &g, &b);
-        if(nc->rstate.fgelidable && nc->rstate.lastr == r && nc->rstate.lastg == g && nc->rstate.lastb == b){
+      if(!cell_fg_default_p(&c)){
+        if(!noforeground){
+          cell_get_fg_rgb(&c, &r, &g, &b);
+          if(nc->rstate.fgelidable && nc->rstate.lastr == r && nc->rstate.lastg == g && nc->rstate.lastb == b){
+            ++nc->stats.fgelisions;
+          }else{
+            term_fg_rgb8(nc, out, r, g, b);
+            ++nc->stats.fgemissions;
+            nc->rstate.fgelidable = true;
+          }
+          nc->rstate.lastr = r; nc->rstate.lastg = g; nc->rstate.lastb = b;
+          nc->rstate.defaultelidable = false;
+        }else{
           ++nc->stats.fgelisions;
-        }else{
-          term_fg_rgb8(nc, out, r, g, b);
-          ++nc->stats.fgemissions;
-          nc->rstate.fgelidable = true;
         }
-        nc->rstate.lastr = r; nc->rstate.lastg = g; nc->rstate.lastb = b;
-        nc->rstate.defaultelidable = false;
       }
-      if(!nobackground && !cell_bg_default_p(&c)){
-        cell_get_bg_rgb(&c, &br, &bg, &bb);
-        if(nc->rstate.bgelidable && nc->rstate.lastbr == br && nc->rstate.lastbg == bg && nc->rstate.lastbb == bb){
-          ++nc->stats.bgelisions;
+      if(!cell_bg_default_p(&c)){
+        if(!nobackground){
+          cell_get_bg_rgb(&c, &br, &bg, &bb);
+          if(nc->rstate.bgelidable && nc->rstate.lastbr == br && nc->rstate.lastbg == bg && nc->rstate.lastbb == bb){
+            ++nc->stats.bgelisions;
+          }else{
+            term_bg_rgb8(nc, out, br, bg, bb);
+            ++nc->stats.bgemissions;
+            nc->rstate.bgelidable = true;
+          }
+          nc->rstate.lastbr = br; nc->rstate.lastbg = bg; nc->rstate.lastbb = bb;
+          nc->rstate.defaultelidable = false;
         }else{
-          term_bg_rgb8(nc, out, br, bg, bb);
-          ++nc->stats.bgemissions;
-          nc->rstate.bgelidable = true;
+          ++nc->stats.bgelisions;
         }
-        nc->rstate.lastbr = br; nc->rstate.lastbg = bg; nc->rstate.lastbb = bb;
-        nc->rstate.defaultelidable = false;
       }
 // fprintf(stderr, "[%02d/%02d] 0x%02x 0x%02x 0x%02x %p\n", y, x, r, g, b, p);
       term_putc(out, p, &c);


### PR DESCRIPTION
* Glyphs with no foreground pixels don't need foreground color updates
* Glyphs with no background pixels don't need background color updates

This eliminates the need for some hand-guided optimizations (they have been removed), and boosts FPS by a max of about 8% in "intro". We get 5% in "eagle", and none seem to slow down. w00t!