### PR TITLE
Implement blitting/boxes using US-ASCII when necessary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.4.2 (not yet released)
+  * Added `notcurses_canutf8()`, to verify use of UTF-8 encoding.
+
 * 1.4.1 (2020-05-11)
   * No user-visible changes (fixed two unit tests).
 

--- a/doc/man/man3/notcurses.3.md
+++ b/doc/man/man3/notcurses.3.md
@@ -150,6 +150,7 @@ previous action.
 **notcurses_palette(3)**,
 **notcurses_plane(3)**,
 **notcurses_plot(3)**,
+**notcurses_reader(3)**,
 **notcurses_reel(3)**,
 **notcurses_refresh(3)**,
 **notcurses_render(3)**,

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2008,11 +2008,9 @@ cells_load_box(struct ncplane* n, uint32_t attrs, uint64_t channels,
   return -1;
 }
 
-static inline int
-cells_rounded_box(struct ncplane* n, uint32_t attr, uint64_t channels,
-                  cell* ul, cell* ur, cell* ll, cell* lr, cell* hl, cell* vl){
-  return cells_load_box(n, attr, channels, ul, ur, ll, lr, hl, vl, "╭╮╰╯─│");
-}
+API int cells_rounded_box(struct ncplane* n, uint32_t attr, uint64_t channels,
+                          cell* ul, cell* ur, cell* ll, cell* lr,
+                          cell* hl, cell* vl);
 
 static inline int
 ncplane_rounded_box(struct ncplane* n, uint32_t attr, uint64_t channels,
@@ -2039,11 +2037,9 @@ ncplane_rounded_box_sized(struct ncplane* n, uint32_t attr, uint64_t channels,
                              x + xlen - 1, ctlword);
 }
 
-static inline int
-cells_double_box(struct ncplane* n, uint32_t attr, uint64_t channels,
-                 cell* ul, cell* ur, cell* ll, cell* lr, cell* hl, cell* vl){
-  return cells_load_box(n, attr, channels, ul, ur, ll, lr, hl, vl, "╔╗╚╝═║");
-}
+API int cells_double_box(struct ncplane* n, uint32_t attr, uint64_t channels,
+                         cell* ul, cell* ur, cell* ll, cell* lr,
+                         cell* hl, cell* vl);
 
 static inline int
 ncplane_double_box(struct ncplane* n, uint32_t attr, uint64_t channels,

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1031,6 +1031,9 @@ API bool notcurses_canchangecolor(const struct notcurses* nc);
 // Can we load images/videos? This requires being built against FFmpeg.
 API bool notcurses_canopen(const struct notcurses* nc);
 
+// Is our encoding UTF-8?
+API bool notcurses_canutf8(const struct notcurses* nc);
+
 typedef struct ncstats {
   // purely increasing stats
   uint64_t renders;          // number of successful notcurses_render() runs

--- a/src/demo/boxdemo.c
+++ b/src/demo/boxdemo.c
@@ -26,26 +26,34 @@ reload_corners(struct ncplane* n, cell* ul, cell* ur, cell* ll, cell* lr){
   return 0;
 }
 
-int box_demo(struct notcurses* nc){
-  int ylen, xlen;
-  struct ncplane* n = notcurses_stddim_yx(nc, &ylen, &xlen);
-  ncplane_erase(n);
-  cell ul = CELL_TRIVIAL_INITIALIZER, ll = CELL_TRIVIAL_INITIALIZER;
-  cell lr = CELL_TRIVIAL_INITIALIZER, ur = CELL_TRIVIAL_INITIALIZER;
-  cell hl = CELL_TRIVIAL_INITIALIZER, vl = CELL_TRIVIAL_INITIALIZER;
-  if(cells_double_box(n, 0, 0, &ul, &ur, &ll, &lr, &hl, &vl)){
+static int
+ascii_target(struct ncplane* n, int ytargbase){
+  if(ncplane_putstr_aligned(n, ytargbase++, NCALIGN_CENTER, "/-----\\") < 0){
     return -1;
   }
-  // target grid is 7x7
-  const int targx = 7;
-  const int targy = 7;
-  int ytargbase = (ylen - targy) / 2;
-  cell c = CELL_SIMPLE_INITIALIZER(' ');
-  cell_set_bg_default(&c);
-  ncplane_set_base_cell(n, &c);
-  cell_release(n, &c);
-  ncplane_set_fg_rgb(n, 180, 40, 180);
-  ncplane_set_bg_default(n);
+  if(ncplane_putstr_aligned(n, ytargbase++, NCALIGN_CENTER, "|/---\\|") < 0){
+    return -1;
+  }
+  if(ncplane_putstr_aligned(n, ytargbase++, NCALIGN_CENTER, "||\\|/||") < 0){
+    return -1;
+  }
+  if(ncplane_putstr_aligned(n, ytargbase++, NCALIGN_CENTER, "||-X-||") < 0){
+    return -1;
+  }
+  if(ncplane_putstr_aligned(n, ytargbase++, NCALIGN_CENTER, "||/|\\||") < 0){
+    return -1;
+  }
+  if(ncplane_putstr_aligned(n, ytargbase++, NCALIGN_CENTER, "|\\---/|") < 0){
+    return -1;
+  }
+  if(ncplane_putstr_aligned(n, ytargbase++, NCALIGN_CENTER, "\\-----/") < 0){
+    return -1;
+  }
+  return 0;
+}
+
+static int
+utf8_target(struct ncplane* n, int ytargbase){
   if(ncplane_putstr_aligned(n, ytargbase++, NCALIGN_CENTER, "┏━━┳━━┓") < 0){
     return -1;
   }
@@ -66,6 +74,38 @@ int box_demo(struct notcurses* nc){
   }
   if(ncplane_putstr_aligned(n, ytargbase++, NCALIGN_CENTER, "┗━━┻━━┛") < 0){
     return -1;
+  }
+  return 0;
+}
+
+int box_demo(struct notcurses* nc){
+  int ylen, xlen;
+  struct ncplane* n = notcurses_stddim_yx(nc, &ylen, &xlen);
+  ncplane_erase(n);
+  cell ul = CELL_TRIVIAL_INITIALIZER, ll = CELL_TRIVIAL_INITIALIZER;
+  cell lr = CELL_TRIVIAL_INITIALIZER, ur = CELL_TRIVIAL_INITIALIZER;
+  cell hl = CELL_TRIVIAL_INITIALIZER, vl = CELL_TRIVIAL_INITIALIZER;
+  if(cells_double_box(n, 0, 0, &ul, &ur, &ll, &lr, &hl, &vl)){
+    return -1;
+  }
+  // target grid is 7x7
+  const int targx = 7;
+  const int targy = 7;
+  int ytargbase = (ylen - targy) / 2;
+  cell c = CELL_SIMPLE_INITIALIZER(' ');
+  cell_set_bg_default(&c);
+  ncplane_set_base_cell(n, &c);
+  cell_release(n, &c);
+  ncplane_set_fg_rgb(n, 180, 40, 180);
+  ncplane_set_bg_default(n);
+  if(notcurses_canutf8(nc)){
+    if(utf8_target(n, ytargbase)){
+      return -1;
+    }
+  }else{
+    if(ascii_target(n, ytargbase)){
+      return -1;
+    }
   }
   if(cell_set_fg_rgb(&ul, 0xff, 0, 0)){
     return -1;

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -45,7 +45,7 @@ tria_blit_ascii(ncplane* nc, int placey, int placex, int linesize,
       }else{
         cell_set_fg_rgb(c, rgbbase_up[rpos], rgbbase_up[1], rgbbase_up[bpos]);
         cell_set_bg_rgb(c, rgbbase_up[rpos], rgbbase_up[1], rgbbase_up[bpos]);
-        if(cell_load(nc, c, "X") <= 0){
+        if(cell_load(nc, c, " ") <= 0){
           return -1;
         }
       }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -627,11 +627,6 @@ int ncplane_resize_internal(ncplane* n, int keepy, int keepx,
 
 int update_term_dimensions(int fd, int* rows, int* cols);
 
-static inline bool
-enforce_utf8(const notcurses* nc){
-  return nc->utf8;
-}
-
 struct ncvisual* ncvisual_create(float timescale);
 
 static inline void*

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -333,6 +333,7 @@ typedef struct notcurses {
   bool palette_damage[NCPALETTESIZE];
   struct esctrie* inputescapes; // trie of input escapes -> ncspecial_keys
   bool ownttyfp;  // do we own ttyfp (and thus must close it?)
+  bool utf8;      // are we using utf-8 encoding, as hoped?
 } notcurses;
 
 void sigwinch_handler(int signo);
@@ -626,17 +627,9 @@ int ncplane_resize_internal(ncplane* n, int keepy, int keepx,
 
 int update_term_dimensions(int fd, int* rows, int* cols);
 
-// might not be particularly fast, use sparingly, ideally once
 static inline bool
-enforce_utf8(void){
-  char* enc = nl_langinfo(CODESET);
-  if(!enc){
-    return false;
-  }
-  if(strcmp(enc, "UTF-8")){
-    return false;
-  }
-  return true;
+enforce_utf8(const notcurses* nc){
+  return nc->utf8;
 }
 
 struct ncvisual* ncvisual_create(float timescale);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1844,6 +1844,10 @@ int notcurses_mouse_disable(notcurses* n){
                    n->ttyfp, true);
 }
 
+bool notcurses_canutf8(const notcurses* nc){
+  return nc->utf8;
+}
+
 bool notcurses_canfade(const notcurses* nc){
   return nc->CCCflag || nc->RGBflag;
 }
@@ -2130,7 +2134,7 @@ int cells_ascii_box(struct ncplane* n, uint32_t attr, uint64_t channels,
 
 int cells_double_box(struct ncplane* n, uint32_t attr, uint64_t channels,
                      cell* ul, cell* ur, cell* ll, cell* lr, cell* hl, cell* vl){
-  if(enforce_utf8(n->nc)){
+  if(notcurses_canutf8(n->nc)){
     return cells_load_box(n, attr, channels, ul, ur, ll, lr, hl, vl, "╔╗╚╝═║");
   }
   return cells_ascii_box(n, attr, channels, ul, ur, ll, lr, hl, vl);
@@ -2138,7 +2142,7 @@ int cells_double_box(struct ncplane* n, uint32_t attr, uint64_t channels,
 
 int cells_rounded_box(struct ncplane* n, uint32_t attr, uint64_t channels,
                       cell* ul, cell* ur, cell* ll, cell* lr, cell* hl, cell* vl){
-  if(enforce_utf8(n->nc)){
+  if(notcurses_canutf8(n->nc)){
     return cells_load_box(n, attr, channels, ul, ur, ll, lr, hl, vl, "╭╮╰╯─│");
   }
   return cells_ascii_box(n, attr, channels, ul, ur, ll, lr, hl, vl);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2122,3 +2122,24 @@ char* ncplane_contents(const ncplane* nc, int begy, int begx, int leny, int lenx
   }
   return ret;
 }
+
+int cells_ascii_box(struct ncplane* n, uint32_t attr, uint64_t channels,
+                    cell* ul, cell* ur, cell* ll, cell* lr, cell* hl, cell* vl){
+  return cells_load_box(n, attr, channels, ul, ur, ll, lr, hl, vl, "/\\\\/-|");
+}
+
+int cells_double_box(struct ncplane* n, uint32_t attr, uint64_t channels,
+                     cell* ul, cell* ur, cell* ll, cell* lr, cell* hl, cell* vl){
+  if(enforce_utf8(n->nc)){
+    return cells_load_box(n, attr, channels, ul, ur, ll, lr, hl, vl, "╔╗╚╝═║");
+  }
+  return cells_ascii_box(n, attr, channels, ul, ur, ll, lr, hl, vl);
+}
+
+int cells_rounded_box(struct ncplane* n, uint32_t attr, uint64_t channels,
+                      cell* ul, cell* ur, cell* ll, cell* lr, cell* hl, cell* vl){
+  if(enforce_utf8(n->nc)){
+    return cells_load_box(n, attr, channels, ul, ur, ll, lr, hl, vl, "╭╮╰╯─│");
+  }
+  return cells_ascii_box(n, attr, channels, ul, ur, ll, lr, hl, vl);
+}

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -127,12 +127,13 @@ int cell_duplicate(ncplane* n, cell* targ, const cell* c){
 // for equality. if they are equal, return 0. otherwise, dup the second onto
 // the first and return non-zero.
 static int
-cellcmp_and_dupfar(egcpool* dampool, cell* damcell, const ncplane* srcplane,
-                   const cell* srccell){
+cellcmp_and_dupfar(egcpool* dampool, cell* damcell,
+                   const ncplane* srcplane, const cell* srccell){
+
   if(damcell->attrword == srccell->attrword){
     if(damcell->channels == srccell->channels){
-      bool damsimple = cell_simple_p(damcell);
       bool srcsimple = cell_simple_p(srccell);
+      bool damsimple = cell_simple_p(damcell);
       if(damsimple == srcsimple){
         if(damsimple){
           if(damcell->gcluster == srccell->gcluster){
@@ -832,7 +833,7 @@ stage_cursor(notcurses* nc, FILE* out, int y, int x){
 
 // Producing the frame requires three steps:
 //  * render -- build up a flat framebuffer from a set of ncplanes
-//  * rasterize -- build up a UTF-8 stream of escapes and EGCs
+//  * rasterize -- build up a UTF-8/ASCII stream of escapes and EGCs
 //  * refresh -- write the stream to the emulator
 
 // Takes a rendered frame (a flat framebuffer, where each cell has the desired

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -495,12 +495,11 @@ ncmultiselector_draw(ncmultiselector* n){
     if(printidx == n->current){
       n->ncp->channels = (uint64_t)channels_bchannel(n->descchannels) << 32u | channels_fchannel(n->descchannels);
     }
-    // FIXME this is the wrong place to do this. see https://github.com/dankamongmen/notcurses/issues/451
-if(enforce_utf8(n->ncp->nc)){
+    if(enforce_utf8(n->ncp->nc)){
       ncplane_putegc_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? "☒" : "☐", NULL);
-}else{
-  ncplane_putsimple_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? 'X' : '-');
-}
+    }else{
+      ncplane_putsimple_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? 'X' : '-');
+    }
     n->ncp->channels = n->opchannels;
     if(printidx == n->current){
       n->ncp->channels = (uint64_t)channels_bchannel(n->opchannels) << 32u | channels_fchannel(n->opchannels);

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -496,11 +496,11 @@ ncmultiselector_draw(ncmultiselector* n){
       n->ncp->channels = (uint64_t)channels_bchannel(n->descchannels) << 32u | channels_fchannel(n->descchannels);
     }
     // FIXME this is the wrong place to do this. see https://github.com/dankamongmen/notcurses/issues/451
-    if(enforce_utf8()){
+if(enforce_utf8(n->ncp->nc)){
       ncplane_putegc_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? "☒" : "☐", NULL);
-    }else{
-      ncplane_putsimple_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? 'X' : '-');
-    }
+}else{
+  ncplane_putsimple_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? 'X' : '-');
+}
     n->ncp->channels = n->opchannels;
     if(printidx == n->current){
       n->ncp->channels = (uint64_t)channels_bchannel(n->opchannels) << 32u | channels_fchannel(n->opchannels);

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -495,7 +495,7 @@ ncmultiselector_draw(ncmultiselector* n){
     if(printidx == n->current){
       n->ncp->channels = (uint64_t)channels_bchannel(n->descchannels) << 32u | channels_fchannel(n->descchannels);
     }
-    if(enforce_utf8(n->ncp->nc)){
+    if(notcurses_canutf8(n->ncp->nc)){
       ncplane_putegc_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? "☒" : "☐", NULL);
     }else{
       ncplane_putsimple_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? 'X' : '-');

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -594,6 +594,7 @@ nc_err_e ncvisual_decode(ncvisual* nc){
 
 static ncvisual*
 ncvisual_open(const char* filename, nc_err_e* ncerr){
+  *ncerr = NCERR_SUCCESS;
   ncvisual* ncv = ncvisual_create(1);
   if(ncv == nullptr){
     // fprintf(stderr, "Couldn't create %s (%s)\n", filename, strerror(errno));
@@ -603,15 +604,14 @@ ncvisual_open(const char* filename, nc_err_e* ncerr){
   memset(ncv, 0, sizeof(*ncv));
   int averr = avformat_open_input(&ncv->fmtctx, filename, nullptr, nullptr);
   if(averr < 0){
-    // fprintf(stderr, "Couldn't open %s (%s)\n", filename, av_err2str(*averr));
+//fprintf(stderr, "Couldn't open %s (%d)\n", filename, averr);
     *ncerr = averr2ncerr(averr);
     ncvisual_destroy(ncv);
     return nullptr;
   }
   averr = avformat_find_stream_info(ncv->fmtctx, nullptr);
   if(averr < 0){
-    /*fprintf(stderr, "Error extracting stream info from %s (%s)\n", filename,
-            av_err2str(*averr));*/
+//fprintf(stderr, "Error extracting stream info from %s (%d)\n", filename, averr);
     *ncerr = averr2ncerr(averr);
     ncvisual_destroy(ncv);
     return nullptr;
@@ -707,7 +707,7 @@ ncvisual* ncplane_visual_open(ncplane* nc, const char* filename, nc_err_e* ncerr
 }
 
 ncvisual* ncvisual_from_file(notcurses* nc, const char* filename,
-                              nc_err_e* ncerr, int y, int x, ncscale_e style){
+                             nc_err_e* ncerr, int y, int x, ncscale_e style){
   ncvisual* ncv = ncvisual_open(filename, ncerr);
   if(ncv == nullptr){
     return nullptr;
@@ -727,6 +727,7 @@ ncvisual* ncvisual_from_file(notcurses* nc, const char* filename,
 // up playback.
 int ncvisual_stream(notcurses* nc, ncvisual* ncv, nc_err_e* ncerr,
                     float timescale, streamcb streamer, void* curry){
+  *ncerr = NCERR_SUCCESS;
   int frame = 1;
   ncv->timescale = timescale;
   struct timespec begin; // time we started
@@ -850,6 +851,7 @@ bool notcurses_canopen(const notcurses* nc __attribute__ ((unused))){
 
 static ncvisual*
 ncvisual_open(const char* filename, nc_err_e* err){
+  *ncerr = NCERR_SUCCESS;
   ncvisual* ncv = ncvisual_create(1);
   if(ncv == nullptr){
     *err = NCERR_NOMEM;
@@ -985,6 +987,7 @@ nc_err_e ncvisual_decode(ncvisual* nc){
 
 int ncvisual_stream(struct notcurses* nc, struct ncvisual* ncv, nc_err_e* ncerr,
                     float timescale, streamcb streamer, void* curry){
+  *ncerr = NCERR_SUCCESS;
   int frame = 1;
   ncv->timescale = timescale;
   struct timespec begin; // time we started

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -2,6 +2,9 @@
 #include "egcpool.h"
 
 TEST_CASE("MultibyteWidth") {
+  if(!enforce_utf8()){
+    return;
+  }
   CHECK(0 == mbswidth(""));       // zero bytes, zero columns
   CHECK(-1 == mbswidth("\x7"));   // single byte, non-printable
   CHECK(1 == mbswidth(" "));      // single byte, one column

--- a/tests/egcpool.cpp
+++ b/tests/egcpool.cpp
@@ -12,6 +12,10 @@ TEST_CASE("EGCpool") {
     CHECK(!pool_.poolused);
   }
 
+  if(!enforce_utf8()){
+    return;
+  }
+
   SUBCASE("UTF8EGC") {
     const char* wstr = "☢";
     int c;

--- a/tests/fills.cpp
+++ b/tests/fills.cpp
@@ -7,6 +7,9 @@ TEST_CASE("Fills") {
   if(getenv("TERM") == nullptr){
     return;
   }
+  if(!enforce_utf8()){
+    return;
+  }
   notcurses_options nopts{};
   nopts.inhibit_alternate_screen = true;
   nopts.suppress_banner = true;

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -86,9 +86,6 @@ auto main(int argc, const char **argv) -> int {
     std::cerr << "Coudln't set locale based on user preferences!" << std::endl;
     return EXIT_FAILURE;
   }
-  if(!enforce_utf8()){
-    return EXIT_SUCCESS; // hrmmm
-  }
   doctest::Context context;
 
   context.setOption("order-by", "name");            // sort the test cases by their name

--- a/tests/main.h
+++ b/tests/main.h
@@ -6,6 +6,7 @@
 #include "version.h"
 #include <notcurses/notcurses.h>
 
-char* find_data(const char* datum);
+auto find_data(const char* datum) -> char*;
+auto enforce_utf8() -> bool;
 
 #endif

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -21,6 +21,9 @@ TEST_CASE("NCPlane") {
   if(getenv("TERM") == nullptr){
     return;
   }
+  if(!enforce_utf8()){
+    return;
+  }
   notcurses_options nopts{};
   nopts.inhibit_alternate_screen = true;
   nopts.suppress_banner = true;

--- a/tests/plot.cpp
+++ b/tests/plot.cpp
@@ -7,6 +7,9 @@ TEST_CASE("Plot") {
   if(getenv("TERM") == nullptr){
     return;
   }
+  if(!enforce_utf8()){
+    return;
+  }
   notcurses_options nopts{};
   nopts.inhibit_alternate_screen = true;
   nopts.suppress_banner = true;

--- a/tests/reader.cpp
+++ b/tests/reader.cpp
@@ -34,7 +34,11 @@ TEST_CASE("Readers") {
     ncreader_options opts{};
     opts.physrows = dimy / 2;
     opts.physcols = dimx / 2;
-    opts.egc = strdup("▒");
+    if(enforce_utf8()){
+      opts.egc = strdup("▒");
+    }else{
+      opts.egc = strdup("x");
+    }
     auto nr = ncreader_create(n_, 0, 0, &opts);
     REQUIRE(nullptr != nr);
     channels_set_fg(&opts.echannels, 0xff44ff);

--- a/tests/rotate.cpp
+++ b/tests/rotate.cpp
@@ -30,6 +30,9 @@ TEST_CASE("Rotate") {
   if(getenv("TERM") == nullptr){
     return;
   }
+  if(!enforce_utf8()){
+    return;
+  }
   notcurses_options nopts{};
   nopts.inhibit_alternate_screen = true;
   nopts.suppress_banner = true;

--- a/tests/visual.cpp
+++ b/tests/visual.cpp
@@ -5,6 +5,9 @@ TEST_CASE("Multimedia") {
   if(getenv("TERM") == nullptr){
     return;
   }
+  if(!enforce_utf8()){
+    return;
+  }
   notcurses_options nopts{};
   nopts.inhibit_alternate_screen = true;
   nopts.suppress_banner = true;

--- a/tests/visual.cpp
+++ b/tests/visual.cpp
@@ -1,11 +1,8 @@
 #include "main.h"
 #include <vector>
 
-TEST_CASE("Multimedia") {
+TEST_CASE("Visual") {
   if(getenv("TERM") == nullptr){
-    return;
-  }
-  if(!enforce_utf8()){
     return;
   }
   notcurses_options nopts{};
@@ -133,7 +130,7 @@ TEST_CASE("Multimedia") {
     std::vector<uint32_t> rgba(dimx * dimy * 2, 0x88bbccff);
     auto ncv = ncvisual_from_rgba(nc_, rgba.data(), dimy * 2, dimx * 4, dimx);
     REQUIRE(ncv);
-    CHECK(dimx * dimy == ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(0 < ncvisual_render(ncv, 0, 0, -1, -1));
     CHECK(0 == notcurses_render(nc_));
     ncvisual_destroy(ncv);
     CHECK(0 == notcurses_render(nc_));
@@ -145,7 +142,7 @@ TEST_CASE("Multimedia") {
     std::vector<uint32_t> rgba(dimx * dimy * 2, 0x88bbccff);
     auto ncv = ncvisual_from_bgra(nc_, rgba.data(), dimy * 2, dimx * 4, dimx);
     REQUIRE(ncv);
-    CHECK(dimx * dimy == ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(0 < ncvisual_render(ncv, 0, 0, -1, -1));
     CHECK(0 == notcurses_render(nc_));
     ncvisual_destroy(ncv);
     CHECK(0 == notcurses_render(nc_));

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -7,6 +7,9 @@ TEST_CASE("Wide") {
   if(getenv("TERM") == nullptr){
     return;
   }
+  if(!enforce_utf8()){
+    return;
+  }
   notcurses_options nopts{};
   nopts.inhibit_alternate_screen = true;
   nopts.suppress_banner = true;


### PR DESCRIPTION
We're absolutely not writing a general UTF-8->ASCII translation layer, but doing it in two places opens up a surprisingly large amount of functionality. We just needed touch:

* box setup, and
* rgba blitting

...and suddenly most of the demos are running in the "C" locale. Neat! Looks surprisingly good, too! Closes #325.