### PR TITLE
Mouse control of selector, refresh in demo

### DIFF
--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -13,7 +13,7 @@
 * Repack DFSG-safe tarball, upload to github
   * download github-spun tarball
   * remove nonfree multimedia:
-    * rm data/chun* data/[deflmPw]* src/demo/jungle.c
+    * rm data/chun* data/[adeflmPw]* src/demo/jungle.c
   * `tar -cJf ../v$VERSION.dfsg.tar.xz -C.. notcurses-$VERSION`
   * upload to github
 * Build new Debian package

--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <limits.h>
+#include <pthread.h>
 #include <stdatomic.h>
 #include <version.h>
 #include <notcurses/notcurses.h>
@@ -145,6 +146,9 @@ int hud_schedule(const char* demoname);
 int demo_render(struct notcurses* nc);
 
 #define DEMO_RENDER(nc) { int demo_render_err = demo_render(nc); if(demo_render_err){ return demo_render_err; }}
+
+// locked by callers to notcurses_render() and notcurses_refresh(), all internal
+extern pthread_mutex_t demo_render_lock;
 
 // if you won't be doing things, and it's a long sleep, consider using
 // demo_nanosleep(). it updates the HUD, which looks better to the user.

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -5,6 +5,8 @@
 // their mouse. it should always be on the top of the z-stack.
 struct ncplane* hud = NULL;
 
+pthread_mutex_t demo_render_lock = PTHREAD_MUTEX_INITIALIZER;
+
 // while the HUD is grabbed by the mouse, these are set to the position where
 // the grab started. they are reset once the HUD is released.
 static int hud_grab_x = -1;
@@ -438,5 +440,9 @@ int demo_render(struct notcurses* nc){
       return -1;
     }
   }
-  return notcurses_render(nc);
+  // lock against a possible notcurses_refresh() on Ctrl+L
+  pthread_mutex_lock(&demo_render_lock);
+  int ret = notcurses_render(nc);
+  pthread_mutex_unlock(&demo_render_lock);
+  return ret;
 }

--- a/src/demo/input.c
+++ b/src/demo/input.c
@@ -92,16 +92,23 @@ ultramegaok_demo(void* vnc){
       continue;
     }
     if(nckey_mouse_p(ni.id)){
-      handle_mouse(&ni);
-    }else{
-      // if this was about the menu or HUD, pass to them, and continue
-      if(menu_or_hud_key(nc, &ni)){
+      if(handle_mouse(&ni)){
         continue;
       }
-      // go ahead and pass keyboard through to demo, even if it was a 'q'
-      // (this might cause the demo to exit immediately, as is desired)
-      pass_along(&ni);
     }
+    if(id == 'L' && ni.ctrl){
+      pthread_mutex_lock(&demo_render_lock);
+      notcurses_refresh(nc);
+      pthread_mutex_unlock(&demo_render_lock);
+      continue;
+    }
+    // if this was about the menu or HUD, pass to them, and continue
+    if(menu_or_hud_key(nc, &ni)){
+      continue;
+    }
+    // go ahead and pass keyboard through to demo, even if it was a 'q'
+    // (this might cause the demo to exit immediately, as is desired)
+    pass_along(&ni);
   }
   return NULL;
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -179,7 +179,7 @@ typedef struct ncselector {
   uint64_t titlechannels;      // title channels
   uint64_t footchannels;       // secondary and footer channels
   uint64_t boxchannels;        // border channels
-  int uarrowy, darrowy, arrowx;// location of scrollarrows, -1 if not present
+  int uarrowy, darrowy, arrowx;// location of scrollarrows, even if not present
 } ncselector;
 
 typedef struct ncdirect {

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -502,6 +502,8 @@ bool ncmenu_offer_input(ncmenu* n, const ncinput* nc){
       return false;
     }
     return true;
+  }else if(nc->id == NCKEY_BUTTON1){
+    // FIXME did we clock on the menu? if so, unroll appropriately
   }
   return false;
 }

--- a/src/poc/menu.c
+++ b/src/poc/menu.c
@@ -58,6 +58,7 @@ run_menu(struct notcurses* nc, struct ncmenu* ncm){
     notcurses_render(nc);
   }
   ncmenu_destroy(ncm);
+  return 0;
 
 err:
   ncplane_destroy(selplane);
@@ -109,10 +110,22 @@ int main(void){
   if(top == NULL){
     goto err;
   }
-
-  struct ncplane* n = notcurses_stdplane(nc);
   int dimy, dimx;
-  ncplane_dim_yx(n, &dimy, &dimx);
+  struct ncplane* n = notcurses_stddim_yx(nc, &dimy, &dimx);
+
+  int averr;
+
+  struct ncvisual* ncv = ncplane_visual_open(n, "../data/ebolavirus_wide-0723bc3f01c644976b4df7e146a1d795aaf9d55e.jpg", &averr);
+  if(!ncv){
+    goto err;
+  }
+  if(!ncvisual_decode(ncv, &averr)){
+    goto err;
+  }
+  if(ncvisual_render(ncv, 0, 0, 0, 0)){
+    goto err;
+  }
+
   uint64_t channels = 0;
   channels_set_fg(&channels, 0x88aa00);
   channels_set_bg(&channels, 0x000088);
@@ -128,6 +141,19 @@ int main(void){
   run_menu(nc, top);
 
   ncplane_erase(n);
+  ncvisual_destroy(ncv);
+
+  ncv = ncplane_visual_open(n, "../data/aidsrobots.jpeg", &averr);
+  if(!ncv){
+    goto err;
+  }
+  if(!ncvisual_decode(ncv, &averr)){
+    goto err;
+  }
+  if(ncvisual_render(ncv, 0, 0, 0, 0)){
+    goto err;
+  }
+
   mopts.bottom = true;
   struct ncmenu* bottom = ncmenu_create(nc, &mopts);
   if(bottom == NULL){
@@ -136,8 +162,9 @@ int main(void){
   if(ncplane_putstr_aligned(n, 0, NCALIGN_RIGHT, " -=+ menu poc. press q to exit +=- ") < 0){
 	  return EXIT_FAILURE;
   }
-  run_menu(nc, top);
+  run_menu(nc, bottom);
 
+  ncvisual_destroy(ncv);
   if(notcurses_stop(nc)){
     return EXIT_FAILURE;
   }

--- a/src/poc/menu.c
+++ b/src/poc/menu.c
@@ -106,6 +106,8 @@ int main(void){
   mopts.sectioncount = sizeof(sections) / sizeof(*sections);
   channels_set_fg(&mopts.headerchannels, 0x00ff00);
   channels_set_bg(&mopts.headerchannels, 0x440000);
+  channels_set_fg(&mopts.sectionchannels, 0xb0d700);
+  channels_set_bg(&mopts.sectionchannels, 0x002000);
   struct ncmenu* top = ncmenu_create(nc, &mopts);
   if(top == NULL){
     goto err;


### PR DESCRIPTION
* demo: `notcurses_refresh()` on Ctrl+L #379 
* fix dumb bugs in poc/menu #383 
* drive ncselector with mouse #305 