### PR TITLE
ncplane_translate() accept NULL dest as standard plane #408

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,7 @@ target_include_directories(notcurses-tetris
 )
 target_link_libraries(notcurses-tetris
   PRIVATE
+    Threads::Threads
     notcurses++
 )
 target_compile_options(notcurses-tetris

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,6 +447,25 @@ target_compile_definitions(notcurses-ncreel
     FORTIFY_SOURCE=2
 )
 
+file(GLOB TETRISSRC CONFIGURE_DEPENDS src/tetris/*.cpp)
+add_executable(notcurses-tetris ${TETRISSRC})
+target_include_directories(notcurses-tetris
+  PRIVATE
+    "${PROJECT_BINARY_DIR}/include"
+)
+target_link_libraries(notcurses-tetris
+  PRIVATE
+    notcurses
+)
+target_compile_options(notcurses-tetris
+  PRIVATE
+    -Wall -Wextra -W -Wshadow ${DEBUG_OPTIONS}
+)
+target_compile_definitions(notcurses-tetris
+  PRIVATE
+    FORTIFY_SOURCE=2
+)
+
 # notcurses-view
 file(GLOB VIEWSRCS CONFIGURE_DEPENDS src/view/*.cpp)
 if(${USE_FFMPEG})
@@ -681,6 +700,7 @@ install(TARGETS notcurses-demo DESTINATION bin)
 install(TARGETS notcurses-input DESTINATION bin)
 install(TARGETS notcurses-ncreel DESTINATION bin)
 install(TARGETS notcurses-tester DESTINATION bin)
+install(TARGETS notcurses-tetris DESTINATION bin)
 if(${USE_FFMPEG})
 install(TARGETS notcurses-view DESTINATION bin)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ target_include_directories(notcurses++-static
   )
 
 target_link_libraries(notcurses++
-  PRIVATE
+  PUBLIC
   notcurses)
 
 set(NCPP_COMPILE_OPTIONS
@@ -452,11 +452,12 @@ file(GLOB TETRISSRC CONFIGURE_DEPENDS src/tetris/*.cpp)
 add_executable(notcurses-tetris ${TETRISSRC})
 target_include_directories(notcurses-tetris
   PRIVATE
+    include
     "${PROJECT_BINARY_DIR}/include"
 )
 target_link_libraries(notcurses-tetris
   PRIVATE
-    notcurses
+    notcurses++
 )
 target_compile_options(notcurses-tetris
   PRIVATE

--- a/README.md
+++ b/README.md
@@ -1730,8 +1730,7 @@ are arranged in a torus (circular loop), allowing for infinite scrolling
 (infinite scrolling can be disabled, resulting in a line segment rather than a
 torus). This works naturally with keyboard navigation, mouse scrolling wheels,
 and touchpads (including the capacitive touchscreens of modern cell phones).
-The "panel" comes from the underlying ncurses objects (each entity corresponds
-to a single panel) and the "reel" from slot machines. An ncreel initially has
+The term "reel" derives from slot machines. An ncreel initially has
 no tablets; at any given time thereafter, it has zero or more tablets, and if
 there is at least one tablet, one tablet is focused (and on-screen). If the
 last tablet is removed, no tablet is focused. A tablet can support navigation
@@ -1739,7 +1738,7 @@ within the tablet, in which case there is an in-tablet focus for the focused
 tablet, which can also move among elements within the tablet.
 
 The ncreel object tracks the size of the screen, the size, number,
-information depth, and order of tablets, and the focuses. It also draws the
+information depth, and order of tablets, and the foci. It also draws the
 optional borders around tablets and the optional border of the reel itself. It
 knows nothing about the actual content of a tablet, save the number of lines it
 occupies at each information depth. The typical control flow is that an
@@ -1747,7 +1746,7 @@ application receives events (from the UI or other event sources), and calls
 into notcurses saying e.g. "Tablet 2 now has 40 valid lines of information".
 notcurses might then call back into the application, asking it to draw some
 line(s) from some tablet(s) at some particular coordinate of that tablet's
-panel. Finally, control returns to the application, and the cycle starts anew.
+plane. Finally, control returns to the application, and the cycle starts anew.
 
 Each tablet might be wholly, partially, or not on-screen. notcurses always
 places as much of the focused tablet as is possible on-screen (if the focused
@@ -1770,7 +1769,7 @@ The controlling application can, at any time,
   * Remove content from a tablet, possibly resizing it, and possibly changing focus within the tablet
   * Add content to the tablet, possibly resizing it, and possibly creating focus within the tablet
 * Navigate within the focused tablet
-* Create or destroy new panels atop the ncreel
+* Create or destroy new planes atop the ncreel
 * Indicate that the screen has been resized or needs be redrawn
 
 A special case arises when moving among the tablets of a reel having multiple
@@ -1793,11 +1792,11 @@ configured instead.
 
 ```c
 // An ncreel is a notcurses region devoted to displaying zero or more
-// line-oriented, contained panels between which the user may navigate. If at
-// least one panel exists, there is an active panel. As much of the active
-// panel as is possible is always displayed. If there is space left over, other
-// panels are included in the display. Panels can come and go at any time, and
-// can grow or shrink at any time.
+// line-oriented, contained planes ("tablets") between which the user may
+// navigate. If at least one tablet exists, there is an active tablet. As much
+// of the active tablet as is possible is always displayed. If there is space
+// left over, other tablets are included in the display. Tablets can come and go
+// at any time, and can grow or shrink at any time.
 //
 // This structure is amenable to line- and page-based navigation via keystrokes,
 // scrolling gestures, trackballs, scrollwheels, touchpads, and verbal commands.
@@ -1807,7 +1806,7 @@ typedef struct ncreel_options {
   // message will be displayed stating that a larger terminal is necessary, and
   // input will be queued. if 0, no minimum will be enforced. may not be
   // negative. note that ncreel_create() does not return error if given a
-  // WINDOW smaller than these minima; it instead patiently waits for the
+  // plane smaller than these minima; it instead patiently waits for the
   // screen to get bigger.
   int min_supported_cols;
   int min_supported_rows;
@@ -1824,7 +1823,7 @@ typedef struct ncreel_options {
   // reached?). if true, 'circular' specifies how to handle the special case of
   // an incompletely-filled reel.
   bool infinitescroll;
-  // is navigation circular (does moving down from the last panel move to the
+  // is navigation circular (does moving down from the last tablet move to the
   // first, and vice versa)? only meaningful when infinitescroll is true. if
   // infinitescroll is false, this must be false.
   bool circular;
@@ -1846,7 +1845,7 @@ struct nctablet;
 struct ncreel;
 
 // Create an ncreel according to the provided specifications. Returns NULL on
-// failure. w must be a valid WINDOW*, to which offsets are relative. Note that
+// failure. 'nc' must be a valid plane, to which offsets are relative. Note that
 // there might not be enough room for the specified offsets, in which case the
 // ncreel will be clipped on the bottom and right. A minimum number of rows
 // and columns can be enforced via popts. efd, if non-negative, is an eventfd
@@ -1900,7 +1899,7 @@ int ncreel_del(struct ncreel* pr, struct nctablet* t);
 // Delete the active tablet. Returns -1 if there are no tablets.
 int ncreel_del_focused(struct ncreel* pr);
 
-// Move to the specified location within the containing WINDOW.
+// Move to the specified location within the containing plane.
 int ncreel_move(struct ncreel* pr, int x, int y);
 
 // Redraw the ncreel in its entirety, for instance after
@@ -1918,7 +1917,7 @@ struct nctablet* ncreel_next(struct ncreel* pr);
 struct nctablet* ncreel_prev(struct ncreel* pr);
 
 // Destroy an ncreel allocated with ncreel_create(). Does not destroy the
-// underlying WINDOW. Returns non-zero on failure.
+// underlying plane. Returns non-zero on failure.
 int ncreel_destroy(struct ncreel* pr);
 
 // Returns a pointer to a user pointer associated with this nctablet.

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ ncplane_dim_x(const struct ncplane* n){
 
 // provided a coordinate relative to the origin of 'src', map it to the same
 // absolute coordinate relative to thte origin of 'dst'. either or both of 'y'
-// and 'x' may be NULL.
+// and 'x' may be NULL. if 'dst' is NULL, it is taken to be the standard plane.
 void ncplane_translate(const struct ncplane* src, const struct ncplane* dst,
                        int* restrict y, int* restrict x);
 

--- a/doc/man/index.html
+++ b/doc/man/index.html
@@ -22,6 +22,7 @@
   <a href="notcurses-ncreel.1.html">notcurses-ncreel</a>—experiments with ncreels<br/>
   <a href="notcurses-pydemo.1.html">notcurses-pydemo</a>—validates the Python wrappers<br/>
   <a href="notcurses-tester.1.html">notcurses-tester</a>—unit test driver<br/>
+  <a href="notcurses-tetris.1.html">notcurses-tetris</a>—Tetris in the terminal<br/>
   <a href="notcurses-view.1.html">notcurses-view</a>—renders images and video to the terminal<br/>
   <h2>C library (section 3)</h2>
   <a href="notcurses_cell.3.html">notcurses_cell</a>—operations on <tt>cell</tt> objects<br/>

--- a/doc/man/man1/notcurses-tetris.1.md
+++ b/doc/man/man1/notcurses-tetris.1.md
@@ -1,0 +1,32 @@
+% notcurses-tetris(1)
+% nick black <nickblack@linux.com>
+% v1.2.3
+
+# NAME
+
+notcurses-tetris - Render images and video to the console
+
+# SYNOPSIS
+
+**notcurses-tetris** [**-h|--help**] [**-l loglevel**]
+
+# DESCRIPTION
+
+**notcurses-tetris** implements Tetris using notcurses.
+
+# OPTIONS
+
+**-h**: Show help and exit.
+
+**-l loglevel**: Log everything (high log level) or nothing (log level 0) to stderr.
+
+# NOTES
+
+Optimal display requires a terminal advertising the **rgb** terminfo(5)
+capability, or that the environment variable **COLORTERM** is defined to
+**24bit** (and that the terminal honors this variable), along with a
+fixed-width font with good coverage of the Unicode Block Drawing Characters.
+
+# SEE ALSO
+
+**notcurses(3)**

--- a/doc/man/man3/notcurses_ncplane.3.md
+++ b/doc/man/man3/notcurses_ncplane.3.md
@@ -147,6 +147,14 @@ It is an error for two threads to concurrently access a single ncplane. So long
 as rendering is not taking place, however, multiple threads may safely output
 to multiple ncplanes.
 
+**ncplane_translate** translates coordinates expressed relative to the plane
+**src**, and writes the coordinates of that cell relative to **dst**. The cell
+need not intersect with **dst**, though this will yield coordinates which are
+invalid for writing or reading on **dst**. If **dst** is **NULL**, it is taken
+to refer to the standard plane. **ncplane_translate_abs** takes coordinates
+expressed relative to the standard plane, and returns coordinates relative to
+**dst**, returning **false** if the coordinates are invalid for **dst**.
+
 # RETURN VALUES
 
 **ncplane_new(3)**, **ncplane_aligned(3)**, and **ncplane_dup(3)** all return a

--- a/include/ncpp/Cell.hh
+++ b/include/ncpp/Cell.hh
@@ -121,7 +121,7 @@ namespace ncpp
 			return cell_simple_p (&_cell);
 		}
 
-		uint32_t get_edc_idx () const noexcept
+		uint32_t get_egc_idx () const noexcept
 		{
 			return cell_egc_idx (&_cell);
 		}

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -861,8 +861,9 @@ namespace ncpp
 		void translate (const Plane *dst, int *y = nullptr, int *x = nullptr) const
 		{
 			if (dst == nullptr)
-				throw invalid_argument ("'dst' must be a valid pointer");
-			translate (*this, *dst, y, x);
+      	ncplane_translate(*this, nullptr, y, x); // FIXME
+      else
+			  translate (*this, *dst, y, x);
 		}
 
 		void translate (const Plane &dst, int *y = nullptr, int *x = nullptr) noexcept
@@ -876,9 +877,9 @@ namespace ncpp
 				throw invalid_argument ("'src' must be a valid pointer");
 
 			if (dst == nullptr)
-				throw invalid_argument ("'dst' must be a valid pointer");
-
-			translate (*src, *dst, y, x);
+	      ncplane_translate(*src, nullptr, y, x); // FIXME
+      else
+			  translate (*src, *dst, y, x);
 		}
 
 		static void translate (const Plane &src, const Plane &dst, int *y = nullptr, int *x = nullptr) noexcept

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -410,7 +410,7 @@ API struct ncplane* ncplane_dup(struct ncplane* n, void* opaque);
 
 // provided a coordinate relative to the origin of 'src', map it to the same
 // absolute coordinate relative to thte origin of 'dst'. either or both of 'y'
-// and 'x' may be NULL.
+// and 'x' may be NULL. if 'dst' is NULL, it is taken to be the standard plane.
 API void ncplane_translate(const struct ncplane* src, const struct ncplane* dst,
                            int* RESTRICT y, int* RESTRICT x);
 

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -364,9 +364,9 @@ summary_json(FILE* f, const char* spec, int rows, int cols){
     if(results[i].result || !results[i].stats.renders){
       continue;
     }
-    ret |= (fprintf(f, "\"%s\":{\"bytes\":\"%ju\",\"frames\":\"%ju\",\"ns\":\"%ju\"},",
+    ret |= (fprintf(f, "\"%s\":{\"bytes\":\"%ju\",\"frames\":\"%ju\",\"ns\":\"%ju\"}%s",
                     demos[results[i].selector - 'a'].name, results[i].stats.render_bytes,
-                    results[i].stats.renders, results[i].timens) < 0);
+                    results[i].stats.renders, results[i].timens, i < strlen(spec) - 1 ? "," : "") < 0);
   }
   ret |= (fprintf(f, "}}}\n") < 0);
   return ret;

--- a/src/lib/fill.c
+++ b/src/lib/fill.c
@@ -434,7 +434,7 @@ rotate_output(ncplane* dst, uint32_t tchan, uint32_t bchan){
 //
 // Ideally, rotation through 360 degrees will restore the original 2x1 squre.
 // Unfortunately, the case where a half block occupies a cell having the same
-// fore- and background will see it roated into a single full block. In
+// fore- and background will see it rotated into a single full block. In
 // addition, lower blocks eventually become upper blocks with their channels
 // reversed. In general:
 //

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -26,7 +26,6 @@
 #include <signal.h>
 #include <wctype.h>
 #include <stdbool.h>
-#include <pthread.h>
 #include "notcurses/notcurses.h"
 #include "egcpool.h"
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1952,6 +1952,9 @@ bool ncplane_translate_abs(const ncplane* n, int* restrict y, int* restrict x){
 
 void ncplane_translate(const ncplane* src, const ncplane* dst,
                        int* restrict y, int* restrict x){
+  if(dst == NULL){
+    dst = ncplane_stdplane_const(src);
+  }
   if(y){
     *y = src->absy - dst->absy + *y;
   }

--- a/src/tetris/main.cpp
+++ b/src/tetris/main.cpp
@@ -4,7 +4,6 @@
 #include <chrono>
 #include <cstdlib>
 #include <clocale>
-//#include <ncpp/Plane.hh>
 #include <ncpp/NotCurses.hh>
 
 using namespace std::chrono_literals;
@@ -38,8 +37,10 @@ public:
     nc_(nc),
     score_(0),
     msdelay_(10ms),
-    curpiece_(nullptr)
+    curpiece_(nullptr),
+    stdplane_(nc_.get_stdplane())
   {
+    curpiece_ = NewPiece();
     DrawBoard();
   }
 
@@ -73,12 +74,12 @@ private:
   uint64_t score_;
   std::mutex mtx_;
   std::chrono::milliseconds msdelay_;
-  ncpp::Plane* curpiece_;
+  std::unique_ptr<ncpp::Plane> curpiece_;
   ncpp::Plane* stdplane_;
 
   void DrawBoard(){
     int y, x;
-    stdplane_ = nc_.get_stdplane(&y, &x);
+    stdplane_->get_dim(&y, &x);
     uint64_t channels = 0;
     channels_set_fg(&channels, 0x00b040);
     if(!stdplane_->cursor_move(y - (BOARD_HEIGHT + 2), x / 2 - (BOARD_WIDTH + 1))){
@@ -101,8 +102,8 @@ private:
     int y, x;
     stdplane_->get_dim(&y, &x);
     const int xoff = x / 2 - BOARD_WIDTH + (random() % BOARD_WIDTH - 3);
-    const int yoff = y - (BOARD_HEIGHT + 2);
-    std::unique_ptr<ncpp::Plane> n = std::make_unique<ncpp::Plane>(1, cols, yoff, xoff, nullptr);
+    const int yoff = y - (BOARD_HEIGHT + 4);
+    std::unique_ptr<ncpp::Plane> n = std::make_unique<ncpp::Plane>(2, cols, yoff, xoff, nullptr);
     if(n){
       uint64_t channels = 0;
       channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);

--- a/src/tetris/main.cpp
+++ b/src/tetris/main.cpp
@@ -9,6 +9,17 @@
 
 using namespace std::chrono_literals;
 
+class TetrisNotcursesErr : public std::runtime_error {
+public:
+  TetrisNotcursesErr(char const* const message) throw()
+    : std::runtime_error(message) {
+  }
+
+  virtual char const* what() const throw(){
+    return exception::what();
+  }
+};
+
 class Tetris {
 public:
   Tetris(ncpp::NotCurses& nc) :
@@ -56,7 +67,17 @@ private:
   void DrawBoard(){
     int y, x;
     stdplane_ = nc_.get_stdplane(&y, &x);
-    stdplane_->rounded_box(); // FIXME
+    uint64_t channels = 0;
+    channels_set_fg(&channels, 0x00b040);
+    if(!stdplane_->cursor_move(y - (BOARD_HEIGHT + 1), x / 2 - BOARD_WIDTH)){
+      throw TetrisNotcursesErr("cursor_move()");
+    }
+    if(!stdplane_->rounded_box(0, channels, y - 1, x / 2 + BOARD_WIDTH, NCBOXMASK_TOP)){
+      throw TetrisNotcursesErr("rounded_box()");
+    }
+    if(!nc_.render()){
+      throw TetrisNotcursesErr("render()");
+    }
   }
 };
 

--- a/src/tetris/main.cpp
+++ b/src/tetris/main.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <clocale>
+//#include <ncpp/Plane.hh>
 #include <ncpp/NotCurses.hh>
 
 using namespace std::chrono_literals;
@@ -13,9 +14,10 @@ public:
   Tetris(ncpp::NotCurses& nc) :
     nc_(nc),
     score_(0),
-    msdelay_(10ms)
+    msdelay_(10ms),
+    curpiece_(nullptr)
   {
-    // FIXME draw board
+    DrawBoard();
   }
 
   // 0.5 cell aspect: One board height == one row. One board width == two columns.
@@ -25,11 +27,15 @@ public:
   // FIXME ideally this would be called from constructor :/
   void Ticker(){
     std::chrono::milliseconds ms;
+    mtx_.lock();
     do{
-      mtx_.lock();
       ms = msdelay_;
       mtx_.unlock();
       std::this_thread::sleep_for(ms);
+      mtx_.lock();
+      if(curpiece_){
+        // FIXME move it down
+      }
     }while(ms != std::chrono::milliseconds::zero());
   }
 
@@ -44,7 +50,14 @@ private:
   uint64_t score_;
   std::mutex mtx_;
   std::chrono::milliseconds msdelay_;
+  ncpp::Plane* curpiece_;
+  ncpp::Plane* stdplane_;
 
+  void DrawBoard(){
+    int y, x;
+    stdplane_ = nc_.get_stdplane(&y, &x);
+    stdplane_->rounded_box(); // FIXME
+  }
 };
 
 int main(void){

--- a/src/tetris/main.cpp
+++ b/src/tetris/main.cpp
@@ -1,0 +1,6 @@
+#include <cstdlib>
+#include <notcurses/notcurses.h>
+
+int main(void){
+  return EXIT_SUCCESS;
+}

--- a/src/tetris/main.cpp
+++ b/src/tetris/main.cpp
@@ -1,6 +1,33 @@
 #include <cstdlib>
-#include <notcurses/notcurses.h>
+#include <clocale>
+#include <ncpp/NotCurses.hh>
+
+class Tetris {
+public:
+  Tetris(ncpp::NotCurses& nc) :
+    nc_(nc),
+    score_(0)
+  {
+    // FIXME draw board
+  }
+
+  // 0.5 cell aspect: One board height == one row. One board width == two columns.
+  static constexpr auto BOARD_WIDTH = 10;
+  static constexpr auto BOARD_HEIGHT = 20;
+
+private:
+  ncpp::NotCurses& nc_;
+  uint64_t score_;
+
+};
 
 int main(void){
-  return EXIT_SUCCESS;
+  if(setlocale(LC_ALL, "") == nullptr){
+    return EXIT_FAILURE;
+  }
+  notcurses_options ncopts{};
+  ncpp::NotCurses nc(ncopts);
+  Tetris t{nc};
+  // FIXME play game
+  return nc.stop() ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/src/tetris/main.cpp
+++ b/src/tetris/main.cpp
@@ -1,13 +1,19 @@
+#include <iostream>
+#include <mutex>
 #include <thread>
+#include <chrono>
 #include <cstdlib>
 #include <clocale>
 #include <ncpp/NotCurses.hh>
+
+using namespace std::chrono_literals;
 
 class Tetris {
 public:
   Tetris(ncpp::NotCurses& nc) :
     nc_(nc),
-    score_(0)
+    score_(0),
+    msdelay_(10ms)
   {
     // FIXME draw board
   }
@@ -18,16 +24,26 @@ public:
 
   // FIXME ideally this would be called from constructor :/
   void Ticker(){
-    // FIXME check whether we ought die
-    while(true){
-      // FIXME get value from level
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+    std::chrono::milliseconds ms;
+    do{
+      mtx_.lock();
+      ms = msdelay_;
+      mtx_.unlock();
+      std::this_thread::sleep_for(ms);
+    }while(ms != std::chrono::milliseconds::zero());
+  }
+
+  void Stop(){
+    mtx_.lock();
+    msdelay_ = std::chrono::milliseconds::zero(); // FIXME wake it up?
+    mtx_.unlock();
   }
 
 private:
   ncpp::NotCurses& nc_;
   uint64_t score_;
+  std::mutex mtx_;
+  std::chrono::milliseconds msdelay_;
 
 };
 
@@ -38,7 +54,23 @@ int main(void){
   notcurses_options ncopts{};
   ncpp::NotCurses nc(ncopts);
   Tetris t{nc};
-  std::thread tid(&Tetris::Ticker, t);
-  while(true); // FIXME spin on keyboard input, play game
+  std::thread tid(&Tetris::Ticker, &t);
+  char32_t input;
+  ncinput ni;
+  while((input = nc.getc(true, &ni)) != (char32_t)-1){
+    if(input == 'q'){
+      break;
+    }
+    switch(input){
+      case NCKEY_LEFT: break;
+      case NCKEY_RIGHT: break;
+    }
+  }
+  if(input == 'q'){
+    t.Stop();
+    tid.join();
+  }else{
+    return EXIT_FAILURE;
+  }
   return nc.stop() ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/tetris/main.cpp
+++ b/src/tetris/main.cpp
@@ -1,3 +1,4 @@
+#include <thread>
 #include <cstdlib>
 #include <clocale>
 #include <ncpp/NotCurses.hh>
@@ -15,6 +16,15 @@ public:
   static constexpr auto BOARD_WIDTH = 10;
   static constexpr auto BOARD_HEIGHT = 20;
 
+  // FIXME ideally this would be called from constructor :/
+  void Ticker(){
+    // FIXME check whether we ought die
+    while(true){
+      // FIXME get value from level
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
 private:
   ncpp::NotCurses& nc_;
   uint64_t score_;
@@ -28,6 +38,7 @@ int main(void){
   notcurses_options ncopts{};
   ncpp::NotCurses nc(ncopts);
   Tetris t{nc};
-  // FIXME play game
-  return nc.stop() ? EXIT_FAILURE : EXIT_SUCCESS;
+  std::thread tid(&Tetris::Ticker, t);
+  while(true); // FIXME spin on keyboard input, play game
+  return nc.stop() ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
* `ncplane_translate_dst()` now accepts NULL, and in this case takes it to be the standard plane. #408 
* Fix up the corresponding C++ wrapper, but not how @grendello would do it, I think. Passing to him for aproval/change.