### PR TITLE
Improved fade API (#659), ncvisual fixes (#660)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,9 +18,9 @@ rearrangements of Notcurses.
     any meaning, and has been removed.
   * The `fadecb` typedef now accepts as its third argument a `const struct
     timespec`. This is the absolute deadline through which the frame ought
-    be displayed. Like the changes to `ncvisual_stream()`, this gives more
-    flexibility to the callback, and allows more precise timing. There will
-    be further changes to the Fade API before API freeze (see #659).
+    be displayed. New functions have been added to the Fade API: like the
+    changes to `ncvisual_stream()`, this gives more flexibility, and allows
+    more precise timing. All old functions remain available.
 
 * 1.4.3 (2020-05-22)
   * Plot: make 8x1 the default, instead of 1x1.

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,12 +9,18 @@ rearrangements of Notcurses.
     `ncblitter_e` field, allowing visuals to be mapped to various plotting
     paradigms including Sixel, Braille and quadrants. Not all backends have
     been implemented, and not all implementations are in their final form.
+    `CELL_ALPHA_BLEND` can now be used for translucent visuals.
   * Added `ncvisual_geom()`, providing access to an `ncvisual` size and
     its pixel-to-cell blitting ratios.
   * Deprecated functions `ncvisual_open_plane()` and `ncplane_visual_open()`
     have been removed. Their functionality is present in
     `ncvisual_from_file()`. The function `ncvisual_plane()` no longer has
     any meaning, and has been removed.
+  * The `fadecb` typedef now accepts as its third argument a `const struct
+    timespec`. This is the absolute deadline through which the frame ought
+    be displayed. Like the changes to `ncvisual_stream()`, this gives more
+    flexibility to the callback, and allows more precise timing. There will
+    be further changes to the Fade API before API freeze (see #659).
 
 * 1.4.3 (2020-05-22)
   * Plot: make 8x1 the default, instead of 1x1.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1200,8 +1200,7 @@ typedef int (*fadecb)(struct notcurses* nc, struct ncplane* ncp, void* curry);
 // Fade the ncplane out over the provided time, calling the specified function
 // when done. Requires a terminal which supports truecolor, or at least palette
 // modification (if the terminal uses a palette, our ability to fade planes is
-// limited, and affected by the complexity of the rest of the screen). It is
-// not safe to resize or destroy the plane during the fadeout FIXME.
+// limited, and affected by the complexity of the rest of the screen).
 int ncplane_fadeout(struct ncplane* n, const struct timespec* ts, fadecb fader, void* curry);
 
 // Fade the ncplane in over the specified time. Load the ncplane with the

--- a/USAGE.md
+++ b/USAGE.md
@@ -1227,7 +1227,7 @@ The more flexible fade API allows for fine control of the process.
 
 ```c
 // paired with a loop over ncplane_fade{in/out}_iteration() + ncfadectx_free().
-struct ncfadectx* ncfadectx_setup(struct ncplane* n, const struct timespec* ts);
+struct ncfadectx* ncfadectx_setup(struct ncplane* n);
 
 // Return the number of iterations through which 'nctx' will fade.
 int ncfadectx_iterations(const struct ncfadectx* nctx);

--- a/doc/man/man3/notcurses_fade.3.md
+++ b/doc/man/man3/notcurses_fade.3.md
@@ -11,11 +11,13 @@ notcurses_fade - fade ncplanes in and out
 **#include <notcurses/notcurses.h>**
 
 ```c
+struct ncfadectx;
+
 // Called for each delta performed in a fade on ncp. If anything but 0 is
 // returned, the fading operation ceases immediately, and that value is
 // propagated out. If provided and not NULL, the faders will not themselves
 // call notcurses_render().
-typedef int (*fadecb)(struct notcurses* nc, struct ncplane* ncp);
+typedef int (*fadecb)(struct notcurses* nc, struct ncplane* ncp, const struct timespec*, void* curry);
 ```
 
 **bool notcurses_canfade(const struct notcurses* nc);**
@@ -26,13 +28,44 @@ typedef int (*fadecb)(struct notcurses* nc, struct ncplane* ncp);
 
 **int ncplane_pulse(struct ncplane* n, const struct timespec* ts, fadecb fader, void* curry);**
 
+**struct ncfadectx* ncfadectx_setup(struct ncplane* n);**
+
+**int ncfadectx_iterations(const struct ncfadectx* nctx);**
+
+**int ncplane_fadeout_iteration(struct ncplane* n, struct ncfadectx* nctx, int iter, fadecb fader, void* curry);**
+
+**int ncplane_fadein_iteration(struct ncplane* n, struct ncfadectx* nctx, int iter, fadecb fader, void* curry);**
+
+**void ncfadectx_free(struct ncfadectx* nctx);**
+
 # DESCRIPTION
+
+**ncplane_fadeout**, **ncplane_fadein**, and **ncplane_pulse** are simple
+APIs for fading planes in and out. Fades require either RGB support or
+palette reprogramming support from the terminal (the RGB method is
+preferred, and will be used whenever possible). The **ts** parameter
+specifies the total amount of time for the fade operation. The operation
+itself is time-adaptive (i.e. if it finds itself falling behind, it will
+skip iterations; if it is proceeding too quickly, it will sleep).
+
+These are wrappers around the more flexible **ncfadectx** API. Create an
+**ncfadectx** with **ncfadectx_setup**. The number of possible state changes
+(iterations) can be accessed with **ncfadectx_iterations**. A state can be
+reached with **ncplane_fadeout_iteration** or **ncplane_fadein_iteration**.
+Finally, destroy the **ncfadectx** with **ncfadectx_free**.
 
 # RETURN VALUES
 
+**ncplane_fadeout_iteration** and **ncplane_fadein_iteration** will propagate
+out any non-zero return value from the callback **fader**.
+
 # BUGS
+
+Palette reprogramming can affect other contents of the terminal in complex
+ways. This is not a problem when the RGB method is used.
 
 # SEE ALSO
 
+**clock_nanosleep(2)**,
 **notcurses(3)**,
 **notcurses_plane(3)**

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1974,8 +1974,7 @@ typedef int (*fadecb)(struct notcurses* nc, struct ncplane* ncp,
 // Fade the ncplane out over the provided time, calling the specified function
 // when done. Requires a terminal which supports truecolor, or at least palette
 // modification (if the terminal uses a palette, our ability to fade planes is
-// limited, and affected by the complexity of the rest of the screen). It is
-// not safe to resize or destroy the plane during the fadeout FIXME.
+// limited, and affected by the complexity of the rest of the screen).
 API int ncplane_fadeout(struct ncplane* n, const struct timespec* ts,
                         fadecb fader, void* curry);
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1987,7 +1987,7 @@ API int ncplane_fadein(struct ncplane* n, const struct timespec* ts,
 
 // Rather than the simple ncplane_fade{in/out}(), ncfadectx_setup() can be
 // paired with a loop over ncplane_fade{in/out}_iteration() + ncfadectx_free().
-API struct ncfadectx* ncfadectx_setup(struct ncplane* n, const struct timespec* ts);
+API struct ncfadectx* ncfadectx_setup(struct ncplane* n);
 
 // Return the number of iterations through which 'nctx' will fade.
 API int ncfadectx_iterations(const struct ncfadectx* nctx);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -203,7 +203,7 @@ void notcurses_reset_stats(struct notcurses* nc, ncstats* stats);
 int ncplane_hline_interp(struct ncplane* n, const cell* c, int len, uint64_t c1, uint64_t c2);
 int ncplane_vline_interp(struct ncplane* n, const cell* c, int len, uint64_t c1, uint64_t c2);
 int ncplane_box(struct ncplane* n, const cell* ul, const cell* ur, const cell* ll, const cell* lr, const cell* hline, const cell* vline, int ystop, int xstop, unsigned ctlword);
-typedef int (*fadecb)(struct notcurses* nc, struct ncplane* ncp, void* curry);
+typedef int (*fadecb)(struct notcurses* nc, struct ncplane* ncp, const struct timespec* ts, void* curry);
 int ncplane_fadeout(struct ncplane* n, const struct timespec* ts, fadecb fader, void* curry);
 int ncplane_fadein(struct ncplane* n, const struct timespec* ts, fadecb fader, void* curry);
 int ncplane_pulse(struct ncplane* n, const struct timespec* ts, fadecb fader, void* curry);

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -79,7 +79,7 @@ static struct {
   { "box", box_demo, false, false, false, },
   {"chunli", chunli_demo, true, false, true, },
   { NULL, NULL, false, false, false, },
-  { "eagle", eagle_demo, true, false, true, },
+  { "eagle", eagle_demo, true, false, false, },
   { "fallin'", fallin_demo, false, false, false, },
   { "grid", grid_demo, false, false, false, },
   { "highcon", highcontrast_demo, false, false, false, },
@@ -89,7 +89,7 @@ static struct {
   { "luigi", luigi_demo, true, false, true, },
   { NULL, NULL, false, false, false, },
   { "normal", normal_demo, false, false, false, },
-  { "outro", outro, false, true, true, },
+  { "outro", outro, false, false, false, },
   { NULL, NULL, false, false, false, },
   { "qrcode", qrcode_demo, false, false, false, }, // is blank without USE_QRCODEGEN
   { "reel", reel_demo, false, false, false, },

--- a/src/demo/eagle.c
+++ b/src/demo/eagle.c
@@ -197,18 +197,17 @@ eagles(struct notcurses* nc){
 
 // motherfucking eagles!
 int eagle_demo(struct notcurses* nc){
-  if(!notcurses_canopen_images(nc)){
-    return 0;
-  }
-  char* map = find_data("eagles.png");
-  struct ncplane* zncp;
+  struct ncplane* zncp = NULL;
   int err;
-  if((zncp = zoom_map(nc, map, &err)) == NULL){
+  if(notcurses_canopen_images(nc)){
+    char* map = find_data("eagles.png");
+    if((zncp = zoom_map(nc, map, &err)) == NULL){
+      free(map);
+      return err;
+    }
     free(map);
-    return err;
   }
   err = eagles(nc);
   ncplane_destroy(zncp);
-  free(map);
   return err;
 }

--- a/src/lib/fade.c
+++ b/src/lib/fade.c
@@ -228,7 +228,8 @@ int ncplane_fadeout_iteration(ncplane* n, ncfadectx* nctx, int iter,
   return ret;
 }
 
-ncfadectx* ncfadectx_setup(ncplane* n, const struct timespec* ts){
+static ncfadectx* 
+ncfadectx_setup_internal(ncplane* n, const struct timespec* ts){
   if(!n->nc->tcache.RGBflag && !n->nc->tcache.CCCflag){ // terminal can't fade
     return NULL;
   }
@@ -242,6 +243,10 @@ ncfadectx* ncfadectx_setup(ncplane* n, const struct timespec* ts){
   return NULL;
 }
 
+ncfadectx* ncfadectx_setup(ncplane* n){
+  return ncfadectx_setup_internal(n, NULL);
+}
+
 void ncfadectx_free(ncfadectx* nctx){
   if(nctx){
     free(nctx->channels);
@@ -250,7 +255,7 @@ void ncfadectx_free(ncfadectx* nctx){
 }
 
 int ncplane_fadeout(ncplane* n, const struct timespec* ts, fadecb fader, void* curry){
-  ncfadectx* pp = ncfadectx_setup(n, ts);
+  ncfadectx* pp = ncfadectx_setup_internal(n, ts);
   if(!pp){
     return -1;
   }
@@ -274,7 +279,7 @@ int ncplane_fadeout(ncplane* n, const struct timespec* ts, fadecb fader, void* c
 }
 
 int ncplane_fadein(ncplane* n, const struct timespec* ts, fadecb fader, void* curry){
-  ncfadectx* nctx = ncfadectx_setup(n, ts);
+  ncfadectx* nctx = ncfadectx_setup_internal(n, ts);
   if(nctx == NULL){
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);

--- a/src/lib/ffmpeg.cpp
+++ b/src/lib/ffmpeg.cpp
@@ -346,13 +346,13 @@ int ncvisual_stream(notcurses* nc, ncvisual* ncv, nc_err_e* ncerr,
       usets = true;
     }
     if((newn = ncvisual_render(nc, ncv, &activevopts)) == NULL){
-      if(activeopts.n != vopts->n){
-        ncplane_destroy(activeopts.n);
+      if(activevopts.n != vopts->n){
+        ncplane_destroy(activevopts.n);
       }
       return -1;
     }
-    if(activeopts.n != newn){
-      activeopts.n = newn;
+    if(activevopts.n != newn){
+      activevopts.n = newn;
     }
     ++frame;
     uint64_t duration = ncv->details.frame->pkt_duration * tbase * NANOSECS_IN_SEC;
@@ -373,17 +373,17 @@ int ncvisual_stream(notcurses* nc, ncvisual* ncv, nc_err_e* ncerr,
     if(streamer){
       r = streamer(newn, ncv, &abstime, curry);
     }else{
-      ncvisual_simple_streamer(activeopts.n, ncv, &abstime, curry);
+      ncvisual_simple_streamer(activevopts.n, ncv, &abstime, curry);
     }
     if(r){
-      if(activeopts.n != vopts->n){
-        ncplane_destroy(activeopts.n);
+      if(activevopts.n != vopts->n){
+        ncplane_destroy(activevopts.n);
       }
       return r;
     }
   }
-  if(activeopts.n != vopts->n){
-    ncplane_destroy(activeopts.n);
+  if(activevopts.n != vopts->n){
+    ncplane_destroy(activevopts.n);
   }
   if(*ncerr == NCERR_EOF){
     return 0;

--- a/src/lib/oiio.cpp
+++ b/src/lib/oiio.cpp
@@ -125,7 +125,7 @@ nc_err_e ncvisual_blit(struct ncvisual* ncv, int rows, int cols,
     stride = ncv->rowstride;
   }
   if(rgba_blit_dispatch(n, bset, placey, placex, stride, data, begy, begx,
-                        leny, lenx, blendcolors)) <= 0){
+                        leny, lenx, blendcolors) <= 0){
     return NCERR_DECODE;
   }
   return NCERR_SUCCESS;

--- a/src/lib/oiio.cpp
+++ b/src/lib/oiio.cpp
@@ -26,9 +26,13 @@ ncvisual* ncvisual_from_file(const char* filename, nc_err_e* err) {
     ncvisual_destroy(ncv);
     return nullptr;
   }
-/*const auto &spec = ncv->details.image->spec_dimensions();
+/*const auto &spec = ncv->details.image->spec_dimensions(0);
 std::cout << "Opened " << filename << ": " << spec.height << "x" <<
 spec.width << "@" << spec.nchannels << " (" << spec.format << ")" << std::endl;*/
+  if((*err = ncvisual_decode(ncv)) != NCERR_SUCCESS){
+    ncvisual_destroy(ncv);
+    return nullptr;
+  }
   return ncv;
 }
 

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -499,6 +499,27 @@ auto ncvisual_destroy(ncvisual* ncv) -> void {
   }
 }
 
+auto ncvisual_simple_streamer(ncplane* n, ncvisual* ncv, const timespec* tspec,
+                              void* curry) -> int {
+  if(notcurses_render(ncplane_notcurses(n))){
+    return -1;
+  }
+  int ret = 0;
+  if(curry){
+    // need a cast for C++ callers
+    ncplane* subncp = static_cast<ncplane*>(curry);
+    char* subtitle = ncvisual_subtitle(ncv);
+    if(subtitle){
+      if(ncplane_putstr_yx(subncp, 0, 0, subtitle) < 0){
+        ret = -1;
+      }
+      free(subtitle);
+    }
+  }
+  clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, tspec, NULL);
+  return ret;
+}
+
 #ifndef USE_OIIO // built without ffmpeg or oiio
 #ifndef USE_FFMPEG
 auto ncvisual_from_file(const char* filename, nc_err_e* err) -> ncvisual* {
@@ -507,22 +528,22 @@ auto ncvisual_from_file(const char* filename, nc_err_e* err) -> ncvisual* {
   return nullptr;
 }
 
-bool notcurses_canopen_images(const notcurses* nc __attribute__ ((unused))) {
+auto notcurses_canopen_images(const notcurses* nc __attribute__ ((unused))) -> bool {
   return false;
 }
 
-bool notcurses_canopen_videos(const notcurses* nc __attribute__ ((unused))) {
+auto notcurses_canopen_videos(const notcurses* nc __attribute__ ((unused))) -> bool {
   return false;
 }
 
-nc_err_e ncvisual_decode(ncvisual* nc) {
+auto ncvisual_decode(ncvisual* nc) -> nc_err_e {
   (void)nc;
   return NCERR_UNIMPLEMENTED;
 }
 
-int ncvisual_stream(notcurses* nc, ncvisual* ncv, nc_err_e* ncerr,
+auto ncvisual_stream(notcurses* nc, ncvisual* ncv, nc_err_e* ncerr,
                     float timescale, streamcb streamer,
-                    const ncvisual_options* vopts, void* curry) {
+                    const ncvisual_options* vopts, void* curry) -> int {
   (void)nc;
   (void)ncv;
   (void)timescale;
@@ -533,20 +554,20 @@ int ncvisual_stream(notcurses* nc, ncvisual* ncv, nc_err_e* ncerr,
   return -1;
 }
 
-char* ncvisual_subtitle(const ncvisual* ncv) {
+auto ncvisual_subtitle(const ncvisual* ncv) -> char* {
   (void)ncv;
   return nullptr;
 }
 
-int ncvisual_init(int loglevel) {
+auto ncvisual_init(int loglevel) -> int {
   (void)loglevel;
   return 0; // allow success here
 }
 
-nc_err_e ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
-                       const struct blitset* bset, int placey, int placex,
-                       int begy, int begx, int leny, int lenx,
-                       bool blendcolors) {
+auto ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
+                   const struct blitset* bset, int placey, int placex,
+                   int begy, int begx, int leny, int lenx,
+                   bool blendcolors) -> nc_err_e {
   (void)rows;
   (void)cols;
   if(rgba_blit_dispatch(n, bset, placey, placex, ncv->rowstride, ncv->data,

--- a/tests/Ncpp.cpp
+++ b/tests/Ncpp.cpp
@@ -28,10 +28,12 @@ TEST_CASE("Ncpp"
 
   SUBCASE("VisualFromFile") {
     NotCurses nc;
-    nc_err_e err;
-    {
-      Visual v = Visual(find_data("changes.jpg"), &err);
-      CHECK(NCERR_SUCCESS == err);
+    if(nc.can_open_images()){
+      nc_err_e err;
+      {
+        Visual v = Visual(find_data("changes.jpg"), &err);
+        CHECK(NCERR_SUCCESS == err);
+      }
     }
     CHECK(nc.stop());
   }

--- a/tests/fade.cpp
+++ b/tests/fade.cpp
@@ -3,7 +3,8 @@
 #include <iostream>
 #include "internal.h"
 
-auto pulser(struct notcurses* nc, struct ncplane* ncp __attribute__ ((unused)), void* curry) -> int {
+auto pulser(struct notcurses* nc, struct ncplane* ncp __attribute__ ((unused)),
+            const struct timespec* ts __attribute__ ((unused)), void* curry) -> int {
   auto pulsestart = static_cast<struct timespec*>(curry);
   if(notcurses_render(nc)){
     return -1;

--- a/tests/fade.cpp
+++ b/tests/fade.cpp
@@ -104,7 +104,7 @@ TEST_CASE("Fade") {
 
   // drive fadeout with the more flexible api
   SUBCASE("FadeOutFlexible") {
-    auto nctx = ncfadectx_setup(n_, nullptr);
+    auto nctx = ncfadectx_setup(n_);
     REQUIRE(nctx);
     auto maxiter = ncfadectx_iterations(nctx);
     CHECK(0 < maxiter);
@@ -115,7 +115,7 @@ TEST_CASE("Fade") {
   }
 
   SUBCASE("FadeOutFlexibleAbort") {
-    auto nctx = ncfadectx_setup(n_, nullptr);
+    auto nctx = ncfadectx_setup(n_);
     REQUIRE(nctx);
     auto maxiter = ncfadectx_iterations(nctx);
     CHECK(0 < maxiter);
@@ -127,7 +127,7 @@ TEST_CASE("Fade") {
 
   // drive fadein with the more flexible api
   SUBCASE("FadeInFlexible") {
-    auto nctx = ncfadectx_setup(n_, nullptr);
+    auto nctx = ncfadectx_setup(n_);
     REQUIRE(nctx);
     auto maxiter = ncfadectx_iterations(nctx);
     CHECK(0 < maxiter);
@@ -138,7 +138,7 @@ TEST_CASE("Fade") {
   }
 
   SUBCASE("FadeInFlexibleAbort") {
-    auto nctx = ncfadectx_setup(n_, nullptr);
+    auto nctx = ncfadectx_setup(n_);
     REQUIRE(nctx);
     auto maxiter = ncfadectx_iterations(nctx);
     CHECK(0 < maxiter);

--- a/tests/fade.cpp
+++ b/tests/fade.cpp
@@ -78,6 +78,28 @@ TEST_CASE("Fade") {
     CHECK(0 < ncplane_pulse(n_, &ts, pulser, &pulsestart));
   }
 
+  SUBCASE("FadeOutUntimed") {
+    auto nctx = ncfadectx_setup(n_, nullptr);
+    REQUIRE(nctx);
+    auto maxiter = ncfadectx_iterations(nctx);
+    CHECK(0 < maxiter);
+    for(int i = 0 ; i < maxiter ; ++i){
+      CHECK(0 == ncplane_fadeout_iteration(n_, nctx, i, nullptr, nullptr));
+    }
+    ncfadectx_free(nctx);
+  }
+
+  SUBCASE("FadeInUntimed") {
+    auto nctx = ncfadectx_setup(n_, nullptr);
+    REQUIRE(nctx);
+    auto maxiter = ncfadectx_iterations(nctx);
+    CHECK(0 < maxiter);
+    for(int i = 0 ; i < maxiter ; ++i){
+      CHECK(0 == ncplane_fadein_iteration(n_, nctx, i, nullptr, nullptr));
+    }
+    ncfadectx_free(nctx);
+  }
+
   CHECK(0 == notcurses_stop(nc_));
 
 }

--- a/tests/metric.cpp
+++ b/tests/metric.cpp
@@ -89,7 +89,6 @@ TEST_CASE("Metric") {
     // FIXME these will change based on the size of intmax_t and uintmax_t
     ncmetric(INTMAX_MAX - 1, 1, buf, 0, 1024, 'i');
     sprintf(gold, "%.2fEi", ((double)(INTMAX_MAX - (1ull << 53))) / (1ull << 60));
-fprintf(stderr, "%d gold: %s buf: %s value: %ju\n", __LINE__, gold, buf, INTMAX_MAX - 1);
     CHECK(!strcmp(gold, buf));
     REQUIRE(ncmetric(INTMAX_MAX + 1ull, 1, buf, 0, 1024, 'i'));
     sprintf(gold, "%.2fEi", ((double)(INTMAX_MAX + 1ull)) / (1ull << 60));
@@ -207,8 +206,7 @@ fprintf(stderr, "%d gold: %s buf: %s value: %ju\n", __LINE__, gold, buf, INTMAX_
     do{
       ncmetric(val, 1, buf, 0, 1000, '\0');
       const int sidx = i / 10;
-      snprintf(gold, sizeof(gold), "%.2f%c",
-          ((double)val) / vfloor, suffixes[sidx]);
+      snprintf(gold, sizeof(gold), "%.2f%c", ((double)val) / vfloor, suffixes[sidx]);
       CHECK(!strcmp(gold, buf));
       if(UINTMAX_MAX / val < 10){
         break;
@@ -231,8 +229,7 @@ fprintf(stderr, "%d gold: %s buf: %s value: %ju\n", __LINE__, gold, buf, INTMAX_
     do{
       ncmetric(val, 1, buf, 0, 1024, 'i');
       const int sidx = i ? (i - 1) / 3 : 0;
-      snprintf(gold, sizeof(gold), "%.2f%ci",
-          ((double)val) / vfloor, suffixes[sidx]);
+      snprintf(gold, sizeof(gold), "%.2f%ci", ((double)val) / vfloor, suffixes[sidx]);
       CHECK(!strcmp(gold, buf));
       if(UINTMAX_MAX / val < 10){
         break;
@@ -255,8 +252,7 @@ fprintf(stderr, "%d gold: %s buf: %s value: %ju\n", __LINE__, gold, buf, INTMAX_
     do{
       ncmetric(val - 1, 1, buf, 0, 1000, '\0');
       const int sidx = i ? (i - 1) / 3 : 0;
-      snprintf(gold, sizeof(gold), "%.2f%c",
-          ((double)(val - 1)) / vfloor, suffixes[sidx]);
+      snprintf(gold, sizeof(gold), "%.2f%c", ((double)(val - 1)) / vfloor, suffixes[sidx]);
       CHECK(!strcmp(gold, buf));
       if(UINTMAX_MAX / val < 10){
         break;
@@ -279,8 +275,7 @@ fprintf(stderr, "%d gold: %s buf: %s value: %ju\n", __LINE__, gold, buf, INTMAX_
     do{
       ncmetric(val + 1, 1, buf, 0, 1000, '\0');
       const int sidx = i / 3;
-      snprintf(gold, sizeof(gold), "%.2f%c",
-          ((double)(val + 1)) / vfloor, suffixes[sidx]);
+      snprintf(gold, sizeof(gold), "%.2f%c", ((double)(val + 1)) / vfloor, suffixes[sidx]);
       CHECK(!strcmp(gold, buf));
       if(UINTMAX_MAX / val < 10){
         break;
@@ -303,8 +298,7 @@ fprintf(stderr, "%d gold: %s buf: %s value: %ju\n", __LINE__, gold, buf, INTMAX_
     do{
       ncmetric(val - 1, 1, buf, 0, 1024, 'i');
       const int sidx = i ? (i - 1) / 3 : 0;
-      snprintf(gold, sizeof(gold), "%.2f%ci",
-          ((double)(val - 1)) / vfloor, suffixes[sidx]);
+      snprintf(gold, sizeof(gold), "%.2f%ci", ((double)(val - 1)) / vfloor, suffixes[sidx]);
       CHECK(!strcmp(gold, buf));
       if(UINTMAX_MAX / val < 10){
         break;

--- a/tests/rotate.cpp
+++ b/tests/rotate.cpp
@@ -180,10 +180,10 @@ TEST_CASE("Rotate") {
     }
     free(rgbaret);
     CHECK(0 == notcurses_render(nc_));
-    for(int y = 0 ; y < height ; ++y){
+    for(int x = 0 ; x < width ; ++x){
       uint32_t attrword;
       uint64_t channels;
-      char* c = notcurses_at_yx(nc_, y, 0, &attrword, &channels);
+      char* c = notcurses_at_yx(nc_, 0, x, &attrword, &channels);
       REQUIRE(c);
       CHECK(0 == strcmp(c, " "));
       if(channels_fg(channels) & CELL_BG_MASK){


### PR DESCRIPTION
* In `ncvisual_stream()`, if we create a plane, reuse it across further `ncvisual_render()` calls, and destroy it upon exit. Closes #660.
* Fade API improvements (closes #659):
  * Much like what we recently did with `ncvisual`, the callback is now responsible for doing the delay, allowing for more accurate timesyncing in complex callbacks.
  * I've broken `ncplane_fadeout()` and `ncplane_fadein()` into three components: `ncfadectx_setup()`, `ncplane_fadeout_iteration()` and `ncplane_fadein_iteration()`, and `ncfadectx_free()`. This allows a fully flexible fading solution, while preserving the simple API.
* Updated the `notcurses_fade.3` man page and `USAGE.md`