### PR TITLE
Sync C++ wrapper with the latest API changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,10 +153,12 @@ target_compile_definitions(notcurses-static
 
 # libnotcurses++
 set(NCPP_SOURCES
+  src/libcpp/Menu.cc
   src/libcpp/NotCurses.cc
   src/libcpp/Plane.cc
   src/libcpp/Reel.cc
   src/libcpp/Root.cc
+  src/libcpp/Selector.cc
   src/libcpp/Tablet.cc
   src/libcpp/Visual.cc
   )

--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -1,0 +1,91 @@
+#ifndef __NCPP_DIRECT_HH
+#define __NCPP_DIRECT_HH
+
+#include <cstdio>
+#include <notcurses.h>
+
+#include "Root.hh"
+#include "Cell.hh"
+
+namespace ncpp
+{
+	class NCPP_API_EXPORT Direct : public Root
+	{
+	public:
+		explicit Direct (const char *termtype, FILE *fp = nullptr)
+		{
+			direct = notcurses_directmode (termtype, fp == nullptr ? stdout : fp);
+			if (direct == nullptr)
+				throw new init_error ("notcurses failed to initialize direct mode");
+		}
+
+		~Direct ()
+		{
+			ncdirect_stop (direct);
+		}
+
+		bool clear () const noexcept
+		{
+			return ncdirect_clear (direct) >= 0;
+		}
+
+		bool set_fg_default () const noexcept
+		{
+			return ncdirect_fg_default (direct) >= 0;
+		}
+
+		bool set_fg (unsigned rgb) const noexcept
+		{
+			return ncdirect_fg (direct, rgb) >= 0;
+		}
+
+		bool set_fg (unsigned r, unsigned g, unsigned b) const noexcept
+		{
+			return ncdirect_fg_rgb8 (direct, r, g, b) >= 0;
+		}
+
+		bool set_bg_default () const noexcept
+		{
+			return ncdirect_bg_default (direct) >= 0;
+		}
+
+		bool set_bg (unsigned rgb) const noexcept
+		{
+			return ncdirect_bg (direct, rgb) >= 0;
+		}
+
+		bool set_bg (unsigned r, unsigned g, unsigned b) const noexcept
+		{
+			return ncdirect_bg_rgb8 (direct, r, g, b) >= 0;
+		}
+
+		int get_dim_x () const noexcept
+		{
+			return ncdirect_dim_x (direct);
+		}
+
+		int get_dim_y () const noexcept
+		{
+			return ncdirect_dim_y (direct);
+		}
+
+		void styles_set (CellStyle stylebits) const noexcept
+		{
+			ncdirect_styles_set (direct, static_cast<unsigned>(stylebits));
+		}
+
+		void styles_on (CellStyle stylebits) const noexcept
+		{
+			ncdirect_styles_on (direct, static_cast<unsigned>(stylebits));
+		}
+
+		void styles_off (CellStyle stylebits) const noexcept
+		{
+			ncdirect_styles_off (direct, static_cast<unsigned>(stylebits));
+		}
+
+	private:
+		ncdirect *direct;
+	};
+}
+#endif

--- a/include/ncpp/Menu.hh
+++ b/include/ncpp/Menu.hh
@@ -1,0 +1,77 @@
+#ifndef __NCPP_MENU_HH
+#define __NCPP_MENU_HH
+
+#include <notcurses.h>
+
+#include "Root.hh"
+
+namespace ncpp
+{
+	class Plane;
+
+	class NCPP_API_EXPORT Menu : public Root
+	{
+	public:
+		static ncmenu_options default_options;
+
+	public:
+		explicit Menu (const ncmenu_options *opts = nullptr)
+		{
+			menu = ncmenu_create (get_notcurses (), opts == nullptr ? &default_options : opts);
+			if (menu == nullptr)
+				throw new init_error ("notcurses failed to create a new menu");
+		}
+
+		~Menu ()
+		{
+			if (!is_notcurses_stopped ())
+				ncmenu_destroy (menu);
+		}
+
+		bool unroll (int sectionidx) const noexcept
+		{
+			return ncmenu_unroll (menu, sectionidx) >= 0;
+		}
+
+		bool rollup () const noexcept
+		{
+			return ncmenu_rollup (menu) >= 0;
+		}
+
+		bool nextsection () const noexcept
+		{
+			return ncmenu_nextsection (menu) >= 0;
+		}
+
+		bool prevsection () const noexcept
+		{
+			return ncmenu_prevsection (menu) >= 0;
+		}
+
+		bool nextitem () const noexcept
+		{
+			return ncmenu_nextitem (menu) >= 0;
+		}
+
+		bool previtem () const noexcept
+		{
+			return ncmenu_previtem (menu) >= 0;
+		}
+
+		const char* get_selected (ncinput *ni = nullptr) const noexcept
+		{
+			return ncmenu_selected (menu, ni);
+		}
+
+		bool offer_input (const struct ncinput* nc) const noexcept
+		{
+			return ncmenu_offer_input (menu, nc);
+		}
+
+		Plane* get_plane () const noexcept;
+
+	private:
+		ncmenu *menu;
+	};
+}
+#endif

--- a/include/ncpp/Selector.hh
+++ b/include/ncpp/Selector.hh
@@ -1,0 +1,87 @@
+#ifndef __NCPP_SELECTOR_HH
+#define __NCPP_SELECTOR_HH
+
+#include <notcurses.h>
+
+#include "Root.hh"
+#include "NCAlign.hh"
+
+namespace ncpp
+{
+	class Plane;
+
+	class NCPP_API_EXPORT Selector : public Root
+	{
+	public:
+		static selector_options default_options;
+
+	public:
+		explicit Selector (Plane *plane, int y, int x, const selector_options *opts = nullptr)
+			: Selector (reinterpret_cast<ncplane*>(plane), y, x, opts)
+		{}
+
+		explicit Selector (Plane const* plane, int y, int x, const selector_options *opts = nullptr)
+			: Selector (const_cast<Plane*>(plane), y, x, opts)
+		{}
+
+		explicit Selector (Plane &plane, int y, int x, const selector_options *opts = nullptr)
+			: Selector (reinterpret_cast<ncplane*>(&plane), y, x, opts)
+		{}
+
+		explicit Selector (Plane const& plane, int y, int x, const selector_options *opts = nullptr)
+			: Selector (const_cast<Plane*>(&plane), y, x, opts)
+		{}
+
+		explicit Selector (ncplane *plane, int y, int x, const selector_options *opts = nullptr)
+		{
+			if (plane == nullptr)
+				throw new invalid_argument ("'plane' must be a valid pointer");
+
+			selector = ncselector_create (plane, y, x, opts == nullptr ? &default_options : opts);
+			if (selector == nullptr)
+				throw new init_error ("notcurses failed to create a new selector");
+		}
+
+		~Selector ()
+		{
+			if (!is_notcurses_stopped ())
+				ncselector_destroy (selector, nullptr);
+		}
+
+		bool additem (const selector_item *item) const noexcept
+		{
+			return ncselector_additem (selector, item) >= 0;
+		}
+
+		bool delitem (const char *item) const noexcept
+		{
+			return ncselector_delitem (selector, item) >= 0;
+		}
+
+		const char* previtem () const noexcept
+		{
+			return ncselector_previtem (selector);
+		}
+
+		const char* nextitem () const noexcept
+		{
+			return ncselector_nextitem (selector);
+		}
+
+		const char* get_selected () const noexcept
+		{
+			return ncselector_selected (selector);
+		}
+
+		bool offer_input (const struct ncinput* nc) const noexcept
+		{
+			return ncselector_offer_input (selector, nc);
+		}
+
+		Plane* get_plane () const noexcept;
+
+	private:
+		ncselector *selector;
+	};
+}
+#endif

--- a/src/libcpp/Menu.cc
+++ b/src/libcpp/Menu.cc
@@ -1,0 +1,18 @@
+#include <ncpp/Plane.hh>
+#include <ncpp/Menu.hh>
+
+using namespace ncpp;
+
+ncmenu_options Menu::default_options = {
+	/* bottom */ false,
+	/* hiding */ true,
+	/* sections */ nullptr,
+	/* sectioncount */ 0,
+	/* headerchannels */ 0,
+	/* sectionchannels */ 0,
+};
+
+Plane* Menu::get_plane () const noexcept
+{
+	return Plane::map_plane (ncmenu_plane (menu));
+}

--- a/src/libcpp/Selector.cc
+++ b/src/libcpp/Selector.cc
@@ -1,0 +1,25 @@
+#include <ncpp/Plane.hh>
+#include <ncpp/Selector.hh>
+
+using namespace ncpp;
+
+selector_options Selector::default_options = {
+	/* title */ nullptr,
+	/* secondary */ nullptr,
+	/* footer */ nullptr,
+	/* items */ nullptr,
+	/* itemcount */ 0,
+	/* defidx */ 0,
+	/* maxdisplay */ 0,
+	/* opchannels */ 0,
+	/* descchannels */ 0,
+	/* titlechannels */ 0,
+	/* footchannels */ 0,
+	/* boxchannels */ 0,
+	/* bgchannels */ 0,
+};
+
+Plane* Selector::get_plane () const noexcept
+{
+	return Plane::map_plane (ncselector_plane (selector));
+}


### PR DESCRIPTION
New classes:

 * Direct (`ncdirect_*`)
 * Menu (`ncmenu_*`)
 * Selector (`ncselector_*`)

Updates:

 * Plane: added copy constructors (mapped to `ncplane_dup`)
 * Plane: added `perimeter` (`ncplane_perimeter`)
 * Plane: added `polyfill` (`ncplane_polyfill`)
 * Plane: added `blit_bgrx` (`ncblit_bgrx`)
 * Plane: added `blit_rgba` (`ncblit_rgba`)