### PR TITLE
Eliminate race of demo rendering vs menu/HUD update #501

### DIFF
--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -62,14 +62,14 @@ void interrupt_and_restart_demos(void);
 // demos should not call notcurses_getc() directly, as it's being monitored by
 // the toplevel event listener. instead, call this intermediate API. just
 // replace 'notcurses' with 'demo'.
-char32_t demo_getc(const struct timespec* ts, ncinput* ni);
+char32_t demo_getc(struct notcurses* nc, const struct timespec* ts, ncinput* ni);
 
 // 'ni' may be NULL if the caller is uninterested in event details. If no event
 // is ready, returns 0.
 static inline char32_t
-demo_getc_nblock(ncinput* ni){
+demo_getc_nblock(struct notcurses* nc, ncinput* ni){
   struct timespec ts = { .tv_sec = 0, .tv_nsec = 0 };
-  return demo_getc(&ts, ni);
+  return demo_getc(nc, &ts, ni);
 }
 
 // Get a fd which can be poll()ed to check for outstanding input. Do not close
@@ -79,8 +79,8 @@ int demo_input_fd(void);
 // 'ni' may be NULL if the caller is uninterested in event details. Blocks
 // until an event is processed or a signal is received.
 static inline char32_t
-demo_getc_blocking(ncinput* ni){
-  return demo_getc(NULL, ni);
+demo_getc_blocking(struct notcurses* nc, ncinput* ni){
+  return demo_getc(nc, NULL, ni);
 }
 /*----------------------------- end demo input API -------------------------*/
 
@@ -150,10 +150,6 @@ int hud_schedule(const char* demoname);
 int demo_render(struct notcurses* nc);
 
 #define DEMO_RENDER(nc) { int demo_render_err = demo_render(nc); if(demo_render_err){ return demo_render_err; }}
-
-// locked by callers to notcurses_render() and notcurses_refresh(), all internal
-void lock_demo_render(void);
-void unlock_demo_render(void);
 
 // if you won't be doing things, and it's a long sleep, consider using
 // demo_nanosleep(). it updates the HUD, which looks better to the user.

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -6,8 +6,6 @@
 // their mouse. it should always be on the top of the z-stack.
 struct ncplane* hud = NULL;
 
-static pthread_mutex_t demo_render_lock = PTHREAD_MUTEX_INITIALIZER;
-
 // while the HUD is grabbed by the mouse, these are set to the position where
 // the grab started. they are reset once the HUD is released.
 static int hud_grab_x = -1;
@@ -346,10 +344,6 @@ int hud_completion_notify(const demoresult* result){
   return 0;
 }
 
-static void unlock_mutex(void* vm){
-  pthread_mutex_unlock(vm);
-}
-
 // inform the HUD of an upcoming demo
 int hud_schedule(const char* demoname){
   elem* cure;
@@ -450,20 +444,5 @@ int demo_render(struct notcurses* nc){
       return -1;
     }
   }
-  int ret = 0;
-  pthread_cleanup_push(unlock_mutex, &demo_render_lock);
-  // lock against a possible notcurses_refresh() on Ctrl+L
-  pthread_mutex_lock(&demo_render_lock);
-  ret = notcurses_render(nc);
-  pthread_mutex_unlock(&demo_render_lock);
-  pthread_cleanup_pop(1);
-  return ret;
-}
-
-void lock_demo_render(void){
-  pthread_mutex_lock(&demo_render_lock);
-}
-
-void unlock_demo_render(void){
-  pthread_mutex_unlock(&demo_render_lock);
+  return notcurses_render(nc);
 }

--- a/src/demo/input.c
+++ b/src/demo/input.c
@@ -17,9 +17,26 @@ static nciqueue** enqueue = &queue;
 static pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
+static int
+handle_mouse(const ncinput* ni){
+  if(ni->id != NCKEY_BUTTON1 && ni->id != NCKEY_RELEASE){
+    return 0;
+  }
+  int ret;
+  if(ni->id == NCKEY_RELEASE){
+    ret = hud_release();
+  }else{
+    ret = hud_grab(ni->y, ni->x);
+  }
+  // do not render here. the demos, if coded properly, will be regularly
+  // rendering (if via demo_nanosleep() if nothing else). rendering based off
+  // HUD movements can cause disruptions due to the main thread being unready.
+  return ret;
+}
+
 // incoming timespec is relative (or even NULL, for blocking), but we need
 // absolute deadline, so convert it up.
-char32_t demo_getc(const struct timespec* ts, ncinput* ni){
+char32_t demo_getc(struct notcurses* nc, const struct timespec* ts, ncinput* ni){
   struct timespec now;
   uint64_t ns;
   struct timespec abstime;
@@ -33,26 +50,46 @@ char32_t demo_getc(const struct timespec* ts, ncinput* ni){
     abstime.tv_sec = ~0;
     abstime.tv_nsec = ~0;
   }
-  pthread_mutex_lock(&lock);
-  while(!queue){
-    clock_gettime(CLOCK_REALTIME, &now);
-    if(timespec_to_ns(&now) > timespec_to_ns(&abstime)){
-      pthread_mutex_unlock(&lock);
-      return 0;
+  bool handoff = false; // does the input go back to the user?
+  char32_t id;
+  do{
+    pthread_mutex_lock(&lock);
+    while(!queue){
+      clock_gettime(CLOCK_REALTIME, &now);
+      if(timespec_to_ns(&now) > timespec_to_ns(&abstime)){
+        pthread_mutex_unlock(&lock);
+        return 0;
+      }
+      pthread_cond_timedwait(&cond, &lock, &abstime);
     }
-    pthread_cond_timedwait(&cond, &lock, &abstime);
-  }
-  nciqueue* q = queue;
-  queue = queue->next;
-  if(queue == NULL){
-    enqueue = &queue;
-  }
-  pthread_mutex_unlock(&lock);
-  char32_t id = q->ni.id;
-  if(ni){
-    memcpy(ni, &q->ni, sizeof(*ni));
-  }
-  free(q);
+    nciqueue* q = queue;
+    queue = queue->next;
+    if(queue == NULL){
+      enqueue = &queue;
+    }
+    pthread_mutex_unlock(&lock);
+    id = q->ni.id;
+    // if this was about the menu or HUD, pass to them, and continue
+    if(!menu_or_hud_key(nc, &q->ni)){
+      if(nckey_mouse_p(q->ni.id)){
+        if(!handle_mouse(&q->ni)){
+          if(id == 'L' && q->ni.ctrl){
+            notcurses_refresh(nc, NULL, NULL);
+          }else{
+            handoff = false;
+          }
+        }
+      }else if(id == 'L' && q->ni.ctrl){
+        notcurses_refresh(nc, NULL, NULL);
+      }else{
+        handoff = false;
+      }
+    }
+    if(handoff && ni){
+      memcpy(ni, &q->ni, sizeof(*ni));
+    }
+    free(q);
+  }while(!handoff);
   return id;
 }
 
@@ -74,23 +111,6 @@ pass_along(const ncinput* ni){
   return ret;
 }
 
-static int
-handle_mouse(const ncinput* ni){
-  if(ni->id != NCKEY_BUTTON1 && ni->id != NCKEY_RELEASE){
-    return 0;
-  }
-  int ret;
-  if(ni->id == NCKEY_RELEASE){
-    ret = hud_release();
-  }else{
-    ret = hud_grab(ni->y, ni->x);
-  }
-  // do not render here. the demos, if coded properly, will be regularly
-  // rendering (if via demo_nanosleep() if nothing else). rendering based off
-  // HUD movements can cause disruptions due to the main thread being unready.
-  return ret;
-}
-
 static void *
 ultramegaok_demo(void* vnc){
   ncinput ni;
@@ -100,23 +120,11 @@ ultramegaok_demo(void* vnc){
     if(id == 0){
       continue;
     }
-    // if this was about the menu or HUD, pass to them, and continue
-    if(menu_or_hud_key(nc, &ni)){
-      continue;
-    }
-    if(nckey_mouse_p(ni.id)){
-      if(handle_mouse(&ni)){
-        continue;
-      }
-    }
-    if(id == 'L' && ni.ctrl){
-      lock_demo_render();
-      notcurses_refresh(nc, NULL, NULL);
-      unlock_demo_render();
-      continue;
-    }
-    // go ahead and pass keyboard through to demo, even if it was a 'q'
-    // (this might cause the demo to exit immediately, as is desired)
+    // go ahead and pass keyboard through to demo, even if it was a 'q' (this
+    // might cause the demo to exit immediately, as is desired). we can't just
+    // mess with the menu/HUD in our own context, as the demo thread(s) might
+    // be rendering, or otherwise fucking with things we musn't fuck with
+    // concurrentwise (z-axis manipulations, etc.).
     pass_along(&ni);
   }
   return NULL;

--- a/src/demo/reel.c
+++ b/src/demo/reel.c
@@ -244,7 +244,7 @@ handle_input(struct notcurses* nc, struct ncreel* pr, int efd,
       if(fds[0].revents & POLLIN){
         uint64_t eventcount;
         if(read(fds[0].fd, &eventcount, sizeof(eventcount)) > 0){
-          key = demo_getc_nblock(NULL);
+          key = demo_getc_nblock(nc, NULL);
           if(key < 0){
             return -1;
           }

--- a/src/demo/view.c
+++ b/src/demo/view.c
@@ -6,7 +6,7 @@ watch_for_keystroke(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((u
   wchar_t w;
   // we don't want a keypress, but allow the ncvisual to handle
   // NCKEY_RESIZE for us
-  if((w = demo_getc_nblock(NULL)) != (wchar_t)-1){
+  if((w = demo_getc_nblock(nc, NULL)) != (wchar_t)-1){
     if(w == 'q'){
       return 1;
     }

--- a/src/demo/whiteout.c
+++ b/src/demo/whiteout.c
@@ -7,12 +7,6 @@
 #include <pthread.h>
 #include "demo.h"
 
-// some random value to differentiate a demo abort, as indicated via
-// demo_render() in worm_thread(). we can't use PTHREAD_CANCELED, since we
-// do actually make use of cancellation.
-static int demo_aborted = 0;
-static void* DEMO_ABORTED = &demo_aborted;
-
 // Fill up the screen with as much crazy Unicode as we can, and then set a
 // gremlin loose, looking to brighten up the world.
 
@@ -131,38 +125,42 @@ wormy(worm* s, int dimy, int dimx){
   return 0;
 }
 
-// each worm wanders around aimlessly. it lights up the cells around it; to do
-// this, we keep an array of 13 cells with the original colors, which we tune up.
-static void *
-worm_thread(void* vnc){
-  struct notcurses* nc = vnc;
-  int dimy, dimx;
-  notcurses_term_dim_yx(nc, &dimy, &dimx);
-  int wormcount = (dimy * dimx) / 800;
-  worm worms[wormcount];
-  for(int s = 0 ; s < wormcount ; ++s){
-    init_worm(&worms[s], dimy, dimx);
+struct worm_ctx {
+  int wormcount;
+  worm* worms;
+};
+
+int init_worms(struct worm_ctx* wctx, int dimy, int dimx){
+  if((wctx->wormcount = (dimy * dimx) / 800) == 0){
+    wctx->wormcount = 1;
   }
-  while(true){
-    pthread_testcancel();
-    for(int s = 0 ; s < wormcount ; ++s){
-      if(wormy_top(nc, &worms[s])){
-        return NULL;
-      }
-    }
-    int err;
-    if( (err = demo_render(nc)) ){
-      if(err > 0){
-        return DEMO_ABORTED;
-      }
-    }
-    for(int s = 0 ; s < wormcount ; ++s){
-      if(wormy(&worms[s], dimy, dimx)){
-        return NULL;
-      }
+  if((wctx->worms = malloc(sizeof(*wctx->worms) * wctx->wormcount)) == NULL){
+    return -1;
+  }
+  for(int s = 0 ; s < wctx->wormcount ; ++s){
+    init_worm(&wctx->worms[s], dimy, dimx);
+  }
+  return 0;
+}
+
+// the whiteworms wander around aimlessly, lighting up cells around themselves
+static int
+worm_move(struct notcurses* nc, struct worm_ctx* wctx, int dimy, int dimx){
+  for(int s = 0 ; s < wctx->wormcount ; ++s){
+    if(wormy_top(nc, &wctx->worms[s])){
+      return -1;
     }
   }
-  return NULL;
+  int err;
+  if( (err = demo_render(nc)) ){
+    return err;
+  }
+  for(int s = 0 ; s < wctx->wormcount ; ++s){
+    if(wormy(&wctx->worms[s], dimy, dimx)){
+      return -1;
+    }
+  }
+  return 0;
 }
 
 static int
@@ -555,27 +553,27 @@ int witherworm_demo(struct notcurses* nc){
         }
         ncplane_fadein(n, &tv, demo_fader, NULL);
       }
-      pthread_t tid;
-      // FIXME this could just be brought inline, no need for a thread
-      pthread_create(&tid, NULL, worm_thread, nc);
+
+      struct worm_ctx wctx;
+      if( (err = init_worms(&wctx, maxy, maxx)) ){
+        return err;
+      }
+      struct timespec cur;
       do{
-        struct timespec left, cur;
-        clock_gettime(CLOCK_MONOTONIC, &cur);
-        timespec_subtract(&left, &screenend, &cur);
-        key = demo_getc(nc, &left, NULL);
-        clock_gettime(CLOCK_MONOTONIC, &cur);
-        int64_t ns = timespec_subtract_ns(&cur, &screenend);
-        if(ns > 0){
+        if( (err = worm_move(nc, &wctx, maxy, maxx)) ){
           break;
         }
-      }while(key < 0);
-      pthread_cancel(tid);
-      void* result = NULL;
-      pthread_join(tid, &result);
+        key = demo_getc_nblock(nc, NULL);
+        clock_gettime(CLOCK_MONOTONIC, &cur);
+        if(timespec_to_ns(&screenend) < timespec_to_ns(&cur)){
+          break;
+        }
+      }while(key == 0);
+
       ncplane_destroy(mess);
       ncplane_destroy(math);
-      if(result == DEMO_ABORTED){
-        return 1;
+      if(err){
+        return err;
       }
       if(key == NCKEY_RESIZE){
         DEMO_RENDER(nc);

--- a/src/demo/whiteout.c
+++ b/src/demo/whiteout.c
@@ -556,12 +556,13 @@ int witherworm_demo(struct notcurses* nc){
         ncplane_fadein(n, &tv, demo_fader, NULL);
       }
       pthread_t tid;
+      // FIXME this could just be brought inline, no need for a thread
       pthread_create(&tid, NULL, worm_thread, nc);
       do{
         struct timespec left, cur;
         clock_gettime(CLOCK_MONOTONIC, &cur);
         timespec_subtract(&left, &screenend, &cur);
-        key = demo_getc(&left, NULL);
+        key = demo_getc(nc, &left, NULL);
         clock_gettime(CLOCK_MONOTONIC, &cur);
         int64_t ns = timespec_subtract_ns(&cur, &screenend);
         if(ns > 0){

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -16,7 +16,7 @@ static const char* leg[] = {
 static int
 watch_for_keystroke(struct notcurses* nc){
   wchar_t w;
-  if((w = demo_getc_nblock(NULL)) != (wchar_t)-1){
+  if((w = demo_getc_nblock(nc, NULL)) != (wchar_t)-1){
     if(w == 'q'){
       return 1;
     }


### PR DESCRIPTION
I noticed that `notcurses-demo` would sometimes segfault out when I unrolled the menu and sat on an arrow key, rapidly iterating between menu options. I traced this down to a race between the demo input thread and the regular rendering thread---`notcurses_render()` excludes all writing functions, so this is not safe. From now on, all menu/HUD processing is done in the context of `demo_getc()`, on the other side of the thread divide. Furthermore, `worm_thread()` has been folded into the main loop of `whiteout`, so all handling is now done in one thread. Testing suggests this to have been a stone cold fix [finger guns].