### PR TITLE
streaming API: client effects delay, not streamer

### DIFF
--- a/OTHERS.md
+++ b/OTHERS.md
@@ -18,6 +18,7 @@
 * [tview](https://github.com/rivo/tview) (Go)
 * [blessings](https://github.com/erikrose/blessings) [Python]
 * [urwid](https://github.com/urwid/urwid) [Python]
+* [ImTui](https://github.com/ggerganov/imtui) [C++]
 
 ## Declarative
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2176,7 +2176,7 @@ ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv,
       free(subtitle);
     }
   }
-  nanosleep(tspec, NULL);
+  clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, tspec, NULL);
   return ret;
 }
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2151,13 +2151,16 @@ API char* ncvisual_subtitle(const struct ncvisual* ncv);
 
 // Called for each frame rendered from 'ncv'. If anything but 0 is returned,
 // the streaming operation ceases immediately, and that value is propagated out.
-typedef int (*streamcb)(struct notcurses* nc, struct ncvisual* ncv, void*);
+// The recommended display time is passed in 'tspec'.
+typedef int (*streamcb)
+ (struct notcurses*, struct ncvisual*, const struct timespec*, void*);
 
 // Shut up and display my frames! Provide as an argument to ncvisual_stream().
 // If you'd like subtitles to be decoded, provide an ncplane as the curry. If the
 // curry is NULL, subtitles will not be displayed.
 static inline int
-ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv, void* curry){
+ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv,
+                         const struct timespec* tspec, void* curry){
   if(notcurses_render(nc)){
     return -1;
   }
@@ -2173,6 +2176,7 @@ ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv, void* curry
       free(subtitle);
     }
   }
+  nanosleep(tspec, NULL);
   return ret;
 }
 

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -299,7 +299,7 @@ void ncvisual_destroy(struct ncvisual* ncv);
 nc_err_e ncvisual_decode(struct ncvisual* nc);
 int ncvisual_render(const struct ncvisual* ncv, int begy, int begx, int leny, int lenx);
 char* ncvisual_subtitle(const struct ncvisual* ncv);
-typedef int (*streamcb)(struct notcurses* nc, struct ncvisual* ncv, void*);
+typedef int (*streamcb)(struct notcurses*, struct ncvisual*, const struct timespec*, void*);
 int ncvisual_stream(struct notcurses* nc, struct ncvisual* ncv, nc_err_e* err, float timescale, streamcb streamer, void* curry);
 int ncblit_bgrx(struct ncplane* nc, int placey, int placex, int linesize, const unsigned char* data, int begy, int begx, int leny, int lenx);
 int ncblit_rgba(struct ncplane* nc, int placey, int placex, int linesize, const unsigned char* data, int begy, int begx, int leny, int lenx);

--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -163,6 +163,14 @@ int demo_render(struct notcurses* nc);
 // rendering or otherwise manipulating state, as it calls notcurses_render().
 int demo_nanosleep(struct notcurses* nc, const struct timespec *ts);
 
+static inline int
+demo_simple_streamer(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
+                     const struct timespec* tspec, void* curry __attribute__ ((unused))){
+  DEMO_RENDER(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, tspec, NULL);
+  return 0;
+}
+
 int demo_fader(struct notcurses* nc, struct ncplane* ncp, void* curry);
 
 // grab the hud with the mouse

--- a/src/demo/outro.c
+++ b/src/demo/outro.c
@@ -8,7 +8,8 @@ static struct ncplane* on;
 static struct ncvisual* chncv;
 
 static int
-perframe(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)), void* vthree){
+perframe(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
+         const struct timespec* abstime, void* vthree){
   int* three = vthree; // move up one every three callbacks
   DEMO_RENDER(nc);
   if(y < targy){
@@ -19,6 +20,7 @@ perframe(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)), vo
     --y;
     *three = 3;
   }
+  clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, abstime, NULL);
   return 0;
 }
 

--- a/src/demo/view.c
+++ b/src/demo/view.c
@@ -2,7 +2,7 @@
 
 static int
 watch_for_keystroke(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
-                    void* curry __attribute__ ((unused))){
+                    const struct timespec* tspec, void* curry __attribute__ ((unused))){
   wchar_t w;
   // we don't want a keypress, but allow the ncvisual to handle
   // NCKEY_RESIZE for us

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -1,5 +1,7 @@
 #include "demo.h"
 
+// FIXME turn this into one large plane and move the plane, ratrher than
+// manually redrawing each time
 static const char* leg[] = {
 "                              88              88            88           88                          88             88               88                        ",
 "                              \"\"              88            88           88                          88             \"\"               \"\"                 ,d     ",
@@ -14,19 +16,8 @@ static const char* leg[] = {
 };
 
 static int
-watch_for_keystroke(struct notcurses* nc){
-  wchar_t w;
-  if((w = demo_getc_nblock(nc, NULL)) != (wchar_t)-1){
-    if(w == 'q'){
-      return 1;
-    }
-  }
-  return demo_render(nc);
-}
-
-static int
 perframecb(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
-           void* vnewplane){
+           const struct timespec* tspec, void* vnewplane){
   static int startr = 0x5f;
   static int startg = 0xaf;
   static int startb = 0x84;
@@ -92,7 +83,9 @@ perframecb(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
     b = t;
   }while(x < dimx);
   ++frameno;
-  return watch_for_keystroke(nc);
+  DEMO_RENDER(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, tspec, NULL);
+  return 0;
 }
 
 int xray_demo(struct notcurses* nc){

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -3,7 +3,7 @@
 void notcurses_debug(notcurses* nc, FILE* debugfp){
   const ncplane* n = nc->top;
   int planeidx = 0;
-  fprintf(debugfp, "********************* notcurses debug state *********************\n");
+  fprintf(debugfp, "*************************** notcurses debug state *****************************\n");
   while(n){
    fprintf(debugfp, "%04d off y: %3d x: %3d geom y: %3d x: %3d curs y: %3d x: %3d %s %p\n",
            planeidx, n->absy, n->absx, n->leny, n->lenx, n->y, n->x,
@@ -11,5 +11,5 @@ void notcurses_debug(notcurses* nc, FILE* debugfp){
     n = n->z;
     ++planeidx;
   }
-  fprintf(debugfp, "*****************************************************************\n");
+  fprintf(debugfp, "*******************************************************************************\n");
 }

--- a/src/lib/metric.c
+++ b/src/lib/metric.c
@@ -7,8 +7,9 @@
 const char *ncmetric(uintmax_t val, uintmax_t decimal, char *buf, int omitdec,
                      unsigned mul, int uprefix){
   const unsigned mult = mul; // FIXME kill
-  const char prefixes[] = "KMGTPEZY"; // 10^21-1 encompasses 2^64-1
-  const char subprefixes[] = "mµnpfazy"; // 10^24-1
+  // these two must have the same number of elements
+  const wchar_t prefixes[] =    L"KMGTPEZY"; // 10^21-1 encompasses 2^64-1
+  const wchar_t subprefixes[] = L"mµnpfazy"; // 10^24-1
   unsigned consumed = 0;
   uintmax_t dv;
 
@@ -19,7 +20,7 @@ const char *ncmetric(uintmax_t val, uintmax_t decimal, char *buf, int omitdec,
   dv = mult;
   if(decimal <= val || val == 0){
     // FIXME verify that input < 2^89, wish we had static_assert() :/
-    while((val / decimal) >= dv && consumed < strlen(prefixes)){
+    while((val / decimal) >= dv && consumed < sizeof(prefixes) / sizeof(*prefixes)){
       dv *= mult;
       ++consumed;
       if(UINTMAX_MAX / dv < mult){ // near overflow--can't scale dv again
@@ -27,7 +28,7 @@ const char *ncmetric(uintmax_t val, uintmax_t decimal, char *buf, int omitdec,
       }
     }
   }else{
-    while(val < decimal && consumed < strlen(subprefixes)){
+    while(val < decimal && consumed < sizeof(subprefixes) / sizeof(*subprefixes)){
       val *= mult;
       ++consumed;
       if(UINTMAX_MAX / dv < mult){ // near overflow--can't scale dv again

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -1179,6 +1179,7 @@ int ncvisual_stream(notcurses* nc, ncvisual* ncv, nc_err_e* ncerr,
       }
     }
     ++frame;
+  }
   if(*ncerr == NCERR_EOF){
     return 0;
   }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -33,11 +33,19 @@ timespec_to_ns(const struct timespec* ts) -> uint64_t {
   return ts->tv_sec * NANOSECS_IN_SEC + ts->tv_nsec;
 }
 
+static inline struct timespec*
+ns_to_timespec(uint64_t ns, struct timespec* ts){
+  ts->tv_sec = ns / NANOSECS_IN_SEC;
+  ts->tv_nsec = ns % NANOSECS_IN_SEC;
+  return ts;
+}
+
 // FIXME internalize this via complex curry
 static struct ncplane* subtitle_plane = nullptr;
 
 // frame count is in the curry. original time is in the ncvisual's ncplane's userptr.
-auto perframe([[maybe_unused]] struct notcurses* _nc, struct ncvisual* ncv, void* vframecount) -> int {
+auto perframe([[maybe_unused]] struct notcurses* _nc, struct ncvisual* ncv,
+              const struct timespec* abstime, void* vframecount) -> int {
   NotCurses &nc = NotCurses::get_instance ();
   auto start = static_cast<struct timespec*>(ncplane_userptr(ncvisual_plane(ncv)));
   if(!start){
@@ -89,12 +97,19 @@ auto perframe([[maybe_unused]] struct notcurses* _nc, struct ncvisual* ncv, void
   ncplane_dim_yx(ncvisual_plane(ncv), &oldy, &oldx);
   keepy = oldy > dimy ? dimy : oldy;
   keepx = oldx > dimx ? dimx : oldx;
-  char32_t keyp;
-  while((keyp = nc.getc(false, nullptr)) != (char32_t)-1){
-    if(keyp == NCKEY_RESIZE){
-      return ncplane_resize(ncvisual_plane(ncv), 0, 0, keepy, keepx, 0, 0, dimy, dimx);
+  struct timespec interval;
+  clock_gettime(CLOCK_MONOTONIC, &interval);
+  uint64_t nsnow = timespec_to_ns(&interval);
+  uint64_t absnow = timespec_to_ns(abstime);
+  if(absnow > nsnow){
+    ns_to_timespec(absnow - nsnow, &interval);
+    char32_t keyp;
+    while((keyp = nc.getc(&interval, nullptr, nullptr)) != (char32_t)-1){
+      if(keyp == NCKEY_RESIZE){
+        return ncplane_resize(ncvisual_plane(ncv), 0, 0, keepy, keepx, 0, 0, dimy, dimx);
+      }
+      return 1;
     }
-    return 1;
   }
   return 0;
 }


### PR DESCRIPTION
Previously, we've called `clock_nanosleep()` directly from within `ncvisual_stream()`, relieving the client of the need to delay while streaming (without a delay, we'd stream the entire file as quickly as possible). This is necessary so that clients can e.g. multiplex file descriptor watching with the delay, and also for more accurate timing, since we now delay based on an absolute time via `CLOCK_MONOTONIC`. Closes #604.