### PR TITLE
[C++] API sync

### DIFF
--- a/include/ncpp/Cell.hh
+++ b/include/ncpp/Cell.hh
@@ -61,6 +61,16 @@ namespace ncpp
 			cell_init (&_cell);
 		}
 
+		uint32_t get_attrword () const noexcept
+		{
+			return _cell.attrword;
+		}
+
+		uint64_t get_channels () const noexcept
+		{
+			return _cell.channels;
+		}
+
 		uint64_t set_fchannel (uint32_t channel) noexcept
 		{
 			return cell_set_fchannel (&_cell, channel);

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -218,6 +218,21 @@ namespace ncpp
 			return new Plane (notcurses_stdplane (nc), true);
 		}
 
+		Plane* get_stdplane (int *y, int *x)
+		{
+			if (y == nullptr)
+				throw invalid_argument ("'y' must be a valid pointer");
+			if (x == nullptr)
+				throw invalid_argument ("'x' must be a valid pointer");
+
+			return get_stdplane (*y, *x);
+		}
+
+		Plane* get_stdplane (int &y, int &x) noexcept
+		{
+			return new Plane (notcurses_stddim_yx (nc, &y, &x));
+		}
+
 		Plane* get_top () noexcept;
 
 	private:


### PR DESCRIPTION
Added:
 * Cell: get_addrword (`cell.attrword`)
 * Cell: get_channels (`cell.channels`)
 * NotCurses: get_stdplane overloads (`notcurses_stddim_yx`)
 * Plane: putc (support for `ncplane_putsimple_stainable`,
   `ncplane_putegc_stainable`, `ncplane_putwegc_stainable`)
 * Plane: format (`ncplane_format`)
 * Plane: stain (`ncplane_stain`)
 * Plane: translate (`ncplane_translate`)