### PR TITLE
Scrolling #323

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@ This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
 * 1.2.6 (not yet released)
+  * ncplane_putsimple_yx() has been exported as a static inline function.
+  * ncplane_set_scrolling() has been added, allowing control over whether a
+    plane scrolls. All planes, including the standard plane, do not scroll by
+    default. If scrolling is enabled, text output via the `*put*` family of
+    functions continues onto the next line when encountering the end of a row.
+    This does not apply to e.g. boxes or lines.
+  * ncplane_putstr_yx() now always returns the inverse of the number of columns
+    advanced on an error (it used to return the positive short count so long as
+    the error was due to plane geometry, not bad input).
 
 * 1.2.5
   * Add ncplot, with support for sliding-windowed horizontal histograms.

--- a/README.md
+++ b/README.md
@@ -658,6 +658,11 @@ int ncplane_mergedown(struct ncplane* restrict src, struct ncplane* restrict dst
 // with this ncplane are invalidated, and must not be used after the call,
 // excluding the base cell.
 void ncplane_erase(struct ncplane* n);
+
+// All planes are created with scrolling disabled. Scrolling can be dynamically
+// controlled with ncplane_set_scrolling(). Returns true if scrolling was
+// previously enabled, or false if it was disabled.
+bool ncplane_set_scrolling(struct ncplane* n, bool scrollp);
 ```
 
 Planes can be freely resized, though they must retain a positive size in

--- a/README.md
+++ b/README.md
@@ -658,7 +658,26 @@ int ncplane_mergedown(struct ncplane* restrict src, struct ncplane* restrict dst
 // with this ncplane are invalidated, and must not be used after the call,
 // excluding the base cell.
 void ncplane_erase(struct ncplane* n);
+```
 
+All planes, including the standard plane, are created with scrolling disabled.
+Attempting to print past the end of a line will stop at the plane boundary,
+and indicate an error. On a plane 10 columns wide and two rows high, printing
+"0123456789" at the origin should succeed, but printing "01234567890" will by
+default fail at the eleventh character. In either case, the cursor will be left
+at location 0x10; it must be moved before further printing can take place. If
+scrolling is enabled, the first row will be filled with 01234546789, the second
+row will have 0 written to its first column, and the cursor will end up at 1x1.
+Note that it is still an error to manually attempt to move the cursor off-plane,
+or to specify off-plane output. Boxes do not scroll; attempting to draw a 2x11
+box on our 2x10 plane will result in an error and no output. When scrolling is
+enabled, and output takes place while the cursor is past the end of the last
+row, the first row is discarded, all other rows are moved up, the last row is
+cleared, and output begins at the beginning of the last row. This does not take
+place until output is generated (i.e. it is possible to fill a plane when
+scrolling is enabled).
+
+```c
 // All planes are created with scrolling disabled. Scrolling can be dynamically
 // controlled with ncplane_set_scrolling(). Returns true if scrolling was
 // previously enabled, or false if it was disabled.

--- a/README.md
+++ b/README.md
@@ -863,7 +863,14 @@ ncplane_putc(struct ncplane* n, const cell* c){
 // Replace the cell at the specified coordinates with the provided 7-bit char
 // 'c'. Advance the cursor by 1. On success, returns 1. On failure, returns -1.
 // This works whether the underlying char is signed or unsigned.
-int ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c);
+static inline int
+ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c){
+  cell ce = CELL_INITIALIZER(c, ncplane_attr(n), ncplane_channels(n));
+  if(!cell_simple_p(&ce)){
+    return -1;
+  }
+  return ncplane_putc_yx(n, y, x, &ce);
+}
 
 // Call ncplane_putsimple_yx() at the current cursor location.
 static inline int

--- a/debian/libnotcurses1.symbols
+++ b/debian/libnotcurses1.symbols
@@ -95,6 +95,7 @@ libnotcurses.so.1 libnotcurses1 #MINVER#
  ncplane_set_fg_palindex@Base 1.2.1
  ncplane_set_fg_rgb@Base 1.2.1
  ncplane_set_fg_rgb_clipped@Base 1.2.1
+ ncplane_set_scrolling@Base 1.2.6
  ncplane_set_userptr@Base 1.2.1
  ncplane_stain@Base 1.2.5
  ncplane_styles@Base 1.2.1

--- a/doc/man/man3/notcurses_lines.3.md
+++ b/doc/man/man3/notcurses_lines.3.md
@@ -77,6 +77,8 @@ ncplane_box_sized(struct ncplane* n, const cell* ul, const cell* ur,
 upper-left corner at the cursor's current position, and its lower-right corner
 at **ystop**, **xstop**.
 
+Box- and line-drawing is unaffected by a plane's scrolling status.
+
 # RETURN VALUES
 
 **ncplane_format** returns -1 if either **ystop** or **xstop** is less than the

--- a/doc/man/man3/notcurses_ncplane.3.md
+++ b/doc/man/man3/notcurses_ncplane.3.md
@@ -184,12 +184,25 @@ expressed relative to the standard plane, and returns coordinates relative to
 of the rendering region. Only those cells where **src** intersects with **dst**
 might see changes. It is an error to merge a plane onto itself.
 
-All planes (including the standard plane) are created with scrolling disabled.
-Control scrolling on a per-plane basis with **ncplane_set_scrolling**. When
-scrolling is enabled, upon reaching the end of a line, the cursor is moved to
-the first column of the subsequent line. If the end of the last line was
-reached, the first row of the plane is discarded, and all other rows are moved
-up one line.
+## Scrolling
+
+All planes, including the standard plane, are created with scrolling disabled.
+Control scrolling on a per-plane basis with **ncplane_set_scrolling**.
+Attempting to print past the end of a line will stop at the plane boundary, and
+indicate an error. On a plane 10 columns wide and two rows high, printing
+"0123456789" at the origin should succeed, but printing "01234567890" will by
+default fail at the eleventh character. In either case, the cursor will be left
+at location 0x10; it must be moved before further printing can take place. If
+scrolling is enabled, the first row will be filled with 01234546789, the second
+row will have 0 written to its first column, and the cursor will end up at 1x1.
+Note that it is still an error to manually attempt to move the cursor
+off-plane, or to specify off-plane output. Boxes do not scroll; attempting to
+draw a 2x11 box on our 2x10 plane will result in an error and no output. When
+scrolling is enabled, and output takes place while the cursor is past the end
+of the last row, the first row is discarded, all other rows are moved up, the
+last row is cleared, and output begins at the beginning of the last row. This
+does not take place until output is generated (i.e. it is possible to fill a
+plane when scrolling is enabled).
 
 # RETURN VALUES
 

--- a/doc/man/man3/notcurses_ncplane.3.md
+++ b/doc/man/man3/notcurses_ncplane.3.md
@@ -132,6 +132,8 @@ notcurses_ncplane - operations on notcurses planes
 
 **void ncplane_erase(struct ncplane* n);**
 
+**bool ncplane_set_scrolling(struct ncplane* n, bool scrollp);**
+
 ## DESCRIPTION
 
 Ncplanes are the fundamental drawing object of notcurses. All output functions
@@ -182,6 +184,13 @@ expressed relative to the standard plane, and returns coordinates relative to
 of the rendering region. Only those cells where **src** intersects with **dst**
 might see changes. It is an error to merge a plane onto itself.
 
+All planes (including the standard plane) are created with scrolling disabled.
+Control scrolling on a per-plane basis with **ncplane_set_scrolling**. When
+scrolling is enabled, upon reaching the end of a line, the cursor is moved to
+the first column of the subsequent line. If the end of the last line was
+reached, the first row of the plane is discarded, and all other rows are moved
+up one line.
+
 # RETURN VALUES
 
 **ncplane_new**, **ncplane_bound**, **ncplane_aligned**, and **ncplane_dup**
@@ -192,6 +201,9 @@ cannot fail.
 
 **ncplane_below** returns the plane below the specified ncplane. If the provided
 plane is the bottommost plane, NULL is returned. It cannot fail.
+
+**ncplane_set_scrolling** returns **true** if scrolling was previously enabled,
+and **false** otherwise.
 
 Functions returning **int** return 0 on success, and non-zero on error.
 

--- a/doc/man/man3/notcurses_output.3.md
+++ b/doc/man/man3/notcurses_output.3.md
@@ -18,7 +18,8 @@ ncplane_putc(struct ncplane* n, const cell* c);**
 **static inline int
 ncplane_putsimple(struct ncplane* n, char c);**
 
-**int ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c);**
+**static inline int
+ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c);**
 
 **int ncplane_putsimple_stainable(struct ncplane* n, char c);**
 

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -118,13 +118,13 @@ namespace ncpp
 			return ncplane_pulse (plane, ts, fader, curry) != -1;
 		}
 
-    bool mergedown (Plane* dst = nullptr) {
-      return ncplane_mergedown(*this, dst ? dst->plane : nullptr);
-    }
+		bool mergedown (Plane* dst = nullptr) {
+			return ncplane_mergedown(*this, dst ? dst->plane : nullptr);
+		}
 
-    bool mergedown (Plane& dst) {
-      return mergedown(&dst);
-    }
+		bool mergedown (Plane& dst) {
+			return mergedown(&dst);
+		}
 
 		bool gradient (const char* egc, uint32_t attrword, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ystop, int xstop) const noexcept
 		{
@@ -539,8 +539,8 @@ namespace ncpp
 		}
 
 		bool box (const Cell &ul, const Cell &ur, const Cell &ll, const Cell &lr,
-				  const Cell &hline, const Cell &vline, int ystop, int xstop,
-				  unsigned ctlword) const noexcept
+					const Cell &hline, const Cell &vline, int ystop, int xstop,
+					unsigned ctlword) const noexcept
 		{
 			return ncplane_box (plane, ul, ur, ll, lr, hline, vline, ystop, xstop, ctlword) != -1;
 		}
@@ -690,6 +690,11 @@ namespace ncpp
 		void set_bg_default () const noexcept
 		{
 			ncplane_set_bg_default (plane);
+		}
+
+		bool set_scrolling (bool scrollp) noexcept
+		{
+			return ncplane_set_scrolling (plane, scrollp);
 		}
 
 		void styles_set (CellStyle styles) const noexcept
@@ -882,7 +887,7 @@ namespace ncpp
 
 		void translate (const Plane *dst, int *y = nullptr, int *x = nullptr) const
 		{
-      ncplane_translate(*this, dst ? dst->plane: nullptr, y, x);
+			ncplane_translate(*this, dst ? dst->plane: nullptr, y, x);
 		}
 
 		void translate (const Plane &dst, int *y = nullptr, int *x = nullptr) noexcept
@@ -895,7 +900,7 @@ namespace ncpp
 			if (src == nullptr)
 				throw invalid_argument ("'src' must be a valid pointer");
 
-      ncplane_translate(*src, dst ? dst->plane : nullptr, y, x);
+			ncplane_translate(*src, dst ? dst->plane : nullptr, y, x);
 		}
 
 		static void translate (const Plane &src, const Plane &dst, int *y = nullptr, int *x = nullptr) noexcept
@@ -951,7 +956,7 @@ namespace ncpp
 	protected:
 		explicit Plane (ncplane *_plane, bool _is_stdplane)
 			: plane (_plane),
-			  is_stdplane (_is_stdplane)
+				is_stdplane (_is_stdplane)
 		{
 			if (_plane == nullptr)
 				throw invalid_argument ("_plane must be a valid pointer");

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -430,6 +430,11 @@ API void ncplane_translate(const struct ncplane* src, const struct ncplane* dst,
 // within 'n', these coordinates will not be within the dimensions of the plane.
 API bool ncplane_translate_abs(const struct ncplane* n, int* RESTRICT y, int* RESTRICT x);
 
+// All planes are created with scrolling disabled. Scrolling can be dynamically
+// controlled with ncplane_set_scrolling(). Returns true if scrolling was
+// previously enabled, or false if it was disabled.
+API bool ncplane_set_scrolling(struct ncplane* n, bool scrollp);
+
 // Capabilities
 
 // Returns a 16-bit bitmask of supported curses-style attributes

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -123,7 +123,6 @@ int ncplane_move_yx(struct ncplane* n, int y, int x);
 void ncplane_yx(struct ncplane* n, int* y, int* x);
 void ncplane_dim_yx(const struct ncplane* n, int* rows, int* cols);
 int ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c);
-int ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c);
 int ncplane_move_top(struct ncplane* n);
 int ncplane_move_bottom(struct ncplane* n);
 int ncplane_move_below(struct ncplane* n, struct ncplane* below);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -432,6 +432,7 @@ struct ncplane* ncplot_plane(struct ncplot* n);
 int ncplot_add_sample(struct ncplot* n, uint64_t x, int64_t y);
 int ncplot_set_sample(struct ncplot* n, uint64_t x, int64_t y);
 void ncplot_destroy(struct ncplot* n);
+bool ncplane_set_scrolling(struct ncplane* n, bool scrollp);
 """)
 
 if __name__ == "__main__":

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -41,13 +41,14 @@ perframecb(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
       return -1;
     }
     *(struct ncplane**)vnewplane = n;
+    uint64_t channels = 0;
+    channels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
+    channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
+    ncplane_set_base(n, channels, 0, " ");
+    ncplane_set_bg_alpha(n, CELL_ALPHA_BLEND);
+    ncplane_set_scrolling(n, true);
   }
   ncplane_dim_yx(n, &dimy, &dimx);
-  uint64_t channels = 0;
-  channels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
-  channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
-  ncplane_set_base(n, channels, 0, " ");
-  ncplane_set_bg_alpha(n, CELL_ALPHA_BLEND);
   // fg/bg rgbs are set within loop
   int x = dimx - (frameno * 2);
   int r = startr;
@@ -79,7 +80,7 @@ perframecb(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
         if(ncplane_set_bg_rgb(n, (l + 1) * 0x2, 0x20, (l + 1) * 0x2)){
           return -1;
         }
-        if(ncplane_printf_yx(n, l, x, "%*.*s", len, len, leg[l] + stroff) != (int)len){
+        if(ncplane_printf_yx(n, l, x, "%*.*s", len, len, leg[l] + stroff) != len){
           return -1;
         }
       }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -72,6 +72,7 @@ typedef struct ncplane {
   void* userptr;        // slot for the user to stick some opaque pointer
   cell basecell;        // cell written anywhere that fb[i].gcluster == 0
   struct notcurses* nc; // notcurses object of which we are a part
+  bool scrolling;       // is scrolling enabled? always disabled by default
 } ncplane;
 
 typedef struct ncvisual {

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -282,6 +282,7 @@ ncplane_create(notcurses* nc, ncplane* n, int rows, int cols,
     return NULL;
   }
   memset(p->fb, 0, fbsize);
+  p->scrolling = false;
   p->userptr = NULL;
   p->leny = rows;
   p->lenx = cols;
@@ -2014,4 +2015,10 @@ ncplane* ncplane_reparent(ncplane* n, ncplane* newparent){
     newparent->blist = n;
   }
   return n;
+}
+
+bool ncplane_set_scrolling(ncplane* n, bool scrollp){
+  bool old = n->scrolling;
+  n->scrolling = scrollp;
+  return old;
 }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1336,7 +1336,6 @@ int ncplane_putc_yx(ncplane* n, int y, int x, const cell* c){
     // FIXME if new n->y >= n->leny, scroll everything up a line and reset n->y
   }
   if(ncplane_cursor_move_yx(n, y, x)){
-fprintf(stderr, "CAN'T MOVE TO %d/%d (real: %d/%d)\n", y, x, n->y, n->x);
     return -1;
   }
   // A wide character obliterates anything to its immediate right (and marks
@@ -1378,14 +1377,6 @@ fprintf(stderr, "CAN'T MOVE TO %d/%d (real: %d/%d)\n", y, x, n->y, n->x);
   }
   n->x += cols;
   return cols;
-}
-
-int ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c){
-  cell ce = CELL_INITIALIZER(c, ncplane_attr(n), ncplane_channels(n));
-  if(!cell_simple_p(&ce)){
-    return -1;
-  }
-  return ncplane_putc_yx(n, y, x, &ce);
 }
 
 int ncplane_putegc_yx(struct ncplane* n, int y, int x, const char* gclust, int* sbytes){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -341,8 +341,7 @@ ncplane* ncplane_aligned(ncplane* n, int rows, int cols, int yoff,
   return ncplane_create(n->nc, NULL, rows, cols, yoff, ncplane_align(n, align, cols), opaque);
 }
 
-static inline int
-ncplane_cursor_move_yx_locked(ncplane* n, int y, int x){
+inline int ncplane_cursor_move_yx(ncplane* n, int y, int x){
   if(x >= n->lenx){
     return -1;
   }else if(x < 0){
@@ -381,7 +380,7 @@ ncplane* ncplane_dup(ncplane* n, void* opaque){
     if(egcpool_dup(&newn->pool, &n->pool)){
       ncplane_destroy(newn);
     }else{
-      ncplane_cursor_move_yx_locked(newn, y, x); // FIXME what about error?
+      ncplane_cursor_move_yx(newn, y, x);
       n->attrword = attr;
       n->channels = chan;
       ncplane_move_above_unsafe(newn, n);
@@ -1320,10 +1319,6 @@ int ncplane_move_bottom(ncplane* n){
   return 0;
 }
 
-int ncplane_cursor_move_yx(ncplane* n, int y, int x){
-  return ncplane_cursor_move_yx_locked(n, y, x);
-}
-
 void ncplane_cursor_yx(const ncplane* n, int* y, int* x){
   if(y){
     *y = n->y;
@@ -1345,7 +1340,7 @@ cell_obliterate(ncplane* n, cell* c){
 }
 
 int ncplane_putc_yx(ncplane* n, int y, int x, const cell* c){
-  if(ncplane_cursor_move_yx_locked(n, y, x)){
+  if(ncplane_cursor_move_yx(n, y, x)){
     return -1;
   }
   bool wide = cell_double_wide_p(c);
@@ -1689,7 +1684,7 @@ int ncplane_vline_interp(ncplane* n, const cell* c, int len,
     bgdef = true;
   }
   for(ret = 0 ; ret < len ; ++ret){
-    if(ncplane_cursor_move_yx_locked(n, ypos + ret, xpos)){
+    if(ncplane_cursor_move_yx(n, ypos + ret, xpos)){
       return -1;
     }
     r1 += deltr;
@@ -1745,7 +1740,7 @@ int ncplane_box(ncplane* n, const cell* ul, const cell* ur,
   }
   if(!(ctlword & NCBOXMASK_TOP)){ // draw top border, if called for
     if(xstop - xoff >= 2){
-      if(ncplane_cursor_move_yx_locked(n, yoff, xoff + 1)){
+      if(ncplane_cursor_move_yx(n, yoff, xoff + 1)){
         return -1;
       }
       if(!(ctlword & NCBOXGRAD_TOP)){ // cell styling, hl
@@ -1761,7 +1756,7 @@ int ncplane_box(ncplane* n, const cell* ul, const cell* ur,
   }
   edges = !(ctlword & NCBOXMASK_TOP) + !(ctlword & NCBOXMASK_RIGHT);
   if(edges >= box_corner_needs(ctlword)){
-    if(ncplane_cursor_move_yx_locked(n, yoff, xstop)){
+    if(ncplane_cursor_move_yx(n, yoff, xstop)){
       return -1;
     }
     if(ncplane_putc(n, ur) < 0){
@@ -1772,7 +1767,7 @@ int ncplane_box(ncplane* n, const cell* ul, const cell* ur,
   // middle rows (vertical lines)
   if(yoff < ystop){
     if(!(ctlword & NCBOXMASK_LEFT)){
-      if(ncplane_cursor_move_yx_locked(n, yoff, xoff)){
+      if(ncplane_cursor_move_yx(n, yoff, xoff)){
         return -1;
       }
       if((ctlword & NCBOXGRAD_LEFT)){ // grad styling, ul->ll
@@ -1786,7 +1781,7 @@ int ncplane_box(ncplane* n, const cell* ul, const cell* ur,
       }
     }
     if(!(ctlword & NCBOXMASK_RIGHT)){
-      if(ncplane_cursor_move_yx_locked(n, yoff, xstop)){
+      if(ncplane_cursor_move_yx(n, yoff, xstop)){
         return -1;
       }
       if((ctlword & NCBOXGRAD_RIGHT)){ // grad styling, ur->lr
@@ -1804,7 +1799,7 @@ int ncplane_box(ncplane* n, const cell* ul, const cell* ur,
   yoff = ystop;
   edges = !(ctlword & NCBOXMASK_BOTTOM) + !(ctlword & NCBOXMASK_LEFT);
   if(edges >= box_corner_needs(ctlword)){
-    if(ncplane_cursor_move_yx_locked(n, yoff, xoff)){
+    if(ncplane_cursor_move_yx(n, yoff, xoff)){
       return -1;
     }
     if(ncplane_putc(n, ll) < 0){
@@ -1813,7 +1808,7 @@ int ncplane_box(ncplane* n, const cell* ul, const cell* ur,
   }
   if(!(ctlword & NCBOXMASK_BOTTOM)){
     if(xstop - xoff >= 2){
-      if(ncplane_cursor_move_yx_locked(n, yoff, xoff + 1)){
+      if(ncplane_cursor_move_yx(n, yoff, xoff + 1)){
         return -1;
       }
       if(!(ctlword & NCBOXGRAD_BOTTOM)){ // cell styling, hl
@@ -1829,7 +1824,7 @@ int ncplane_box(ncplane* n, const cell* ul, const cell* ur,
   }
   edges = !(ctlword & NCBOXMASK_BOTTOM) + !(ctlword & NCBOXMASK_RIGHT);
   if(edges >= box_corner_needs(ctlword)){
-    if(ncplane_cursor_move_yx_locked(n, yoff, xstop)){
+    if(ncplane_cursor_move_yx(n, yoff, xstop)){
       return -1;
     }
     if(ncplane_putc(n, lr) < 0){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1488,10 +1488,7 @@ int ncplane_putstr_yx(ncplane* n, int y, int x, const char* gclusters){
   int ret = 0;
   // FIXME speed up this blissfully naive solution
   while(*gclusters){
-    // FIXME can we not dispense with this cell, and print directly in?
-    cell c;
-    memset(&c, 0, sizeof(c));
-    int wcs = cell_load(n, &c, gclusters);
+    int wcs;
     int cols = ncplane_putegc_yx(n, y, x, gclusters, &wcs);
     if(cols < 0){
       if(wcs < 0){

--- a/tests/fade.cpp
+++ b/tests/fade.cpp
@@ -40,6 +40,7 @@ TEST_CASE("Fade") {
   c.gcluster = '*';
   cell_set_fg_rgb(&c, 0xff, 0xff, 0xff);
   unsigned rgb = 0xffffffu;
+  CHECK(!ncplane_set_scrolling(n_, true));
   for(int y = 0 ; y < dimy ; ++y){
     for(int x = 0 ; x < dimx ; ++x){
       rgb -= 32;

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -211,6 +211,7 @@ TEST_CASE("NCPlane") {
       L"🍺🚬🌿💉💊🔫💣🤜🤛🐌🐎🐑🐒🐔🐗🐘🐙🐚"
       "🐛🐜🐝🐞🐟🐠🐡🐢🐣🐤🐥🐦🐧🐨🐩🐫🐬🐭🐮"
       "🐯🐰🐱🐲🐳🐴🐵🐶🐷🐹🐺🐻🐼🦉🐊🦕🦖🐬🐙🦠🦀";
+    CHECK(!ncplane_set_scrolling(n_, true));
     int wrote = ncplane_putwstr(n_, e);
     CHECK(0 < wrote);
     int x, y;
@@ -539,20 +540,20 @@ TEST_CASE("NCPlane") {
     ncplane_styles_set(n_, 0);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_putstr(n_, STR1));
+    cell testcell = CELL_TRIVIAL_INITIALIZER;
+    REQUIRE(0 == ncplane_at_cursor(n_, &testcell)); // want nothing at the cursor
+    CHECK(0 == testcell.gcluster);
+    CHECK(0 == testcell.attrword);
+    CHECK(0 == testcell.channels);
     int dimy, dimx;
     ncplane_dim_yx(n_, &dimy, &dimx);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 1, dimx - strlen(STR2)));
     REQUIRE(0 < ncplane_putstr(n_, STR2));
     int y, x;
     ncplane_cursor_yx(n_, &y, &x);
-    REQUIRE(2 == y);
-    REQUIRE(0 == x);
-    REQUIRE(0 < ncplane_putstr(n_, STR3));
-    cell testcell = CELL_TRIVIAL_INITIALIZER;
-    REQUIRE(0 == ncplane_at_cursor(n_, &testcell)); // want nothing at the cursor
-    CHECK(0 == testcell.gcluster);
-    CHECK(0 == testcell.attrword);
-    CHECK(0 == testcell.channels);
+    REQUIRE(1 == y);
+    REQUIRE(dimx == x);
+    REQUIRE(0 == ncplane_putstr(n_, STR3));
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_at_cursor(n_, &testcell)); // want first char of STR1
     CHECK(STR1[0] == testcell.gcluster);
@@ -575,20 +576,20 @@ TEST_CASE("NCPlane") {
     ncplane_styles_set(n_, 0);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_putstr(n_, STR1));
+    cell testcell = CELL_TRIVIAL_INITIALIZER;
+    ncplane_at_cursor(n_, &testcell); // should be nothing at the cursor
+    CHECK(0 == testcell.gcluster);
+    CHECK(0 == testcell.attrword);
+    CHECK(0 == testcell.channels);
     int dimy, dimx;
     ncplane_dim_yx(n_, &dimy, &dimx);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 1, dimx - mbstowcs(NULL, STR2, 0)));
     REQUIRE(0 < ncplane_putstr(n_, STR2));
     int y, x;
     ncplane_cursor_yx(n_, &y, &x);
-    REQUIRE(2 == y);
-    REQUIRE(0 == x);
-    REQUIRE(0 < ncplane_putstr(n_, STR3));
-    cell testcell = CELL_TRIVIAL_INITIALIZER;
-    ncplane_at_cursor(n_, &testcell); // should be nothing at the cursor
-    CHECK(0 == testcell.gcluster);
-    CHECK(0 == testcell.attrword);
-    CHECK(0 == testcell.channels);
+    REQUIRE(1 == y);
+    REQUIRE(dimx == x);
+    REQUIRE(0 == ncplane_putstr(n_, STR3));
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_at_cursor(n_, &testcell)); // want first char of STR1
     CHECK(!strcmp("Σ", cell_extended_gcluster(n_, &testcell)));
@@ -916,7 +917,7 @@ TEST_CASE("NCPlane") {
     int dimx, dimy;
     ncplane_dim_yx(n_, &dimy, &dimx);
     CHECK(0 == ncplane_rounded_box_sized(ncp, 0, 0, 3, 4, 0));
-    CHECK(0 < ncplane_putegc_yx(ncp, 1, 1, "\xf0\x9f\xa6\x82", NULL));
+    CHECK(2 == ncplane_putegc_yx(ncp, 1, 1, "\xf0\x9f\xa6\x82", NULL)); // scorpion
     CHECK(0 == notcurses_render(nc_));
     cell c = CELL_TRIVIAL_INITIALIZER;
     REQUIRE(0 < ncplane_at_yx(ncp, 1, 0, &c));

--- a/tests/scrolling.cpp
+++ b/tests/scrolling.cpp
@@ -35,6 +35,27 @@ TEST_CASE("Scrolling") {
     CHECK(!ncplane_set_scrolling(n, true)); // enable scrolling
     // try to write 40 EGCs; it ought succeed
     CHECK(40 == ncplane_putstr(n, "01234567890123456789012345678901234567689"));
+    int y, x;
+    ncplane_cursor_yx(n, &y, &x);
+    CHECK(1 == y);
+    CHECK(20 == x);
+    CHECK(0 == notcurses_render(nc_));
+  }
+
+  SUBCASE("ScrollingSplitStr"){
+    struct ncplane* n = ncplane_new(nc_, 2, 20, 1, 1, nullptr);
+    REQUIRE(n);
+    CHECK(20 == ncplane_putstr(n, "01234567890123456789"));
+    int y, x;
+    ncplane_cursor_yx(n, &y, &x);
+    CHECK(0 == y);
+    CHECK(20 == x);
+    CHECK(0 > ncplane_putstr(n, "01234567890123456789"));
+    CHECK(!ncplane_set_scrolling(n, true)); // enable scrolling
+    CHECK(20 > ncplane_putstr(n, "01234567890123456789"));
+    ncplane_cursor_yx(n, &y, &x);
+    CHECK(1 == y);
+    CHECK(20 == x);
     CHECK(0 == notcurses_render(nc_));
   }
 
@@ -53,12 +74,19 @@ TEST_CASE("Scrolling") {
         CHECK(0 > ret);
       }
     }
+    int y, x;
+    ncplane_cursor_yx(n, &y, &x);
+    CHECK(0 == y);
+    CHECK(20 == x);
     CHECK(0 == ncplane_cursor_move_yx(n, 0, 0));
     CHECK(!ncplane_set_scrolling(n, true)); // enable scrolling
     // try to write 40 EGCs; all ought succeed
     for(const char* c = out ; *c ; ++c){
       CHECK(1 == ncplane_putsimple(n, *c));
     }
+    ncplane_cursor_yx(n, &y, &x);
+    CHECK(1 == y);
+    CHECK(20 == x);
     CHECK(0 == notcurses_render(nc_));
   }
 

--- a/tests/scrolling.cpp
+++ b/tests/scrolling.cpp
@@ -1,0 +1,71 @@
+#include "main.h"
+#include <array>
+#include <cstdlib>
+#include "internal.h"
+
+TEST_CASE("Scrolling") {
+  if(getenv("TERM") == nullptr){
+    return;
+  }
+  notcurses_options nopts{};
+  nopts.inhibit_alternate_screen = true;
+  nopts.suppress_banner = true;
+  FILE* outfp_ = fopen("/dev/tty", "wb");
+  REQUIRE(outfp_);
+  struct notcurses* nc_ = notcurses_init(&nopts, outfp_);
+  REQUIRE(nc_);
+  struct ncplane* n_ = notcurses_stdplane(nc_);
+  REQUIRE(n_);
+
+  // verify that the standard plane has scrolling disabled initially, and that
+  // we can enable it at runtime.
+  SUBCASE("ScollingDisabledStdplane"){
+    CHECK(!ncplane_set_scrolling(n_, true));
+    CHECK(ncplane_set_scrolling(n_, false));
+  }
+
+  SUBCASE("ScrollingStr"){
+    struct ncplane* n = ncplane_new(nc_, 2, 20, 1, 1, nullptr);
+    REQUIRE(n);
+    // verify that the new plane was started without scrolling
+    CHECK(!ncplane_set_scrolling(n, false));
+    // try to write 40 EGCs; it ought fail
+    CHECK(0 > ncplane_putstr(n, "01234567890123456789012345678901234567689"));
+    CHECK(0 == ncplane_cursor_move_yx(n, 0, 0));
+    CHECK(!ncplane_set_scrolling(n, true)); // enable scrolling
+    // try to write 40 EGCs; it ought succeed
+    CHECK(40 == ncplane_putstr(n, "01234567890123456789012345678901234567689"));
+    CHECK(0 == notcurses_render(nc_));
+  }
+
+  SUBCASE("ScrollingEGC"){
+    const char* out = "01234567890123456789012345678901234567689";
+    struct ncplane* n = ncplane_new(nc_, 2, 20, 1, 1, nullptr);
+    REQUIRE(n);
+    // verify that the new plane was started without scrolling
+    CHECK(!ncplane_set_scrolling(n, false));
+    // try to write 40 EGCs; the last 20 ought fail
+    for(const char* c = out ; *c ; ++c){
+      int ret = ncplane_putsimple(n, *c);
+      if(c - out < 20){
+        CHECK(1 == ret);
+      }else{
+        CHECK(0 > ret);
+      }
+    }
+    CHECK(0 == ncplane_cursor_move_yx(n, 0, 0));
+    CHECK(!ncplane_set_scrolling(n, true)); // enable scrolling
+    // try to write 40 EGCs; all ought succeed
+    for(const char* c = out ; *c ; ++c){
+      CHECK(1 == ncplane_putsimple(n, *c));
+    }
+    CHECK(0 == notcurses_render(nc_));
+  }
+
+  // FIXME add one verifying boxes don't exceed the right side
+  // FIXME add one where we go past the end of the plane
+
+  CHECK(0 == notcurses_stop(nc_));
+  CHECK(0 == fclose(outfp_));
+
+}


### PR DESCRIPTION
* Add `ncplane_set_scrolling()` to control scrolling on a per-plane basis. Update docs. Add Python wrapper. #323
* If scrolling is enabled, when generating text output, move onto the next line upon reaching the end of a line. Update docs. #323 
* Unit tests for scrolling, both positive (verify it works) and negative (verify scrolling does not occur when not requested).
* Make `ncplane_putsimple_yx()` a static inline. Remove it from python wrappers. Update docs.