### PR TITLE
ncpp: stop() propagate out return value, public linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ target_include_directories(notcurses++-static
   )
 
 target_link_libraries(notcurses++
-  PRIVATE
+  PUBLIC
   notcurses)
 
 set(NCPP_COMPILE_OPTIONS

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -90,10 +90,10 @@ namespace ncpp
 			if (nc == nullptr)
 				throw invalid_state_error (ncpp_invalid_state_message);
 
-			notcurses_stop (nc);
+			bool ret = notcurses_stop (nc);
 			nc = nullptr;
 
-			return true;
+			return ret;
 		}
 
 		bool can_fade () const noexcept

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -90,7 +90,7 @@ namespace ncpp
 			if (nc == nullptr)
 				throw invalid_state_error (ncpp_invalid_state_message);
 
-			bool ret = notcurses_stop (nc);
+			bool ret = !notcurses_stop (nc);
 			nc = nullptr;
 
 			return ret;


### PR DESCRIPTION
* `Notcurses::stop()` returns bool, as I would expect (barring the conversion of `notcurses_stop()`'s return value into an exception), but it doesn't actually return a value based on this return. We now return `true` only if `notcurses_stop()` returned 0 (success).

* Change notcurses++ linkage on notcurses to PUBLIC, which seems entirely necessary (I was otherwise getting linkage errors about `notcurses_stop`.