### PR TITLE
Change notcurses.spec to follow Fedora Packaging Policy

### DIFF
--- a/tools/notcurses.spec
+++ b/tools/notcurses.spec
@@ -1,49 +1,109 @@
-Name: notcurses
-Version: 1.2.5
-Release: 1
-Summary: Character graphics and TUI library
-License: ASL 2.0
-Source0: https://github.com/dankamongmen/%{name}/archive/v%{version}.tar.gz
-Source1: https://github.com/dankamongmen/%{name}/releases/v%{version}/v%{version}.tar.gz.asc
-Source2: https://dank.qemfd.net/dankamongmen.gpg
-BuildRequires: gnupg2 cmake make gcc-c++ ncurses-devel pandoc python3-devel
+Name:          notcurses
+Version:       1.2.6
+Release:       1%{?dist}
+Summary:       Character graphics and TUI library
+License:       ASL 2.0
+URL:           https://nick-black.com/dankwiki/index.php/Notcurses
+Source0:       https://github.com/dankamongmen/%{name}/archive/v%{version}.tar.gz
+Source1:       https://github.com/dankamongmen/%{name}/releases/v%{version}/v%{version}.tar.gz.asc
+Source2:       https://dank.qemfd.net/dankamongmen.gpg
+
+BuildRequires: gnupg2
+BuildRequires: cmake
+BuildRequires: gcc-c++
+BuildRequires: pandoc
+BuildRequires: python3-devel
+BuildRequires: pkgconfig(ncurses)
 
 %description
 notcurses facilitates the creation of modern TUI programs,
 making full use of Unicode and 24-bit direct color. It presents
 an API similar to that of Curses, and rides atop Terminfo.
 
+%package devel
+Summary:       Development files for the notcurses library
+License:       ASL 2.0
+Requires:      %{name} = %{version}-%{release}
+
+%description devel
+This package contains the development files for the notcurses
+library.
+
+%package static
+Summary:       Static library for the notcurses library
+License:       ASL 2.0
+Requires:      %{name}-devel = %{version}-%{release}
+
+%description static
+The notcurses-static package includes the static notcurses library.
+
 %prep
 %{gpgverify} --keyring='%{SOURCE2}' --signature='%{SOURCE1}' --data='%{SOURCE0}'
-%setup
+%autosetup
 
 %build
-%cmake -DUSE_FFMPEG=off -DUSE_TEST=off .
+%cmake -DUSE_FFMPEG=off -DUSE_TESTS=off .
 %make_build
 
 %install
 %make_install
 
 %files
-/usr/bin/notcurses-demo
-/usr/bin/notcurses-input
-/usr/bin/notcurses-ncreel
-/usr/bin/notcurses-pydemo
-/usr/bin/notcurses-tester
-/usr/bin/notcurses-tetris
-/usr/bin/notcurses-view
-/usr/include/notcurses/nckeys.h
-/usr/include/notcurses/notcurses.h
-/usr/lib/x86_64-linux-gnu/libnotcurses.so.{version}
-/usr/lib/x86_64-linux-gnu/libnotcurses.so.1
-/usr/lib/x86_64-linux-gnu/libnotcurses.so
-/usr/lib/x86_64-linux-gnu/cmake/notcurses/notcursesConfig.cmake
-/usr/lib/x86_64-linux-gnu/cmake/notcurses/notcursesConfigVersion.cmake
-/usr/lib/x86_64-linux-gnu/libnotcurses.a
-/usr/lib/x86_64-linux-gnu/pkgconfig
-/usr/lib/x86_64-linux-gnu/pkgconfig/notcurses.pc
-%license LICENSE
+%doc CHANGELOG.md README.md
+%license COPYRIGHT LICENSE
+%{_libdir}/libnotcurses.so.%{version}
+%{_libdir}/libnotcurses.so.1
+%{_libdir}/libnotcurses++.so.1
+%{_libdir}/libnotcurses++.so.%{version}
+
+%files devel
+%{_bindir}/notcurses-demo
+%{_bindir}/notcurses-input
+%{_bindir}/notcurses-ncreel
+%{_bindir}/notcurses-pydemo
+%{_bindir}/notcurses-tetris
+%{_includedir}/notcurses/nckeys.h
+%{_includedir}/notcurses/notcurses.h
+%{_libdir}/libnotcurses.so
+%{_libdir}/libnotcurses++.so
+%{_libdir}/cmake/notcurses
+%{_libdir}/pkgconfig/notcurses.pc
+%{_libdir}/pkgconfig/notcurses++.pc
+%{_mandir}/man1/colloquy.1.gz
+%{_mandir}/man1/notcurses-demo.1.gz
+%{_mandir}/man1/notcurses-input.1.gz
+%{_mandir}/man1/notcurses-ncreel.1.gz
+%{_mandir}/man1/notcurses-pydemo.1.gz
+%{_mandir}/man1/notcurses-tester.1.gz
+%{_mandir}/man/man1/notcurses-tetris.1.gz
+%{_mandir}/man1/notcurses-view.1.gz
+%{_mandir}/man3/notcurses.3.gz
+%{_mandir}/man3/notcurses_cell.3.gz
+%{_mandir}/man3/notcurses_channels.3.gz
+%{_mandir}/man3/notcurses_directmode.3.gz
+%{_mandir}/man3/notcurses_fade.3.gz
+%{_mandir}/man3/notcurses_init.3.gz
+%{_mandir}/man3/notcurses_input.3.gz
+%{_mandir}/man3/notcurses_lines.3.gz
+%{_mandir}/man3/notcurses_menu.3.gz
+%{_mandir}/man3/notcurses_multiselector.3.gz
+%{_mandir}/man3/notcurses_ncplane.3.gz
+%{_mandir}/man3/notcurses_ncvisual.3.gz
+%{_mandir}/man3/notcurses_output.3.gz
+%{_mandir}/man3/notcurses_palette.3.gz
+%{_mandir}/man3/notcurses_plot.3.gz
+%{_mandir}/man3/notcurses_reel.3.gz
+%{_mandir}/man3/notcurses_refresh.3.gz
+%{_mandir}/man3/notcurses_render.3.gz
+%{_mandir}/man3/notcurses_selector.3.gz
+%{_mandir}/man3/notcurses_stats.3.gz
+%{_mandir}/man3/notcurses_stdplane.3.gz
+%{_mandir}/man3/notcurses_stop.3.gz
+
+%files static
+%{_libdir}/libnotcurses.a
+%{_libdir}/libnotcurses++.a
 
 %changelog
-* Tue, Apr 07 2020 Nick Black <dankamongmen@gmail.com> - 1.2.5-1
+* Tue Apr 07 2020 Nick Black <dankamongmen@gmail.com> - 1.2.6-1
 - Initial Fedora packaging


### PR DESCRIPTION
More or less.  Here's a list of things I changed:
* Single line BuildRequires which is more of a convention than a
  requirement.
* Drop make from BuildRequires.  That's one we do actually provide.
* Use pkgconfig(ncurses) to get the ncurses-devel BuildRequires.
* Add a 'devel' subject and move development files there.
* Add a 'static' package for the .a libraries which is common
  for other packages that provide static libraries.
* Add doc files using %doc
* -DUSE_TEST=off -> -DUSE_TESTS=off
* Use %autosetup in %setup which covers adding patches in the future
  for downstream packaging.
* Use path macros in %files
* Correct the date format in the %changelog entry
* Use the 1.2.6 release as an example

Things that could use more consideration:
* The release artifacts don't match what GitHub provides.  Their
  automated download link gives you notcurses-1.2.6.tar.gz but the URL
  calls it v1.2.6.tar.gz.
* There is no signature file uploaded.
* notcurses-tester and notcurses-viewer do not build.
* Should the demo programs go in the main package or devel.  I felt
  devel was more appropriate.
* Should the packaging be further refined to split out the C++ runtime
  and static libraries to separate subpackages?

I did some local test runs using mock.  I ran the SRPM through rpmlint
which would happen when the package is submitted for inclusion.

For the download archive and signature, I create new release posts on
my github projects and create a separate tarball and sign that and
upload them there.  It is separate from the GitHub automated
make-me-a-tarball download link.  That might be what you're planning
on doing.