### PR TITLE
Add bound planes (#70) plus docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,16 @@ struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols,
 struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols,
                                 int yoff, ncalign_e align, void* opaque);
 
+// Create a plane bound to plane 'n'. Being bound to 'n' means that 'yoff' and
+// 'xoff' are interpreted relative to that plane's origin, and that if that
+// plane is moved later, this new plane is moved by the same amount.
+struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols,
+                              int yoff, int xoff, void* opaque);
+
+// Plane 'n' will be unbound from its parent plane, if it is currently bound,
+// and will be made a bound child of 'newparent', if 'newparent' is not NULL.
+struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparent);
+
 // Duplicate an existing ncplane. The new plane will have the same geometry,
 // will duplicate all content, and will start with the same rendering state.
 // The new plane will be immediately above the old one on the z axis.

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -403,6 +403,16 @@ API struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols,
 API struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols,
                                     int yoff, ncalign_e align, void* opaque);
 
+// Create a plane bound to plane 'n'. Being bound to 'n' means that 'yoff' and
+// 'xoff' are interpreted relative to that plane's origin, and that if that
+// plane is moved later, this new plane is moved by the same amount.
+API struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols,
+                                  int yoff, int xoff, void* opaque);
+
+// Plane 'n' will be unbound from its parent plane, if it is currently bound,
+// and will be made a bound child of 'newparent', if 'newparent' is not NULL.
+API struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparent);
+
 // Duplicate an existing ncplane. The new plane will have the same geometry,
 // will duplicate all content, and will start with the same rendering state.
 // The new plane will be immediately above the old one on the z axis.

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -100,6 +100,8 @@ void notcurses_drop_planes(struct notcurses* nc);
 int notcurses_refresh(struct notcurses* n);
 int notcurses_resize(struct notcurses* n, int* y, int* x);
 struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque);
+struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque);
+struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparent);
 typedef enum {
   NCALIGN_LEFT,
   NCALIGN_CENTER,

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -63,6 +63,9 @@ typedef struct ncplane {
   int absx, absy;       // origin of the plane relative to the screen
   int lenx, leny;       // size of the plane, [0..len{x,y}) is addressable
   struct ncplane* z;    // plane below us
+  struct ncplane* bnext;// next in the bound list of plane to which we are bound
+  struct ncplane* blist;// head of our own bound list, if any
+  struct ncplane* bound;// plane to which we are bound, if any
   egcpool pool;         // attached storage pool for UTF-8 EGCs
   uint64_t channels;    // works the same way as cells
   uint32_t attrword;    // same deal as in a cell


### PR DESCRIPTION
* `Add ncplane_bound(3)`. This allows a new plane N to be created in the *bound* state relative to another ncplane B. If B moves, N moves the same amount. If N is moved, the coordinates are taken relative to B as opposed to the standard plane. If B is destroyed, N is destroyed. Each plane can have many planes bound to it, but can only be bound to a single plane.
* Add `ncplane_reparent(3)`. This allows a plane to be detached from any plane to which it is bound, and optionally rebound to a new plane. The standard plane cannot be reparented.
* Documentation and unit tests have been added for both.