### PR TITLE
[C++] API sync + some (breaking) changes

### DIFF
--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -12,11 +12,11 @@ namespace ncpp
 	class NCPP_API_EXPORT Direct : public Root
 	{
 	public:
-		explicit Direct (const char *termtype, FILE *fp = nullptr)
+		explicit Direct (const char *termtype = nullptr, FILE *fp = nullptr)
 		{
 			direct = notcurses_directmode (termtype, fp == nullptr ? stdout : fp);
 			if (direct == nullptr)
-				throw new init_error ("notcurses failed to initialize direct mode");
+				throw init_error ("notcurses failed to initialize direct mode");
 		}
 
 		~Direct ()

--- a/include/ncpp/Menu.hh
+++ b/include/ncpp/Menu.hh
@@ -19,7 +19,7 @@ namespace ncpp
 		{
 			menu = ncmenu_create (get_notcurses (), opts == nullptr ? &default_options : opts);
 			if (menu == nullptr)
-				throw new init_error ("notcurses failed to create a new menu");
+				throw init_error ("notcurses failed to create a new menu");
 		}
 
 		~Menu ()

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -49,9 +49,9 @@ namespace ncpp
 		static NotCurses& get_instance ()
 		{
 			if (_instance == nullptr)
-				throw new invalid_state_error ("NotCurses instance not found.");
+				throw invalid_state_error ("NotCurses instance not found.");
 			if (_instance->nc == nullptr)
-				throw new invalid_state_error (ncpp_invalid_state_message);
+				throw invalid_state_error (ncpp_invalid_state_message);
 
 			return *_instance;
 		}
@@ -88,7 +88,7 @@ namespace ncpp
 		bool stop ()
 		{
 			if (nc == nullptr)
-				throw new invalid_state_error (ncpp_invalid_state_message);
+				throw invalid_state_error (ncpp_invalid_state_message);
 
 			notcurses_stop (nc);
 			nc = nullptr;
@@ -122,7 +122,7 @@ namespace ncpp
 		void reset_stats (ncstats *stats) const
 		{
 			if (stats == nullptr)
-				throw new invalid_argument ("'stats' must be a valid pointer");
+				throw invalid_argument ("'stats' must be a valid pointer");
 
 			notcurses_reset_stats (nc, stats);
 		}
@@ -130,7 +130,7 @@ namespace ncpp
 		bool use (const Palette256 *p) const
 		{
 			if (p == nullptr)
-				throw new invalid_argument ("'p' must be a valid pointer");
+				throw invalid_argument ("'p' must be a valid pointer");
 
 			return use (*p);
 		}
@@ -206,6 +206,11 @@ namespace ncpp
 		char* get_at (int yoff, int xoff, Cell &c) const noexcept
 		{
 			return notcurses_at_yx (nc, yoff, xoff, c);
+		}
+
+		void drop_planes () const noexcept
+		{
+			notcurses_drop_planes (nc);
 		}
 
 		Plane* get_stdplane () noexcept

--- a/include/ncpp/Palette256.hh
+++ b/include/ncpp/Palette256.hh
@@ -13,7 +13,7 @@ namespace ncpp
 		{
 			palette = palette256_new (get_notcurses ());
 			if (palette == nullptr)
-				throw new init_error ("notcurses failed to create a new palette");
+				throw init_error ("notcurses failed to create a new palette");
 		}
 
 		~Palette256 ()
@@ -44,11 +44,11 @@ namespace ncpp
 		bool get (int idx, unsigned *r, unsigned *g, unsigned *b) const
 		{
 			if (r == nullptr)
-				throw new invalid_argument ("'r' must be a valid pointer");
+				throw invalid_argument ("'r' must be a valid pointer");
 			if (g == nullptr)
-				throw new invalid_argument ("'g' must be a valid pointer");
+				throw invalid_argument ("'g' must be a valid pointer");
 			if (b == nullptr)
-				throw new invalid_argument ("'b' must be a valid pointer");
+				throw invalid_argument ("'b' must be a valid pointer");
 
 			return get (idx, *r, *g, *b);
 		}

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -43,7 +43,7 @@ namespace ncpp
 			);
 
 			if (plane == nullptr)
-				throw new init_error ("notcurses failed to create a new plane");
+				throw init_error ("notcurses failed to create a new plane");
 
 			map_plane (plane, this);
 		}
@@ -61,7 +61,7 @@ namespace ncpp
 		explicit Plane (Plane *n, int rows, int cols, int yoff, NCAlign align, void *opaque = nullptr)
 		{
 			if (n == nullptr)
-				throw new invalid_argument ("'n' must be a valid pointer");
+				throw invalid_argument ("'n' must be a valid pointer");
 
 			plane = create_plane (*n, rows, cols, yoff, align, opaque);
 		}
@@ -69,7 +69,7 @@ namespace ncpp
 		explicit Plane (Plane const* n, int rows, int cols, int yoff, NCAlign align, void *opaque = nullptr)
 		{
 			if (n == nullptr)
-				throw new invalid_argument ("'n' must be a valid pointer");
+				throw invalid_argument ("'n' must be a valid pointer");
 
 			plane = create_plane (const_cast<Plane&>(*n), rows, cols, yoff, align, opaque);
 		}
@@ -116,6 +116,16 @@ namespace ncpp
 		bool pulse (const timespec* ts, fadecb fader, void* curry) const noexcept
 		{
 			return ncplane_pulse (plane, ts, fader, curry) != -1;
+		}
+
+		bool gradient (const char* egc, uint32_t attrword, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ystop, int xstop) const noexcept
+		{
+			return ncplane_gradient (plane, egc, attrword, ul, ur, ll, lr, ystop, xstop) != -1;
+		}
+
+		bool gradient_sized (const char* egc, uint32_t attrword, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ylen, int xstop) const noexcept
+		{
+			return ncplane_gradient_sized (plane, egc, attrword, ul, ur, ll, lr, ylen, xstop) != -1;
 		}
 
 		void greyscale () const noexcept
@@ -231,7 +241,7 @@ namespace ncpp
 		bool move_below (Plane *below) const
 		{
 			if (below == nullptr)
-				throw new invalid_argument ("'below' must be a valid pointer");
+				throw invalid_argument ("'below' must be a valid pointer");
 
 			return move_below (*below);
 		}
@@ -244,7 +254,7 @@ namespace ncpp
 		bool move_below_unsafe (Plane *below) const
 		{
 			if (below == nullptr)
-				throw new invalid_argument ("'below' must be a valid pointer");
+				throw invalid_argument ("'below' must be a valid pointer");
 
 			return move_below_unsafe (*below);
 		}
@@ -257,7 +267,7 @@ namespace ncpp
 		bool move_above (Plane *above) const
 		{
 			if (above == nullptr)
-				throw new invalid_argument ("'above' must be a valid pointer");
+				throw invalid_argument ("'above' must be a valid pointer");
 
 			return move_above (*above);
 		}
@@ -270,7 +280,7 @@ namespace ncpp
 		bool move_above_unsafe (Plane *above) const
 		{
 			if (above == nullptr)
-				throw new invalid_argument ("'above' must be a valid pointer");
+				throw invalid_argument ("'above' must be a valid pointer");
 
 			return move_above (*above);
 		}
@@ -298,7 +308,7 @@ namespace ncpp
 		int putc (const Cell *c) const
 		{
 			if (c == nullptr)
-				throw new invalid_argument ("'c' must be a valid pointer");
+				throw invalid_argument ("'c' must be a valid pointer");
 
 			return putc (*c);
 		}
@@ -773,7 +783,7 @@ namespace ncpp
 		int duplicate (Cell &target, Cell *source) const
 		{
 			if (source == nullptr)
-				throw new invalid_argument ("'source' must be a valid pointer");
+				throw invalid_argument ("'source' must be a valid pointer");
 
 			return duplicate (target, *source);
 		}
@@ -781,7 +791,7 @@ namespace ncpp
 		int duplicate (Cell &target, Cell const* source) const
 		{
 			if (source == nullptr)
-				throw new invalid_argument ("'source' must be a valid pointer");
+				throw invalid_argument ("'source' must be a valid pointer");
 
 			return duplicate (target, *source);
 		}
@@ -789,9 +799,9 @@ namespace ncpp
 		int duplicate (Cell *target, Cell *source) const
 		{
 			if (target == nullptr)
-				throw new invalid_argument ("'target' must be a valid pointer");
+				throw invalid_argument ("'target' must be a valid pointer");
 			if (source == nullptr)
-				throw new invalid_argument ("'source' must be a valid pointer");
+				throw invalid_argument ("'source' must be a valid pointer");
 
 			return duplicate (*target, *source);
 		}
@@ -799,9 +809,9 @@ namespace ncpp
 		int duplicate (Cell *target, Cell const* source) const
 		{
 			if (target == nullptr)
-				throw new invalid_argument ("'target' must be a valid pointer");
+				throw invalid_argument ("'target' must be a valid pointer");
 			if (source == nullptr)
-				throw new invalid_argument ("'source' must be a valid pointer");
+				throw invalid_argument ("'source' must be a valid pointer");
 
 			return duplicate (*target, *source);
 		}
@@ -809,7 +819,7 @@ namespace ncpp
 		int duplicate (Cell *target, Cell &source) const
 		{
 			if (target == nullptr)
-				throw new invalid_argument ("'target' must be a valid pointer");
+				throw invalid_argument ("'target' must be a valid pointer");
 
 			return duplicate (*target, source);
 		}
@@ -817,7 +827,7 @@ namespace ncpp
 		int duplicate (Cell *target, Cell const& source) const
 		{
 			if (target == nullptr)
-				throw new invalid_argument ("'target' must be a valid pointer");
+				throw invalid_argument ("'target' must be a valid pointer");
 
 			return duplicate (*target, source);
 		}
@@ -858,7 +868,7 @@ namespace ncpp
 			  is_stdplane (_is_stdplane)
 		{
 			if (_plane == nullptr)
-				throw new invalid_argument ("_plane must be a valid pointer");
+				throw invalid_argument ("_plane must be a valid pointer");
 		}
 
 		static void unmap_plane (Plane *p) noexcept;
@@ -876,7 +886,7 @@ namespace ncpp
 			);
 
 			if (ret == nullptr)
-				throw new init_error ("notcurses failed to create an aligned plane");
+				throw init_error ("notcurses failed to create an aligned plane");
 
 			map_plane (plane, this);
 
@@ -887,7 +897,7 @@ namespace ncpp
 		{
 			ncplane *ret = ncplane_dup (other.plane, opaque);
 			if (ret == nullptr)
-				throw new init_error ("notcurses failed to duplicate plane");
+				throw init_error ("notcurses failed to duplicate plane");
 
 			is_stdplane = other.is_stdplane;
 			return ret;

--- a/include/ncpp/Reel.hh
+++ b/include/ncpp/Reel.hh
@@ -16,18 +16,22 @@ namespace ncpp
 	public:
 		static ncreel_options default_options;
 
-		explicit NcReel (Plane *plane, const ncreel_options *popts, int efd)
+		explicit NcReel (Plane &plane, const ncreel_options *popts = nullptr, int efd = -1)
+			: NcReel (&plane, popts, efd)
+		{}
+
+		explicit NcReel (Plane *plane, const ncreel_options *popts = nullptr, int efd = -1)
 		{
 			if (plane == nullptr)
-				throw new invalid_argument ("'plane' must be a valid pointer");
+				throw invalid_argument ("'plane' must be a valid pointer");
 
 			create_reel (reinterpret_cast<ncplane*>(plane), popts, efd);
 		}
 
-		explicit NcReel (ncplane *plane, const ncreel_options *popts, int efd)
+		explicit NcReel (ncplane *plane, const ncreel_options *popts = nullptr, int efd = -1)
 		{
 			if (plane == nullptr)
-				throw new invalid_argument ("'plane' must be a valid pointer");
+				throw invalid_argument ("'plane' must be a valid pointer");
 
 			create_reel (plane, popts, efd);
 		}
@@ -53,7 +57,7 @@ namespace ncpp
 		{
 			nctablet *t = ncreel_add (reel, get_tablet (after), get_tablet (before), cb, opaque);
 			if (t == nullptr)
-				throw new init_error ("notcurses failed to create a new tablet");
+				throw init_error ("notcurses failed to create a new tablet");
 
 			return NcTablet::map_tablet (t);
 		}
@@ -145,7 +149,7 @@ namespace ncpp
 		{
 			reel = ncreel_create (plane, popts == nullptr ? &default_options : popts, efd);
 			if (reel == nullptr)
-				throw new init_error ("notcurses failed to create a new ncreel");
+				throw init_error ("notcurses failed to create a new ncreel");
 		}
 
 	private:

--- a/include/ncpp/Selector.hh
+++ b/include/ncpp/Selector.hh
@@ -35,11 +35,11 @@ namespace ncpp
 		explicit Selector (ncplane *plane, int y, int x, const selector_options *opts = nullptr)
 		{
 			if (plane == nullptr)
-				throw new invalid_argument ("'plane' must be a valid pointer");
+				throw invalid_argument ("'plane' must be a valid pointer");
 
 			selector = ncselector_create (plane, y, x, opts == nullptr ? &default_options : opts);
 			if (selector == nullptr)
-				throw new init_error ("notcurses failed to create a new selector");
+				throw init_error ("notcurses failed to create a new selector");
 		}
 
 		~Selector ()

--- a/include/ncpp/Tablet.hh
+++ b/include/ncpp/Tablet.hh
@@ -19,7 +19,7 @@ namespace ncpp
 			: _tablet (t)
 		{
 			if (t == nullptr)
-				throw new invalid_argument ("'t' must be a valid pointer");
+				throw invalid_argument ("'t' must be a valid pointer");
 		};
 
 	public:

--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -17,21 +17,33 @@ namespace ncpp
 			: Visual (reinterpret_cast<ncplane*>(plane), file, averr)
 		{}
 
+		explicit Visual (Plane const* plane, const char *file, int *averr)
+			: Visual (const_cast<Plane*>(plane), file, averr)
+		{}
+
+		explicit Visual (Plane &plane, const char *file, int *averr)
+			: Visual (reinterpret_cast<ncplane*>(&plane), file, averr)
+		{}
+
+		explicit Visual (Plane const& plane, const char *file, int *averr)
+			: Visual (const_cast<Plane&>(plane), file, averr)
+		{}
+
 		explicit Visual (ncplane *plane, const char *file, int *averr)
 		{
 			if (plane == nullptr)
-				throw new invalid_argument ("'plane' must be a valid pointer");
+				throw invalid_argument ("'plane' must be a valid pointer");
 
 			visual = ncplane_visual_open (reinterpret_cast<ncplane*>(plane), file, averr);
 			if (visual == nullptr)
-				throw new init_error ("notcurses failed to create a new visual");
+				throw init_error ("notcurses failed to create a new visual");
 		}
 
 		explicit Visual (const char *file, int *averr, int y, int x, NCScale scale)
 		{
 			visual = ncvisual_open_plane (get_notcurses (), file, averr, y, x, static_cast<ncscale_e>(scale));
 			if (visual == nullptr)
-				throw new init_error ("notcurses failed to create a new visual");
+				throw init_error ("notcurses failed to create a new visual");
 		}
 
 		~Visual () noexcept

--- a/src/poc/ncpp_build.cpp
+++ b/src/poc/ncpp_build.cpp
@@ -1,0 +1,57 @@
+//
+// This is a **build** test - it does nothing else except ensure that all the C++ wrapper classes are included and that
+// the program builds.
+//
+// Once there are demos which exercise all the C++ classes this "test" can be removed
+//
+#include <cstdlib>
+#include <clocale>
+#include <iostream>
+#include <ncpp/NotCurses.hh>
+#include <ncpp/Menu.hh>
+#include <ncpp/Plane.hh>
+#include <ncpp/Reel.hh>
+#include <ncpp/Selector.hh>
+#include <ncpp/Visual.hh>
+#include <ncpp/Direct.hh>
+
+using namespace ncpp;
+
+int run ()
+{
+	NotCurses nc;
+
+	const char *ncver = nc.version ();
+	Plane plane (1, 1, 0, 0);
+
+	nc.stop ();
+
+	Direct direct (getenv ("TERM"));
+	direct.set_fg (0xb5, 0x0d, 0xff);
+	std::cout << "notcurses version: ";
+	direct.set_bg (0x05, 0x6e, 0xee);
+	direct.set_fg (0xe2, 0xbf, 0x00);
+	std::cout << ncver << std::endl;
+
+	return 0;
+}
+
+int main ()
+{
+	if (!setlocale (LC_ALL, "")){
+		std::cerr << "Couldn't set locale based on user preferences" << std::endl;
+		return EXIT_FAILURE;
+	}
+	
+	try {
+		return run ();
+	} catch (ncpp::init_error &e) {
+		std::cerr << "Initialization error: " << e.what () << std::endl;
+	} catch (ncpp::invalid_state_error &e) {
+		std::cerr << "Invalid state error: " << e.what () << std::endl;
+	} catch (ncpp::invalid_argument &e) {
+		std::cerr << "Invalid argument error: " << e.what () << std::endl;
+	}
+
+	return 1;
+}


### PR DESCRIPTION
Added:

 * Plane: gradient (`ncplane_gradient`)
 * Plane: gradient_sized (`ncplane_gradient_sized`)
 * NotCurses: drop_planes (`ncplane_drop_planes`)
 * NcReel: constructor which takes `Plane&`
 * Visual: constructors which take `Plane const*`, `Plane&` and `Plane const&`)
 * ncpp_build: a nonsensical "demo" which exists purely to test whether
   the C++ builds and does absolutely nothing interesting.

Broke:
 * All exceptions throw temporary objects instead of allocated
   instances. Less typing in `catch` :P (and more conventional)