### PR TITLE
Prevent -I/usr/usr/include in the pkg-config files.

### DIFF
--- a/tools/notcurses++.pc.in
+++ b/tools/notcurses++.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: C++ bindings for notcurses

--- a/tools/notcurses.pc.in
+++ b/tools/notcurses.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: TUI library for modern terminal emulators


### PR DESCRIPTION
Pretty self-explanatory.  The ${prefix} isn't required here and dropping it results in a clean output of:

```
pkg-config --cflags notcurses
```

As expected that gives me nothing.  But with ${prefix} present it gives me -I/usr/usr/include and that's not helpful.