### PR TITLE
Change DSO versioning scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,38 @@
 cmake_minimum_required(VERSION 3.14)
-project(notcurses VERSION 1.4.3
+
+# Shared library versioning is done in the same way as SDL:
+#
+# If the version changes, then:
+#
+#   NOTCURSES_VERSION_MICRO += 1;
+#   NOTCURSES_INTERFACE_AGE += 1;
+#   NOTCURSES_BINARY_AGE += 1;
+# if any functions/classes/methods have been added, set NOTCURSES_INTERFACE_AGE to 0.
+# if backwards compatibility has been broken,
+# set NOTCURSES_BINARY_AGE and NOTCURSES_INTERFACE_AGE to 0.
+
+set(NOTCURSES_VERSION_MAJOR 1)
+set(NOTCURSES_VERSION_MINOR 5)
+set(NOTCURSES_VERSION_MICRO 0)
+
+set(NOTCURSES_INTERFACE_AGE 0)
+set(NOTCURSES_BINARY_AGE 1)
+
+set(NOTCURSES_VERSION "${NOTCURSES_VERSION_MAJOR}.${NOTCURSES_VERSION_MINOR}.${NOTCURSES_VERSION_MICRO}")
+
+# Calculate a libtool-like version number (taken from SDL2 CMakeLists.txt)
+math(EXPR LT_CURRENT "${NOTCURSES_VERSION_MICRO} - ${NOTCURSES_INTERFACE_AGE}")
+math(EXPR LT_AGE "${NOTCURSES_BINARY_AGE} - ${NOTCURSES_INTERFACE_AGE}")
+math(EXPR LT_MAJOR "${LT_CURRENT} - ${LT_AGE}")
+set(LT_REVISION "${NOTCURSES_INTERFACE_AGE}")
+set(LT_RELEASE "${NOTCURSES_VERSION_MAJOR}.${NOTCURSES_VERSION_MINOR}")
+set(LT_VERSION "${LT_MAJOR}.${LT_AGE}.${LT_REVISION}")
+
+project(notcurses VERSION ${NOTCURSES_VERSION_MAJOR}.${NOTCURSES_VERSION_MINOR}.${NOTCURSES_VERSION_MICRO}
   DESCRIPTION "UI for modern terminal emulators"
   HOMEPAGE_URL "https://nick-black.com/dankwiki/index.php/notcurses"
   LANGUAGES C CXX)
+
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
@@ -94,17 +124,15 @@ add_library(notcurses-static STATIC EXCLUDE_FROM_ALL ${NCSRCS})
 endif()
 set_target_properties(
   notcurses-static PROPERTIES
-  OUTPUT_NAME notcurses
+  OUTPUT_NAME notcurses-${LT_RELEASE}
 )
 
 set_target_properties(notcurses PROPERTIES
-  VERSION ${PROJECT_VERSION}
-  SOVERSION ${PROJECT_VERSION_MAJOR}
+  VERSION ${NOTCURSES_VERSION}
+  SOVERSION ${LT_REVISION}
+  OUTPUT_NAME notcurses-${LT_RELEASE}
 )
-set_target_properties(notcurses-static PROPERTIES
-  VERSION ${PROJECT_VERSION}
-  SOVERSION ${PROJECT_VERSION_MAJOR}
-)
+
 target_include_directories(notcurses
   PRIVATE
     include
@@ -239,14 +267,14 @@ add_library(notcurses++-static STATIC EXCLUDE_FROM_ALL ${NCPP_SOURCES})
 endif()
 set_target_properties(
   notcurses++-static PROPERTIES
-  OUTPUT_NAME notcurses++
+  OUTPUT_NAME notcurses++-${LT_RELEASE}
   )
 
 set_target_properties(
   notcurses++ PROPERTIES
-  VERSION ${PROJECT_VERSION}
-  SOVERSION ${PROJECT_VERSION_MAJOR}
-  OUTPUT_NAME "notcurses++")
+  VERSION ${NOTCURSES_VERSION}
+  SOVERSION ${LT_REVISION}
+  OUTPUT_NAME notcurses++-${LT_RELEASE})
 
 set(NCPP_INCLUDE_DIRS
   include

--- a/tools/notcurses++.pc.in
+++ b/tools/notcurses++.pc.in
@@ -5,8 +5,8 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: C++ bindings for notcurses
-Version: @PROJECT_VERSION@
+Version: @NOTCURSES_VERSION@
 
-Requires: notcurses >= @PROJECT_VERSION@
-Libs: -L${libdir} -lnotcurses++
+Requires: notcurses = @NOTCURSES_VERSION@
+Libs: -L${libdir} -lnotcurses++-@LT_RELEASE@
 Cflags: -I${includedir}

--- a/tools/notcurses.pc.in
+++ b/tools/notcurses.pc.in
@@ -5,8 +5,8 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: TUI library for modern terminal emulators
-Version: @PROJECT_VERSION@
+Version: @NOTCURSES_VERSION@
 
 Requires:
-Libs: -L${libdir} -lnotcurses
+Libs: -L${libdir} -lnotcurses-@LT_RELEASE@
 Cflags: -I${includedir}

--- a/tools/notcursesConfig.cmake.in
+++ b/tools/notcursesConfig.cmake.in
@@ -6,4 +6,4 @@ get_filename_component(NOTCURSES_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(NOTCURSES_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 set(NOTCURSES_LIBRARY_DIRS "@CONF_LIBRARY_DIRS@")
 
-set(notcurses_LIBRARIES -lnotcurses)
+set(notcurses_LIBRARIES -lnotcurses-@LT_RELEASE@)

--- a/tools/setup.py.in
+++ b/tools/setup.py.in
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name="notcurses",
-    version="${PROJECT_VERSION}",
+    version="${NOTCURSES_VERSION}",
     packages=['notcurses'],
     package_dir={ '': '${CMAKE_CURRENT_BINARY_DIR}/python/src' },
     author="Nick Black",


### PR DESCRIPTION
This commit introduces the same shared library versioning scheme as used
by the SDL library.  The advantage is that different versions of
notcurses can be installed alongside each other (which is not an
unlikely scenario, as SDL itself certifies) and that, if the versioning
protocol is followed, any change to ABI will produce a DSO whose name
will not break any applications linked against any previous version.

I think it's worth making this change before the API freeze.