### PR TITLE
notcurses_refresh(): properly reset damage buffer #380

### DIFF
--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -939,7 +939,7 @@ int notcurses_refresh(notcurses* nc){
   }
   memset(rvec, 0, size);
   for(int i = 0 ; i < nc->lfdimy * nc->lfdimx ; ++i){
-    rvec->damaged = true;
+    rvec[i].damaged = true;
   }
   int ret = notcurses_rasterize(nc, rvec);
   free(rvec);

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -946,12 +946,6 @@ int notcurses_refresh(notcurses* nc){
   if(ret < 0){
     return -1;
   }
-  if(blocking_write(nc->ttyfd, nc->rstate.mstream, nc->rstate.mstrsize)){
-    return -1;
-  }
-  if(fflush(nc->ttyfp)){
-    return -1;
-  }
   return 0;
 }
 


### PR DESCRIPTION
Resolves #380. We were only initializing the first member of the rvec array properly, hence `notcurses_refresh()` was missing most of the old output.