### PR TITLE
[C++] Sync API changes

### DIFF
--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -89,6 +89,26 @@ namespace ncpp
 			return ncdirect_cursor_move_yx (direct, y, x);
 		}
 
+		int cursor_up (int num) const noexcept
+		{
+			return ncdirect_cursor_up (direct, num);
+		}
+
+		int cursor_left (int num) const noexcept
+		{
+			return ncdirect_cursor_left (direct, num);
+		}
+
+		int cursor_right (int num) const noexcept
+		{
+			return ncdirect_cursor_right (direct, num);
+		}
+
+		int cursor_down (int num) const noexcept
+		{
+			return ncdirect_cursor_down (direct, num);
+		}
+
 		bool cursor_enable () const noexcept
 		{
 			return ncdirect_cursor_enable (direct) != -1;

--- a/include/ncpp/Plot.hh
+++ b/include/ncpp/Plot.hh
@@ -13,26 +13,26 @@ namespace ncpp
 	class NCPP_API_EXPORT Plot : public Root
 	{
 	public:
-		static plot_options default_options;
+		static ncplot_options default_options;
 
 	public:
-		explicit Plot (Plane *plane, const plot_options *opts = nullptr)
+		explicit Plot (Plane *plane, const ncplot_options *opts = nullptr)
 			: Plot (reinterpret_cast<ncplane*>(plane), opts)
 		{}
 
-		explicit Plot (Plane const* plane, const plot_options *opts = nullptr)
+		explicit Plot (Plane const* plane, const ncplot_options *opts = nullptr)
 			: Plot (const_cast<Plane*>(plane), opts)
 		{}
 
-		explicit Plot (Plane &plane, const plot_options *opts = nullptr)
+		explicit Plot (Plane &plane, const ncplot_options *opts = nullptr)
 			: Plot (reinterpret_cast<ncplane*>(&plane), opts)
 		{}
 
-		explicit Plot (Plane const& plane, const plot_options *opts = nullptr)
+		explicit Plot (Plane const& plane, const ncplot_options *opts = nullptr)
 			: Plot (const_cast<Plane*>(&plane), opts)
 		{}
 
-		explicit Plot (ncplane *plane, const plot_options *opts = nullptr)
+		explicit Plot (ncplane *plane, const ncplot_options *opts = nullptr)
 		{
 			if (plane == nullptr)
 				throw invalid_argument ("'plane' must be a valid pointer");
@@ -48,15 +48,15 @@ namespace ncpp
 				ncplot_destroy (plot);
 		}
 
-    int add_sample(uint64_t x, uint64_t y)
-    {
+		bool add_sample(uint64_t x, uint64_t y)
+		{
 			return ncplot_add_sample (plot, x, y) >= 0;
-    }
+		}
 
-    int set_sample(uint64_t x, uint64_t y)
-    {
+		bool set_sample(uint64_t x, uint64_t y)
+		{
 			return ncplot_set_sample (plot, x, y) >= 0;
-    }
+		}
 
 		Plane* get_plane () const noexcept;
 

--- a/src/libcpp/Plot.cc
+++ b/src/libcpp/Plot.cc
@@ -1,0 +1,21 @@
+#include <ncpp/Plot.hh>
+#include <ncpp/Plane.hh>
+
+using namespace ncpp;
+
+ncplot_options Plot::default_options = {
+	0, // maxchannel
+	0, // minchannel
+	ncgridgeom_e::NCPLOT_1x1, // ncgridgeom_e
+	0, // rangex
+	0, // miny
+	0, // maxy
+	false, // labelaxisd,
+	false, // exponentialy
+	false, // verticalindep
+};
+
+Plane* Plot::get_plane () const noexcept
+{
+	return Plane::map_plane (ncplot_plane (plot));
+}

--- a/src/poc/ncpp_build.cpp
+++ b/src/poc/ncpp_build.cpp
@@ -15,6 +15,7 @@
 #include <ncpp/Selector.hh>
 #include <ncpp/Visual.hh>
 #include <ncpp/Direct.hh>
+#include <ncpp/Plot.hh>
 
 using namespace ncpp;
 


### PR DESCRIPTION
Been a while, but here goes, sync to the latest API changes.

Added:

  * Direct:   cursor_{up,left,right,down} (`ncdirect_cursor_{up,left,right,down}`)
  * Plane: constructors to use `ncplane_bound`
  * Plane: reparent (`ncplane_reparent`)
  * Plot: definition of `default_options`

Changed:

  * Plane (breaking): the `*gradient*` functions now return `int`
  * Plane (breaking): `polyfill` returns `int`
  * Plane (breaking): `stain` returns `int`
  * Plane (breaking): `blit_bgrx` takes `const void*` for `data`
  * Plane (breaking): `blit_rgba` takes `const void*` for `data`
  * Plot: `plot_optons` -> `ncplot_options`
  * Plot (breaking): `{add,set}_sample` now return `bool`