### PR TITLE
Plots; add y-axis label option + implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,7 @@ target_include_directories(notcurses-keyplot
 )
 target_link_libraries(notcurses-keyplot
   PRIVATE
+    Threads::Threads
     notcurses++
 )
 target_compile_options(notcurses-keyplot

--- a/doc/man/man3/notcurses_plot.3.md
+++ b/doc/man/man3/notcurses_plot.3.md
@@ -31,9 +31,9 @@ typedef struct ncplot_options {
   // dependent min and max. set both equal to 0 to
   // use domain autodiscovery.
   int64_t miny, maxy;
-  bool exponentialy;  // is dependent exponential?
-  // independent variable is vertical, not horizontal
-  bool vertical_indep;
+  bool labelaxisd;     // label dependent axis
+  bool exponentialy;   // is dependent exponential?
+  bool vertical_indep; // vertical independent variable
 } ncplot_options;
 ```
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2518,15 +2518,14 @@ typedef struct ncplot_options {
   // applied across the domain between these two.
   uint64_t maxchannel;
   uint64_t minchannel;
-  // number of "pixels" per row x column
-  ncgridgeom_e gridtype;
+  ncgridgeom_e gridtype; // number of "pixels" per row x column
   // independent variable can either be a contiguous range, or a finite set
   // of keys. for a time range, say the previous hour sampled with second
   // resolution, the independent variable would be the range [0..3600): 3600.
   // if rangex is 0, it is dynamically set to the number of columns.
   uint64_t rangex;
-  // y axis min and max. for autodiscovery, these must be equal
-  int64_t miny, maxy;
+  int64_t miny, maxy; // y axis min and max. for autodiscovery, set them equal.
+  bool labelaxisd; // generate labels for the dependent axis
   bool exponentialy;  // is y-axis exponential? (not yet implemented)
   // independent variable is vertical rather than horizontal
   bool vertical_indep;

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -423,8 +423,8 @@ typedef struct ncplot_options {
   ncgridgeom_e gridtype;
   uint64_t rangex;
   int64_t miny, maxy;
+  bool labelaxisd;
   bool exponentialy;
-  bool detectdomain;
   bool vertical_indep;
 } ncplot_options;
 struct ncplot* ncplot_create(struct ncplane* n, const ncplot_options* opts);

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -1,6 +1,7 @@
 #include <time.h>
 #include <wchar.h>
 #include <stdio.h>
+#include <errno.h>
 #include <limits.h>
 #include <string.h>
 #include <locale.h>
@@ -8,7 +9,6 @@
 #include <getopt.h>
 #include <stdlib.h>
 #include <stdatomic.h>
-#include <errno.h>
 #include "demo.h"
 
 // (non-)ansi terminal definition-4-life

--- a/src/input/keyplot.cpp
+++ b/src/input/keyplot.cpp
@@ -34,6 +34,7 @@ int main(void){
   planes.emplace_back(6, plotlen, 23,  1, nullptr);
   planes.emplace_back(6, plotlen, 31,  1, nullptr);
   struct ncplot_options popts{};
+  popts.labelaxisd = true;
   std::array<struct ncplot*, 5> plots;
   for(auto i = 0u ; i < plots.size() ; ++i){
     popts.maxchannel = 0;

--- a/src/input/keyplot.cpp
+++ b/src/input/keyplot.cpp
@@ -34,10 +34,12 @@ int main(void){
   planes.emplace_back(6, plotlen, 23,  1, nullptr);
   planes.emplace_back(6, plotlen, 31,  1, nullptr);
   struct ncplot_options popts{};
-  popts.labelaxisd = true;
   std::array<struct ncplot*, 5> plots;
   for(auto i = 0u ; i < plots.size() ; ++i){
-    popts.maxchannel = 0;
+    if(i == plots.size() - 1){
+      popts.labelaxisd = true;
+    }
+    popts.minchannel = popts.maxchannel = 0;
     channels_set_fg_rgb(&popts.maxchannel, random() % 256, random() % 256, random() % 256);
     channels_set_fg_rgb(&popts.minchannel, random() % 256, random() % 256, random() % 256);
     popts.gridtype = static_cast<ncgridgeom_e>(i);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -167,6 +167,7 @@ typedef struct ncplot {
   unsigned slotstart; // slot index corresponding to slotx
   uint64_t slotx; // x value corresponding to slots[slotstart]
   unsigned slotcount;
+  bool labelaxisd; // label dependent axis
   bool exponentialy;
   bool detectdomain;
 } ncplot;

--- a/src/lib/plot.c
+++ b/src/lib/plot.c
@@ -132,7 +132,6 @@ update_sample(ncplot* n, uint64_t x, int64_t y, bool reset){
   if(reset){
     n->slots[idx] = y;
   }else{
-fprintf(stderr, "%jd/%jd\n", n->slots[idx], y);
     n->slots[idx] += y;
   }
 }
@@ -147,7 +146,6 @@ redraw_plot(ncplot* n){
   double interval = (n->maxy - n->miny + 1) / ((double)dimy * states); // FIXME
   int idx = n->slotstart;
   const int startx = n->labelaxisd ? PREFIXSTRLEN : 0;
-fprintf(stderr, "startx: %d dimx: %d slotcount: %d slotstart: %d\n", startx, dimx, n->slotcount, n->slotstart);
   for(uint64_t x = startx ; x < n->slotcount + startx ; ++x){
     if(x >= dimx){
       break;

--- a/src/lib/plot.c
+++ b/src/lib/plot.c
@@ -147,7 +147,7 @@ redraw_plot(ncplot* n){
   int idx = n->slotstart;
   const int startx = n->labelaxisd ? PREFIXSTRLEN : 0;
   for(uint64_t x = startx ; x < n->slotcount + startx ; ++x){
-    if(x >= dimx){
+    if(x >= (unsigned)dimx){
       break;
     }
     int64_t gval = n->slots[idx]; // clip the value at the limits of the graph

--- a/src/lib/plot.c
+++ b/src/lib/plot.c
@@ -37,6 +37,13 @@ ncplot* ncplot_create(ncplane* n, const ncplot_options* opts){
     if(dimx < ret->rangex){
       ret->slotcount = dimx;
     }
+    if( (ret->labelaxisd = opts->labelaxisd) ){
+      if(ret->slotcount + PREFIXSTRLEN > dimx){
+        if(dimx > PREFIXSTRLEN){
+          ret->slotcount = dimx - PREFIXSTRLEN;
+        }
+      }
+    }
     size_t slotsize = sizeof(*ret->slots) * ret->slotcount;
     ret->slots = malloc(slotsize);
     if(ret->slots){
@@ -48,7 +55,6 @@ ncplot* ncplot_create(ncplane* n, const ncplot_options* opts){
       ret->maxy = opts->maxy;
       ret->vertical_indep = opts->vertical_indep;
       ret->gridtype = opts->gridtype;
-      ret->labelaxisd = opts->labelaxisd;
       ret->exponentialy = opts->exponentialy;
       ret->detectdomain = opts->miny == opts->maxy;
       ret->windowbase = 0;
@@ -139,7 +145,11 @@ redraw_plot(ncplot* n){
   const size_t states = wcslen(geomdata[n->gridtype].egcs);
   double interval = (n->maxy - n->miny + 1) / ((double)dimy * states);
   int idx = n->slotstart;
-  for(uint64_t x = 0 ; x < n->slotcount ; ++x){
+  const int startx = n->labelaxisd ? PREFIXSTRLEN : 0;
+  for(uint64_t x = startx ; x < n->slotcount + startx ; ++x){
+    if(x >= dimx){
+      break;
+    }
     int64_t gval = n->slots[idx]; // clip the value at the limits of the graph
     if(gval < n->miny){
       gval = n->miny;

--- a/src/lib/plot.c
+++ b/src/lib/plot.c
@@ -48,6 +48,7 @@ ncplot* ncplot_create(ncplane* n, const ncplot_options* opts){
       ret->maxy = opts->maxy;
       ret->vertical_indep = opts->vertical_indep;
       ret->gridtype = opts->gridtype;
+      ret->labelaxisd = opts->labelaxisd;
       ret->exponentialy = opts->exponentialy;
       ret->detectdomain = opts->miny == opts->maxy;
       ret->windowbase = 0;

--- a/src/lib/plot.c
+++ b/src/lib/plot.c
@@ -146,6 +146,13 @@ redraw_plot(ncplot* n){
   double interval = (n->maxy - n->miny + 1) / ((double)dimy * states); // FIXME
   int idx = n->slotstart;
   const int startx = n->labelaxisd ? PREFIXSTRLEN : 0;
+  if(n->labelaxisd){
+    for(int y = 0 ; y < dimy ; ++y){
+      char buf[PREFIXSTRLEN + 1];
+      ncmetric(interval * states * y, 1, buf, 0, 1000, '\0');
+      ncplane_putstr_yx(ncplot_plane(n), dimy - y - 1, PREFIXSTRLEN - strlen(buf), buf);
+    }
+  }
   for(uint64_t x = startx ; x < n->slotcount + startx ; ++x){
     if(x >= (unsigned)dimx){
       break;

--- a/src/tetris/gravity.h
+++ b/src/tetris/gravity.h
@@ -1,11 +1,11 @@
+static constexpr int MAX_LEVEL = 15;
 // the number of milliseconds before a drop is forced at the given level,
 // using the NES fps counter of 50ms
 static constexpr int Gravity(int level) {
   constexpr int MS_PER_GRAV = 30; // 10MHz*63/88/455/525 (~29.97fps) in NTSC
   // The number of frames before a drop is forced, per level
-  constexpr std::array<int, 30> Gravities = {
-    48, 43, 38, 33, 28, 23, 18, 13, 8, 6, 5, 5, 5,
-    4, 4, 4, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1
+  constexpr std::array<int, MAX_LEVEL + 1> Gravities = {
+    43, 38, 33, 28, 23, 18, 13, 8, 6, 5, 5, 4, 4, 3, 2, 1
   };
   if(level < 0){
     throw std::out_of_range("Illegal level");

--- a/src/tetris/lock.h
+++ b/src/tetris/lock.h
@@ -33,7 +33,7 @@ bool LockPiece(){ // returns true if game has ended by reaching level 16
       linescleared_ += cleared;
       static constexpr int points[] = {50, 150, 350, 1000};
       score_ += (level_ + 1) * points[cleared - 1];
-      if((level_ = linescleared_ / 10) > 15){
+      if((level_ = linescleared_ / 10) > MAX_LEVEL){
         return true;
       }
       msdelay_ = std::chrono::milliseconds(Gravity(level_));

--- a/src/tetris/ticker.h
+++ b/src/tetris/ticker.h
@@ -1,7 +1,7 @@
 void Ticker() { // FIXME ideally this would be called from constructor :/
   std::chrono::milliseconds ms;
-  mtx_.lock();
   do{
+    mtx_.lock();
     ms = msdelay_;
     mtx_.unlock();
     std::this_thread::sleep_for(ms);


### PR DESCRIPTION
* Complete #438 by adding the `labelaxisd` field to `ncplot_options`. When set, `PREFIXSTRLEN` columns will be reserved for y-axis labeling. This labeling tracks the domain, whether static or dynamic.
* Add `Ticker()` thread to `notcurses-keyplot`, so that the keyplot is advanced each second whether there was input or not.
* Factor out `MAX_LEVEL` in Tetris, fix up a locking oversight