### PR TITLE
Setting the stage for Python bindings #149

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: debian-unstable
 
 steps:
 - name: debian-build
-  image: dankamongmen/unstable_builder:2020-01-05
+  image: dankamongmen/unstable_builder:2020-01-06a
   commands:
     - apt-get update
     - apt-get -y dist-upgrade
@@ -26,7 +26,7 @@ name: ubuntu-focal
 
 steps:
 - name: ubuntu-build
-  image: dankamongmen/focal:2020-01-05
+  image: dankamongmen/focal:2020-01-06a
   commands:
     - apt-get update
     - apt-get -y dist-upgrade

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 debian
 obj-x86_64-linux-gnu
 python/.eggs/
+python/build/
 python/dist/
 python/src/notcurses.egg-info/
+python/src/_notcurses.so
 rust/target
+*.pyc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,10 @@ write_basic_package_version_file(
   COMPATIBILITY SameMajorVersion
 )
 
+# Python bindings
+find_package(Python3 COMPONENTS Development REQUIRED)
+# FIXME
+
 # Installation
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/notcursesConfig.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(notcurses VERSION 1.0.0
+project(notcurses VERSION 1.1.0
   DESCRIPTION "UI for modern terminal emulators"
   HOMEPAGE_URL "https://nick-black.com/dankwiki/index.php/notcurses"
   LANGUAGES C CXX)

--- a/README.md
+++ b/README.md
@@ -735,63 +735,51 @@ int ncplane_cursor_move_yx(struct ncplane* n, int y, int x);
 // Get the current position of the cursor within n. y and/or x may be NULL.
 void ncplane_cursor_yx(struct ncplane* n, int* RESTRICT y, int* RESTRICT x);
 
-// Replace the cell underneath the cursor with the provided cell 'c', and
-// advance the cursor by the width of the cell (but not past the end of the
+// Replace the cell at the specified coordinates with the provided cell 'c',
+// and advance the cursor by the width of the cell (but not past the end of the
 // plane). On success, returns the number of columns the cursor was advanced.
 // On failure, -1 is returned.
-int ncplane_putc(struct ncplane* n, const cell* c);
+API int ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c);
 
-// Call ncplane_putc() after successfully moving to y, x on the specified plane.
+// Call ncplane_putc_yx() for the current cursor location.
 static inline int
-ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c){
-  if(ncplane_cursor_move_yx(n, y, x)){
-    return -1;
-  }
-  return ncplane_putc(n, c);
+ncplane_putc(struct ncplane* n, const cell* c){
+  return ncplane_putc_yx(n, -1, -1, c);
 }
 
-// Replace the cell underneath the cursor with the provided 7-bit char 'c'.
-// Advance the cursor by 1. On success, returns 1. On failure, returns -1.
+// Replace the cell at the specified coordinates with the provided 7-bit char
+// 'c'. Advance the cursor by 1. On success, returns 1. On failure, returns -1.
 // This works whether the underlying char is signed or unsigned.
-int ncplane_putsimple(struct ncplane* n, char c);
+API int ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c);
 
-// Call ncplane_simple() after successfully moving to y, x.
+// Call ncplane_putsimple_yx() at the current cursor location.
 static inline int
-ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c){
-  if(ncplane_cursor_move_yx(n, y, x)){
-    return -1;
-  }
-  return ncplane_putsimple(n, c);
+ncplane_putsimple(struct ncplane* n, char c){
+  return ncplane_putsimple_yx(n, -1, -1, c);
 }
 
-// Replace the cell underneath the cursor with the provided wide char 'w'.
-// Advance the cursor by the character's width as reported by wcwidth(). On
-// success, returns 1. On failure, returns -1.
-int ncplane_putwc(struct ncplane* n, wchar_t w);
+// Replace the cell at the specified coordinates with the provided wide char
+// 'w'. Advance the cursor by the character's width as reported by wcwidth().
+// On success, returns 1. On failure, returns -1.
+API int ncplane_putwc_yx(struct ncplane* n, int y, int x, wchar_t w);
 
-// Call ncplane_putwc() after successfully moving to y, x.
+// Call ncplane_putwc() at the current cursor position.
 static inline int
-ncplane_putwc_yx(struct ncplane* n, int y, int x, wchar_t w){
-  if(ncplane_cursor_move_yx(n, y, x)){
-    return -1;
-  }
-  return ncplane_putwc(n, w);
+ncplane_putwc(struct ncplane* n, wchar_t w){
+  return ncplane_putwc_yx(n, -1, -1, w);
 }
 
-// Replace the cell underneath the cursor with the provided EGC, and advance
-// the cursor by the width of the cluster (but not past the end of the plane).
-// On success, returns the number of columns the cursor was advanced. On
-// failure, -1 is returned. The number of bytes converted from gclust is
+// Replace the cell at the specified coordinates with the provided EGC, and
+// advance the cursor by the width of the cluster (but not past the end of the
+// plane). On success, returns the number of columns the cursor was advanced.
+// On failure, -1 is returned. The number of bytes converted from gclust is
 // written to 'sbytes' if non-NULL.
-int ncplane_putegc(struct ncplane* n, const char* gclust, int* sbytes);
+API int ncplane_putegc_yx(struct ncplane* n, int y, int x, const char* gclust, int* sbytes);
 
-// Call ncplane_putegc() after successfully moving to y, x.
+// Call ncplane_putegc() at the current cursor location.
 static inline int
-ncplane_putegc_yx(struct ncplane* n, int y, int x, const char* gclust, int* sbytes){
-  if(ncplane_cursor_move_yx(n, y, x)){
-    return -1;
-  }
-  return ncplane_putegc(n, gclust, sbytes);
+ncplane_putegc(struct ncplane* n, const char* gclust, int* sbytes){
+  return ncplane_putegc_yx(n, -1, -1, gclust, sbytes);
 }
 
 #define WCHAR_MAX_UTF8BYTES 6
@@ -817,7 +805,8 @@ ncplane_putwegc(struct ncplane* n, const wchar_t* gclust, int* sbytes){
 
 // Call ncplane_putwegc() after successfully moving to y, x.
 static inline int
-ncplane_putwegc_yx(struct ncplane* n, int y, int x, const wchar_t* gclust, int* sbytes){
+ncplane_putwegc_yx(struct ncplane* n, int y, int x, const wchar_t* gclust,
+                   int* sbytes){
   if(ncplane_cursor_move_yx(n, y, x)){
     return -1;
   }
@@ -830,14 +819,15 @@ ncplane_putwegc_yx(struct ncplane* n, int y, int x, const wchar_t* gclust, int* 
 // (though not beyond the end of the plane); this number is returned on success.
 // On error, a non-positive number is returned, indicating the number of cells
 // which were written before the error.
-int ncplane_putstr_yx(struct ncplane* n, int y, int x, const char* gclustarr);
+API int ncplane_putstr_yx(struct ncplane* n, int y, int x, const char* gclustarr);
 
 static inline int
 ncplane_putstr(struct ncplane* n, const char* gclustarr){
   return ncplane_putstr_yx(n, -1, -1, gclustarr);
 }
 
-int ncplane_putstr_aligned(struct ncplane* n, int y, ncalign_e align, const char* s);
+API int ncplane_putstr_aligned(struct ncplane* n, int y, ncalign_e align,
+                               const char* s);
 
 // ncplane_putstr(), but following a conversion from wchar_t to UTF-8 multibyte.
 static inline int

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ that fine library.
 * From NCURSES: terminfo 6.1+
 * (OPTIONAL) From FFMpeg: libswscale 5.0+, libavformat 57.0+, libavutil 56.0+
 * (documentation) [pandoc](https://pandoc.org/index.html) 1.19.2+
+* (Python bindings): Python + CFFI
 
 ### Building
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+notcurses (1.1.0-1) UNRELEASED; urgency=medium
+
+  * Add python3-all-dev build-dep (#149)
+
+ -- Nick Black <dankamongmen@gmail.com>  Tue, 07 Jan 2020 16:06:56 -0500
+
 notcurses (1.0.0-1) unstable; urgency=medium
 
   * Let's light this candle. Upstream GA release.

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Priority: optional
 Maintainer: Nick Black <dankamongmen@gmail.com>
 Build-Depends: debhelper-compat (= 12), cmake (>= 3.13), pkg-config (>= 0.29),
  libncurses-dev (>= 6.1), libavformat-dev (>= 57.0), libswscale-dev (>= 5.0),
- libavutil-dev (>= 56.0), pandoc (>= 1.19.2.4)
+ libavutil-dev (>= 56.0), pandoc (>= 1.19.2.4), python3-all-dev (>= 3.2)
 Standards-Version: 4.4.1.1
 Section: libs
 Homepage: https://nick-black.com/dankwiki/index.php/notcurses

--- a/doc/man/man1/notcurses-demo.1
+++ b/doc/man/man1/notcurses-demo.1
@@ -1,4 +1,4 @@
-.TH notcurses-demo 1 "v1.0.0"
+.TH notcurses-demo 1 "v1.1.0"
 .SH NAME
 notcurses-demo \- Show off some notcurses features
 .SH SYNOPSIS

--- a/doc/man/man1/notcurses-input.1
+++ b/doc/man/man1/notcurses-input.1
@@ -1,4 +1,4 @@
-.TH notcurses-input. 1 "v1.0.0"
+.TH notcurses-input. 1 "v1.1.0"
 .SH NAME
 notcurses-input \- Display and decode input
 .SH SYNOPSIS

--- a/doc/man/man1/notcurses-planereel.1
+++ b/doc/man/man1/notcurses-planereel.1
@@ -1,4 +1,4 @@
-.TH notcurses-planereel 1 "v1.0.0"
+.TH notcurses-planereel 1 "v1.1.0"
 .SH NAME
 notcurses-planereel \- Experiment with panelreels
 .SH SYNOPSIS

--- a/doc/man/man1/notcurses-view.1
+++ b/doc/man/man1/notcurses-view.1
@@ -1,4 +1,4 @@
-.TH notcurses-view 1 "v1.0.0"
+.TH notcurses-view 1 "v1.1.0"
 .SH NAME
 notcurses-view \- Render multimedia to the terminal
 .SH SYNOPSIS

--- a/doc/man/man3/notcurses.3.md
+++ b/doc/man/man3/notcurses.3.md
@@ -1,6 +1,6 @@
 % notcurses(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 
@@ -56,7 +56,7 @@ notcurses supports input from keyboards (via **stdin**) and pointing devices (vi
 a broker such as GPM, X, or Wayland). Input is delivered as 32-bit Unicode
 code points. Synthesized events such as mouse button presses and arrow keys
 are mapped into Unicode's
-[Supplementary Private Use Area-B](https://unicode.org/charts/PDF/U100000.pdf).
+[Supplementary Private Use Area-B](https://unicode.org/charts/PDF/U1.1.00.pdf).
 Information on input is available at **notcurses_input(3)**.
 
 ## Ncplanes

--- a/doc/man/man3/notcurses_cell.3.md
+++ b/doc/man/man3/notcurses_cell.3.md
@@ -1,6 +1,6 @@
 % notcurses_cell(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/doc/man/man3/notcurses_channels.3.md
+++ b/doc/man/man3/notcurses_channels.3.md
@@ -1,6 +1,6 @@
 % notcurses_channels(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/doc/man/man3/notcurses_init.3.md
+++ b/doc/man/man3/notcurses_init.3.md
@@ -1,6 +1,6 @@
 % notcurses_init(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/doc/man/man3/notcurses_input.3.md
+++ b/doc/man/man3/notcurses_input.3.md
@@ -1,6 +1,6 @@
 % notcurses_input(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 
@@ -39,7 +39,7 @@ notcurses supports input from keyboards and mice, and any device that looks
 like them. Mouse support requires a broker such as GPM, Wayland, or Xorg, and
 must be explicitly enabled via **notcurses_mouse_enable(3)**. The full 32-bit
 range of Unicode is supported (see **unicode(7)**), with synthesized events
-mapped into the [Supplementary Private Use Area-B](https://unicode.org/charts/PDF/U100000.pdf).
+mapped into the [Supplementary Private Use Area-B](https://unicode.org/charts/PDF/U1.1.00.pdf).
 Unicode characters are returned directly as UCS-32, one codepoint at a time.
 
 notcurses takes its keyboard input from **stdin**, which will be placed into

--- a/doc/man/man3/notcurses_lines.3.md
+++ b/doc/man/man3/notcurses_lines.3.md
@@ -1,6 +1,6 @@
 % notcurses_lines(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/doc/man/man3/notcurses_ncplane.3.md
+++ b/doc/man/man3/notcurses_ncplane.3.md
@@ -1,6 +1,6 @@
 % notcurses_ncplane(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/doc/man/man3/notcurses_ncvisual.3.md
+++ b/doc/man/man3/notcurses_ncvisual.3.md
@@ -1,6 +1,6 @@
 % notcurses_ncvisual(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 notcurses_ncvisual - notcurses multimedia

--- a/doc/man/man3/notcurses_output.3.md
+++ b/doc/man/man3/notcurses_output.3.md
@@ -1,6 +1,6 @@
 % notcurses_output(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 
@@ -10,25 +10,25 @@ notcurses_output - output to ncplanes
 
 **#include <notcurses.h>**
 
-**int ncplane_putc(struct ncplane* n, const cell* c);**
+**static inline int
+ncplane_putc(struct ncplane* n, const cell* c);**
+
+**int ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c);**
 
 **static inline int
-ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c);**
+ncplane_putsimple(struct ncplane* n, char c);**
 
-**int ncplane_putsimple(struct ncplane* n, char c);**
-
-**static inline int
-ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c);**
-
-**int ncplane_putwc(struct ncplane* n, wchar_t w);**
+**int ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c);**
 
 **static inline int
-ncplane_putwc_yx(struct ncplane* n, int y, int x, wchar_t w);**
+ncplane_putwc(struct ncplane* n, wchar_t w);**
 
-**int ncplane_putegc(struct ncplane* n, const char* gclust, int* sbytes);**
+**int ncplane_putwc_yx(struct ncplane* n, int y, int x, wchar_t w);**
 
 **static inline int
-ncplane_putegc_yx(struct ncplane* n, int y, int x, const char* gclust, int* sbytes);**
+ncplane_putegc(struct ncplane* n, const char* gclust, int* sbytes);**
+
+**int ncplane_putegc_yx(struct ncplane* n, int y, int x, const char* gclust, int* sbytes);**
 
 **static inline int
 ncplane_putwegc(struct ncplane* n, const wchar_t* gclust, int* sbytes);**
@@ -44,8 +44,7 @@ ncplane_putstr(struct ncplane* n, const char* gclustarr);**
 **int ncplane_putstr_aligned(struct ncplane* n, int y, ncalign_e align,
                                const char* s);**
 
-**static inline int
-ncplane_putwstr_yx(struct ncplane* n, int y, int x, const wchar_t* gclustarr);**
+**int ncplane_putwstr_yx(struct ncplane* n, int y, int x, const wchar_t* gclustarr);**
 
 **static inline int
 ncplane_putwstr_aligned(struct ncplane* n, int y, ncalign_e align,

--- a/doc/man/man3/notcurses_panelreel.3.md
+++ b/doc/man/man3/notcurses_panelreel.3.md
@@ -1,6 +1,6 @@
 % notcurses_panelreels(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/doc/man/man3/notcurses_render.3.md
+++ b/doc/man/man3/notcurses_render.3.md
@@ -1,6 +1,6 @@
 % notcurses_render(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/doc/man/man3/notcurses_stats.3.md
+++ b/doc/man/man3/notcurses_stats.3.md
@@ -1,6 +1,6 @@
 % notcurses_stats(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/doc/man/man3/notcurses_stdplane.3.md
+++ b/doc/man/man3/notcurses_stdplane.3.md
@@ -1,6 +1,6 @@
 % notcurses_stdplane(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/doc/man/man3/notcurses_stop.3.md
+++ b/doc/man/man3/notcurses_stop.3.md
@@ -1,6 +1,6 @@
 % notcurses_stop(3)
 % nick black <nickblack@linux.com>
-% v1.0.0
+% v1.1.0
 
 # NAME
 

--- a/include/notcurses.h
+++ b/include/notcurses.h
@@ -402,11 +402,6 @@ API void notcurses_stats(struct notcurses* nc, ncstats* stats);
 // Reset all cumulative stats (immediate ones, such as fbbytes, are not reset).
 API void notcurses_reset_stats(struct notcurses* nc, ncstats* stats);
 
-// Retrieve the cell at the specified location on the specified plane, returning
-// it in 'c'. This copy is safe to use until the ncplane is destroyed/erased.
-// Returns the length of the EGC in bytes.
-API char* notcurses_at_yx(struct notcurses* nc, int y, int x, cell* c);
-
 // Return the dimensions of this ncplane.
 API void ncplane_dim_yx(struct ncplane* n, int* RESTRICT rows, int* RESTRICT cols);
 
@@ -552,62 +547,51 @@ API int ncplane_cursor_move_yx(struct ncplane* n, int y, int x);
 // Get the current position of the cursor within n. y and/or x may be NULL.
 API void ncplane_cursor_yx(struct ncplane* n, int* RESTRICT y, int* RESTRICT x);
 
-// Replace the cell underneath the cursor with the provided cell 'c', and
-// advance the cursor by the width of the cell (but not past the end of the
+// Replace the cell at the specified coordinates with the provided cell 'c',
+// and advance the cursor by the width of the cell (but not past the end of the
 // plane). On success, returns the number of columns the cursor was advanced.
 // On failure, -1 is returned.
-API int ncplane_putc(struct ncplane* n, const cell* c);
+API int ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c);
 
-// Call ncplane_putc() after successfully moving to y, x on the specified plane.
+// Call ncplane_putc_yx() for the current cursor location.
 static inline int
-ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c){
-  if(ncplane_cursor_move_yx(n, y, x)){
-    return -1;
-  }
-  return ncplane_putc(n, c);
+ncplane_putc(struct ncplane* n, const cell* c){
+  return ncplane_putc_yx(n, -1, -1, c);
 }
 
-// Replace the cell underneath the cursor with the provided 7-bit char 'c'.
-// Advance the cursor by 1. On success, returns 1. On failure, returns -1.
+// Replace the cell at the specified coordinates with the provided 7-bit char
+// 'c'. Advance the cursor by 1. On success, returns 1. On failure, returns -1.
 // This works whether the underlying char is signed or unsigned.
-API int ncplane_putsimple(struct ncplane* n, char c);
+API int ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c);
 
-// Call ncplane_simple() after successfully moving to y, x.
+// Call ncplane_putsimple_yx() at the current cursor location.
 static inline int
-ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c){
-  if(ncplane_cursor_move_yx(n, y, x)){
-    return -1;
-  }
-  return ncplane_putsimple(n, c);
+ncplane_putsimple(struct ncplane* n, char c){
+  return ncplane_putsimple_yx(n, -1, -1, c);
 }
 
-// Replace the cell underneath the cursor with the provided wide char 'w'.
-// Advance the cursor by the character's width as reported by wcwidth(). On
-// success, returns 1. On failure, returns -1.
-API int ncplane_putwc(struct ncplane* n, wchar_t w);
+// Replace the cell at the specified coordinates with the provided wide char
+// 'w'. Advance the cursor by the character's width as reported by wcwidth().
+// On success, returns 1. On failure, returns -1.
+API int ncplane_putwc_yx(struct ncplane* n, int y, int x, wchar_t w);
 
-// Call ncplane_putwc() after successfully moving to y, x.
+// Call ncplane_putwc() at the current cursor position.
 static inline int
-ncplane_putwc_yx(struct ncplane* n, int y, int x, wchar_t w){
-  if(ncplane_cursor_move_yx(n, y, x)){
-    return -1;
-  }
-  return ncplane_putwc(n, w);
+ncplane_putwc(struct ncplane* n, wchar_t w){
+  return ncplane_putwc_yx(n, -1, -1, w);
 }
 
-// Replace the cell underneath the cursor with the provided EGC, and advance the cursor by the
-// width of the cluster (but not past the end of the plane). On success, returns
-// the number of columns the cursor was advanced. On failure, -1 is returned.
-// The number of bytes converted from gclust is written to 'sbytes' if non-NULL.
-API int ncplane_putegc(struct ncplane* n, const char* gclust, int* sbytes);
+// Replace the cell at the specified coordinates with the provided EGC, and
+// advance the cursor by the width of the cluster (but not past the end of the
+// plane). On success, returns the number of columns the cursor was advanced.
+// On failure, -1 is returned. The number of bytes converted from gclust is
+// written to 'sbytes' if non-NULL.
+API int ncplane_putegc_yx(struct ncplane* n, int y, int x, const char* gclust, int* sbytes);
 
-// Call ncplane_putegc() after successfully moving to y, x.
+// Call ncplane_putegc() at the current cursor location.
 static inline int
-ncplane_putegc_yx(struct ncplane* n, int y, int x, const char* gclust, int* sbytes){
-  if(ncplane_cursor_move_yx(n, y, x)){
-    return -1;
-  }
-  return ncplane_putegc(n, gclust, sbytes);
+ncplane_putegc(struct ncplane* n, const char* gclust, int* sbytes){
+  return ncplane_putegc_yx(n, -1, -1, gclust, sbytes);
 }
 
 #define WCHAR_MAX_UTF8BYTES 6

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,12 @@
+# notcurses
+
+Python bindings for the C [https://github.com/dankamongmen/notcurses notcurses]
+library. notcurses is a library for building complex, vibrant textual user
+interfaces (TUIs) on modern terminal emulators.
+
+by [nick black](https://nick-black.com/dankwiki/index.php/Hack_on) (<nickblack@linux.com>)
+
+for more information, see [my wiki](https://nick-black.com/dankwiki/index.php/Notcurses).
+
+[![Build Status](https://drone.dsscaw.com:4443/api/badges/dankamongmen/notcurses/status.svg)](https://drone.dsscaw.com:4443/dankamongmen/notcurses)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,2 +1,8 @@
-[aliases]
-test=pytest
+[nosetests]
+verbosity=1
+detailed-errors=1
+with-coverage=1
+cover-package=nose
+debug=nose.loader
+pdb=1
+pdb-failures=1

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,32 @@
+from setuptools import setup, find_packages
+import os
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+setup(
+    name="notcurses",
+    version="1.0.0",
+    package_dir={'': 'src'},
+    packages=find_packages('src'),
+    author="Nick Black",
+    author_email="nickblack@linux.com",
+    description="Blingful TUI construction library",
+    keywords="ncurses curses tui console graphics",
+    license='Apache License, Version 2.0',
+    url='https://github.com/dankamongmen/notcurses',
+    zip_safe=True,
+    platforms=["any"],
+    long_description=read('README.md'),
+    long_description_content_type="text/markdown",
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
+    # see https://pypi.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Console',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Programming Language :: Python',
+    ],
+)

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages('src'),
     author="Nick Black",
     author_email="nickblack@linux.com",
-    description="Blingful TUI construction library",
+    description="Blingful TUI construction library (python bindings)",
     keywords="ncurses curses tui console graphics",
     license='Apache License, Version 2.0',
     url='https://github.com/dankamongmen/notcurses',
@@ -19,8 +19,10 @@ setup(
     platforms=["any"],
     long_description=read('README.md'),
     long_description_content_type="text/markdown",
-    setup_requires=["pytest-runner"],
-    tests_require=["pytest"],
+    setup_requires=["cffi"],
+    cffi_modules=["src/notcurses/build_notcurses.py:ffibuild"],
+    install_requires=["cffi"],
+    py_modules=["notcurses"],
     # see https://pypi.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name="notcurses",
-    version="1.0.0",
+    version="1.1.0",
     package_dir={'': 'src'},
     packages=find_packages('src'),
     author="Nick Black",

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -1,0 +1,17 @@
+from cffi import FFI
+ffibuild = FFI()
+
+ffibuild.set_source(
+    "_notcurses",
+    """
+    #include <notcurses.h>
+    """,
+    libraries=["notcurses"],
+)
+
+ffibuild.cdef("""
+struct notcurses_options;
+struct notcurses* notcurses_init(const struct notcurses_options*, FILE*);
+int notcurses_stop(struct notcurses*);
+int notcurses_render(struct notcurses*);
+""")

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -10,8 +10,51 @@ ffibuild.set_source(
 )
 
 ffibuild.cdef("""
-struct notcurses_options;
-struct notcurses* notcurses_init(const struct notcurses_options*, FILE*);
+typedef enum {
+  NCLOGLEVEL_SILENT,  // default. print nothing once fullscreen service begins
+  NCLOGLEVEL_PANIC,   // print diagnostics immediately related to crashing
+  NCLOGLEVEL_FATAL,   // we're hanging around, but we've had a horrible fault
+  NCLOGLEVEL_ERROR,   // we can't keep doin' this, but we can do other things
+  NCLOGLEVEL_WARNING, // you probably don't want what's happening to happen
+  NCLOGLEVEL_INFO,    // "standard information"
+  NCLOGLEVEL_VERBOSE, // "detailed information"
+  NCLOGLEVEL_DEBUG,   // this is honestly a bit much
+  NCLOGLEVEL_TRACE,   // there's probably a better way to do what you want
+} ncloglevel_e;
+typedef struct notcurses_options {
+  // The name of the terminfo database entry describing this terminal. If NULL,
+  // the environment variable TERM is used. Failure to open the terminal
+  // definition will result in failure to initialize notcurses.
+  const char* termtype;
+  // If smcup/rmcup capabilities are indicated, notcurses defaults to making
+  // use of the "alternate screen". This flag inhibits use of smcup/rmcup.
+  bool inhibit_alternate_screen;
+  // By default, we hide the cursor if possible. This flag inhibits use of
+  // the civis capability, retaining the cursor.
+  bool retain_cursor;
+  // Notcurses does not clear the screen on startup unless thus requested to.
+  bool clear_screen_start;
+  // Notcurses typically prints version info in notcurses_init() and performance
+  // info in notcurses_stop(). This inhibits that output.
+  bool suppress_banner;
+  // We typically install a signal handler for SIG{INT, SEGV, ABRT, QUIT} that
+  // restores the screen, and then calls the old signal handler. Set to inhibit
+  // registration of these signal handlers.
+  bool no_quit_sighandlers;
+  // We typically install a signal handler for SIGWINCH that generates a resize
+  // event in the notcurses_getc() queue. Set to inhibit this handler.
+  bool no_winch_sighandler;
+  // If non-NULL, notcurses_render() will write each rendered frame to this
+  // FILE* in addition to outfp. This is used primarily for debugging.
+  FILE* renderfp;
+  // Progressively higher log levels result in more logging to stderr. By
+  // default, nothing is printed to stderr once fullscreen service begins.
+  ncloglevel_e loglevel;
+} notcurses_options;
+struct notcurses* notcurses_init(const notcurses_options*, FILE*);
 int notcurses_stop(struct notcurses*);
 int notcurses_render(struct notcurses*);
 """)
+
+if __name__ == "__main__":
+    ffibuild.compile(verbose=True)

--- a/python/src/notcurses/notcurses.py
+++ b/python/src/notcurses/notcurses.py
@@ -1,17 +1,20 @@
+import sys
+import locale
 from _notcurses import lib, ffi
 
 class Notcurses:
     def __init__(self):
-        self.nc = lib.notcurses_init()
+        opts = ffi.new("notcurses_options *")
+        self.nc = lib.notcurses_init(opts, sys.stdout)
 
     def __del__(self):
         lib.notcurses_stop(self.nc)
 
-    def render():
+    def render(self):
         return lib.notcurses_render(self.nc)
 
-def main():
-    print('ohhhh yeah')
+if __name__ == '__main__':
+    locale.setlocale(locale.LC_ALL, "")
     nc = Notcurses()
     nc.render()
     print('ohhhh yeah')

--- a/python/src/notcurses/notcurses.py
+++ b/python/src/notcurses/notcurses.py
@@ -1,0 +1,17 @@
+from _notcurses import lib, ffi
+
+class Notcurses:
+    def __init__(self):
+        self.nc = lib.notcurses_init()
+
+    def __del__(self):
+        lib.notcurses_stop(self.nc)
+
+    def render():
+        return lib.notcurses_render(self.nc)
+
+def main():
+    print('ohhhh yeah')
+    nc = Notcurses()
+    nc.render()
+    print('ohhhh yeah')

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notcurses"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["nick black <dankamongmen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
* Add Python CFFI skeleton up through PoC `notcurses_init()`/`notcurses_stop()` sequence, works
* Add Python3 dep to README, CMake, debian #149 
* Update to newest drones
* Thought I'd gotten all of these, but for all output functions, simple calls complex, not the other way around. That way, the move + output can be atomic.