### PR TITLE
Bugfixes while working on wide weirdness

### DIFF
--- a/doc/man/man1/notcurses-demo.1.md
+++ b/doc/man/man1/notcurses-demo.1.md
@@ -25,7 +25,7 @@ The demonstrations include:
 * (c)hunli—the strongest woman in the world
 * (g)rid—a gradient of color lain atop a great grid
 * (s)liders—a missing-piece puzzle made up of colorful blocks
-* (w)hiteworm—a great Nothing slowly robs the world of color
+* (w)itherworm—a great Nothing slowly robs the world of color
 * (u)niblocks—a series of blocks detailing Unicode pages
 * (b)oxes—pulsating boxes with a transparent center
 * (v)iew—images and a video are rendered as text
@@ -55,6 +55,7 @@ demospec: Select which demos to run, and what order to run them in. The default 
 
 # NOTES
 Proper display requires:
+
 * A terminal advertising the **rgb** terminfo(5) capability, or that the environment variable **COLORTERM** is defined to **24bit** (and that the terminal honors this variable),
 * A monospaced font, and
 * Good Unicode support in your libc, font, and terminal emulator.

--- a/src/lib/fade.c
+++ b/src/lib/fade.c
@@ -97,6 +97,9 @@ int ncplane_fadein(ncplane* n, const struct timespec* ts, fadecb fader){
   int maxbsteps = pp.maxbg > pp.maxbr ? (pp.maxbb > pp.maxbg ? pp.maxbb : pp.maxbg) :
                   (pp.maxbb > pp.maxbr ? pp.maxbb : pp.maxbr);
   int maxsteps = maxfsteps > maxbsteps ? maxfsteps : maxbsteps;
+  if(maxsteps == 0){
+    maxsteps = 1;
+  }
   uint64_t nanosecs_total = ts->tv_sec * NANOSECS_IN_SEC + ts->tv_nsec;
   uint64_t nanosecs_step = nanosecs_total / maxsteps;
   struct timespec times;
@@ -172,6 +175,9 @@ int ncplane_fadeout(struct ncplane* n, const struct timespec* ts, fadecb fader){
   int maxbsteps = pp.maxbg > pp.maxbr ? (pp.maxbb > pp.maxbg ? pp.maxbb : pp.maxbg) :
                   (pp.maxbb > pp.maxbr ? pp.maxbb : pp.maxbr);
   int maxsteps = maxfsteps > maxbsteps ? maxfsteps : maxbsteps;
+  if(maxsteps == 0){
+    maxsteps = 1;
+  }
   uint64_t nanosecs_total = ts->tv_sec * NANOSECS_IN_SEC + ts->tv_nsec;
   uint64_t nanosecs_step = nanosecs_total / maxsteps;
   struct timespec times;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1034,6 +1034,9 @@ ncplane_cursor_move_yx_locked(ncplane* n, int y, int x){
   }else{
     n->y = y;
   }
+  if(cursor_invalid_p(n)){
+    return -1;
+  }
   return 0;
 }
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -853,7 +853,7 @@ int notcurses_stop(notcurses* nc){
         char minbuf[BPREFIXSTRLEN + 1];
         char maxbuf[BPREFIXSTRLEN + 1];
         double avg = nc->stashstats.render_ns / (double)nc->stashstats.renders;
-        fprintf(stderr, "\n%ju render%s, %.03gs total (%.03gs min, %.03gs max, %.02gs avg %.1f fps)\n",
+        fprintf(stderr, "\n%ju render%s, %.03gs total (%.03gs min, %.03gs max, %.03gs avg %.1f fps)\n",
                 nc->stashstats.renders, nc->stashstats.renders == 1 ? "" : "s",
                 nc->stashstats.render_ns / 1000000000.0,
                 nc->stashstats.render_min_ns / 1000000000.0,
@@ -863,7 +863,7 @@ int notcurses_stop(notcurses* nc){
         bprefix(nc->stashstats.render_bytes, 1, totalbuf, 0),
         bprefix(nc->stashstats.render_min_bytes, 1, minbuf, 0),
         bprefix(nc->stashstats.render_max_bytes, 1, maxbuf, 0),
-        fprintf(stderr, "%sB total (%sB min, %sB max, %.02fKiB avg)\n",
+        fprintf(stderr, "%sB total (%sB min, %sB max, %.03gKiB avg)\n",
                 totalbuf, minbuf, maxbuf,
                 avg / 1024);
       }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -671,6 +671,11 @@ ffmpeg_log_level(ncloglevel_e level){
 }
 
 notcurses* notcurses_init(const notcurses_options* opts, FILE* outfp){
+  notcurses_options defaultopts;
+  memset(&defaultopts, 0, sizeof(defaultopts));
+  if(!opts){
+    opts = &defaultopts;
+  }
   const char* encoding = nl_langinfo(CODESET);
   if(encoding == NULL || strcmp(encoding, "UTF-8")){
     fprintf(stderr, "Encoding (\"%s\") wasn't UTF-8, refusing to start\n",
@@ -1248,7 +1253,8 @@ unsigned ncplane_styles(ncplane* n){
 
 // i hate the big allocation and two copies here, but eh what you gonna do?
 // well, for one, we don't need the huge allocation FIXME
-char* ncplane_vprintf_prep(ncplane* n, const char* format, va_list ap){
+static char*
+ncplane_vprintf_prep(ncplane* n, const char* format, va_list ap){
   const size_t size = n->lenx + 1; // healthy estimate, can embiggen below
   char* buf = malloc(size);
   if(buf == NULL){
@@ -1266,6 +1272,7 @@ char* ncplane_vprintf_prep(ncplane* n, const char* format, va_list ap){
       return NULL;
     }
     buf = tmp;
+    vsprintf(buf, format, ap);
   }
   return buf;
 }

--- a/src/poc/mathtext.cpp
+++ b/src/poc/mathtext.cpp
@@ -1,0 +1,51 @@
+#include <cstdlib>
+#include <locale.h>
+#include <unistd.h>
+#include <notcurses.h>
+
+int mathtext(struct notcurses* nc){
+  int dimx, dimy;
+  notcurses_term_dim_yx(nc, &dimy, &dimx);
+  const int HEIGHT = 9;
+  const int WIDTH = dimx;
+  struct ncplane* n = ncplane_new(nc, HEIGHT, WIDTH, dimy - HEIGHT - 1, dimx - WIDTH - 1, NULL);
+  cell b = CELL_TRIVIAL_INITIALIZER;
+  cell_set_bg_alpha(&b, CELL_ALPHA_TRANSPARENT);
+  cell_set_fg_alpha(&b, CELL_ALPHA_TRANSPARENT);
+  ncplane_set_base(n, &b);
+  cell_release(n, &b);
+  if(n){
+    struct ncplane* stdn = notcurses_stdplane(nc);
+    ncplane_set_bg_alpha(n, CELL_ALPHA_TRANSPARENT);
+    // FIXME reenable the left parts of these strings, issue #260*/
+    ncplane_printf_aligned(n, 0, NCALIGN_RIGHT, /*∮E⋅da=Q,n→∞,∑f(i)=∏g(i)*/"⎧⎡⎛┌─────┐⎞⎤⎫");
+    ncplane_printf_aligned(n, 1, NCALIGN_RIGHT, "⎪⎢⎜│a²+b³ ⎟⎥⎪");
+    ncplane_printf_aligned(n, 2, NCALIGN_RIGHT, /*∀x∈ℝ:⌈x⌉=−⌊−x⌋,α∧¬β=¬(¬α∨β)*/"⎪⎢⎜│───── ⎟⎥⎪");
+    ncplane_printf_aligned(n, 3, NCALIGN_RIGHT, "⎪⎢⎜⎷ c₈   ⎟⎥⎪");
+    ncplane_printf_aligned(n, 4, NCALIGN_RIGHT, /*ℕ⊆ℕ₀⊂ℤ⊂ℚ⊂ℝ⊂ℂ(z̄=ℜ(z)−ℑ(z)⋅𝑖)*/"⎨⎢⎜       ⎟⎥⎬");
+    ncplane_printf_aligned(n, 5, NCALIGN_RIGHT, "⎪⎢⎜ ∞     ⎟⎥⎪");
+    ncplane_printf_aligned(n, 6, NCALIGN_RIGHT, /*⊥<a≠b≡c≤d≪⊤⇒(⟦A⟧⇔⟪B⟫)*/"⎪⎢⎜ ⎲     ⎟⎥⎪");
+    ncplane_printf_aligned(n, 7, NCALIGN_RIGHT, "⎪⎢⎜ ⎳aⁱ-bⁱ⎟⎥⎪");
+    ncplane_printf_aligned(n, 8, NCALIGN_RIGHT, /*2H₂+O₂⇌2H₂O,R=4.7kΩ,⌀200µm*/"⎩⎣⎝i=1    ⎠⎦⎭");
+  }
+  return 0;
+}
+
+int main(void){
+  if(setlocale(LC_ALL, "") == nullptr){
+    return EXIT_FAILURE;
+  }
+  notcurses_options opts{};
+  opts.inhibit_alternate_screen = true;
+  struct notcurses* nc = notcurses_init(&opts, stdout);
+  if(nc == nullptr){
+    return EXIT_FAILURE;
+  }
+  if(mathtext(nc)){
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
+  }
+  notcurses_render(nc);
+  notcurses_stop(nc);
+  return 0;
+}

--- a/src/poc/mathtext.cpp
+++ b/src/poc/mathtext.cpp
@@ -9,24 +9,17 @@ int mathtext(struct notcurses* nc){
   const int HEIGHT = 9;
   const int WIDTH = dimx;
   struct ncplane* n = ncplane_new(nc, HEIGHT, WIDTH, dimy - HEIGHT - 1, dimx - WIDTH - 1, NULL);
-  cell b = CELL_TRIVIAL_INITIALIZER;
-  cell_set_bg_alpha(&b, CELL_ALPHA_TRANSPARENT);
-  cell_set_fg_alpha(&b, CELL_ALPHA_TRANSPARENT);
-  ncplane_set_base(n, &b);
-  cell_release(n, &b);
   if(n){
     struct ncplane* stdn = notcurses_stdplane(nc);
-    ncplane_set_bg_alpha(n, CELL_ALPHA_TRANSPARENT);
-    // FIXME reenable the left parts of these strings, issue #260*/
-    ncplane_printf_aligned(n, 0, NCALIGN_RIGHT, /*∮E⋅da=Q,n→∞,∑f(i)=∏g(i)*/"⎧⎡⎛┌─────┐⎞⎤⎫");
+    ncplane_printf_aligned(n, 0, NCALIGN_RIGHT, "∮E⋅da=Q,n→∞,∑f(i)=∏g(i)⎧⎡⎛┌─────┐⎞⎤⎫");
     ncplane_printf_aligned(n, 1, NCALIGN_RIGHT, "⎪⎢⎜│a²+b³ ⎟⎥⎪");
-    ncplane_printf_aligned(n, 2, NCALIGN_RIGHT, /*∀x∈ℝ:⌈x⌉=−⌊−x⌋,α∧¬β=¬(¬α∨β)*/"⎪⎢⎜│───── ⎟⎥⎪");
+    ncplane_printf_aligned(n, 2, NCALIGN_RIGHT, "∀x∈ℝ:⌈x⌉=−⌊−x⌋,α∧¬β=¬(¬α∨β)⎪⎢⎜│───── ⎟⎥⎪");
     ncplane_printf_aligned(n, 3, NCALIGN_RIGHT, "⎪⎢⎜⎷ c₈   ⎟⎥⎪");
-    ncplane_printf_aligned(n, 4, NCALIGN_RIGHT, /*ℕ⊆ℕ₀⊂ℤ⊂ℚ⊂ℝ⊂ℂ(z̄=ℜ(z)−ℑ(z)⋅𝑖)*/"⎨⎢⎜       ⎟⎥⎬");
+    ncplane_printf_aligned(n, 4, NCALIGN_RIGHT, "ℕ⊆ℕ₀⊂ℤ⊂ℚ⊂ℝ⊂ℂ(z̄=ℜ(z)−ℑ(z)⋅𝑖)⎨⎢⎜       ⎟⎥⎬");
     ncplane_printf_aligned(n, 5, NCALIGN_RIGHT, "⎪⎢⎜ ∞     ⎟⎥⎪");
-    ncplane_printf_aligned(n, 6, NCALIGN_RIGHT, /*⊥<a≠b≡c≤d≪⊤⇒(⟦A⟧⇔⟪B⟫)*/"⎪⎢⎜ ⎲     ⎟⎥⎪");
+    ncplane_printf_aligned(n, 6, NCALIGN_RIGHT, "⊥<a≠b≡c≤d≪⊤⇒(⟦A⟧⇔⟪B⟫)⎪⎢⎜ ⎲     ⎟⎥⎪");
     ncplane_printf_aligned(n, 7, NCALIGN_RIGHT, "⎪⎢⎜ ⎳aⁱ-bⁱ⎟⎥⎪");
-    ncplane_printf_aligned(n, 8, NCALIGN_RIGHT, /*2H₂+O₂⇌2H₂O,R=4.7kΩ,⌀200µm*/"⎩⎣⎝i=1    ⎠⎦⎭");
+    ncplane_printf_aligned(n, 8, NCALIGN_RIGHT, "2H₂+O₂⇌2H₂O,R=4.7kΩ,⌀200µm⎩⎣⎝i=1    ⎠⎦⎭");
   }
   return 0;
 }


### PR DESCRIPTION
* Add mathtext PoC
* Reprint after resizing in vfprintf()-style output #260 
* Don't divide by zero when fading an empty plane #269 
* Implement `-r` option in `notcurses-demo`
* Match rounding in output summary #268 
* Don't print beyond the ncplane using nil move #270 