### PR TITLE
Better video scheduling #113

### DIFF
--- a/README.md
+++ b/README.md
@@ -1466,11 +1466,12 @@ int ncvisual_render(const struct ncvisual* ncv, int begy, int begx, int leny, in
 
 // Called for each frame rendered from 'ncv'. If anything but 0 is returned,
 // the streaming operation ceases immediately, and that value is propagated out.
-typedef int (*streamcb)(struct notcurses* nc, struct ncvisual* ncv);
+typedef int (*streamcb)(struct notcurses* nc, struct ncvisual* ncv, void* curry);
 
 // Shut up and display my frames! Provide as an argument to ncvisual_stream().
 static inline int
-ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused))){
+ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
+                         void* curry __attribute__ ((unused))){
   return notcurses_render(nc);
 }
 
@@ -1478,7 +1479,7 @@ ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv __attribute_
 // obviously. streamer may be NULL; it is otherwise called for each frame, and
 // its return value handled as outlined for stream cb. Pretty raw; beware.
 int ncvisual_stream(struct notcurses* nc, struct ncvisual* ncv,
-                    int* averr, streamcb streamer);
+                    int* averr, streamcb streamer, void* curry);
 
 // Return the plane to which this ncvisual is bound.
 struct ncplane* ncvisual_plane(struct ncvisual* ncv);

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -1516,11 +1516,12 @@ API int ncvisual_render(const struct ncvisual* ncv, int begy, int begx,
 
 // Called for each frame rendered from 'ncv'. If anything but 0 is returned,
 // the streaming operation ceases immediately, and that value is propagated out.
-typedef int (*streamcb)(struct notcurses* nc, struct ncvisual* ncv);
+typedef int (*streamcb)(struct notcurses* nc, struct ncvisual* ncv, void*);
 
 // Shut up and display my frames! Provide as an argument to ncvisual_stream().
 static inline int
-ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused))){
+ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
+                         void* curry __attribute__ ((unused))){
   return notcurses_render(nc);
 }
 
@@ -1528,7 +1529,7 @@ ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv __attribute_
 // obviously. streamer may be NULL; it is otherwise called for each frame, and
 // its return value handled as outlined for stream cb. Pretty raw; beware.
 API int ncvisual_stream(struct notcurses* nc, struct ncvisual* ncv,
-                        int* averr, streamcb streamer);
+                        int* averr, streamcb streamer, void* curry);
 
 // Return the plane to which this ncvisual is bound.
 API struct ncplane* ncvisual_plane(struct ncvisual* ncv);

--- a/src/demo/outro.c
+++ b/src/demo/outro.c
@@ -8,16 +8,16 @@ static struct ncplane* on;
 static struct ncvisual* chncv;
 
 static int
-perframe(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused))){
-  static int three = 3; // move up one every three callbacks
+perframe(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)), void* vthree){
+  int* three = vthree; // move up one every three callbacks
   demo_render(nc);
   if(y < targy){
     return 0;
   }
   ncplane_move_yx(on, y, xstart);
-  if(--three == 0){
+  if(--*three == 0){
     --y;
-    three = 3;
+    *three = 3;
   }
   return 0;
 }
@@ -47,7 +47,8 @@ fadethread(void* vnc){
   ncplane_set_bg_rgb(apiap, 0, 0, 0);
   ncplane_putstr_aligned(apiap, 0, NCALIGN_CENTER,
       "Apia 🡺 Atlanta. Samoa, tula'i ma sisi ia lau fu'a, lou pale lea!");
-  ncvisual_stream(nc, ncv, &averr, perframe);
+  int three = 3;
+  ncvisual_stream(nc, ncv, &averr, perframe, &three);
   ncvisual_destroy(ncv);
   ncplane_erase(ncp);
   fade.tv_sec = 2;

--- a/src/demo/view.c
+++ b/src/demo/view.c
@@ -2,7 +2,8 @@
 #include "demo.h"
 
 static int
-watch_for_keystroke(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused))){
+watch_for_keystroke(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
+                    void* curry __attribute__ ((unused))){
   wchar_t w;
   // we don't want a keypress, but should handle NCKEY_RESIZE
   if((w = demo_getc_nblock(NULL)) != (wchar_t)-1){
@@ -29,7 +30,7 @@ view_video_demo(struct notcurses* nc){
     return -1;
   }
   free(fm6);
-  if(ncvisual_stream(nc, ncv, &averr, watch_for_keystroke) < 0){
+  if(ncvisual_stream(nc, ncv, &averr, watch_for_keystroke, NULL) < 0){
     ncvisual_destroy(ncv);
     return -1;
   }

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -13,10 +13,9 @@ static const char* leg[] = {
 "                                                                                                                  888P                                          ",
 };
 
-static struct ncplane* killme; // FIXME
-
 static int
-perframecb(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused))){
+perframecb(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
+           void* vnewplane){
   static struct ncplane* n = NULL;
   static int startr = 0x80;
   static int startg = 0xff;
@@ -32,7 +31,7 @@ perframecb(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused))){
     if(n == NULL){
       return -1;
     }
-    killme = n;
+    *(struct ncplane**)vnewplane = n;
   }
   ncplane_dim_yx(n, &dimy, &dimx);
   y = 0;
@@ -106,9 +105,10 @@ int xray_demo(struct notcurses* nc){
   if(ncvisual_decode(ncv, &averr) == NULL){
     return -1;
   }
-  ncvisual_stream(nc, ncv, &averr, perframecb);
+  struct ncplane* newpanel = NULL;
+  ncvisual_stream(nc, ncv, &averr, perframecb, &newpanel);
   ncvisual_destroy(ncv);
   ncplane_destroy(n);
-  ncplane_destroy(killme);
+  ncplane_destroy(newpanel);
   return 0;
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -264,6 +264,18 @@ cell* ncplane_cell_ref_yx(ncplane* n, int y, int x);
 
 #define NANOSECS_IN_SEC 1000000000
 
+static inline uint64_t
+timespec_to_ns(const struct timespec* t){
+  return t->tv_sec * NANOSECS_IN_SEC + t->tv_nsec;
+}
+
+static inline struct timespec*
+ns_to_timespec(uint64_t ns, struct timespec* ts){
+  ts->tv_sec = ns / NANOSECS_IN_SEC;
+  ts->tv_nsec = ns % NANOSECS_IN_SEC;
+  return ts;
+}
+
 // no CLOCK_MONOTONIC_RAW on FreeBSD as of 12.0 :/
 #ifndef CLOCK_MONOTONIC_RAW
 #define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC

--- a/src/lib/libav.c
+++ b/src/lib/libav.c
@@ -364,7 +364,8 @@ int ncvisual_render(const ncvisual* ncv, int begy, int begx, int leny, int lenx)
   return 0;
 }
 
-int ncvisual_stream(notcurses* nc, ncvisual* ncv, int* averr, streamcb streamer){
+int ncvisual_stream(notcurses* nc, ncvisual* ncv, int* averr,
+                    streamcb streamer, void* curry){
   ncplane* n = ncv->ncp;
   int frame = 1;
   AVFrame* avf;
@@ -378,7 +379,7 @@ int ncvisual_stream(notcurses* nc, ncvisual* ncv, int* averr, streamcb streamer)
       return -1;
     }
     if(streamer){
-      int r = streamer(nc, ncv);
+      int r = streamer(nc, ncv, curry);
       if(r){
         return r;
       }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -4,11 +4,6 @@
 #include <sys/poll.h>
 #include "internal.h"
 
-static inline uint64_t
-timespec_to_ns(const struct timespec* t){
-  return t->tv_sec * NANOSECS_IN_SEC + t->tv_nsec;
-}
-
 static void
 mutex_unlock(void* vlock){
   pthread_mutex_unlock(vlock);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -20,14 +20,33 @@ void usage(std::ostream& o, const char* name, int exitcode){
   exit(exitcode);
 }
 
-// frame count is in the ncplane's user pointer
+constexpr auto NANOSECS_IN_SEC = 1000000000ll;
+
+static inline uint64_t
+timespec_to_ns(const struct timespec* ts){
+  return ts->tv_sec * NANOSECS_IN_SEC + ts->tv_nsec;
+}
+
+// frame count is in the curry. original time is in the ncplane's userptr.
 int perframe(struct notcurses* nc, struct ncvisual* ncv, void* vframecount){
+  const struct timespec* start = static_cast<struct timespec*>(ncplane_userptr(ncvisual_plane(ncv)));
   struct ncplane* stdn = notcurses_stdplane(nc);
   int* framecount = static_cast<int*>(vframecount);
   ++*framecount;
   ncplane_set_fg(stdn, 0x80c080);
   ncplane_cursor_move_yx(stdn, 0, 0);
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+  int64_t ns = timespec_to_ns(&now) - timespec_to_ns(start);
   ncplane_printf(stdn, "Got frame %05d\u2026", *framecount);
+  const int64_t h = ns / (60 * 60 * NANOSECS_IN_SEC);
+  ns -= h * (60 * 60 * NANOSECS_IN_SEC);
+  const int64_t m = ns / (60 * NANOSECS_IN_SEC);
+  ns -= m * (60 * NANOSECS_IN_SEC);
+  const int64_t s = ns / NANOSECS_IN_SEC;
+  ns -= s * NANOSECS_IN_SEC;
+  ncplane_printf_aligned(stdn, 0, NCALIGN_RIGHT, "%02ld:%02ld:%02ld.%04ld",
+                         h, m, s, ns / 1000000);
   if(ncvisual_render(ncv, 0, 0, 0, 0)){
     return -1;
   }
@@ -49,7 +68,8 @@ int main(int argc, char** argv){
   }
   int dimy, dimx;
   notcurses_term_dim_yx(nc, &dimy, &dimx);
-  auto ncp = notcurses_newplane(nc, dimy - 1, dimx, 1, 0, nullptr);
+  struct timespec start;
+  auto ncp = notcurses_newplane(nc, dimy - 1, dimx, 1, 0, &start);
   if(ncp == nullptr){
     notcurses_stop(nc);
     return EXIT_FAILURE;
@@ -65,6 +85,7 @@ int main(int argc, char** argv){
       std::cerr << "Error opening " << argv[i] << ": " << errbuf.data() << std::endl;
       return EXIT_FAILURE;
     }
+    clock_gettime(CLOCK_MONOTONIC, &start);
     if(ncvisual_stream(nc, ncv, &averr, perframe, &frames)){
       av_make_error_string(errbuf.data(), errbuf.size(), averr);
       notcurses_stop(nc);


### PR DESCRIPTION
* When PTS (presentation time stamp) is available, use that to schedule frame display #113 
* Keep a sum of the packet durations otherwise, and use that to sync #113 
* Pass a void* curry to the streaming callback
* Rewrite `notcurses-view` in terms of `ncvisual_stream()`

With these two changes, 'notcursesI.avi' takes the expected 20s (up from 4s), and 'fm6.mkv' takes the expected 25s (down from 32s).