### PR TITLE
Reworking of ncvisual API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,6 @@ set(NCPP_SOURCES
   src/libcpp/Subproc.cc
   src/libcpp/Tablet.cc
   src/libcpp/Utilities.cc
-  src/libcpp/Visual.cc
   )
 
 add_library(notcurses++ SHARED ${NCPP_SOURCES})

--- a/USAGE.md
+++ b/USAGE.md
@@ -2451,13 +2451,11 @@ bool notcurses_canopen(const struct notcurses* nc);
 // (NCSCALE_SCALE) or abandoning it (NCSCALE_STRETCH).
 struct ncvisual* ncvisual_from_file(struct notcurses* nc, const char* file, nc_err_e* err, int y, int x, ncscale_e style);
 
-// Return the plane to which this ncvisual is bound.
-struct ncplane* ncvisual_plane(struct ncvisual* ncv);
-
 // Get the size and ratio of ncvisual pixels to output cells along the y
-// ('toy') and x ('tox') axes. A ncvisual of '*y'X'*x' pixels will require
-// ('*y' * '*toy')X('x' * 'tox') cells for full output.
-void ncvisual_geom(const struct ncvisual* n, int* y, int* x, int* toy, int* tox);
+// ('toy') and x ('tox') axes, assuming 'blitter'. A ncvisual of '*y'X'*x'
+// pixels will require ('*y' * '*toy')X('x' * 'tox') cells for full output.
+void ncvisual_geom(const struct ncvisual* n, ncblitter_e blitter,
+                   int* y, int* x, int* toy, int* tox);
 
 // Destroy an ncvisual. Rendered elements will not be disrupted, but the visual
 // can be neither decoded nor rendered any further.
@@ -2467,15 +2465,15 @@ void ncvisual_destroy(struct ncvisual* ncv);
 // and NCERR_SUCCESS on success, otherwise some other NCERR.
 nc_err_e ncvisual_decode(struct ncvisual* nc);
 
-// Render the decoded frame to the associated ncplane. The frame will be scaled
-// to the size of the ncplane per the ncscale_e style. A subregion of the
-// frame can be specified using 'begx', 'begy', 'lenx', and 'leny'. To render
-// the rectangle formed by begy x begx and the lower-right corner, -1 can be
-// supplied to 'leny' and 'lenx'. {0, 0, -1, -1} will thus render the entire
-// visual. Negative values for 'begy' or 'begx' are an error. It is an error to
-// specify any region beyond the boundaries of the frame. Returns the number of
-// cells written, or -1 on failure.
-int ncvisual_render(const struct ncvisual* ncv, int begy, int begx, int leny, int lenx);
+// Render the decoded frame to the specified ncplane (if one is not provided,
+// one will be created, having the exact size necessary to display the visual.
+// In this case, 'style' must be NCSTYLE_NONE). A subregion of the visual can
+// be rendered using 'begx', 'begy', 'lenx', and 'leny'. Negative values for
+// 'begy' or 'begx' are an error. It is an error to specify any region beyond
+// the boundaries of the frame. Returns the plane to which we drew (if ncv->n
+// is NULL, a new plane will be created).
+struct ncplane* ncvisual_render(struct notcurses* nc, struct ncvisual* ncv,
+                                const struct ncvisual_options* vopts);
 
 // Shut up and display my frames! Provide as an argument to ncvisual_stream().
 // If you'd like subtitles to be decoded, provide an ncplane as the curry. If the

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -41,16 +41,13 @@ typedef int (*streamcb)(struct notcurses*, struct ncvisual*, void*);
 
 **struct ncvisual* ncvisual_from_plane(struct ncplane* n);**
 
-**struct ncplane* ncvisual_plane(struct ncvisual* ncv);**
-
-**void ncvisual_geom(const struct ncvisual* n, int* y, int* x, int* toy, int* tox);**
+**void ncvisual_geom(const struct ncvisual* n, ncblitter_e blitter, int* y, int* x, int* toy, int* tox);**
 
 **void ncvisual_destroy(struct ncvisual* ncv);**
 
 **nc_err_e ncvisual_decode(struct ncvisual* nc);**
 
-**int ncvisual_render(const struct ncvisual* ncv, int begy, int begx,
-                        int leny, int lenx);**
+**struct ncplane* ncvisual_render(struct notcurses* nc, struct ncvisual* ncv, const struct visual_options* vopts);**
 
 **int ncvisual_simple_streamer(struct notcurses* nc, struct ncvisual* ncv, void* curry);**
 
@@ -123,7 +120,12 @@ make a firm codec identification. It does not imply that the entire file is
 properly-formed. On failure, **err** will be updated. **ncvisual_decode**
 returns **NCERR_SUCCESS** on success, or **NCERR_EOF** on end of file, or some
 other **nc_err_e** on failure. It likewise updates **err** in the event of an
-error. **ncvisual_render** returns the number of cells emitted, or -1 on error.
+error.
+
+**ncvisual_render** returns **NULL** on error, and otherwise the plane to
+which the visual was rendered. If **opts->n** is provided, this will be
+**opts->n**. Otherwise, a plane will be created, perfectly sized for the
+visual and the specified blitter.
 
 **ncvisual_from_plane** returns **NULL** if the **ncvisual** cannot be created
 and bound. This is usually due to illegal content in the source **ncplane**.

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -10,7 +10,6 @@
 
 #include "Root.hh"
 #include "Cell.hh"
-#include "Visual.hh"
 #include "Reel.hh"
 #include "CellStyle.hh"
 #include "NCAlign.hh"
@@ -860,11 +859,6 @@ namespace ncpp
 			return static_cast<T*>(get_userptr ());
 		}
 
-		Visual* visual_open (const ncvisual_options* opts, const char *file, nc_err_e *ncerr) const
-		{
-			return new Visual (opts, file, ncerr);
-		}
-
 		NcReel* ncreel_create (const ncreel_options *popts = nullptr, int efd = -1) const
 		{
 			return new NcReel (plane, popts, efd);
@@ -1095,7 +1089,6 @@ namespace ncpp
 		static std::mutex plane_map_mutex;
 
 		friend class NotCurses;
-		friend class Visual;
 		friend class NcReel;
 		friend class Tablet;
 	};

--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -4,6 +4,7 @@
 #include <notcurses/notcurses.h>
 
 #include "Root.hh"
+#include "Plane.hh"
 #include "Utilities.hh"
 
 namespace ncpp
@@ -13,9 +14,9 @@ namespace ncpp
 	class NCPP_API_EXPORT Visual : public Root
 	{
 	public:
-		explicit Visual (const ncvisual_options *opts, const char *file, nc_err_e *ncerr)
+		explicit Visual (const char *file, nc_err_e *ncerr)
 		{
-			visual = ncvisual_from_file (get_notcurses (), opts, file, ncerr);
+			visual = ncvisual_from_file (file, ncerr);
 			if (visual == nullptr)
 				throw init_error ("Notcurses failed to create a new visual");
 		}
@@ -41,22 +42,20 @@ namespace ncpp
 			return ncvisual_decode (visual);
 		}
 
-		bool render (int begy, int begx, int leny, int lenx) const NOEXCEPT_MAYBE
+		ncplane* render (const ncvisual_options* vopts) const NOEXCEPT_MAYBE
 		{
-			return error_guard (ncvisual_render (visual, begy, begx, leny, lenx), -1);
+			return ncvisual_render (get_notcurses (), visual, vopts); // FIXME error_guard
 		}
 
-		int stream (nc_err_e* ncerr, float timescale, streamcb streamer, void *curry = nullptr) const NOEXCEPT_MAYBE
+		int stream (Plane& p, nc_err_e* ncerr, float timescale, streamcb streamer, void *curry = nullptr) const NOEXCEPT_MAYBE
 		{
-			return error_guard<int> (ncvisual_stream (get_notcurses (), visual, ncerr, timescale, streamer, curry), -1);
+			return error_guard<int> (ncvisual_stream (p.to_ncplane (), visual, ncerr, timescale, streamer, curry), -1);
 		}
 
 		char* subtitle () const noexcept
 		{
 			return ncvisual_subtitle (visual);
 		}
-
-		Plane* get_plane () const noexcept;
 
 		bool rotate (double rads) const NOEXCEPT_MAYBE
 		{

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -300,25 +300,27 @@ typedef enum {
   NCBLIT_8x1,     // eight vert/horz levels    █▇▆▅▄▃▂▁ / ▏▎▍▌▋▊▉█
   NCBLIT_SIXEL,   // 6 rows, 1 col (RGB)
 } ncblitter_e;
+struct ncvisual* ncvisual_from_file(const char* file, nc_err_e* ncerr);
+struct ncvisual* ncvisual_from_rgba(const void* rgba, int rows, int rowstride, int cols);
+struct ncvisual* ncvisual_from_bgra(const void* rgba, int rows, int rowstride, int cols);
+struct ncvisual* ncvisual_from_plane(const struct ncplane* n, int begy, int begx, int leny, int lenx);
+int ncvisual_geom(const struct notcurses* nc, const struct ncvisual* n, ncblitter_e blitter, int* y, int* x, int* toy, int* tox);
+void ncvisual_destroy(struct ncvisual* ncv);
+nc_err_e ncvisual_decode(struct ncvisual* nc);
+int ncvisual_rotate(struct ncvisual* n, double rads);
+struct ncplane* ncvisual_render(struct notcurses* nc, struct ncvisual* ncv, const struct ncvisual_options* vopts);
+char* ncvisual_subtitle(const struct ncvisual* ncv);
+typedef int (*streamcb)(struct ncplane*, struct ncvisual*, const struct timespec*, void*);
+int ncvisual_stream(struct ncplane* n, struct ncvisual* ncv, nc_err_e* ncerr, float timescale, streamcb streamer, void* curry);
 struct ncvisual_options {
   struct ncplane* n;
-  ncscale_e style;
+  ncscale_e scaling;
   int y, x;
+  int begy, begx;
+  int leny, lenx;
   ncblitter_e glyphs;
   uint64_t flags;
 };
-struct ncvisual* ncvisual_from_file(struct notcurses* nc, const struct ncvisual_options* opts, const char* file, nc_err_e* ncerr);
-struct ncvisual* ncvisual_from_rgba(struct notcurses* nc, const struct ncvisual_options* opts, const void* rgba, int rows, int rowstride, int cols);
-struct ncvisual* ncvisual_from_bgra(struct notcurses* nc, const struct ncvisual_options* opts, const void* rgba, int rows, int rowstride, int cols);
-struct ncvisual* ncvisual_from_plane(const struct ncplane* n, const struct ncvisual_options* opts, int begy, int begx, int leny, int lenx);
-struct ncplane* ncvisual_plane(struct ncvisual* ncv);
-void ncvisual_geom(const struct ncvisual* n, int* y, int* x, int* toy, int* tox);
-void ncvisual_destroy(struct ncvisual* ncv);
-nc_err_e ncvisual_decode(struct ncvisual* nc);
-int ncvisual_render(const struct ncvisual* ncv, int begy, int begx, int leny, int lenx);
-char* ncvisual_subtitle(const struct ncvisual* ncv);
-typedef int (*streamcb)(struct notcurses*, struct ncvisual*, const struct timespec*, void*);
-int ncvisual_stream(struct notcurses* nc, struct ncvisual* ncv, nc_err_e* err, float timescale, streamcb streamer, void* curry);
 int ncblit_bgrx(struct ncplane* nc, int placey, int placex, int linesize, const unsigned char* data, int begy, int begx, int leny, int lenx);
 int ncblit_rgba(struct ncplane* nc, int placey, int placex, int linesize, const unsigned char* data, int begy, int begx, int leny, int lenx);
 struct ncselector_item {
@@ -451,7 +453,6 @@ int ncplane_format(struct ncplane* n, int ystop, int xstop, uint32_t attrword);
 int ncplane_stain(struct ncplane* n, int ystop, int xstop, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr);
 int ncplane_rotate_cw(struct ncplane* n);
 int ncplane_rotate_ccw(struct ncplane* n);
-int ncvisual_rotate(struct ncvisual* n, double rads);
 void ncplane_translate(const struct ncplane* src, const struct ncplane* dst, int* y, int* x);
 bool ncplane_translate_abs(const struct ncplane* n, int* y, int* x);
 typedef struct ncplot_options {

--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -164,9 +164,9 @@ int demo_render(struct notcurses* nc);
 int demo_nanosleep(struct notcurses* nc, const struct timespec *ts);
 
 static inline int
-demo_simple_streamer(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
+demo_simple_streamer(struct ncplane* nc, struct ncvisual* ncv __attribute__ ((unused)),
                      const struct timespec* tspec, void* curry __attribute__ ((unused))){
-  DEMO_RENDER(nc);
+  DEMO_RENDER(ncplane_notcurses(nc));
   clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, tspec, NULL);
   return 0;
 }

--- a/src/demo/fallin.c
+++ b/src/demo/fallin.c
@@ -178,10 +178,7 @@ int fallin_demo(struct notcurses* nc){
 #ifndef DFSG_BUILD
   nc_err_e err = NCERR_SUCCESS;
   char* path = find_data("lamepatents.jpg");
-  struct ncvisual_options vopts = {
-    .n = stdn,
-  };
-  struct ncvisual* ncv = ncvisual_from_file(nc, &vopts, path, &err);
+  struct ncvisual* ncv = ncvisual_from_file(path, &err);
   free(path);
   if(ncv == NULL){
     goto err;
@@ -190,7 +187,11 @@ int fallin_demo(struct notcurses* nc){
     ncvisual_destroy(ncv);
     goto err;
   }
-  if(ncvisual_render(ncv, 0, 0, -1, -1) <= 0){
+  struct ncvisual_options vopts = {
+    .n = stdn,
+    .scaling = NCSCALE_STRETCH,
+  };
+  if(ncvisual_render(nc, ncv, &vopts) == NULL){
     ncvisual_destroy(ncv);
     goto err;
   }

--- a/src/demo/luigi.c
+++ b/src/demo/luigi.c
@@ -149,9 +149,7 @@ int luigi_demo(struct notcurses* nc){
   int rows, cols;
   nc_err_e ncerr = NCERR_SUCCESS;
   char* map = find_data("megaman2.bmp");
-  struct ncvisual_options vopts = {};
-  vopts.n = notcurses_stddim_yx(nc, &rows, &cols);
-  struct ncvisual* nv = ncvisual_from_file(nc, &vopts, map, &ncerr);
+  struct ncvisual* nv = ncvisual_from_file(map, &ncerr);
   free(map);
   if(nv == NULL){
     return -1;
@@ -159,7 +157,11 @@ int luigi_demo(struct notcurses* nc){
   if((ncerr = ncvisual_decode(nv)) != NCERR_SUCCESS){
     return -1;
   }
-  if(ncvisual_render(nv, 0, 0, -1, -1) <= 0){
+  struct ncvisual_options vopts = {
+    .n = notcurses_stddim_yx(nc, &rows, &cols),
+    .scaling = NCSCALE_STRETCH,
+  };
+  if(ncvisual_render(nc, nv, &vopts) == NULL){
     return -1;
   }
   assert(NCERR_EOF == ncvisual_decode(nv));
@@ -188,7 +190,7 @@ int luigi_demo(struct notcurses* nc){
   if(fname == NULL){
     return -1;
   }
-  wmncv = ncvisual_from_file(nc, NULL, fname, &ncerr);
+  wmncv = ncvisual_from_file(fname, &ncerr);
   free(fname);
   if(wmncv == NULL){
     return -1;
@@ -200,11 +202,12 @@ int luigi_demo(struct notcurses* nc){
   uint64_t channels = 0;
   channels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
   channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
-  ncplane_set_base(ncvisual_plane(wmncv), "", 0, channels);
-  if(ncvisual_render(wmncv, 0, 0, -1, -1) <= 0){
+  struct ncplane* wmplane = ncvisual_render(nc, wmncv, NULL);
+  if(wmplane == NULL){
     ncvisual_destroy(wmncv);
     return -1;
   }
+  ncplane_set_base(wmplane, "", 0, channels);
   for(i = 0 ; i < cols - 16 - 1 + 50 ; ++i){
     if(i + 16 >= cols - 16 - 1){
       --yoff;
@@ -214,14 +217,16 @@ int luigi_demo(struct notcurses* nc){
       ncplane_move_top(lastseen);
     }
     ncplane_move_yx(lastseen, yoff, i);
-    int dimy = ncplane_dim_y(ncvisual_plane(wmncv));
-    ncplane_move_yx(ncvisual_plane(wmncv), rows * 4 / 5 - dimy + 1 + (i % 2), i - 60);
+    int dimy;
+    ncvisual_geom(nc, wmncv, NCBLIT_DEFAULT, &dimy, NULL, NULL, NULL);
+    ncplane_move_yx(wmplane, rows * 4 / 5 - dimy + 1 + (i % 2), i - 60);
     DEMO_RENDER(nc);
     demo_nanosleep(nc, &stepdelay);
   }
   for(i = 0 ; i < 3 ; ++i){
     ncplane_destroy(lns[i]);
   }
+  ncplane_destroy(wmplane);
   ncvisual_destroy(nv);
   ncvisual_destroy(wmncv);
   return 0;

--- a/src/demo/normal.c
+++ b/src/demo/normal.c
@@ -81,6 +81,7 @@ int normal_demo(struct notcurses* nc){
   if(n == NULL){
     return -1;
   }
+  ncplane_cursor_move_yx(n, 0, 0);
   // we can't rotate a plane unless it has an even number of columns :/
   int nx;
   if((nx = ncplane_dim_x(n)) % 2){
@@ -129,15 +130,16 @@ int normal_demo(struct notcurses* nc){
   channels_set_fg_rgb(&tr, random() % 256, random() % 256, random() % 256);
   channels_set_fg_rgb(&bl, random() % 256, random() % 256, random() % 256);
   channels_set_fg_rgb(&br, random() % 256, random() % 256, random() % 256);
-  if(ncplane_stain(n, (dy / VSCALE) - 1, dx - 1, tl, tr, bl, br) < 0){
+  ncplane_dim_yx(n, &dy, &dx);
+  if(ncplane_stain(n, dy - 1, dx - 1, tl, tr, bl, br) < 0){
     goto err;
   }
   DEMO_RENDER(nc);
   demo_nanosleep(nc, &demodelay);
+  struct ncvisual* ncv = ncvisual_from_plane(n, 0, 0, dy, dx);
   struct ncvisual_options vopts = {
     .n = n,
   };
-  struct ncvisual* ncv = ncvisual_from_plane(n, &vopts, 0, 0, (dy / VSCALE) - 1, dx - 1);
   if(!ncv){
     goto err;
   }
@@ -151,7 +153,7 @@ int normal_demo(struct notcurses* nc){
       failed = true;
       break;
     }
-    if(ncvisual_render(ncv, 0, 0, -1, -1) < 0){
+    if(ncvisual_render(nc, ncv, &vopts) == NULL){
       failed = true;
       break;
     }

--- a/src/demo/outro.c
+++ b/src/demo/outro.c
@@ -8,10 +8,10 @@ static struct ncplane* on;
 static struct ncvisual* chncv;
 
 static int
-perframe(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
+perframe(struct ncplane* n, struct ncvisual* ncv __attribute__ ((unused)),
          const struct timespec* abstime, void* vthree){
   int* three = vthree; // move up one every three callbacks
-  DEMO_RENDER(nc);
+  DEMO_RENDER(ncplane_notcurses(n));
   if(y < targy){
     return 0;
   }
@@ -35,10 +35,7 @@ fadethread(void* vnc){
   ncvisual_destroy(chncv);
   nc_err_e err;
   char* path = find_data("samoa.avi");
-  struct ncvisual_options vopts = {
-    .n = ncp,
-  };
-  struct ncvisual* ncv = ncvisual_from_file(nc, &vopts, path, &err);
+  struct ncvisual* ncv = ncvisual_from_file(path, &err);
   free(path);
   if(ncv == NULL){
     return NULL;
@@ -49,7 +46,7 @@ fadethread(void* vnc){
   ncplane_putstr_aligned(apiap, 0, NCALIGN_CENTER,
       "Apia 🡺 Atlanta. Samoa, tula'i ma sisi ia lau fu'a, lou pale lea!");
   int three = 3;
-  int canceled = ncvisual_stream(nc, ncv, &err, delaymultiplier, perframe, &three);
+  int canceled = ncvisual_stream(ncp, ncv, &err, delaymultiplier, perframe, &three);
   ncvisual_destroy(ncv);
   ncplane_erase(ncp);
   ncplane_destroy(apiap);
@@ -136,10 +133,7 @@ int outro(struct notcurses* nc){
   ncplane_erase(ncp);
   nc_err_e err = 0;
   char* path = find_data("changes.jpg");
-  struct ncvisual_options vopts = {
-    .n = ncp,
-  };
-  chncv = ncvisual_from_file(nc, &vopts, path, &err);
+  chncv = ncvisual_from_file(path, &err);
   free(path);
   if(chncv == NULL){
     return -1;
@@ -148,7 +142,11 @@ int outro(struct notcurses* nc){
     ncvisual_destroy(chncv);
     return -1;
   }
-  if(ncvisual_render(chncv, 0, 0, -1, -1) <= 0){
+  struct ncvisual_options vopts = {
+    .n = ncp,
+    .scaling = NCSCALE_STRETCH,
+  };
+  if(ncvisual_render(nc, chncv, &vopts) == NULL){
     ncvisual_destroy(chncv);
     return -1;
   }

--- a/src/demo/view.c
+++ b/src/demo/view.c
@@ -7,16 +7,13 @@ view_video_demo(struct notcurses* nc){
   nc_err_e err;
   struct ncvisual* ncv;
   char* fm6 = find_data("fm6.mkv");
-  struct ncvisual_options vopts = {
-    .n = ncp,
-  };
-  ncv = ncvisual_from_file(nc, &vopts, fm6, &err);
+  ncv = ncvisual_from_file(fm6, &err);
   if(!ncv){
     free(fm6);
     return -1;
   }
   free(fm6);
-  int ret = ncvisual_stream(nc, ncv, &err, 2.0/3.0 * delaymultiplier,
+  int ret = ncvisual_stream(ncp, ncv, &err, 2.0/3.0 * delaymultiplier,
                             demo_simple_streamer, NULL);
   ncvisual_destroy(ncv);
   return ret;
@@ -69,10 +66,7 @@ view_images(struct notcurses* nc, struct ncplane* nstd, int dimy, int dimx){
   }
   nc_err_e err = NCERR_SUCCESS;
   char* pic = find_data("dsscaw-purp.png");
-  struct ncvisual_options vopts = {
-    .n = dsplane,
-  };
-  struct ncvisual* ncv2 = ncvisual_from_file(nc, &vopts, pic, &err);
+  struct ncvisual* ncv2 = ncvisual_from_file(pic, &err);
   if(ncv2 == NULL){
     free(pic);
     ncplane_destroy(dsplane);
@@ -84,7 +78,11 @@ view_images(struct notcurses* nc, struct ncplane* nstd, int dimy, int dimx){
     ncplane_destroy(dsplane);
     return -1;
   }
-  if(ncvisual_render(ncv2, 0, 0, -1, -1) <= 0){
+  struct ncvisual_options vopts = {
+    .n = dsplane,
+    .scaling = NCSCALE_STRETCH,
+  };
+  if(ncvisual_render(nc, ncv2, &vopts) == NULL){
     ncvisual_destroy(ncv2);
     ncplane_destroy(dsplane);
     return -1;
@@ -92,14 +90,14 @@ view_images(struct notcurses* nc, struct ncplane* nstd, int dimy, int dimx){
   uint64_t channels = 0;
   channels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
   channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
-  ncplane_set_base(ncvisual_plane(ncv2), "", 0, channels);
+  ncplane_set_base(dsplane, "", 0, channels);
   ncvisual_destroy(ncv2);
   demo_render(nc);
   demo_nanosleep(nc, &demodelay);
   // now we open PurpleDrank on the standard plane, and hide DSSAW
   ncplane_move_bottom(dsplane);
   pic = find_data("PurpleDrank.jpg");
-  struct ncvisual* ncv = ncvisual_from_file(nc, &vopts, pic, &err);
+  struct ncvisual* ncv = ncvisual_from_file(pic, &err);
   if(ncv == NULL){
     ncplane_destroy(dsplane);
     free(pic);
@@ -111,7 +109,7 @@ view_images(struct notcurses* nc, struct ncplane* nstd, int dimy, int dimx){
     ncplane_destroy(dsplane);
     return -1;
   }
-  if(ncvisual_render(ncv, 0, 0, -1, -1) <= 0){
+  if(ncvisual_render(nc, ncv, &vopts) == NULL){
     ncvisual_destroy(ncv);
     ncplane_destroy(dsplane);
     return -1;

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -51,8 +51,9 @@ make_slider(struct notcurses* nc, int dimy){
 }
 
 static int
-perframecb(struct notcurses* nc, struct ncvisual* ncv __attribute__ ((unused)),
+perframecb(struct ncplane* stdn, struct ncvisual* ncv __attribute__ ((unused)),
            const struct timespec* tspec, void* vnewplane){
+  struct notcurses* nc = ncplane_notcurses(stdn);
   static int frameno = 0;
   int y, x;
   struct ncplane* n = vnewplane;
@@ -77,10 +78,7 @@ int xray_demo(struct notcurses* nc){
   }
   char* path = find_data("notcursesI.avi");
   nc_err_e err;
-  struct ncvisual_options vopts = {
-    .n = n,
-  };
-  struct ncvisual* ncv = ncvisual_from_file(nc, &vopts, path, &err);
+  struct ncvisual* ncv = ncvisual_from_file(path, &err);
   free(path);
   if(ncv == NULL){
     return -1;
@@ -91,7 +89,7 @@ int xray_demo(struct notcurses* nc){
     ncplane_destroy(n);
     return -1;
   }
-  int ret = ncvisual_stream(nc, ncv, &err, 0.5 * delaymultiplier, perframecb, newpanel);
+  int ret = ncvisual_stream(n, ncv, &err, 0.5 * delaymultiplier, perframecb, newpanel);
   ncvisual_destroy(ncv);
   ncplane_destroy(n);
   ncplane_destroy(newpanel);

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -1,5 +1,7 @@
 #include "internal.h"
 
+static const unsigned char zeroes[] = "\x00\x00\x00\x00";
+
 // alpha comes to us 0--255, but we have only 3 alpha values to map them to.
 // settled on experimentally.
 static inline bool
@@ -62,6 +64,7 @@ static inline int
 tria_blit(ncplane* nc, int placey, int placex, int linesize,
           const void* data, int begy, int begx,
           int leny, int lenx, bool bgr){
+//fprintf(stderr, "%d X %d @ %d X %d (%p) place: %d X %d\n", leny, lenx, begy, begx, data, placey, placex);
   const int bpp = 32;
   const int rpos = bgr ? 2 : 0;
   const int bpos = bgr ? 0 : 2;
@@ -78,7 +81,7 @@ tria_blit(ncplane* nc, int placey, int placex, int linesize,
     int visx = begx;
     for(x = placex ; visx < (begx + lenx) && x < dimx ; ++x, ++visx){
       const unsigned char* rgbbase_up = dat + (linesize * visy) + (visx * bpp / CHAR_BIT);
-      const unsigned char* rgbbase_down = (const unsigned char*)"\x00\x00\x00\x00";
+      const unsigned char* rgbbase_down = zeroes;
       if(visy < begy + leny - 1){
         rgbbase_down = dat + (linesize * (visy + 1)) + (visx * bpp / CHAR_BIT);
       }
@@ -146,9 +149,9 @@ quadrant_blit(ncplane* nc, int placey, int placex, int linesize,
     int visx = begx;
     for(x = placex ; visx < (begx + lenx) && x < dimx ; ++x, visx += 2){
       const unsigned char* rgbbase_tl = dat + (linesize * visy) + (visx * bpp / CHAR_BIT);
-      const unsigned char* rgbbase_tr = (const unsigned char*)"\x00\x00\x00\x00";
-      const unsigned char* rgbbase_bl = (const unsigned char*)"\x00\x00\x00\x00";
-      const unsigned char* rgbbase_br = (const unsigned char*)"\x00\x00\x00\x00";
+      const unsigned char* rgbbase_tr = zeroes;
+      const unsigned char* rgbbase_bl = zeroes;
+      const unsigned char* rgbbase_br = zeroes;
       if(visx < begx + lenx - 1){
         rgbbase_tr = dat + (linesize * visy) + ((visx + 1) * bpp / CHAR_BIT);
         if(visy < begy + leny - 1){
@@ -217,13 +220,13 @@ braille_blit(ncplane* nc, int placey, int placex, int linesize,
     int visx = begx;
     for(x = placex ; visx < (begx + lenx) && x < dimx ; ++x, visx += 2){
       const unsigned char* rgbbase_l0 = dat + (linesize * visy) + (visx * bpp / CHAR_BIT);
-      const unsigned char* rgbbase_r0 = (const unsigned char*)"\x00\x00\x00\x00";
-      const unsigned char* rgbbase_l1 = (const unsigned char*)"\x00\x00\x00\x00";
-      const unsigned char* rgbbase_r1 = (const unsigned char*)"\x00\x00\x00\x00";
-      const unsigned char* rgbbase_l2 = (const unsigned char*)"\x00\x00\x00\x00";
-      const unsigned char* rgbbase_r2 = (const unsigned char*)"\x00\x00\x00\x00";
-      const unsigned char* rgbbase_l3 = (const unsigned char*)"\x00\x00\x00\x00";
-      const unsigned char* rgbbase_r3 = (const unsigned char*)"\x00\x00\x00\x00";
+      const unsigned char* rgbbase_r0 = zeroes;
+      const unsigned char* rgbbase_l1 = zeroes;
+      const unsigned char* rgbbase_r1 = zeroes;
+      const unsigned char* rgbbase_l2 = zeroes;
+      const unsigned char* rgbbase_r2 = zeroes;
+      const unsigned char* rgbbase_l3 = zeroes;
+      const unsigned char* rgbbase_r3 = zeroes;
       if(visx < begx + lenx - 1){
         rgbbase_r0 = dat + (linesize * visy) + ((visx + 1) * bpp / CHAR_BIT);
         if(visy < begy + leny - 1){

--- a/src/lib/ffmpeg.cpp
+++ b/src/lib/ffmpeg.cpp
@@ -1,0 +1,429 @@
+#include "version.h"
+#ifdef USE_FFMPEG
+#include "ffmpeg.h"
+#include "internal.h"
+#include "visual-details.h"
+
+#define IMGALLOCALIGN 32
+
+bool notcurses_canopen_images(const notcurses* nc __attribute__ ((unused))) {
+  return true;
+}
+
+bool notcurses_canopen_videos(const notcurses* nc __attribute__ ((unused))) {
+  return true;
+}
+
+/*static void
+print_frame_summary(const AVCodecContext* cctx, const AVFrame* f) {
+  char pfmt[128];
+  av_get_pix_fmt_string(pfmt, sizeof(pfmt), static_cast<enum AVPixelFormat>(f->format));
+  fprintf(stderr, "Frame %05d (%d? %d?) %dx%d pfmt %d (%s)\n",
+          cctx->frame_number,
+          f->coded_picture_number,
+          f->display_picture_number,
+          f->width, f->height,
+          f->format, pfmt);
+  fprintf(stderr, " Data (%d):", AV_NUM_DATA_POINTERS);
+  int i;
+  for(i = 0 ; i < AV_NUM_DATA_POINTERS ; ++i){
+    fprintf(stderr, " %p", f->data[i]);
+  }
+  fprintf(stderr, "\n Linesizes:");
+  for(i = 0 ; i < AV_NUM_DATA_POINTERS ; ++i){
+    fprintf(stderr, " %d", f->linesize[i]);
+  }
+  if(f->sample_aspect_ratio.num == 0 && f->sample_aspect_ratio.den == 1){
+    fprintf(stderr, "\n Aspect ratio unknown");
+  }else{
+    fprintf(stderr, "\n Aspect ratio %d:%d", f->sample_aspect_ratio.num, f->sample_aspect_ratio.den);
+  }
+  if(f->interlaced_frame){
+    fprintf(stderr, " [ILaced]");
+  }
+  if(f->palette_has_changed){
+    fprintf(stderr, " [NewPal]");
+  }
+  fprintf(stderr, " PTS %ld Flags: 0x%04x\n", f->pts, f->flags);
+  fprintf(stderr, " %lums@%lums (%skeyframe) qual: %d\n",
+          f->pkt_duration, // FIXME in 'time_base' units
+          f->best_effort_timestamp,
+          f->key_frame ? "" : "non-",
+          f->quality);
+}*/
+
+static char*
+deass(const char* ass) {
+  // SSA/ASS formats:
+  // Dialogue: Marked=0,0:02:40.65,0:02:41.79,Wolf main,Cher,0000,0000,0000,,Et les enregistrements de ses ondes delta ?
+  // FIXME more
+  if(strncmp(ass, "Dialogue:", strlen("Dialogue:"))){
+    return nullptr;
+  }
+  const char* delim = strchr(ass, ',');
+  int commas = 0; // we want 8
+  while(delim && commas < 8){
+    delim = strchr(delim + 1, ',');
+    ++commas;
+  }
+  if(!delim){
+    return nullptr;
+  }
+  // handle ASS syntax...\i0, \b0, etc.
+  char* dup = strdup(delim + 1);
+  char* c = dup;
+  while(*c){
+    if(*c == '\\'){
+      *c = ' ';
+      ++c;
+      if(*c){
+        *c = ' ';;
+      }
+    }
+    ++c;
+  }
+  return dup;
+}
+
+auto ncvisual_subtitle(const ncvisual* ncv) -> char* {
+  for(unsigned i = 0 ; i < ncv->details.subtitle.num_rects ; ++i){
+    const AVSubtitleRect* rect = ncv->details.subtitle.rects[i];
+    if(rect->type == SUBTITLE_ASS){
+      return deass(rect->ass);
+    }else if(rect->type == SUBTITLE_TEXT) {;
+      return strdup(rect->text);
+    }
+  }
+  return nullptr;
+}
+
+static nc_err_e
+averr2ncerr(int averr){
+  if(averr == AVERROR_EOF){
+    return NCERR_EOF;
+  }
+  // FIXME need to map averror codes to ncerrors
+//fprintf(stderr, "AVERR: %d/%x %d/%x\n", averr, averr, -averr, -averr);
+  return NCERR_DECODE;
+}
+
+nc_err_e ncvisual_decode(ncvisual* nc){
+  if(nc->details.fmtctx == nullptr){ // not a file-backed ncvisual
+    return NCERR_DECODE;
+  }
+  bool have_frame = false;
+  bool unref = false;
+  // FIXME what if this was set up with e.g. ncvisual_from_rgba()?
+  av_freep(&nc->details.oframe->data[0]);
+  do{
+    do{
+      if(nc->details.packet_outstanding){
+        break;
+      }
+      if(unref){
+        av_packet_unref(nc->details.packet);
+      }
+      int averr;
+      if((averr = av_read_frame(nc->details.fmtctx, nc->details.packet)) < 0){
+        /*if(averr != AVERROR_EOF){
+          fprintf(stderr, "Error reading frame info (%s)\n", av_err2str(*averr));
+        }*/
+        return averr2ncerr(averr);
+      }
+      unref = true;
+      if(nc->details.packet->stream_index == nc->details.sub_stream_index){
+        int result = 0, ret;
+        ret = avcodec_decode_subtitle2(nc->details.subtcodecctx, &nc->details.subtitle, &result, nc->details.packet);
+        if(ret >= 0 && result){
+          // FIXME?
+        }
+      }
+    }while(nc->details.packet->stream_index != nc->details.stream_index);
+    ++nc->details.packet_outstanding;
+    if(avcodec_send_packet(nc->details.codecctx, nc->details.packet) < 0){
+      //fprintf(stderr, "Error processing AVPacket (%s)\n", av_err2str(*ncerr));
+      return ncvisual_decode(nc);
+    }
+    --nc->details.packet_outstanding;
+    av_packet_unref(nc->details.packet);
+    int averr = avcodec_receive_frame(nc->details.codecctx, nc->details.frame);
+    if(averr >= 0){
+      have_frame = true;
+    }else if(averr == AVERROR(EAGAIN) || averr == AVERROR_EOF){
+      have_frame = false;
+    }else if(averr < 0){
+      //fprintf(stderr, "Error decoding AVPacket (%s)\n", av_err2str(averr));
+      return averr2ncerr(averr);
+    }
+  }while(!have_frame);
+//print_frame_summary(nc->details.codecctx, nc->details.frame);
+  memcpy(nc->details.oframe, nc->details.frame, sizeof(*nc->details.oframe));
+  const int targformat = AV_PIX_FMT_RGBA;
+  nc->details.swsctx = sws_getCachedContext(nc->details.swsctx,
+                                    nc->details.frame->width,
+                                    nc->details.frame->height,
+                                    static_cast<AVPixelFormat>(nc->details.frame->format),
+                                    nc->details.frame->width,
+                                    nc->details.frame->height,
+                                    static_cast<AVPixelFormat>(targformat),
+                                    SWS_LANCZOS,
+                                    nullptr, nullptr, nullptr);
+  if(nc->details.swsctx == nullptr){
+    //fprintf(stderr, "Error retrieving swsctx\n");
+    return NCERR_DECODE;
+  }
+  memcpy(nc->details.oframe, nc->details.frame, sizeof(*nc->details.oframe));
+  nc->details.oframe->format = targformat;
+  nc->cols = nc->details.oframe->width = nc->details.frame->width;
+  nc->rows = nc->details.oframe->height = nc->details.frame->height;
+//fprintf(stderr, "SIZE DECODED: %d %d\n", nc->rows, nc->cols);
+  int size = av_image_alloc(nc->details.oframe->data, nc->details.oframe->linesize,
+                            nc->details.oframe->width, nc->details.oframe->height,
+                            static_cast<AVPixelFormat>(nc->details.oframe->format),
+                            IMGALLOCALIGN);
+  if(size < 0){
+//fprintf(stderr, "Error allocating visual data (%d)\n", size);
+    return NCERR_NOMEM;
+  }
+  int height = sws_scale(nc->details.swsctx, (const uint8_t* const*)nc->details.frame->data,
+                         nc->details.frame->linesize, 0,
+                         nc->details.frame->height, nc->details.oframe->data,
+                         nc->details.oframe->linesize);
+  if(height < 0){
+    //fprintf(stderr, "Error applying scaling (%s)\n", av_err2str(height));
+    return NCERR_NOMEM;
+  }
+  sws_freeContext(nc->details.swsctx);
+  nc->details.swsctx = nullptr;
+//print_frame_summary(nc->details.codecctx, nc->details.oframe);
+  av_frame_unref(nc->details.frame);
+  const AVFrame* f = nc->details.oframe;
+  int bpp = av_get_bits_per_pixel(av_pix_fmt_desc_get(static_cast<AVPixelFormat>(f->format)));
+  if(bpp != 32){
+//fprintf(stderr, "Bad bits-per-pixel (wanted 32, got %d)\n", bpp);
+	  return NCERR_DECODE;
+  }
+  nc->rowstride = f->linesize[0];
+//fprintf(stderr, "good decode! %d/%d %p\n", nc->details.frame->height, nc->details.frame->width, f->data);
+  ncvisual_set_data(nc, reinterpret_cast<uint32_t*>(f->data[0]), false);
+  return NCERR_SUCCESS;
+}
+
+ncvisual* ncvisual_from_file(const char* filename, nc_err_e* ncerr) {
+  *ncerr = NCERR_SUCCESS;
+  ncvisual* ncv = ncvisual_create(1);
+  if(ncv == nullptr){
+    // fprintf(stderr, "Couldn't create %s (%s)\n", filename, strerror(errno));
+    *ncerr = NCERR_NOMEM;
+    return nullptr;
+  }
+  memset(ncv, 0, sizeof(*ncv));
+//fprintf(stderr, "FRAME FRAME: %p\n", ncv->details.frame);
+  int averr = avformat_open_input(&ncv->details.fmtctx, filename, nullptr, nullptr);
+  if(averr < 0){
+//fprintf(stderr, "Couldn't open %s (%d)\n", filename, averr);
+    *ncerr = averr2ncerr(averr);
+    ncvisual_destroy(ncv);
+    return nullptr;
+  }
+  averr = avformat_find_stream_info(ncv->details.fmtctx, nullptr);
+  if(averr < 0){
+//fprintf(stderr, "Error extracting stream info from %s (%d)\n", filename, averr);
+    *ncerr = averr2ncerr(averr);
+    ncvisual_destroy(ncv);
+    return nullptr;
+  }
+//av_dump_format(ncv->details.fmtctx, 0, filename, false);
+  if((averr = av_find_best_stream(ncv->details.fmtctx, AVMEDIA_TYPE_SUBTITLE, -1, -1, &ncv->details.subtcodec, 0)) >= 0){
+    ncv->details.sub_stream_index = averr;
+    if((ncv->details.subtcodecctx = avcodec_alloc_context3(ncv->details.subtcodec)) == nullptr){
+      //fprintf(stderr, "Couldn't allocate decoder for %s\n", filename);
+      *ncerr = NCERR_NOMEM;
+      ncvisual_destroy(ncv);
+      return nullptr;
+    }
+    // FIXME do we need avcodec_parameters_to_context() here?
+    if((averr = avcodec_open2(ncv->details.subtcodecctx, ncv->details.subtcodec, nullptr)) < 0){
+      //fprintf(stderr, "Couldn't open codec for %s (%s)\n", filename, av_err2str(*averr));
+      *ncerr = averr2ncerr(averr);
+      ncvisual_destroy(ncv);
+      return nullptr;
+    }
+  }else{
+    ncv->details.sub_stream_index = -1;
+  }
+//fprintf(stderr, "FRAME FRAME: %p\n", ncv->details.frame);
+  if((ncv->details.packet = av_packet_alloc()) == nullptr){
+    // fprintf(stderr, "Couldn't allocate packet for %s\n", filename);
+    *ncerr = NCERR_NOMEM;
+    ncvisual_destroy(ncv);
+    return nullptr;
+  }
+  if((averr = av_find_best_stream(ncv->details.fmtctx, AVMEDIA_TYPE_VIDEO, -1, -1, &ncv->details.codec, 0)) < 0){
+    // fprintf(stderr, "Couldn't find visuals in %s (%s)\n", filename, av_err2str(*averr));
+    *ncerr = averr2ncerr(averr);
+    ncvisual_destroy(ncv);
+    return nullptr;
+  }
+  ncv->details.stream_index = averr;
+  if(ncv->details.codec == nullptr){
+    //fprintf(stderr, "Couldn't find decoder for %s\n", filename);
+    ncvisual_destroy(ncv);
+    return nullptr;
+  }
+  AVStream* st = ncv->details.fmtctx->streams[ncv->details.stream_index];
+  if((ncv->details.codecctx = avcodec_alloc_context3(ncv->details.codec)) == nullptr){
+    //fprintf(stderr, "Couldn't allocate decoder for %s\n", filename);
+    *ncerr = NCERR_NOMEM;
+    goto err;
+  }
+  if(avcodec_parameters_to_context(ncv->details.codecctx, st->codecpar) < 0){
+    goto err;
+  }
+  if((averr = avcodec_open2(ncv->details.codecctx, ncv->details.codec, nullptr)) < 0){
+    //fprintf(stderr, "Couldn't open codec for %s (%s)\n", filename, av_err2str(*averr));
+    *ncerr = averr2ncerr(averr);
+    goto err;
+  }
+  /*if((ncv->cparams = avcodec_parameters_alloc()) == nullptr){
+    //fprintf(stderr, "Couldn't allocate codec params for %s\n", filename);
+    *averr = NCERR_NOMEM;
+    goto err;
+  }
+  if((*averr = avcodec_parameters_from_context(ncv->cparams, ncv->details.codecctx)) < 0){
+    //fprintf(stderr, "Couldn't get codec params for %s (%s)\n", filename, av_err2str(*averr));
+    goto err;
+  }*/
+  if((ncv->details.frame = av_frame_alloc()) == nullptr){
+    // fprintf(stderr, "Couldn't allocate frame for %s\n", filename);
+    *ncerr = NCERR_NOMEM;
+    goto err;
+  }
+//fprintf(stderr, "FRAME FRAME: %p\n", ncv->details.frame);
+  if((ncv->details.oframe = av_frame_alloc()) == nullptr){
+    // fprintf(stderr, "Couldn't allocate output frame for %s\n", filename);
+    *ncerr = NCERR_NOMEM;
+    goto err;
+  }
+  if((ncv->details.sframe = av_frame_alloc()) == nullptr){
+    // fprintf(stderr, "Couldn't allocate output frame for %s\n", filename);
+    *ncerr = NCERR_NOMEM;
+    goto err;
+  }
+  return ncv;
+
+err:
+  ncvisual_destroy(ncv);
+  return nullptr;
+}
+
+// iterative over the decoded frames, calling streamer() with curry for each.
+// frames carry a presentation time relative to the beginning, so we get an
+// initial timestamp, and check each frame against the elapsed time to sync
+// up playback.
+int ncvisual_stream(ncplane* n, ncvisual* ncv, nc_err_e* ncerr,
+                    float timescale, streamcb streamer, void* curry) {
+  *ncerr = NCERR_SUCCESS;
+  int frame = 1;
+  ncv->timescale = timescale;
+  struct timespec begin; // time we started
+  clock_gettime(CLOCK_MONOTONIC, &begin);
+  uint64_t nsbegin = timespec_to_ns(&begin);
+  bool usets = false;
+  // each frame has a pkt_duration in milliseconds. keep the aggregate, in case
+  // we don't have PTS available.
+  uint64_t sum_duration = 0;
+  struct ncvisual_options vopts{};
+  vopts.n = n;
+  vopts.scaling = NCSCALE_STRETCH;
+  while((*ncerr = ncvisual_decode(ncv)) == NCERR_SUCCESS){
+    // codecctx seems to be off by a factor of 2 regularly. instead, go with
+    // the time_base from the avformatctx.
+    double tbase = av_q2d(ncv->details.fmtctx->streams[ncv->details.stream_index]->time_base);
+    int64_t ts = ncv->details.oframe->best_effort_timestamp;
+    if(frame == 1 && ts){
+      usets = true;
+    }
+    if(!ncvisual_render(ncplane_notcurses(n), ncv, &vopts)){
+      return -1;
+    }
+    ++frame;
+    uint64_t duration = ncv->details.oframe->pkt_duration * tbase * NANOSECS_IN_SEC;
+//fprintf(stderr, "use: %u dur: %ju ts: %ju cctx: %f fctx: %f\n", usets, duration, ts, av_q2d(ncv->details.codecctx->time_base), av_q2d(ncv->details.fmtctx->streams[ncv->stream_index]->time_base));
+    double schedns = nsbegin;
+    if(usets){
+      if(tbase == 0){
+        tbase = duration;
+      }
+      schedns += ts * (tbase * ncv->timescale) * NANOSECS_IN_SEC;
+    }else{
+      sum_duration += (duration * ncv->timescale);
+      schedns += sum_duration;
+    }
+    if(streamer){
+      struct timespec abstime;
+      ns_to_timespec(schedns, &abstime);
+      int r = streamer(n, ncv, &abstime, curry);
+      if(r){
+        return r;
+      }
+    }
+  }
+  if(*ncerr == NCERR_EOF){
+    return 0;
+  }
+  return -1;
+}
+
+nc_err_e ncvisual_resize(ncvisual* ncv, int rows, int cols) {
+  if(cols != ncv->cols || rows != ncv->rows){
+    const int targformat = AV_PIX_FMT_RGBA;
+    //fprintf(stderr, "FRAME: %p\n", ncv->details.frame);
+    //fprintf(stderr, "WHN NCV: %d/%d\n", ncv->details.oframe->width, ncv->details.oframe->height);
+    ncv->details.swsctx = sws_getCachedContext(ncv->details.swsctx,
+                                      ncv->cols,
+                                      ncv->rows,
+                                      static_cast<AVPixelFormat>(ncv->details.oframe->format),
+                                      cols, rows,
+                                      static_cast<AVPixelFormat>(targformat),
+                                      SWS_LANCZOS,
+                                      nullptr, nullptr, nullptr);
+    if(ncv->details.swsctx == nullptr){
+      //fprintf(stderr, "Error retrieving details.swsctx\n");
+      return NCERR_DECODE;
+    }
+    memcpy(ncv->details.sframe, ncv->details.oframe, sizeof(*ncv->details.oframe));
+    ncv->details.sframe->format = targformat;
+    ncv->details.sframe->width = cols;
+    ncv->details.sframe->height = rows;
+    int size = av_image_alloc(ncv->details.sframe->data, ncv->details.sframe->linesize,
+                              ncv->details.sframe->width, ncv->details.sframe->height,
+                              static_cast<AVPixelFormat>(ncv->details.sframe->format),
+                              IMGALLOCALIGN);
+    if(size < 0){
+//fprintf(stderr, "Error allocating visual data (%s)\n", av_err2str(size));
+      return NCERR_NOMEM;
+    }
+    int height = sws_scale(ncv->details.swsctx, (const uint8_t* const*)ncv->details.oframe->data,
+                           ncv->details.oframe->linesize, 0,
+                           ncv->details.oframe->height, ncv->details.sframe->data,
+                           ncv->details.sframe->linesize);
+    if(height < 0){
+      //fprintf(stderr, "Error applying scaling (%s)\n", av_err2str(height));
+      return NCERR_DECODE;
+    }
+    sws_freeContext(ncv->details.swsctx);
+    ncv->details.swsctx = nullptr;
+    const AVFrame* f = ncv->details.sframe;
+    ncv->rowstride = f->linesize[0];
+    ncvisual_set_data(ncv, reinterpret_cast<uint32_t*>(f->data[0]), true);
+  }
+  return NCERR_SUCCESS;
+}
+
+int ncvisual_init(int loglevel) {
+  av_log_set_level(loglevel);
+  // FIXME could also use av_log_set_callback() and capture the message...
+  return 0;
+}
+#endif

--- a/src/lib/ffmpeg.h
+++ b/src/lib/ffmpeg.h
@@ -1,0 +1,69 @@
+#ifndef NOTCURSES_FFMPEG
+#define NOTCURSES_FFMPEG
+
+#include "version.h"
+#ifdef USE_FFMPEG
+
+extern "C" {
+
+#include <libavutil/error.h>
+#include <libavutil/frame.h>
+#include <libavutil/pixdesc.h>
+#include <libavutil/version.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/rational.h>
+#include <libswscale/swscale.h>
+#include <libswscale/version.h>
+#include <libavformat/version.h>
+#include <libavformat/avformat.h>
+
+} // extern "C"
+
+struct AVFormatContext;
+struct AVCodecContext;
+struct AVFrame;
+struct AVCodec;
+struct AVCodecParameters;
+struct AVPacket;
+
+typedef struct ncvisual_details {
+  int packet_outstanding;
+  struct AVFormatContext* fmtctx;
+  struct AVCodecContext* codecctx;     // video codec context
+  struct AVCodecContext* subtcodecctx; // subtitle codec context
+  struct AVFrame* frame;               // frame as read
+  struct AVFrame* oframe;              // scaled frame
+  struct AVFrame* sframe;              // RGBA frame
+  struct AVCodec* codec;
+  struct AVCodecParameters* cparams;
+  struct AVCodec* subtcodec;
+  struct AVPacket* packet;
+  struct SwsContext* swsctx;
+  AVSubtitle subtitle;
+  int stream_index;        // match against this following av_read_frame()
+  int sub_stream_index;    // subtitle stream index, can be < 0 if no subtitles
+} ncvisual_details;
+
+static inline void
+ncvisual_details_init(ncvisual_details *deets){
+  memset(deets, 0, sizeof(*deets));
+  deets->stream_index = -1;
+  deets->sub_stream_index = -1;
+}
+
+static inline void
+ncvisual_details_destroy(ncvisual_details* deets){
+  avcodec_close(deets->codecctx);
+  avcodec_free_context(&deets->codecctx);
+  av_frame_free(&deets->frame);
+  av_freep(&deets->oframe);
+  //avcodec_parameters_free(&ncv->cparams);
+  sws_freeContext(deets->swsctx);
+  av_packet_free(&deets->packet);
+  avformat_close_input(&deets->fmtctx);
+  avsubtitle_free(&deets->subtitle);
+}
+
+#endif
+
+#endif

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -617,8 +617,6 @@ int ncplane_resize_internal(ncplane* n, int keepy, int keepx,
 
 int update_term_dimensions(int fd, int* rows, int* cols);
 
-struct ncvisual* ncvisual_create(const struct blitset* bset, float timescale);
-
 static inline void*
 memdup(const void* src, size_t len){
   void* ret = malloc(len);
@@ -659,6 +657,8 @@ ncplane_center(const ncplane* n, int* RESTRICT y, int* RESTRICT x){
 
 int ncvisual_bounding_box(const struct ncvisual* ncv, int* leny, int* lenx,
                           int* offy, int* offx);
+
+nc_err_e ncvisual_resize(struct ncvisual* ncv, int rows, int cols);
 
 #ifdef __cplusplus
 }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -203,6 +203,8 @@ char* ncplane_at_yx(const ncplane* n, int y, int x, uint32_t* attrword, uint64_t
 }
 
 cell* ncplane_cell_ref_yx(ncplane* n, int y, int x){
+  assert(y < n->leny);
+  assert(x < n->lenx);
   return &n->fb[nfbcellidx(n, y, x)];
 }
 

--- a/src/lib/oiio.cpp
+++ b/src/lib/oiio.cpp
@@ -1,0 +1,171 @@
+#include "version.h"
+#ifdef USE_OIIO
+#include "oiio.h"
+#include "internal.h"
+#include "visual-details.h"
+
+bool notcurses_canopen_images(const notcurses* nc __attribute__ ((unused))){
+  return true;
+}
+
+bool notcurses_canopen_videos(const notcurses* nc __attribute__ ((unused))){
+  return false; // too slow for reliable use at the moment
+}
+
+ncvisual* ncvisual_from_file(const char* filename, nc_err_e* err){
+  *err = NCERR_SUCCESS;
+  ncvisual* ncv = ncvisual_create(1);
+  if(ncv == nullptr){
+    *err = NCERR_NOMEM;
+    return nullptr;
+  }
+  ncv->details.image = OIIO::ImageInput::open(filename);
+  if(!ncv->details.image){
+    // fprintf(stderr, "Couldn't create %s (%s)\n", filename, strerror(errno));
+    *err = NCERR_DECODE;
+    ncvisual_destroy(ncv);
+    return nullptr;
+  }
+/*const auto &spec = ncv->details.image->spec_dimensions();
+std::cout << "Opened " << filename << ": " << spec.height << "x" <<
+spec.width << "@" << spec.nchannels << " (" << spec.format << ")" << std::endl;*/
+  return ncv;
+}
+
+nc_err_e ncvisual_decode(ncvisual* nc){
+//fprintf(stderr, "current subimage: %d frame: %p\n", nc->details.image->current_subimage(), nc->details.frame.get());
+  const auto &spec = nc->details.image->spec_dimensions(nc->details.framenum);
+  if(nc->details.frame){
+//fprintf(stderr, "seeking subimage: %d\n", nc->details.image->current_subimage() + 1);
+    OIIO::ImageSpec newspec;
+    if(!nc->details.image->seek_subimage(nc->details.image->current_subimage() + 1, 0, newspec)){
+       return NCERR_EOF;
+    }
+    // FIXME check newspec vis-a-vis image->spec()?
+  }
+//fprintf(stderr, "SUBIMAGE: %d\n", nc->details.image->current_subimage());
+  auto pixels = spec.width * spec.height;// * spec.nchannels;
+  if(spec.nchannels < 3 || spec.nchannels > 4){
+    return NCERR_DECODE; // FIXME get some to test with
+  }
+  nc->details.frame = std::make_unique<uint32_t[]>(pixels);
+  if(spec.nchannels == 3){ // FIXME replace with channel shuffle
+    std::fill(nc->details.frame.get(), nc->details.frame.get() + pixels, 0xfffffffful);
+  }
+//fprintf(stderr, "READING: %d %ju\n", nc->details.image->current_subimage(), nc->details.framenum);
+  if(!nc->details.image->read_image(nc->details.framenum++, 0, 0, spec.nchannels, OIIO::TypeDesc(OIIO::TypeDesc::UINT8, 4), nc->details.frame.get(), 4)){
+    return NCERR_DECODE;
+  }
+//fprintf(stderr, "READ: %d %ju\n", nc->details.image->current_subimage(), nc->details.framenum);
+/*for(int i = 0 ; i < pixels ; ++i){
+  //fprintf(stderr, "%06d %02x %02x %02x %02x\n", i,
+  fprintf(stderr, "%06d %d %d %d %d\n", i,
+      (nc->details.frame[i]) & 0xff,
+      (nc->details.frame[i] >> 8) & 0xff,
+      (nc->details.frame[i] >> 16) & 0xff,
+      nc->details.frame[i] >> 24
+      );
+}*/
+  nc->cols = spec.width;
+  nc->rows = spec.height;
+  nc->rowstride = nc->cols * 4;
+  OIIO::ImageSpec rgbaspec = spec;
+  rgbaspec.nchannels = 4;
+  nc->details.ibuf = std::make_unique<OIIO::ImageBuf>(rgbaspec, nc->details.frame.get());
+//fprintf(stderr, "SUBS: %d\n", nc->details.ibuf->nsubimages());
+  ncvisual_set_data(nc, static_cast<uint32_t*>(nc->details.ibuf->localpixels()), false);
+fprintf(stderr, "POST-DECODE DATA: %d %d %p %p\n", nc->rows, nc->cols, nc->data, nc->details.ibuf->localpixels());
+  return NCERR_SUCCESS;
+}
+
+auto ncvisual_resize(ncvisual* ncv, int rows, int cols) -> nc_err_e {
+fprintf(stderr, "%d/%d -> %d/%d on the resize\n", ncv->rows, ncv->cols, rows, cols);
+  if(ncv->cols != cols || ncv->rows != rows){ // scale it
+    auto tmpibuf = std::move(*ncv->details.ibuf);
+    ncv->details.ibuf = std::make_unique<OIIO::ImageBuf>();
+    OIIO::ImageSpec sp{};
+    sp.width = cols;
+    sp.height = rows;
+    ncv->details.ibuf->reset(sp, OIIO::InitializePixels::Yes);
+    OIIO::ROI roi(0, ncv->cols, 0, ncv->rows, 0, 1, 0, 4);
+    if(!OIIO::ImageBufAlgo::resize(*ncv->details.ibuf, tmpibuf, "", 0, roi)){
+      return NCERR_DECODE; // FIXME need we do anything further?
+    }
+    ncv->rowstride = ncv->cols * 4;
+fprintf(stderr, "HAVE SOME NEW DATA: %p\n", ncv->details.ibuf->localpixels());
+    ncvisual_set_data(ncv, static_cast<uint32_t*>(ncv->details.ibuf->localpixels()), false);
+  }
+  return NCERR_SUCCESS;
+}
+
+int ncvisual_stream(ncplane* n, ncvisual* ncv, nc_err_e* ncerr,
+                    float timescale, streamcb streamer, void* curry){
+  *ncerr = NCERR_SUCCESS;
+  int frame = 1;
+  ncv->timescale = timescale;
+  struct timespec begin; // time we started
+  clock_gettime(CLOCK_MONOTONIC, &begin);
+  ncvisual_options vopts{};
+  vopts.n = n;
+  vopts.scaling = NCSCALE_STRETCH;
+  while((*ncerr = ncvisual_decode(ncv)) == NCERR_SUCCESS){
+    if(ncvisual_render(ncplane_notcurses(n), ncv, &vopts) == nullptr){
+      return -1;
+    }
+    if(streamer){
+      // currently OIIO is so slow for videos that there's no real point in
+      // any kind of delay FIXME
+      struct timespec now;
+      clock_gettime(CLOCK_MONOTONIC, &now);
+      int r = streamer(n, ncv, &now, curry);
+      if(r){
+        return r;
+      }
+    }
+    ++frame;
+  }
+  if(*ncerr == NCERR_EOF){
+    return 0;
+  }
+  return -1;
+}
+
+char* ncvisual_subtitle(const ncvisual* ncv){ // no support in OIIO
+  (void)ncv;
+  return nullptr;
+}
+
+// FIXME before we can enable this, we need build an OIIO::APPBUFFER-style
+// ImageBuf in ncvisual in ncvisual_from_rgba().
+/*
+auto ncvisual_rotate(ncvisual* ncv, double rads) -> int {
+  OIIO::ROI roi(0, ncv->cols, 0, ncv->rows, 0, 1, 0, 4);
+  auto tmpibuf = std::move(*ncv->details.ibuf);
+  ncv->details.ibuf = std::make_unique<OIIO::ImageBuf>();
+  OIIO::ImageSpec sp{};
+  sp.set_format(OIIO::TypeDesc(OIIO::TypeDesc::UINT8, 4));
+  sp.nchannels = 4;
+  ncv->details.ibuf->reset();
+  if(!OIIO::ImageBufAlgo::rotate(*ncv->details.ibuf, tmpibuf, rads, "", 0, true, roi)){
+    return NCERR_DECODE; // FIXME need we do anything further?
+  }
+  ncv->rowstride = ncv->cols * 4;
+  ncvisual_set_data(ncv, static_cast<uint32_t*>(ncv->details.ibuf->localpixels()), false);
+  return NCERR_SUCCESS;
+}
+*/
+
+int ncvisual_init(int loglevel){
+  // FIXME set OIIO global attribute "debug" based on loglevel
+  (void)loglevel;
+  // FIXME check OIIO_VERSION_STRING components against linked openimageio_version()
+  return 0; // allow success here
+}
+
+extern "C" {
+// FIXME would be nice to have OIIO::attributes("libraries") in here
+const char* oiio_version(void){
+  return OIIO_VERSION_STRING;
+}
+}
+#endif

--- a/src/lib/oiio.h
+++ b/src/lib/oiio.h
@@ -1,0 +1,37 @@
+#ifndef NOTCURSES_OIIO
+#define NOTCURSES_OIIO
+
+// OpenImageIO implementation of ncvisual_details
+#include "version.h"
+#ifdef USE_OIIO
+#include <OpenImageIO/filter.h>
+#include <OpenImageIO/version.h>
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/imagebuf.h>
+#include <OpenImageIO/imagebufalgo.h>
+
+typedef struct ncvisual_details {
+  std::unique_ptr<OIIO::ImageInput> image;  // must be close()d
+  std::unique_ptr<OIIO::ImageBuf> ibuf;
+  std::unique_ptr<uint32_t[]> frame;
+  uint64_t framenum;
+} ncvisual_details;
+
+static inline auto
+ncvisual_details_init(ncvisual_details *deets) -> void {
+  deets->image = nullptr;
+  deets->ibuf = nullptr;
+  deets->frame = nullptr;
+  deets->framenum = 0;
+}
+
+static inline auto
+ncvisual_details_destroy(ncvisual_details* deets) -> void {
+  if(deets->image){
+    deets->image->close();
+  }
+}
+
+#endif
+
+#endif

--- a/src/lib/plot.h
+++ b/src/lib/plot.h
@@ -114,7 +114,7 @@ class ncppplot {
    ncplane_dim_yx(ncp, &dimy, &dimx);
    const int scaleddim = dimx * scale;
    // each transition is worth this much change in value
-   const size_t states = bset->height;
+   const size_t states = bset->height + 1;
    // FIXME can we not rid ourselves of this meddlesome double? either way, the
    // interval is one row's range (for linear plots), or the base (base^slots==
    // maxy-miny) of the range (for exponential plots).

--- a/src/lib/visual-details.h
+++ b/src/lib/visual-details.h
@@ -1,0 +1,61 @@
+#ifndef NOTCURSES_VISUAL_DETAILS
+#define NOTCURSES_VISUAL_DETAILS
+
+#include "version.h"
+#include "notcurses/notcurses.h"
+
+#ifdef USE_FFMPEG
+#include "ffmpeg.h"
+#else
+#ifdef USE_OIIO
+#include "oiio.h"
+#else
+typedef struct ncvisual_details {
+} ncvisual_details;
+
+static inline auto
+ncvisual_details_init(ncvisual_details* deets) -> void {
+  (void)deets;
+}
+
+static inline auto
+ncvisual_details_destroy(ncvisual_details* deets) -> void {
+  (void)deets;
+}
+#endif
+#endif
+
+struct ncplane;
+
+typedef struct ncvisual {
+  int cols, rows;
+  // FIXME should be able to contain this in ncvisual_stream()
+  float timescale; // scale frame duration by this value
+  // lines are sometimes padded. this many true bytes per row in data.
+  int rowstride;
+  ncvisual_details details;// implementation-specific details
+  uint32_t* data; // (scaled) RGBA image data, rowstride bytes per row
+  bool owndata; // we own data iff owndata == true
+} ncvisual;
+
+static inline auto
+ncvisual_create(float timescale) -> ncvisual* {
+  auto ret = new ncvisual{};
+  if(ret == nullptr){
+    return nullptr;
+  }
+  ret->timescale = timescale;
+  ncvisual_details_init(&ret->details);
+  return ret;
+}
+
+static inline auto
+ncvisual_set_data(ncvisual* ncv, uint32_t* data, bool owned) -> void {
+  if(ncv->owndata){
+    free(ncv->data);
+  }
+  ncv->data = data;
+  ncv->owndata = owned;
+}
+
+#endif

--- a/src/libcpp/Visual.cc
+++ b/src/libcpp/Visual.cc
@@ -1,9 +1,0 @@
-#include <ncpp/Visual.hh>
-#include <ncpp/Plane.hh>
-
-using namespace ncpp;
-
-Plane* Visual::get_plane () const noexcept
-{
-	return Plane::map_plane (ncvisual_plane (visual));
-}

--- a/src/poc/multiselect.c
+++ b/src/poc/multiselect.c
@@ -85,18 +85,18 @@ int main(void){
 
   if(notcurses_canopen_images(nc)){
     nc_err_e err;
-    struct ncvisual_options vopts = {
-      .style = NCSCALE_STRETCH,
-      .n = n,
-    };
-    struct ncvisual* ncv = ncvisual_from_file(nc, &vopts, "../data/covid19.jpg", &err);
+    struct ncvisual* ncv = ncvisual_from_file("../data/covid19.jpg", &err);
     if(!ncv){
       goto err;
     }
     if((err = ncvisual_decode(ncv)) != NCERR_SUCCESS){
       goto err;
     }
-    if(ncvisual_render(ncv, 0, 0, -1, -1) <= 0){
+    struct ncvisual_options vopts = {
+      .scaling = NCSCALE_STRETCH,
+      .n = n,
+    };
+    if(ncvisual_render(nc, ncv, &vopts) == NULL){
       goto err;
     }
   }

--- a/src/poc/selector.c
+++ b/src/poc/selector.c
@@ -86,18 +86,18 @@ int main(void){
 
   if(notcurses_canopen_images(nc)){
     nc_err_e err;
-    struct ncvisual_options vopts = {
-      .style = NCSCALE_STRETCH,
-      .n = n,
-    };
-    struct ncvisual* ncv = ncvisual_from_file(nc, &vopts, "../data/changes.jpg", &err);
+    struct ncvisual* ncv = ncvisual_from_file("../data/changes.jpg", &err);
     if(!ncv){
       goto err;
     }
     if((err = ncvisual_decode(ncv)) != NCERR_SUCCESS){
       goto err;
     }
-    if(ncvisual_render(ncv, 0, 0, -1, -1) <= 0){
+    struct ncvisual_options vopts = {
+      .scaling = NCSCALE_STRETCH,
+      .n = n,
+    };
+    if(ncvisual_render(nc, ncv, &vopts) == NULL){
       goto err;
     }
   }

--- a/src/poc/visual.cpp
+++ b/src/poc/visual.cpp
@@ -27,21 +27,21 @@ int main(int argc, char** argv){
     notcurses_stop(nc);
     return EXIT_FAILURE;
   }
+  struct ncvisual_options vopts{};
   int dimx, dimy;
   ncplane_dim_yx(n, &dimy, &dimx);
   bool failed = false;
   nc_err_e ncerr;
-  struct ncvisual_options vopts{};
-  vopts.style = NCSCALE_STRETCH;
-  vopts.n = n;
-  auto ncv = ncvisual_from_file(nc, &vopts, file, &ncerr);
+  auto ncv = ncvisual_from_file(file, &ncerr);
   if(!ncv){
     goto err;
   }
   if((ncerr = ncvisual_decode(ncv)) != NCERR_SUCCESS){
     goto err;
   }
-  if(ncvisual_render(ncv, 0, 0, -1, -1) <= 0){
+  vopts.scaling = NCSCALE_STRETCH;
+  vopts.n = n;
+  if(ncvisual_render(nc, ncv, &vopts) == nullptr){
     goto err;
   }
   if(notcurses_render(nc)){
@@ -53,7 +53,7 @@ int main(int argc, char** argv){
       failed = true;
       break;
     }
-    if(ncvisual_render(ncv, 0, 0, -1, -1) < 0){
+    if(ncvisual_render(nc, ncv, &vopts) == nullptr){
       failed = true;
       break;
     }

--- a/src/tetris/background.h
+++ b/src/tetris/background.h
@@ -1,11 +1,11 @@
 void DrawBackground(const std::string& s) { // drawn to the standard plane
   nc_err_e err;
-  ncvisual_options opts{};
-  opts.style = NCSCALE_STRETCH;
-  backg_ = std::make_unique<ncpp::Visual>(&opts, s.c_str(), &err);
+  backg_ = std::make_unique<ncpp::Visual>(s.c_str(), &err);
   backg_->decode();
-  backg_->render(0, 0, -1, -1);
-  backg_->get_plane()->greyscale();
+  ncvisual_options opts{};
+  opts.scaling = NCSCALE_STRETCH;
+  auto p = backg_->render(&opts);
+  ncplane_greyscale(p);
 }
 
 void DrawBoard() { // draw all fixed components of the game

--- a/src/tetris/main.cpp
+++ b/src/tetris/main.cpp
@@ -10,6 +10,7 @@
 #include <clocale>
 #include <unistd.h>
 #include <ncpp/NotCurses.hh>
+#include <ncpp/Visual.hh>
 #include "version.h"
 
 std::mutex ncmtx;

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -43,15 +43,15 @@ ns_to_timespec(uint64_t ns, struct timespec* ts){
 // FIXME internalize this via complex curry
 static struct ncplane* subtitle_plane = nullptr;
 
-// frame count is in the curry. original time is in the ncvisual's ncplane's userptr.
-auto perframe([[maybe_unused]] struct notcurses* _nc, struct ncvisual* ncv,
+// frame count is in the curry. original time is kept in n's userptr.
+auto perframe(struct ncplane* n, struct ncvisual* ncv,
               const struct timespec* abstime, void* vframecount) -> int {
   NotCurses &nc = NotCurses::get_instance ();
-  auto start = static_cast<struct timespec*>(ncplane_userptr(ncvisual_plane(ncv)));
+  auto start = static_cast<struct timespec*>(ncplane_userptr(n));
   if(!start){
     start = new struct timespec;
     clock_gettime(CLOCK_MONOTONIC, start);
-    ncplane_set_userptr(ncvisual_plane(ncv), start);
+    ncplane_set_userptr(n, start);
   }
   std::unique_ptr<Plane> stdn(nc.get_stdplane());
   int* framecount = static_cast<int*>(vframecount);
@@ -60,14 +60,14 @@ auto perframe([[maybe_unused]] struct notcurses* _nc, struct ncvisual* ncv,
   struct timespec now;
   clock_gettime(CLOCK_MONOTONIC, &now);
   intmax_t ns = timespec_to_ns(&now) - timespec_to_ns(start);
-  stdn->erase();
+  // clear top line only
   stdn->printf(0, NCAlign::Left, "frame %06d\u2026", *framecount);
   char* subtitle = ncvisual_subtitle(ncv);
   if(subtitle){
     if(!subtitle_plane){
       int dimx, dimy;
-      notcurses_term_dim_yx(_nc, &dimy, &dimx);
-      subtitle_plane = ncplane_new(_nc, 1, dimx, dimy - 1, 0, nullptr);
+      ncplane_dim_yx(n, &dimy, &dimx);
+      subtitle_plane = ncplane_new(nc, 1, dimx, dimy - 1, 0, nullptr);
       uint64_t channels = 0;
       channels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
       channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
@@ -94,7 +94,7 @@ auto perframe([[maybe_unused]] struct notcurses* _nc, struct ncvisual* ncv,
   }
   int dimx, dimy, oldx, oldy, keepy, keepx;
   nc.get_term_dim(&dimy, &dimx);
-  ncplane_dim_yx(ncvisual_plane(ncv), &oldy, &oldx);
+  ncplane_dim_yx(n, &oldy, &oldx);
   keepy = oldy > dimy ? dimy : oldy;
   keepx = oldx > dimx ? dimx : oldx;
   struct timespec interval;
@@ -106,7 +106,7 @@ auto perframe([[maybe_unused]] struct notcurses* _nc, struct ncvisual* ncv,
     char32_t keyp;
     while((keyp = nc.getc(&interval, nullptr, nullptr)) != (char32_t)-1){
       if(keyp == NCKEY_RESIZE){
-        return ncplane_resize(ncvisual_plane(ncv), 0, 0, keepy, keepx, 0, 0, dimy, dimx);
+        return ncplane_resize(n, 0, 0, keepy, keepx, 0, 0, dimy, dimx);
       }
       return 1;
     }
@@ -196,27 +196,24 @@ auto main(int argc, char** argv) -> int {
   }
   int dimy, dimx;
   nc.get_term_dim(&dimy, &dimx);
+  std::unique_ptr<Plane> stdn(nc.get_stdplane()); // FIXME combine with above
   for(auto i = nonopt ; i < argc ; ++i){
     int frames = 0;
     nc_err_e err;
     std::unique_ptr<Visual> ncv;
     try{
-      struct ncvisual_options opts{};
-      opts.style = scalemode;
-      opts.y = 1;
-      ncv = std::make_unique<Visual>(&opts, argv[i], &err);
+      ncv = std::make_unique<Visual>(argv[i], &err);
     }catch(std::exception& e){
       nc.stop();
       std::cerr << argv[i] << ": " << e.what() << "\n";
       return EXIT_FAILURE;
     }
-    int r = ncv->stream(&err, timescale, perframe, &frames);
+    int r = ncv->stream(*stdn, &err, timescale, perframe, &frames);
     if(r < 0){ // positive is intentional abort
       nc.stop();
       std::cerr << "Error decoding " << argv[i] << ": " << nc_strerror(err) << std::endl;
       return EXIT_FAILURE;
     }else if(r == 0){
-      std::unique_ptr<Plane> stdn(nc.get_stdplane());
       stdn->printf(0, NCAlign::Center, "press any key to advance");
       nc.render();
       char32_t ie = nc.getc(true);
@@ -227,10 +224,6 @@ auto main(int argc, char** argv) -> int {
       }else if(ie == NCKey::Resize){
         --i; // rerun with the new size
         if(!nc.refresh(&dimy, &dimx)){
-          return EXIT_FAILURE;
-        }
-        if(!ncv->get_plane()->resize(dimy, dimx)){
-          nc.stop();
           return EXIT_FAILURE;
         }
       }

--- a/tests/fds.cpp
+++ b/tests/fds.cpp
@@ -48,8 +48,7 @@ auto testfdeofdestroys(struct ncfdplane* n, int fderrno, void* curry) -> int {
 
 // test ncfdplanes and ncsubprocs
 TEST_CASE("FdsAndSubprocs"
-          * doctest::description("Fdplanes and subprocedures")
-          * doctest::timeout(10)) {
+          * doctest::description("Fdplanes and subprocedures")) {
   notcurses_options nopts{};
   nopts.inhibit_alternate_screen = true;
   nopts.suppress_banner = true;

--- a/tests/rotate.cpp
+++ b/tests/rotate.cpp
@@ -113,14 +113,15 @@ TEST_CASE("Rotate") {
     int height = dimy / 2;
     int width = dimx / 2;
     std::vector<uint32_t> rgba(width * height, 0xffbbccff);
-    auto ncv = ncvisual_from_rgba(nc_, nullptr, rgba.data(), height, width * 4, width);
+    auto ncv = ncvisual_from_rgba(rgba.data(), height, width * 4, width);
     REQUIRE(ncv);
-    int rendered = ncvisual_render(ncv, 0, 0, -1, -1);
-    CHECK(0 < rendered);
+    ncvisual_options opts{};
+    auto rendered = ncvisual_render(nc_, ncv, &opts);
+    CHECK(rendered);
     CHECK(0 == notcurses_render(nc_));
-    uint32_t* rgbaret = ncplane_rgba(ncvisual_plane(ncv), 0, 0, -1, -1);
+    uint32_t* rgbaret = ncplane_rgba(rendered, 0, 0, -1, -1);
     REQUIRE(rgbaret);
-    for(int i = 0 ; i < rendered / 2 ; ++i){
+    for(int i = 0 ; i < height * width / 2 ; ++i){
       CHECK(rgbaret[i] == htonl(rgba[i]));
     }
     free(rgbaret);
@@ -134,19 +135,22 @@ TEST_CASE("Rotate") {
       CHECK(0xffccbb == (channels_bg(channels) & CELL_BG_MASK));
       free(c);
     }
+    opts.n = rendered;
+    // FIXME check pixels after all rotations
     CHECK(0 == ncvisual_rotate(ncv, M_PI / 2));
-    CHECK(0 <= ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_rotate(ncv, M_PI / 2));
-    CHECK(0 <= ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_rotate(ncv, M_PI / 2));
-    CHECK(0 <= ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_rotate(ncv, M_PI / 2));
-    CHECK(0 <= ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     ncvisual_destroy(ncv);
+    ncplane_destroy(rendered);
     CHECK(0 == notcurses_render(nc_));
   }
 
@@ -154,14 +158,15 @@ TEST_CASE("Rotate") {
     int height = dimy / 2;
     int width = dimx / 2;
     std::vector<uint32_t> rgba(width * height, 0xffbbccff);
-    auto ncv = ncvisual_from_rgba(nc_, nullptr, rgba.data(), height, width * 4, width);
+    auto ncv = ncvisual_from_rgba(rgba.data(), height, width * 4, width);
     REQUIRE(ncv);
-    int rendered = ncvisual_render(ncv, 0, 0, -1, -1);
-    CHECK(0 < rendered);
+    ncvisual_options opts{};
+    auto rendered = ncvisual_render(nc_, ncv, &opts);
+    CHECK(rendered);
     CHECK(0 == notcurses_render(nc_));
-    uint32_t* rgbaret = ncplane_rgba(ncvisual_plane(ncv), 0, 0, -1, -1);
+    uint32_t* rgbaret = ncplane_rgba(rendered, 0, 0, -1, -1);
     REQUIRE(rgbaret);
-    for(int i = 0 ; i < rendered ; ++i){
+    for(int i = 0 ; i < height * width / 2 ; ++i){
       CHECK(rgbaret[i] == htonl(rgba[i]));
     }
     free(rgbaret);
@@ -175,19 +180,22 @@ TEST_CASE("Rotate") {
       CHECK(0xffccbb == (channels_bg(channels) & CELL_BG_MASK));
       free(c);
     }
+    // FIXME check pixels after all rotations
+    opts.n = rendered;
     CHECK(0 == ncvisual_rotate(ncv, -M_PI / 2));
-    CHECK(0 <= ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_rotate(ncv, -M_PI / 2));
-    CHECK(0 <= ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_rotate(ncv, -M_PI / 2));
-    CHECK(0 <= ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_rotate(ncv, -M_PI / 2));
-    CHECK(0 <= ncvisual_render(ncv, 0, 0, -1, -1));
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     ncvisual_destroy(ncv);
+    ncplane_destroy(rendered);
     CHECK(0 == notcurses_render(nc_));
   }
 

--- a/tests/visual.cpp
+++ b/tests/visual.cpp
@@ -26,19 +26,21 @@ TEST_CASE("Visual") {
     nc_err_e ncerr = NCERR_SUCCESS;
     int dimy, dimx;
     ncplane_dim_yx(ncp_, &dimy, &dimx);
-    struct ncvisual_options opts{};
-    opts.style = NCSCALE_STRETCH;
-    auto ncv = ncvisual_from_file(nc_, &opts, find_data("changes.jpg"), &ncerr);
+    auto ncv = ncvisual_from_file(find_data("changes.jpg"), &ncerr);
     REQUIRE(ncv);
     REQUIRE(NCERR_SUCCESS == ncerr);
     ncerr = ncvisual_decode(ncv);
     REQUIRE(NCERR_SUCCESS == ncerr);
     /*CHECK(dimy * 2 == frame->height);
     CHECK(dimx == frame->width); FIXME */
-    CHECK(0 < ncvisual_render(ncv, 0, 0, -1, -1));
+    struct ncvisual_options opts{};
+    opts.scaling = NCSCALE_STRETCH;
+    auto newn = ncvisual_render(nc_, ncv, &opts);
+    CHECK(newn);
     CHECK(0 == notcurses_render(nc_));
     ncerr = ncvisual_decode(ncv);
     CHECK(NCERR_EOF == ncerr);
+    ncplane_destroy(newn);
     ncvisual_destroy(ncv);
   }
 
@@ -46,17 +48,17 @@ TEST_CASE("Visual") {
     nc_err_e ncerr = NCERR_SUCCESS;
     int dimy, dimx;
     ncplane_dim_yx(ncp_, &dimy, &dimx);
-    struct ncvisual_options opts{};
-    opts.style = NCSCALE_STRETCH;
-    opts.n = ncp_;
-    auto ncv = ncvisual_from_file(nc_, &opts, find_data("changes.jpg"), &ncerr);
+    auto ncv = ncvisual_from_file(find_data("changes.jpg"), &ncerr);
     REQUIRE(ncv);
     REQUIRE(0 == ncerr);
     ncerr = ncvisual_decode(ncv);
     REQUIRE(NCERR_SUCCESS == ncerr);
     /*CHECK(dimy * 2 == frame->height);
     CHECK(dimx == frame->width); FIXME */
-    CHECK(0 < ncvisual_render(ncv, 0, 0, -1, -1));
+    struct ncvisual_options opts{};
+    opts.scaling = NCSCALE_STRETCH;
+    opts.n = ncp_;
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     ncerr = ncvisual_decode(ncv);
     CHECK(NCERR_EOF == ncerr);
@@ -67,20 +69,20 @@ TEST_CASE("Visual") {
     nc_err_e ncerr = NCERR_SUCCESS;
     int dimy, dimx;
     ncplane_dim_yx(ncp_, &dimy, &dimx);
-    struct ncvisual_options opts{};
-    opts.style = NCSCALE_STRETCH;
-    opts.n = ncp_;
-    auto ncv = ncvisual_from_file(nc_, &opts, find_data("changes.jpg"), &ncerr);
+    auto ncv = ncvisual_from_file(find_data("changes.jpg"), &ncerr);
     REQUIRE(ncv);
     REQUIRE(NCERR_SUCCESS == ncerr);
     ncerr = ncvisual_decode(ncv);
     REQUIRE(NCERR_SUCCESS == ncerr);
     /*CHECK(dimy * 2 == frame->height);
     CHECK(dimx == frame->width); FIXME */
-    CHECK(0 < ncvisual_render(ncv, 0, 0, -1, -1));
+    struct ncvisual_options opts{};
+    opts.n = ncp_;
+    opts.scaling = NCSCALE_STRETCH;
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     void* needle = malloc(1);
     REQUIRE(nullptr != needle);
-    struct ncplane* newn = ncplane_dup(ncvisual_plane(ncv), needle);
+    struct ncplane* newn = ncplane_dup(ncp_, needle);
     int ndimx, ndimy;
     REQUIRE(nullptr != newn);
     ncvisual_destroy(ncv);
@@ -97,10 +99,7 @@ TEST_CASE("Visual") {
       nc_err_e ncerr = NCERR_SUCCESS;
       int dimy, dimx;
       ncplane_dim_yx(ncp_, &dimy, &dimx);
-      struct ncvisual_options opts{};
-      opts.style = NCSCALE_STRETCH;
-      opts.n = ncp_;
-      auto ncv = ncvisual_from_file(nc_, &opts, find_data("notcursesI.avi"), &ncerr);
+      auto ncv = ncvisual_from_file(find_data("notcursesI.avi"), &ncerr);
       REQUIRE(ncv);
       CHECK(NCERR_SUCCESS == ncerr);
       for(;;){ // run at the highest speed we can
@@ -111,7 +110,10 @@ TEST_CASE("Visual") {
         CHECK(NCERR_SUCCESS == ncerr);
         /*CHECK(dimy * 2 == frame->height);
         CHECK(dimx == frame->width); FIXME */
-        CHECK(0 < ncvisual_render(ncv, 0, 0, -1, -1));
+        struct ncvisual_options opts{};
+        opts.scaling = NCSCALE_STRETCH;
+        opts.n = ncp_;
+        CHECK(ncvisual_render(nc_, ncv, &opts));
         CHECK(0 == notcurses_render(nc_));
       }
       ncvisual_destroy(ncv);
@@ -123,17 +125,19 @@ TEST_CASE("Visual") {
       nc_err_e ncerr = NCERR_SUCCESS;
       int dimy, dimx;
       ncplane_dim_yx(ncp_, &dimy, &dimx);
-      struct ncvisual_options opts{};
-      opts.style = NCSCALE_STRETCH;
-      auto ncv = ncvisual_from_file(nc_, &opts, find_data("notcursesI.avi"), &ncerr);
+      auto ncv = ncvisual_from_file(find_data("notcursesI.avi"), &ncerr);
       REQUIRE(ncv);
       CHECK(NCERR_SUCCESS == ncerr);
       ncerr = ncvisual_decode(ncv);
       CHECK(NCERR_SUCCESS == ncerr);
       /*CHECK(dimy * 2 == frame->height);
       CHECK(dimx == frame->width); FIXME */
-      CHECK(0 < ncvisual_render(ncv, 0, 0, -1, -1));
+      struct ncvisual_options opts{};
+      opts.scaling = NCSCALE_STRETCH;
+      auto newn = ncvisual_render(nc_, ncv, &opts);
+      CHECK(newn);
       CHECK(0 == notcurses_render(nc_));
+      ncplane_destroy(newn);
       ncvisual_destroy(ncv);
     }
   }
@@ -143,9 +147,11 @@ TEST_CASE("Visual") {
     int dimy, dimx;
     ncplane_dim_yx(ncp_, &dimy, &dimx);
     std::vector<uint32_t> rgba(dimx * dimy * 2, 0x88bbccff);
-    auto ncv = ncvisual_from_rgba(nc_, nullptr, rgba.data(), dimy * 2, dimx * 4, dimx);
+    auto ncv = ncvisual_from_rgba(rgba.data(), dimy * 2, dimx * 4, dimx);
     REQUIRE(ncv);
-    CHECK(0 < ncvisual_render(ncv, 0, 0, -1, -1));
+    struct ncvisual_options opts{};
+    opts.n = ncp_;
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     ncvisual_destroy(ncv);
     CHECK(0 == notcurses_render(nc_));
@@ -155,9 +161,11 @@ TEST_CASE("Visual") {
     int dimy, dimx;
     ncplane_dim_yx(ncp_, &dimy, &dimx);
     std::vector<uint32_t> rgba(dimx * dimy * 2, 0x88bbccff);
-    auto ncv = ncvisual_from_bgra(nc_, nullptr, rgba.data(), dimy * 2, dimx * 4, dimx);
+    auto ncv = ncvisual_from_bgra(rgba.data(), dimy * 2, dimx * 4, dimx);
     REQUIRE(ncv);
-    CHECK(0 < ncvisual_render(ncv, 0, 0, -1, -1));
+    struct ncvisual_options opts{};
+    opts.n = ncp_;
+    CHECK(ncvisual_render(nc_, ncv, &opts));
     CHECK(0 == notcurses_render(nc_));
     ncvisual_destroy(ncv);
     CHECK(0 == notcurses_render(nc_));


### PR DESCRIPTION
Massive simplification + increased flexibility for the ncvisual
(pixel) API. Visuals are no longer bound through their lifetimes
to planes. A visual is loaded from disk, memory, or a plane.
Resizing is now its own function. Only ncvisual_render() requires
options, which can be NULL (to indicate render the full visual with
no scaling). The same visual can now be rendered multiple times, to
multiple planes.