### PR TITLE
Correctly cast `ncpp::Plane` to `ncplane*`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ set(NCPP_SOURCES
   src/libcpp/Selector.cc
   src/libcpp/Subproc.cc
   src/libcpp/Tablet.cc
+  src/libcpp/Utilities.cc
   src/libcpp/Visual.cc
   )
 

--- a/include/ncpp/MultiSelector.hh
+++ b/include/ncpp/MultiSelector.hh
@@ -5,6 +5,7 @@
 
 #include "Root.hh"
 #include "NCAlign.hh"
+#include "Utilities.hh"
 
 namespace ncpp
 {
@@ -17,7 +18,7 @@ namespace ncpp
 
 	public:
 		explicit MultiSelector (Plane *plane, int y, int x, const ncmultiselector_options *opts = nullptr)
-			: MultiSelector (reinterpret_cast<ncplane*>(plane), y, x, opts)
+			: MultiSelector (Utilities::to_ncplane (plane), y, x, opts)
 		{}
 
 		explicit MultiSelector (Plane const* plane, int y, int x, const ncmultiselector_options *opts = nullptr)
@@ -25,7 +26,7 @@ namespace ncpp
 		{}
 
 		explicit MultiSelector (Plane &plane, int y, int x, const ncmultiselector_options *opts = nullptr)
-			: MultiSelector (reinterpret_cast<ncplane*>(&plane), y, x, opts)
+			: MultiSelector (plane.to_ncplane (), y, x, opts)
 		{}
 
 		explicit MultiSelector (Plane const& plane, int y, int x, const ncmultiselector_options *opts = nullptr)

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -115,6 +115,11 @@ namespace ncpp
 			return plane;
 		}
 
+		ncplane* to_ncplane () noexcept
+		{
+			return plane;
+		}
+
 		bool resize (int keepy, int keepx, int keepleny, int keeplenx, int yoff, int xoff, int ylen, int xlen) const NOEXCEPT_MAYBE
 		{
 			int ret = ncplane_resize (

--- a/include/ncpp/Plot.hh
+++ b/include/ncpp/Plot.hh
@@ -7,11 +7,10 @@
 
 #include "Root.hh"
 #include "NCAlign.hh"
+#include "Utilities.hh"
 
 namespace ncpp
 {
-	class Plane;
-
 	template<typename TPlot, typename TCoord>
 	class NCPP_API_EXPORT PlotBase : public Root
 	{
@@ -97,7 +96,7 @@ namespace ncpp
 
 	public:
 		explicit PlotU (Plane *plane, const ncplot_options *opts = nullptr)
-			: PlotU (reinterpret_cast<ncplane*>(plane), opts)
+			: PlotU (Utilities::to_ncplane (plane), opts)
 		{}
 
 		explicit PlotU (Plane const* plane, const ncplot_options *opts = nullptr)
@@ -105,7 +104,7 @@ namespace ncpp
 		{}
 
 		explicit PlotU (Plane &plane, const ncplot_options *opts = nullptr)
-			: PlotU (reinterpret_cast<ncplane*>(&plane), opts)
+			: PlotU (Utilities::to_ncplane (plane), opts)
 		{}
 
 		explicit PlotU (Plane const& plane, const ncplot_options *opts = nullptr)
@@ -127,7 +126,7 @@ namespace ncpp
 
 	public:
 		explicit PlotD (Plane *plane, const ncplot_options *opts = nullptr)
-			: PlotD (reinterpret_cast<ncplane*>(plane), opts)
+			: PlotD (Utilities::to_ncplane (plane), opts)
 		{}
 
 		explicit PlotD (Plane const* plane, const ncplot_options *opts = nullptr)
@@ -135,7 +134,7 @@ namespace ncpp
 		{}
 
 		explicit PlotD (Plane &plane, const ncplot_options *opts = nullptr)
-			: PlotD (reinterpret_cast<ncplane*>(&plane), opts)
+			: PlotD (Utilities::to_ncplane (plane), opts)
 		{}
 
 		explicit PlotD (Plane const& plane, const ncplot_options *opts = nullptr)

--- a/include/ncpp/Reader.hh
+++ b/include/ncpp/Reader.hh
@@ -6,6 +6,7 @@
 #include "Root.hh"
 #include "NCAlign.hh"
 #include "NotCurses.hh"
+#include "Utilities.hh"
 
 namespace ncpp
 {
@@ -15,7 +16,7 @@ namespace ncpp
 	{
 	public:
 		explicit Reader (Plane *p, int y, int x, const ncreader_options *opts)
-			: Reader (reinterpret_cast<ncplane*>(p), y, x, opts)
+			: Reader (Utilities::to_ncplane (p), y, x, opts)
 		{}
 
 		explicit Reader (Plane const* p, int y, int x, const ncreader_options *opts)

--- a/include/ncpp/Reel.hh
+++ b/include/ncpp/Reel.hh
@@ -6,6 +6,7 @@
 
 #include "Tablet.hh"
 #include "Root.hh"
+#include "Utilities.hh"
 
 namespace ncpp
 {
@@ -25,7 +26,7 @@ namespace ncpp
 			if (plane == nullptr)
 				throw invalid_argument ("'plane' must be a valid pointer");
 
-			create_reel (reinterpret_cast<ncplane*>(plane), popts, efd);
+			create_reel (Utilities::to_ncplane (plane), popts, efd);
 		}
 
 		explicit NcReel (ncplane *plane, const ncreel_options *popts = nullptr, int efd = -1)

--- a/include/ncpp/Selector.hh
+++ b/include/ncpp/Selector.hh
@@ -5,11 +5,10 @@
 
 #include "Root.hh"
 #include "NCAlign.hh"
+#include "Utilities.hh"
 
 namespace ncpp
 {
-	class Plane;
-
 	class NCPP_API_EXPORT Selector : public Root
 	{
 	public:
@@ -17,7 +16,7 @@ namespace ncpp
 
 	public:
 		explicit Selector (Plane *plane, int y, int x, const ncselector_options *opts = nullptr)
-			: Selector (reinterpret_cast<ncplane*>(plane), y, x, opts)
+			: Selector (Utilities::to_ncplane (plane), y, x, opts)
 		{}
 
 		explicit Selector (Plane const* plane, int y, int x, const ncselector_options *opts = nullptr)
@@ -25,7 +24,7 @@ namespace ncpp
 		{}
 
 		explicit Selector (Plane &plane, int y, int x, const ncselector_options *opts = nullptr)
-			: Selector (reinterpret_cast<ncplane*>(&plane), y, x, opts)
+			: Selector (plane.to_ncplane (), y, x, opts)
 		{}
 
 		explicit Selector (Plane const& plane, int y, int x, const ncselector_options *opts = nullptr)

--- a/include/ncpp/Utilities.hh
+++ b/include/ncpp/Utilities.hh
@@ -1,0 +1,23 @@
+#ifndef __NCPP_UTILITIES_HH
+#define __NCPP_UTILITIES_HH
+
+#include <notcurses/notcurses.h>
+
+#include "_helpers.hh"
+
+namespace ncpp
+{
+	class Plane;
+
+	class NCPP_API_EXPORT Utilities
+	{
+	public:
+		static ncplane* to_ncplane (const Plane *plane) noexcept;
+
+		static ncplane* to_ncplane (const Plane &plane) noexcept
+		{
+			return to_ncplane (&plane);
+		}
+	};
+}
+#endif

--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -5,6 +5,7 @@
 
 #include "Root.hh"
 #include "NCScale.hh"
+#include "Utilities.hh"
 
 namespace ncpp
 {
@@ -14,7 +15,7 @@ namespace ncpp
 	{
 	public:
 		explicit Visual (Plane *plane, const char *file, nc_err_e* ncerr)
-			: Visual (reinterpret_cast<ncplane*>(plane), file, ncerr)
+			: Visual (Utilities::to_ncplane (plane), file, ncerr)
 		{}
 
 		explicit Visual (Plane const* plane, const char *file, nc_err_e* ncerr)
@@ -22,7 +23,7 @@ namespace ncpp
 		{}
 
 		explicit Visual (Plane &plane, const char *file, nc_err_e* ncerr)
-			: Visual (reinterpret_cast<ncplane*>(&plane), file, ncerr)
+			: Visual (Utilities::to_ncplane (plane), file, ncerr)
 		{}
 
 		explicit Visual (Plane const& plane, const char *file, nc_err_e* ncerr)
@@ -34,7 +35,7 @@ namespace ncpp
 			if (plane == nullptr)
 				throw invalid_argument ("'plane' must be a valid pointer");
 
-			visual = ncplane_visual_open (reinterpret_cast<ncplane*>(plane), file, ncerr);
+			visual = ncplane_visual_open (plane, file, ncerr);
 			if (visual == nullptr)
 				throw init_error ("Notcurses failed to create a new visual");
 		}

--- a/src/libcpp/Utilities.cc
+++ b/src/libcpp/Utilities.cc
@@ -1,0 +1,12 @@
+#include <ncpp/Utilities.hh>
+#include <ncpp/Plane.hh>
+
+using namespace ncpp;
+
+ncplane* Utilities::to_ncplane (const Plane *plane) noexcept
+{
+	if (plane == nullptr)
+		return nullptr;
+
+	return const_cast<Plane*>(plane)->to_ncplane ();
+}


### PR DESCRIPTION
Fixes: https://github.com/dankamongmen/notcurses/issues/616

SIGSEGV was caused by an invalid cast.

Short explanation: PEBKAC

Long explanation: `Selector.hh`, `Plot.hh` and `MultiSelector.hh` did
not include `Plane.hh`, they merely declared `class Plane;` because
inclusion of `Plane.hh` would cause circular dependencies to appear and
the compiler would be unhappy.  On top of that, yours truly wrenched the
compiler's hands and caused it to believe that a pointer to `Plane` is
really a pointer to `ncplane*` which was quite a silly thing to do as
the compiler, not having included `Plane.hh` and thus not knowing full
definition of the type, wasn't able to look up the type cast operator in
`Plane`.

Don't abuse `reinterpret_cast`, kids!