### PR TITLE
Fully general optimized moves #483

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -118,6 +118,11 @@ typedef struct renderstate {
   FILE* mstreamfp;// FILE* for rendering memstream
   size_t mstrsize;// size of rendering memstream
 
+  // the current cursor position. this is independent of whether the cursor is
+  // visible. it is the cell at which the next write will take place. this is
+  // modified by: output, cursor moves, clearing the screen (during refresh)
+  int y, x;
+
   uint32_t curattr;// current attributes set (does not include colors)
   unsigned lastr;  // foreground rgb, overloaded for palindexed fg
   unsigned lastg;
@@ -296,6 +301,7 @@ typedef struct notcurses {
   int colors;     // number of colors terminfo reported usable for this screen
   char* cup;      // move cursor
   char* cuf;      // move n cells right
+  char* cub;      // move n cells right
   char* cuf1;     // move 1 cell right
   char* cub1;     // move 1 cell left
   char* civis;    // hide cursor

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -602,8 +602,9 @@ interrogate_terminfo(notcurses* nc, const notcurses_options* opts, int* dimy, in
   term_verify_seq(&nc->cleareol, "el");
   term_verify_seq(&nc->clearbol, "el1");
   term_verify_seq(&nc->cuf, "cuf"); // n non-destructive spaces
+  term_verify_seq(&nc->cub, "cub"); // n non-destructive backspaces
   term_verify_seq(&nc->cuf1, "cuf1"); // non-destructive space
-  term_verify_seq(&nc->cub1, "cub1");
+  term_verify_seq(&nc->cub1, "cub1"); // non-destructive backspace
   term_verify_seq(&nc->smkx, "smkx"); // set application mode
   if(nc->smkx){
     if(putp(tiparm(nc->smkx)) != OK){


### PR DESCRIPTION
Introduce `stage_cursor()` for fully general optimized cursor moves. Retain cursor position across renders. We can now perform character-at-a-time rendering with 0 overhead. #483.