### PR TITLE
debian: update c++ symbols based on ubuntu focal build

### DIFF
--- a/debian/libnotcurses++1.symbols
+++ b/debian/libnotcurses++1.symbols
@@ -1,20 +1,49 @@
 libnotcurses++.so.1 libnotcurses++1 #MINVER#
+ _ZN4ncpp10init_errorD0Ev@Base 1.1.0
+ _ZN4ncpp10init_errorD1Ev@Base 1.1.0
+ _ZN4ncpp10init_errorD2Ev@Base 1.1.0
+ _ZN4ncpp16invalid_argumentD0Ev@Base 1.1.0
+ _ZN4ncpp16invalid_argumentD1Ev@Base 1.1.0
+ _ZN4ncpp16invalid_argumentD2Ev@Base 1.1.0
+ _ZN4ncpp19invalid_state_errorD0Ev@Base 1.1.0
+ _ZN4ncpp19invalid_state_errorD1Ev@Base 1.1.0
+ _ZN4ncpp19invalid_state_errorD2Ev@Base 1.1.0
+ _ZN4ncpp4Root26ncpp_invalid_state_messageE@Base 1.1.0
  _ZN4ncpp5Plane11unmap_planeEPS0_@Base 1.1.0
  _ZN4ncpp5Plane15plane_map_mutexE@Base 1.1.0
  _ZN4ncpp5Plane9map_planeEP7ncplanePS0_@Base 1.1.0
  _ZN4ncpp5Plane9plane_mapE@Base 1.1.0
+ _ZN4ncpp5PlaneD1Ev@Base 1.1.0
+ _ZN4ncpp5PlaneD2Ev@Base 1.1.0
  _ZN4ncpp6Tablet10map_tabletEP6tablet@Base 1.1.0
  _ZN4ncpp6Tablet10tablet_mapE@Base 1.1.0
  _ZN4ncpp6Tablet12unmap_tabletEPS0_@Base 1.1.0
  _ZN4ncpp6Tablet16tablet_map_mutexE@Base 1.1.0
+ _ZN4ncpp6Visual13destroy_planeEPNS_5PlaneE@Base 1.1.0
+ _ZN4ncpp9NotCurses10init_mutexE@Base 1.1.0
  _ZN4ncpp9NotCurses25default_notcurses_optionsE@Base 1.1.0
- _ZN4ncpp9NotCurses4initERK17notcurses_optionsP8_IO_FILE@Base 1.1.0
  _ZN4ncpp9NotCurses7get_topEv@Base 1.1.0
  _ZN4ncpp9NotCurses9_instanceE@Base 1.1.0
- _ZN4ncpp9NotCursesD1Ev@Base 1.1.0
- _ZN4ncpp9NotCursesD2Ev@Base 1.1.0
+ _ZN4ncpp9NotCursesC1ERK17notcurses_optionsP8_IO_FILE@Base 1.1.0
+ _ZN4ncpp9NotCursesC2ERK17notcurses_optionsP8_IO_FILE@Base 1.1.0
  _ZN4ncpp9PanelReel15default_optionsE@Base 1.1.0
  _ZNK4ncpp4Root13get_notcursesEv@Base 1.1.0
+ _ZNK4ncpp4Root20is_notcurses_stoppedEv@Base 1.1.0
  _ZNK4ncpp6Tablet9get_planeEv@Base 1.1.0
  _ZNK4ncpp6Visual9get_planeEv@Base 1.1.0
  _ZNK4ncpp9PanelReel9get_planeEv@Base 1.1.0
+ _ZTIN4ncpp10init_errorE@Base 1.1.0
+ _ZTIN4ncpp16invalid_argumentE@Base 1.1.0
+ _ZTIN4ncpp19invalid_state_errorE@Base 1.1.0
+ _ZTIPN4ncpp10init_errorE@Base 1.1.0
+ _ZTIPN4ncpp16invalid_argumentE@Base 1.1.0
+ _ZTIPN4ncpp19invalid_state_errorE@Base 1.1.0
+ _ZTSN4ncpp10init_errorE@Base 1.1.0
+ _ZTSN4ncpp16invalid_argumentE@Base 1.1.0
+ _ZTSN4ncpp19invalid_state_errorE@Base 1.1.0
+ _ZTSPN4ncpp10init_errorE@Base 1.1.0
+ _ZTSPN4ncpp16invalid_argumentE@Base 1.1.0
+ _ZTSPN4ncpp19invalid_state_errorE@Base 1.1.0
+ _ZTVN4ncpp10init_errorE@Base 1.1.0
+ _ZTVN4ncpp16invalid_argumentE@Base 1.1.0
+ _ZTVN4ncpp19invalid_state_errorE@Base 1.1.0


### PR DESCRIPTION
Ubuntu Focal wanted these changes, but the Debian Unstable build went just fine with what you had, so I'm not convinced that this is a desirable change. I'll admit that it's just copied-and-trimmed output from `dpkg-gensymbols` as part of a `debuild` run, not anything hand-crafted or thought out.

I have *not* tested the Debian Unstable build with this in place, which is certainly a precondition to committing. Just wanted to run it by you asap. Don't hesitate to NAK.