### PR TITLE
[C++] Forbid duplication of stdplane

### DIFF
--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -968,7 +968,6 @@ namespace ncpp
 			if (ret == nullptr)
 				throw init_error ("notcurses failed to duplicate plane");
 
-			is_stdplane = other.is_stdplane;
 			return ret;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/dankamongmen/notcurses/issues/409

Standard planes cannot (and must not) be duplicated. Make sure this
isn't happening.