### PR TITLE
Properly clean up when NotCurses instance is destructed

### DIFF
--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -31,17 +31,10 @@ namespace ncpp
 		explicit NotCurses (const notcurses_options &nc_opts, FILE *fp = nullptr);
 
 		// Must not move or copy a NotCurses instance because we have no way to guarantee validity of any other copy
-		// when even a single instance is destructed as that operation would close not curses.
+		// when even a single instance is destructed as that operation would close notcurses.
 		NotCurses (const NotCurses &other) = delete;
 		NotCurses (NotCurses &&other) = delete;
-
-		~NotCurses ()
-		{
-			if (nc == nullptr)
-				return;
-
-			notcurses_stop (nc);
-		}
+		~NotCurses ();
 
 		operator notcurses* () noexcept
 		{

--- a/src/libcpp/NotCurses.cc
+++ b/src/libcpp/NotCurses.cc
@@ -17,6 +17,17 @@ notcurses_options NotCurses::default_notcurses_options = {
 NotCurses *NotCurses::_instance = nullptr;
 std::mutex NotCurses::init_mutex;
 
+NotCurses::~NotCurses ()
+{
+	const std::lock_guard<std::mutex> lock (init_mutex);
+
+	if (nc == nullptr)
+		return;
+
+	notcurses_stop (nc);
+	_instance = nullptr;
+}
+
 NotCurses::NotCurses (const notcurses_options &nc_opts, FILE *fp)
 {
 	const std::lock_guard<std::mutex> lock (init_mutex);


### PR DESCRIPTION
We need to set `_instance` to `nullptr` or we'll leave a dangling
pointer.