### PR TITLE
C++ wrappers: kill Visual::destroy_plane() #299

### DIFF
--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -36,7 +36,6 @@ namespace ncpp
 
 		~Visual () noexcept
 		{
-			destroy_plane (get_plane ());
 			if (!is_notcurses_stopped ())
 				ncvisual_destroy (visual);
 		}
@@ -67,9 +66,6 @@ namespace ncpp
 		}
 
 		Plane* get_plane () const noexcept;
-
-	private:
-		static void destroy_plane (Plane *plane) noexcept;
 
 	private:
 		ncvisual *visual = nullptr;

--- a/src/libcpp/Visual.cc
+++ b/src/libcpp/Visual.cc
@@ -7,8 +7,3 @@ Plane* Visual::get_plane () const noexcept
 {
 	return Plane::map_plane (ncvisual_plane (visual));
 }
-
-void Visual::destroy_plane (Plane *plane) noexcept
-{
-	delete plane;
-}


### PR DESCRIPTION
ncvisual_destroy() already calls ncplane_destroy() when
appropriate. There's never a need for the C++ wrappers
to explicitly free the Visual's underlying Plane. With
this change, valgrind no longer complains upon exiting
notcurses-view(1).