### PR TITLE
Properly set up right side of obliterated wide glyph #362

### DIFF
--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1250,6 +1250,7 @@ int ncplane_putc_yx(ncplane* n, int y, int x, const cell* c){
       }
       cell_obliterate(n, candidate);
       cell_set_wide(candidate);
+      candidate->channels = c->channels;
     }
   }
   n->x += cols;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1239,14 +1239,8 @@ int ncplane_putc_yx(ncplane* n, int y, int x, const cell* c){
     return -1;
   }
   int cols = 1;
-  if(wide){
-    ++cols;
-    cell* rtarg = &n->fb[nfbcellidx(n, n->y, n->x + 1)];
-    cell_release(n, rtarg);
-    cell_init(rtarg);
-    cell_set_wide(rtarg);
-  }
   if(wide){ // must set our right wide, and check for further damage
+    ++cols;
     if(n->x < n->lenx - 1){ // check to our right
       cell* candidate = &n->fb[nfbcellidx(n, n->y, n->x + 1)];
       if(n->x < n->lenx - 2){
@@ -1254,8 +1248,8 @@ int ncplane_putc_yx(ncplane* n, int y, int x, const cell* c){
           cell_obliterate(n, &n->fb[nfbcellidx(n, n->y, n->x + 2)]);
         }
       }
+      cell_obliterate(n, candidate);
       cell_set_wide(candidate);
-      cell_release(n, candidate);
     }
   }
   n->x += cols;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -279,7 +279,7 @@ paint(ncplane* p, cell* lastframe, struct crender* rvec,
       const cell* vis = &p->fb[nfbcellidx(p, y, x)];
       // if we never loaded any content into the cell (or obliterated it by
       // writing in a zero), use the plane's base cell.
-      if(vis->gcluster == 0){
+      if(vis->gcluster == 0 && !cell_wide_right_p(vis)){
         vis = &p->basecell;
       }
       // if we have no character in this cell, we continue to look for a

--- a/tests/render.cpp
+++ b/tests/render.cpp
@@ -103,7 +103,7 @@ TEST_CASE("RenderTest") {
     // should be nothing, having been stomped
     egc = notcurses_at_yx(nc_, 0, 0, &c.attrword, &c.channels);
     REQUIRE(egc);
-    CHECK(0 == strcmp("", egc));
+    CHECK(0 == strcmp(" ", egc));
     free(egc);
     cell_init(&c);
     // should be character from higher plane
@@ -122,7 +122,7 @@ TEST_CASE("RenderTest") {
     // should be nothing, having been stomped
     egc = notcurses_at_yx(nc_, 0, 3, &c.attrword, &c.channels);
     REQUIRE(egc);
-    CHECK(0 == strcmp("", egc));
+    CHECK(0 == strcmp(" ", egc));
     free(egc);
     cell_init(&c);
 

--- a/tests/render.cpp
+++ b/tests/render.cpp
@@ -122,7 +122,7 @@ TEST_CASE("RenderTest") {
     // should be nothing, having been stomped
     egc = notcurses_at_yx(nc_, 0, 3, &c.attrword, &c.channels);
     REQUIRE(egc);
-    CHECK(0 == strcmp(" ", egc));
+    CHECK(0 == strcmp("", egc));
     free(egc);
     cell_init(&c);
 

--- a/tests/render.cpp
+++ b/tests/render.cpp
@@ -103,30 +103,30 @@ TEST_CASE("RenderTest") {
     // should be nothing, having been stomped
     egc = notcurses_at_yx(nc_, 0, 0, &c.attrword, &c.channels);
     REQUIRE(egc);
-    CHECK(!strcmp(" ", egc));
+    CHECK(0 == strcmp("", egc));
     free(egc);
     cell_init(&c);
     // should be character from higher plane
     egc = notcurses_at_yx(nc_, 0, 1, &c.attrword, &c.channels);
     REQUIRE(egc);
-    CHECK(!strcmp("A", egc));
+    CHECK(0 == strcmp("A", egc));
     free(egc);
     cell_init(&c);
 
     egc = notcurses_at_yx(nc_, 0, 2, &c.attrword, &c.channels);
     REQUIRE(egc);
-    CHECK(!strcmp("B", egc));
+    CHECK(0 == strcmp("B", egc));
     free(egc);
     cell_init(&c);
 
     // should be nothing, having been stomped
     egc = notcurses_at_yx(nc_, 0, 3, &c.attrword, &c.channels);
     REQUIRE(egc);
-    CHECK(!strcmp(" ", egc));
+    CHECK(0 == strcmp("", egc));
     free(egc);
     cell_init(&c);
 
-    CHECK(!ncplane_destroy(n));
+    CHECK(0 == ncplane_destroy(n));
   }
 
 


### PR DESCRIPTION
Fix longstanding bug that showed up when running the `whiteout` demo with the HUD up. Moving the HUD over a bunch of wide glyphs would result in a checkerboard pattern in the HUD background. I tracked this down to the right side of wide glyphs not having their channels set the same way as the left side. I added a new unit test, `Ncplane::OverWide`, which exercises this case, and it failed as expected. We now copy the active channels into the right side of our wide glyphs, and do not fall back to the basecell on these cells. That fixes this issue, fixes the unit test, and fixes the weird behavior we've always seen in the `widestomp` PoC.

With that said, we do now leave little turdlets of the HUD atop the same demos when we really whip it around. I'm calling that a distinct bug (I believe it to be due to a bug in rasterization regarding damage detection).

I like this fix. I'll look into the capgras delusions we're generating. #362 