### PR TITLE
[C++] Allow multiple instances of `NotCurses`

### DIFF
--- a/include/ncpp/Cell.hh
+++ b/include/ncpp/Cell.hh
@@ -10,6 +10,8 @@
 
 namespace ncpp
 {
+	class NotCurses;
+
 	class NCPP_API_EXPORT Cell : public Root
 	{
 	public:
@@ -26,17 +28,20 @@ namespace ncpp
 		static constexpr int AlphaOpaque        = CELL_ALPHA_OPAQUE;
 
 	public:
-		Cell () noexcept
+		Cell (NotCurses *ncinst = nullptr) noexcept
+			: Root (ncinst)
 		{
 			init ();
 		}
 
-		explicit Cell (uint32_t c) noexcept
+		explicit Cell (uint32_t c, NotCurses *ncinst = nullptr) noexcept
+			: Root (ncinst)
 		{
 			_cell = CELL_SIMPLE_INITIALIZER (c);
 		}
 
-		explicit Cell (uint32_t c, uint32_t a, uint64_t chan) noexcept
+		explicit Cell (uint32_t c, uint32_t a, uint64_t chan, NotCurses *ncinst = nullptr) noexcept
+			: Root (ncinst)
 		{
 			_cell = CELL_INITIALIZER (c, a, chan);
 		}

--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -9,10 +9,13 @@
 
 namespace ncpp
 {
+	class NotCurses;
+
 	class NCPP_API_EXPORT Direct : public Root
 	{
 	public:
-		explicit Direct (const char *termtype = nullptr, FILE *fp = nullptr)
+		explicit Direct (const char *termtype = nullptr, FILE *fp = nullptr, NotCurses *ncinst = nullptr)
+			: Root (ncinst)
 		{
 			direct = ncdirect_init (termtype, fp == nullptr ? stdout : fp);
 			if (direct == nullptr)

--- a/include/ncpp/FDPlane.hh
+++ b/include/ncpp/FDPlane.hh
@@ -3,7 +3,7 @@
 
 #include <notcurses/notcurses.h>
 
-#include "Root.hh"
+#include "Utilities.hh"
 #include "Plane.hh"
 
 namespace ncpp
@@ -18,20 +18,38 @@ namespace ncpp
 			: FDPlane (n, fd, nullptr, cbfxn, donecbfxn)
 		{}
 
+		explicit FDPlane (const Plane* n, int fd, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: FDPlane (n, fd, nullptr, cbfxn, donecbfxn)
+		{}
+
 		explicit FDPlane (Plane* n, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: FDPlane (static_cast<const Plane*>(n), fd, opts, cbfxn, donecbfxn)
+		{}
+
+		explicit FDPlane (const Plane* n, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Root (Utilities::get_notcurses_cpp (n))
 		{
 			if (n == nullptr)
 				throw invalid_argument ("'n' must be a valid pointer");
-			create_fdplane (*n, fd, opts, cbfxn, donecbfxn);
+			create_fdplane (const_cast<Plane&>(*n), fd, opts, cbfxn, donecbfxn);
 		}
+
+		explicit FDPlane (const Plane& n, int fd, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: FDPlane (n, fd, nullptr, cbfxn, donecbfxn)
+		{}
 
 		explicit FDPlane (Plane& n, int fd, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
 			: FDPlane (n, fd, nullptr, cbfxn, donecbfxn)
 		{}
 
 		explicit FDPlane (Plane& n, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: FDPlane (static_cast<Plane const&>(n), fd, opts, cbfxn, donecbfxn)
+		{}
+
+		explicit FDPlane (const Plane& n, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Root (Utilities::get_notcurses_cpp (n))
 		{
-			create_fdplane (n, fd, opts, cbfxn, donecbfxn);
+			create_fdplane (const_cast<Plane&>(n), fd, opts, cbfxn, donecbfxn);
 		}
 
 		~FDPlane ()

--- a/include/ncpp/Menu.hh
+++ b/include/ncpp/Menu.hh
@@ -7,6 +7,7 @@
 
 namespace ncpp
 {
+	class NotCurses;
 	class Plane;
 
 	class NCPP_API_EXPORT Menu : public Root
@@ -15,10 +16,10 @@ namespace ncpp
 		static ncmenu_options default_options;
 
 	public:
-		explicit Menu (const ncmenu_options *opts = nullptr)
+		explicit Menu (const ncmenu_options *opts = nullptr, NotCurses *ncinst = nullptr)
+			: Root (ncinst)
 		{
-			menu = ncmenu_create (notcurses_stdplane(get_notcurses ()),
-                            opts == nullptr ? &default_options : opts);
+			menu = ncmenu_create (notcurses_stdplane (get_notcurses ()), opts == nullptr ? &default_options : opts);
 			if (menu == nullptr)
 				throw init_error ("Notcurses failed to create a new menu");
 		}
@@ -64,9 +65,9 @@ namespace ncpp
 			return ncmenu_selected (menu, ni);
 		}
 
-		bool offer_input (const struct ncinput* nc) const noexcept
+		bool offer_input (const struct ncinput* ni) const noexcept
 		{
-			return ncmenu_offer_input (menu, nc);
+			return ncmenu_offer_input (menu, ni);
 		}
 
 		Plane* get_plane () const noexcept;

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -56,8 +56,11 @@ namespace ncpp
 			return *_instance;
 		}
 
-		static bool is_notcurses_stopped ()
+		static bool is_notcurses_stopped (const NotCurses *ncinst = nullptr)
 		{
+			if (ncinst != nullptr)
+				return ncinst->nc == nullptr;
+
 			return *_instance == nullptr || _instance->nc == nullptr;
 		}
 

--- a/include/ncpp/Palette256.hh
+++ b/include/ncpp/Palette256.hh
@@ -6,10 +6,13 @@
 
 namespace ncpp
 {
+	class NotCurses;
+
 	class NCPP_API_EXPORT Palette256 : public Root
 	{
 	public:
-		Palette256 ()
+		Palette256 (NotCurses *ncinst = nullptr)
+			: Root (ncinst)
 		{
 			palette = palette256_new (get_notcurses ());
 			if (palette == nullptr)

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -22,11 +22,13 @@ namespace ncpp
 	{
 	public:
 		Plane (Plane const& other)
+			: Root (nullptr)
 		{
 			plane = duplicate_plane (other, nullptr);
 		}
 
 		explicit Plane (Plane const& other, void *opaque)
+			: Root (nullptr)
 		{
 			plane = duplicate_plane (other, opaque);
 		}
@@ -36,6 +38,7 @@ namespace ncpp
 		{}
 
 		explicit Plane (const Plane *n, int rows, int cols, int yoff, int xoff, void *opaque = nullptr)
+			: Root (nullptr)
 		{
 			if (n == nullptr)
 				throw invalid_argument ("'n' must be a valid pointer");
@@ -44,11 +47,13 @@ namespace ncpp
 		}
 
 		explicit Plane (const Plane &n, int rows, int cols, int yoff, int xoff, void *opaque = nullptr)
+			: Root (nullptr)
 		{
 			plane = create_plane (n, rows, cols, yoff, xoff, opaque);
 		}
 
-		explicit Plane (int rows, int cols, int yoff, int xoff, void *opaque = nullptr)
+		explicit Plane (int rows, int cols, int yoff, int xoff, void *opaque = nullptr, NotCurses *ncinst = nullptr)
+			: Root (ncinst)
 		{
 			plane = ncplane_new (
 				get_notcurses (),
@@ -66,16 +71,19 @@ namespace ncpp
 		}
 
 		explicit Plane (Plane &n, int rows, int cols, int yoff, NCAlign align, void *opaque = nullptr)
+			: Root (nullptr)
 		{
 			plane = create_plane (n, rows, cols, yoff, align, opaque);
 		}
 
 		explicit Plane (Plane const& n, int rows, int cols, int yoff, NCAlign align, void *opaque = nullptr)
+			: Root (nullptr)
 		{
 			plane = create_plane (const_cast<Plane&>(n), rows, cols, yoff, align, opaque);
 		}
 
 		explicit Plane (Plane *n, int rows, int cols, int yoff, NCAlign align, void *opaque = nullptr)
+			: Root (nullptr)
 		{
 			if (n == nullptr)
 				throw invalid_argument ("'n' must be a valid pointer");
@@ -84,6 +92,7 @@ namespace ncpp
 		}
 
 		explicit Plane (Plane const* n, int rows, int cols, int yoff, NCAlign align, void *opaque = nullptr)
+			: Root (nullptr)
 		{
 			if (n == nullptr)
 				throw invalid_argument ("'n' must be a valid pointer");
@@ -92,7 +101,8 @@ namespace ncpp
 		}
 
 		explicit Plane (ncplane *_plane) noexcept
-			: plane (_plane)
+			: Root (nullptr),
+			  plane (_plane)
 		{}
 
 		~Plane () noexcept
@@ -118,7 +128,7 @@ namespace ncpp
 		void center_abs (int *y, int *x) const noexcept
 		{
 			ncplane_center_abs (plane, y, x);
-    }
+		}
 
 		ncplane* to_ncplane () noexcept
 		{
@@ -862,12 +872,12 @@ namespace ncpp
 
 		Visual* visual_open (const char *file, nc_err_e *ncerr) const
 		{
-			return new Visual (plane, file, ncerr);
+			return new Visual (this, file, ncerr);
 		}
 
 		NcReel* ncreel_create (const ncreel_options *popts = nullptr, int efd = -1) const
 		{
-			return new NcReel (plane, popts, efd);
+			return new NcReel (this, popts, efd);
 		}
 
 		// Some Cell APIs go here since they act on individual panels even though it may seem weird at points (e.g.
@@ -1031,8 +1041,9 @@ namespace ncpp
 
 	protected:
 		explicit Plane (ncplane *_plane, bool _is_stdplane)
-			: plane (_plane),
-				is_stdplane (_is_stdplane)
+			: Root (nullptr),
+			  plane (_plane),
+			  is_stdplane (_is_stdplane)
 		{
 			if (_plane == nullptr)
 				throw invalid_argument ("_plane must be a valid pointer");

--- a/include/ncpp/Plot.hh
+++ b/include/ncpp/Plot.hh
@@ -5,8 +5,8 @@
 
 #include <notcurses/notcurses.h>
 
-#include "Root.hh"
 #include "NCAlign.hh"
+#include "Plane.hh"
 #include "Utilities.hh"
 
 namespace ncpp
@@ -44,7 +44,8 @@ namespace ncpp
 		}
 
 	protected:
-		explicit PlotBase (ncplane *plane, const ncplot_options *opts, TCoord miny = 0, TCoord maxy = 0)
+		explicit PlotBase (Plane *plane, const ncplot_options *opts, TCoord miny = 0, TCoord maxy = 0)
+			: Root (Utilities::get_notcurses_cpp (plane))
 		{
 			static_assert (is_double || is_uint64, "PlotBase must be parameterized with either 'double' or 'uint64_t' types");
 			if constexpr (is_double) {
@@ -60,9 +61,9 @@ namespace ncpp
 				throw invalid_argument ("'opts' must be a valid pointer");
 
 			if constexpr (is_uint64) {
-				plot = ncuplot_create (plane, opts, miny, maxy);
+				plot = ncuplot_create (Utilities::to_ncplane (plane), opts, miny, maxy);
 			} else {
-				plot = ncdplot_create (plane, opts, miny, maxy);
+				plot = ncdplot_create (Utilities::to_ncplane (plane), opts, miny, maxy);
 			}
 
 			if (plot == nullptr)
@@ -96,24 +97,19 @@ namespace ncpp
 
 	public:
 		explicit PlotU (Plane *plane, const ncplot_options *opts = nullptr)
-			: PlotU (Utilities::to_ncplane (plane), opts)
+			: PlotU (static_cast<const Plane*>(plane), opts)
 		{}
 
 		explicit PlotU (Plane const* plane, const ncplot_options *opts = nullptr)
-			: PlotU (const_cast<Plane*>(plane), opts)
+			: PlotBase (const_cast<Plane*>(plane), opts == nullptr ? &default_options : opts)
 		{}
 
 		explicit PlotU (Plane &plane, const ncplot_options *opts = nullptr)
-			: PlotU (Utilities::to_ncplane (plane), opts)
+			: PlotU (static_cast<Plane const&>(plane), opts)
 		{}
 
 		explicit PlotU (Plane const& plane, const ncplot_options *opts = nullptr)
-			: PlotU (const_cast<Plane*>(&plane), opts)
-		{}
-
-		explicit PlotU (ncplane *plane, const ncplot_options *opts = nullptr,
-		                uint64_t miny = 0, uint64_t maxy = 0)
-			: PlotBase (plane, opts == nullptr ? &default_options : opts, miny, maxy)
+			: PlotBase (const_cast<Plane*>(&plane), opts == nullptr ? &default_options : opts)
 		{}
 
 		Plane* get_plane () const noexcept;
@@ -126,24 +122,19 @@ namespace ncpp
 
 	public:
 		explicit PlotD (Plane *plane, const ncplot_options *opts = nullptr)
-			: PlotD (Utilities::to_ncplane (plane), opts)
+			: PlotD (static_cast<const Plane*>(plane), opts)
 		{}
 
 		explicit PlotD (Plane const* plane, const ncplot_options *opts = nullptr)
-			: PlotD (const_cast<Plane*>(plane), opts)
+			: PlotBase (const_cast<Plane*>(plane), opts == nullptr ? &default_options : opts)
 		{}
 
 		explicit PlotD (Plane &plane, const ncplot_options *opts = nullptr)
-			: PlotD (Utilities::to_ncplane (plane), opts)
+			: PlotD (static_cast<Plane const&>(plane), opts)
 		{}
 
 		explicit PlotD (Plane const& plane, const ncplot_options *opts = nullptr)
-			: PlotD (const_cast<Plane*>(&plane), opts)
-		{}
-
-		explicit PlotD (ncplane *plane, const ncplot_options *opts = nullptr,
-		                double miny = 0, double maxy = 0)
-			: PlotBase (plane, opts == nullptr ? &default_options : opts, miny, maxy)
+			: PlotBase (const_cast<Plane*>(&plane), opts == nullptr ? &default_options : opts)
 		{}
 
 		Plane* get_plane () const noexcept;

--- a/include/ncpp/Root.hh
+++ b/include/ncpp/Root.hh
@@ -15,12 +15,26 @@ namespace ncpp {
 #define NOEXCEPT_MAYBE noexcept
 #endif
 
+	class NotCurses;
+
 	class NCPP_API_EXPORT Root
 	{
 	protected:
 		static constexpr char ncpp_invalid_state_message[] = "notcurses++ is in an invalid state (already stopped?)";
 
+	public:
+		notcurses* get_notcurses () const;
+
+		NotCurses* get_notcurses_cpp () const
+		{
+			return nc;
+		}
+
 	protected:
+		explicit Root (NotCurses *ncinst)
+			: nc (ncinst)
+		{}
+
 		template<typename TRet = bool, typename TValue = int>
 		TRet error_guard (TValue ret, TValue error_value) const
 		{
@@ -77,13 +91,14 @@ namespace ncpp {
 #endif
 		}
 
-		notcurses* get_notcurses () const;
-
 		// All the objects which need to destroy notcurses entities (planes, panelreel etc etc) **have to** call this
 		// function before calling to notcurses from their destructor. This is to prevent a segfault when
 		// NotCurses::stop has been called and the app uses smart pointers holding NotCurses objects which may be
 		// destructed **after** notcurses is stopped.
 		bool is_notcurses_stopped () const noexcept;
+
+	private:
+		NotCurses *nc = nullptr;
 	};
 }
 #endif

--- a/include/ncpp/Subproc.hh
+++ b/include/ncpp/Subproc.hh
@@ -20,14 +20,33 @@ namespace ncpp
 			: Subproc (n, bin, nullptr, use_path, arg, env, cbfxn, donecbfxn)
 		{}
 
+		explicit Subproc (const Plane* n, const char* bin, bool use_path = true,
+		                  char* const arg[] = nullptr, char* const env[] = nullptr,
+		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Subproc (n, bin, nullptr, use_path, arg, env, cbfxn, donecbfxn)
+		{}
+
 		explicit Subproc (Plane* n, const char* bin, const ncsubproc_options* opts, bool use_path = true,
 		                  char* const arg[] = nullptr, char* const env[] = nullptr,
 		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Subproc (static_cast<const Plane*>(n), bin, opts, use_path, arg, env, cbfxn, donecbfxn)
+		{}
+
+		explicit Subproc (const Plane* n, const char* bin, const ncsubproc_options* opts, bool use_path = true,
+		                  char* const arg[] = nullptr, char* const env[] = nullptr,
+		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Root (Utilities::get_notcurses_cpp (n))
 		{
 			if (n == nullptr)
 				throw invalid_argument ("'n' must be a valid pointer");
-			create_subproc (*n, bin, opts, use_path, arg, env, cbfxn, donecbfxn);
+			create_subproc (const_cast<Plane&>(*n), bin, opts, use_path, arg, env, cbfxn, donecbfxn);
 		}
+
+		explicit Subproc (Plane const& n, const char* bin, bool use_path = true,
+		                  char* const arg[] = nullptr, char* const env[] = nullptr,
+		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Subproc (n, bin, nullptr, use_path, arg, env, cbfxn, donecbfxn)
+		{}
 
 		explicit Subproc (Plane& n, const char* bin, bool use_path = true,
 		                  char* const arg[] = nullptr, char* const env[] = nullptr,
@@ -38,8 +57,15 @@ namespace ncpp
 		explicit Subproc (Plane& n, const char* bin, const ncsubproc_options* opts, bool use_path = true,
 		                  char* const arg[] = nullptr, char* const env[] = nullptr,
 		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Subproc (static_cast<Plane const&>(n), bin, opts, use_path, arg, env, cbfxn, donecbfxn)
+		{}
+
+		explicit Subproc (const Plane& n, const char* bin, const ncsubproc_options* opts, bool use_path = true,
+		                  char* const arg[] = nullptr, char* const env[] = nullptr,
+		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Root (Utilities::get_notcurses_cpp (n))
 		{
-			create_subproc (n, bin, opts, use_path, arg, env, cbfxn, donecbfxn);
+			create_subproc (const_cast<Plane&>(n), bin, opts, use_path, arg, env, cbfxn, donecbfxn);
 		}
 
 		~Subproc ()

--- a/include/ncpp/Tablet.hh
+++ b/include/ncpp/Tablet.hh
@@ -11,12 +11,14 @@
 namespace ncpp
 {
 	class Plane;
+	class NotCurses;
 
 	class NCPP_API_EXPORT NcTablet : public Root
 	{
 	protected:
-		explicit NcTablet (nctablet *t)
-			: _tablet (t)
+		explicit NcTablet (nctablet *t, NotCurses *ncinst)
+			: Root (ncinst),
+			  _tablet (t)
 		{
 			if (t == nullptr)
 				throw invalid_argument ("'t' must be a valid pointer");
@@ -40,7 +42,7 @@ namespace ncpp
 		}
 
 		Plane* get_plane () const noexcept;
-		static NcTablet* map_tablet (nctablet *t) noexcept;
+		static NcTablet* map_tablet (nctablet *t, NotCurses *ncinst = nullptr) noexcept;
 
 	protected:
 		static void unmap_tablet (NcTablet *p) noexcept;

--- a/include/ncpp/Utilities.hh
+++ b/include/ncpp/Utilities.hh
@@ -7,7 +7,9 @@
 
 namespace ncpp
 {
+	class NotCurses;
 	class Plane;
+	class Root;
 
 	class NCPP_API_EXPORT Utilities
 	{
@@ -17,6 +19,20 @@ namespace ncpp
 		static ncplane* to_ncplane (const Plane &plane) noexcept
 		{
 			return to_ncplane (&plane);
+		}
+
+		static NotCurses* get_notcurses_cpp (const Root *o) noexcept;
+
+		static NotCurses* get_notcurses_cpp (const Root &o) noexcept
+		{
+			return get_notcurses_cpp (&o);
+		}
+
+		static NotCurses* get_notcurses_cpp (const Plane *plane) noexcept;
+
+		static NotCurses* get_notcurses_cpp (const Plane &plane) noexcept
+		{
+			return get_notcurses_cpp (&plane);
 		}
 	};
 }

--- a/src/libcpp/NotCurses.cc
+++ b/src/libcpp/NotCurses.cc
@@ -30,20 +30,20 @@ NotCurses::~NotCurses ()
 		return;
 
 	notcurses_stop (nc);
-	_instance = nullptr;
+	if (_instance == this)
+		_instance = nullptr;
 }
 
 NotCurses::NotCurses (const notcurses_options &nc_opts, FILE *fp)
+	: Root (nullptr)
 {
 	const std::lock_guard<std::mutex> lock (init_mutex);
-
-	if (_instance != nullptr)
-		throw new init_error ("There can be only one instance of the NotCurses class. Use NotCurses::get_instance() to access the existing instance.");
 
 	nc = notcurses_init (&nc_opts, fp);
 	if (nc == nullptr)
 		throw new init_error ("notcurses failed to initialize");
-	_instance = this;
+	if (_instance == nullptr)
+		_instance = this;
 }
 
 Plane* NotCurses::get_top () noexcept
@@ -67,8 +67,9 @@ bool NotCurses::stop ()
   bool ret = !notcurses_stop (nc);
   nc = nullptr;
 
-	const std::lock_guard<std::mutex> lock (init_mutex);
-  _instance = nullptr;
+  const std::lock_guard<std::mutex> lock (init_mutex);
+  if (_instance == this)
+	  _instance = nullptr;
 
   return ret;
 }

--- a/src/libcpp/Root.cc
+++ b/src/libcpp/Root.cc
@@ -5,7 +5,13 @@ using namespace ncpp;
 
 notcurses* Root::get_notcurses () const
 {
-	notcurses *ret = NotCurses::get_instance ();
+	notcurses *ret;
+
+	if (nc != nullptr)
+		ret = *nc;
+	else
+		ret = NotCurses::get_instance ();
+
 	if (ret == nullptr)
 		throw new invalid_state_error (ncpp_invalid_state_message);
 	return ret;
@@ -13,5 +19,5 @@ notcurses* Root::get_notcurses () const
 
 bool Root::is_notcurses_stopped () const noexcept
 {
-	return NotCurses::is_notcurses_stopped ();
+	return NotCurses::is_notcurses_stopped (nc);
 }

--- a/src/libcpp/Tablet.cc
+++ b/src/libcpp/Tablet.cc
@@ -7,7 +7,7 @@ using namespace ncpp;
 std::map<nctablet*,NcTablet*> *NcTablet::tablet_map = nullptr;
 std::mutex NcTablet::tablet_map_mutex;
 
-NcTablet* NcTablet::map_tablet (nctablet *t) noexcept
+NcTablet* NcTablet::map_tablet (nctablet *t, NotCurses *ncinst) noexcept
 {
 	if (t == nullptr)
 		return nullptr;
@@ -17,7 +17,7 @@ NcTablet* NcTablet::map_tablet (nctablet *t) noexcept
 		tablet_map_mutex,
 		t,
 		[&] (nctablet *_t) -> NcTablet* {
-			return new NcTablet (_t);
+			return new NcTablet (_t, ncinst);
 		}
 	);
 }

--- a/src/libcpp/Utilities.cc
+++ b/src/libcpp/Utilities.cc
@@ -10,3 +10,16 @@ ncplane* Utilities::to_ncplane (const Plane *plane) noexcept
 
 	return const_cast<Plane*>(plane)->to_ncplane ();
 }
+
+NotCurses* Utilities::get_notcurses_cpp (const Root *o) noexcept
+{
+	if (o == nullptr)
+		return nullptr;
+
+	return const_cast<Root*>(o)->get_notcurses_cpp ();
+}
+
+NotCurses* Utilities::get_notcurses_cpp (const Plane *plane) noexcept
+{
+	return get_notcurses_cpp (static_cast<const Root*>(plane));
+}

--- a/src/poc/ncpp_build.cpp
+++ b/src/poc/ncpp_build.cpp
@@ -26,12 +26,12 @@ int run ()
 	NotCurses nc;
 
 	const char *ncver = nc.version ();
-  {
-    Plane plane (1, 1, 0, 0);
-    Plot plot1 (plane);
-    PlotU plot2 (plane);
-    PlotD plot3 (plane);
-  }
+	{
+		Plane plane (1, 1, 0, 0);
+		Plot plot1 (plane);
+		PlotU plot2 (plane);
+		PlotD plot3 (plane);
+	}
 
 	nc.stop ();
 


### PR DESCRIPTION
This is to make it possible, in the future, to create multiple instances
of `NotCurses` for multiple terminals.  The first instance of
`NotCurses` becomes the default one, so that any instances of other
classes that aren't explicitly created with a pointer to another
`NotCurses` instance still work as expected.

Note that currently trying to call `notcurses_init` twice results in the
following error for me:

    0x55555559bfc0 is already registered for signals
    Couldn't drop signals: 0x55555559bfc0 != 0x5555555b6720
    terminate called after throwing an instance of 'ncpp::init_error*'

    Program received signal SIGABRT, Aborted.

The error is signalled by `setup_signals` and the pointer shown in the
message points to the first `struct notcurses` instance created.