### PR TITLE
Quadrant blitter #648

### DIFF
--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1821,7 +1821,8 @@ cell_set_bg_rgb_clipped(cell* cl, int r, int g, int b){
   channels_set_bg_rgb_clipped(&cl->channels, r, g, b);
 }
 
-// Same, but with an assembled 24-bit RGB value.
+// Same, but with an assembled 24-bit RGB value. A value over 0xffffff
+// will be rejected, with a non-zero return value.
 static inline int
 cell_set_bg(cell* c, uint32_t channel){
   return channels_set_bg(&c->channels, channel);

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -9,7 +9,7 @@ lerp(uint32_t c0, uint32_t c1){
   unsigned r0, g0, b0, r1, g1, b1;
   channel_rgb(c0, &r0, &g0, &b0);
   channel_rgb(c1, &r1, &g1, &b1);
-  channel_set_rgb(&ret, (r0 + r1) / 2, (g0 + g1) / 2, (b0 + b1) / 2);
+  channel_set_rgb(&ret, (r0 + r1 + 1) / 2, (g0 + g1 + 1) / 2, (b0 + b1 + 1) / 2);
   return ret;
 }
 

--- a/src/poc/blitters.c
+++ b/src/poc/blitters.c
@@ -14,6 +14,7 @@ int main(int argc, char** argv){
   }
   struct notcurses_options nopts = {
     .flags = NCOPTION_INHIBIT_SETLOCALE,
+    .inhibit_alternate_screen = true,
   };
   struct notcurses* nc = notcurses_init(&nopts, NULL);
   struct ncplane* std = notcurses_stdplane(nc);
@@ -51,7 +52,11 @@ int main(int argc, char** argv){
           goto err;
         }
         notcurses_render(nc);
-sleep(2); // FIXME wait for key
+        struct timespec ts = {
+          .tv_sec = 0,
+          .tv_nsec = 500000000,
+        };
+        clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);
         ncvisual_destroy(ncv);
       }
     }


### PR DESCRIPTION
New quadrant blitter for `ncvisual` building upon the generalized visual work of #622. This is, so far as I know, a novel technique, one which serves to effectively double terminal horizontal resolution over the method of Unicode half-blocks.

We define a distance function between RGB colors as |r0-r1|+|g0-g1|+|b0-b1|. First we find the closest pair according to this definition, and lerp those two pixels, and the other two pixels (the "excluded pair"). We then check the two excluded pixels against the two lerped values. If one is closer, we merge it into the foreground lerp. The final excluded one is used for the background color.

This can still be improved. We probably want to trilerp upon a merge (this is marked with FIXMEs). We ought choose the closer of the two excluded pixels, rather than the current broken symmetry. I'll make these changes, but wanted to get this out, as I believe it a fundamental advance in terminal visualization.

One final note is that we might want to provide a 4x2 blitter in addition to this 2x2 blitter, to effect a 1:1 cell aspect ratio similar to that of the technique of half blocks (this solution offers a 2:1 CAR similar to the technique of spaces).