### PR TITLE
ncsubproc: decay to fork()/kill() on FreeBSD #374

### DIFF
--- a/doc/FreeBSD-Makefile
+++ b/doc/FreeBSD-Makefile
@@ -13,6 +13,8 @@ LICENSE=Apache-2.0
 USE_GITHUB=yes
 GH_ACCOUNT=dankamongmen
 
+LIB_DEPENDS=libqrcodegen.so:graphics/qr-code-generator
+
 # deps: doxygen, dia, doctest (not present?), ffmpeg
 
 .include <bsd.port.mk>


### PR DESCRIPTION
FreeBSD doesn't have clone3 or pidfd, so there we'll just use fork() and kill(). Also drop the waitid().