### PR TITLE
demo.c needs errno.h

### DIFF
--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -8,6 +8,7 @@
 #include <getopt.h>
 #include <stdlib.h>
 #include <stdatomic.h>
+#include <errno.h>
 #include "demo.h"
 
 // (non-)ansi terminal definition-4-life


### PR DESCRIPTION
Woo, contributing.  The most boring of all contributions, though yesterday I did contribute a one line change to configure.ac for cups-filters to remove bash-specific syntax.  Enjoy.