### PR TITLE
Open some whoopass on ncvisual rotation 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.5.0 (not yet released)
+  * `ncblit_rgba()` and `ncblit_bgrx()` have been renamed `ncplane_blit_rgba()`
+    and `ncplane_blit_bgrx()`, to match every other existing ncplane function.
+    In addition, they both now accept an `ncblitter_e` to select the blitting
+    method. `NCBLIT_DEFAULT` will use `NCBLITTER_2x1`.
+
 * 1.4.4.1 (2020-06-01)
   * Got the `ncvisual` API ready for API freeze: `ncvisual_render()` and
     `ncvisual_stream()` now take a `struct ncvisual_options`. `ncstyle_e`

--- a/USAGE.md
+++ b/USAGE.md
@@ -1253,17 +1253,17 @@ Raw streams of RGBA or BGRx data can be blitted directly to an ncplane:
 // from the upper left by 'placey' and 'placex'. Each row ought occupy
 // 'linesize' bytes (this might be greater than lenx * 4 due to padding). A
 // subregion of the input can be specified with 'begy'x'begx' and 'leny'x'lenx'.
-int ncblit_bgrx(struct ncplane* nc, int placey, int placex, int linesize,
-                const unsigned char* data, int begy, int begx,
-                int leny, int lenx);
+int ncplane_blit_bgrx(struct ncplane* nc, int placey, int placex, int linesize,
+                      ncblitter_e blitter, const unsigned char* data,
+                      int begy, int begx, int leny, int lenx);
 
 // Blit a flat array 'data' of RGBA 32-bit values to the ncplane 'nc', offset
 // from the upper left by 'placey' and 'placex'. Each row ought occupy
 // 'linesize' bytes (this might be greater than lenx * 4 due to padding). A
 // subregion of the input can be specified with 'begy'x'begx' and 'leny'x'lenx'.
-int ncblit_rgba(struct ncplane* nc, int placey, int placex, int linesize,
-                const unsigned char* data, int begy, int begx,
-                int leny, int lenx);
+int ncplane_blit_rgba(struct ncplane* nc, int placey, int placex, int linesize,
+                      ncblitter_e blitter, const unsigned char* data,
+                      int begy, int begx, int leny, int lenx);
 ```
 
 

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -128,9 +128,9 @@ notcurses_plane - operations on ncplanes
 
 **void ncplane_greyscale(struct ncplane* n);**
 
-**int ncblit_bgrx(struct ncplane* nc, int placey, int placex, int linesize, const unsigned char* data, int begy, int begx, int leny, int lenx);**
+**int ncplane_blit_bgrx(struct ncplane* nc, int placey, int placex, int linesize, ncblitter_e blitter, const unsigned char* data, int begy, int begx, int leny, int lenx);**
 
-**int ncblit_rgba(struct ncplane* nc, int placey, int placex, int linesize, const unsigned char* data, int begy, int begx, int leny, int lenx);**
+**int ncplane_blit_rgba(struct ncplane* nc, int placey, int placex, int linesize, ncblitter_e blitter, const unsigned char* data, int begy, int begx, int leny, int lenx);**
 
 **int ncplane_destroy(struct ncplane* ncp);**
 

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -1017,13 +1017,13 @@ namespace ncpp
 
 		bool blit_bgrx (int placey, int placex, int linesize, const void* data, int begy, int begx, int leny, int lenx) const NOEXCEPT_MAYBE
 		{
-			bool ret = ncblit_bgrx (plane, placey, placex, linesize, data, begy, begx, leny, lenx) < 0;
+			bool ret = ncplane_blit_bgrx (plane, placey, placex, linesize, NCBLIT_DEFAULT, data, begy, begx, leny, lenx) < 0;
 			return error_guard_cond<bool, bool> (ret, ret);
 		}
 
 		bool blit_rgba (int placey, int placex, int linesize, const void* data, int begy, int begx, int leny, int lenx) const NOEXCEPT_MAYBE
 		{
-			bool ret = ncblit_rgba (plane, placey, placex, linesize, data, begy, begx, leny, lenx) < 0;
+			bool ret = ncplane_blit_rgba (plane, placey, placex, linesize, NCBLIT_DEFAULT, data, begy, begx, leny, lenx) < 0;
 			return error_guard_cond<bool, bool> (ret, ret);
 		}
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2236,15 +2236,17 @@ API int ncvisual_stream(struct notcurses* nc, struct ncvisual* ncv,
 // from the upper left by 'placey' and 'placex'. Each row ought occupy
 // 'linesize' bytes (this might be greater than lenx * 4 due to padding). A
 // subregion of the input can be specified with 'begy'x'begx' and 'leny'x'lenx'.
-API int ncblit_bgrx(struct ncplane* nc, int placey, int placex, int linesize,
-                    const void* data, int begy, int begx, int leny, int lenx);
+API int ncplane_blit_bgrx(struct ncplane* nc, int placey, int placex,
+                          int linesize, ncblitter_e blitter, const void* data,
+                          int begy, int begx, int leny, int lenx);
 
 // Blit a flat array 'data' of RGBA 32-bit values to the ncplane 'nc', offset
 // from the upper left by 'placey' and 'placex'. Each row ought occupy
 // 'linesize' bytes (this might be greater than lenx * 4 due to padding). A
 // subregion of the input can be specified with 'begy'x'begx' and 'leny'x'lenx'.
-API int ncblit_rgba(struct ncplane* nc, int placey, int placex, int linesize,
-                    const void* data, int begy, int begx, int leny, int lenx);
+API int ncplane_blit_rgba(struct ncplane* nc, int placey, int placex,
+                          int linesize, ncblitter_e blitter, const void* data,
+                          int begy, int begx, int leny, int lenx);
 
 // An ncreel is a notcurses region devoted to displaying zero or more
 // line-oriented, contained panels between which the user may navigate. If at

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -323,8 +323,8 @@ struct ncvisual_options {
   ncblitter_e blitter;
   uint64_t flags;
 };
-int ncblit_bgrx(struct ncplane* nc, int placey, int placex, int linesize, const unsigned char* data, int begy, int begx, int leny, int lenx);
-int ncblit_rgba(struct ncplane* nc, int placey, int placex, int linesize, const unsigned char* data, int begy, int begx, int leny, int lenx);
+int ncplane_blit_bgrx(struct ncplane* nc, int placey, int placex, int linesize, ncblitter_e blitter, const unsigned char* data, int begy, int begx, int leny, int lenx);
+int ncplane_blit_rgba(struct ncplane* nc, int placey, int placex, int linesize, ncblitter_e blitter, const unsigned char* data, int begy, int begx, int leny, int lenx);
 struct ncselector_item {
   char* option;
   char* desc;

--- a/src/demo/normal.c
+++ b/src/demo/normal.c
@@ -61,8 +61,8 @@ rotate_visual(struct notcurses* nc, struct ncplane* n, int dy, int dx){
   timespec_div(&demodelay, ROTATIONS / 8, &scaled);
   struct ncvisual_options vopts = {
   };
+  ncplane_erase(n);
   for(double i = 0 ; i < ROTATIONS ; ++i){
-    ncplane_erase(n);
     demo_nanosleep(nc, &scaled);
     if(ncvisual_rotate(ncv, M_PI / 2)){
       failed = true;

--- a/src/demo/normal.c
+++ b/src/demo/normal.c
@@ -68,21 +68,21 @@ rotate_visual(struct notcurses* nc, struct ncplane* n, int dy, int dx){
       failed = true;
       break;
     }
-    int vy, vx, vyscale;
-    ncvisual_geom(nc, ncv, NCBLIT_DEFAULT, &vy, &vx, &vyscale, NULL);
+    int vy, vx, vyscale, vxscale;
+    ncvisual_geom(nc, ncv, NCBLIT_DEFAULT, &vy, &vx, &vyscale, &vxscale);
+    vopts.x = (dimx - (vx / vxscale)) / 2;
+    vopts.y = (dimy - (vy / vyscale)) / 2;
     struct ncplane* newn;
     if((newn = ncvisual_render(nc, ncv, &vopts)) == NULL){
       failed = true;
       break;
     }
-    ncplane_move_yx(newn, (dimy - (vy / vyscale)) / 2, (dimx - vx) / 2);
-    vopts.n = newn;
     if(notcurses_render(nc)){
       failed = true;
       break;
     }
+    ncplane_destroy(newn);
   }
-  ncplane_destroy(vopts.n);
   ncvisual_destroy(ncv);
   return failed ? -1 : 0;
 }

--- a/src/demo/normal.c
+++ b/src/demo/normal.c
@@ -53,29 +53,36 @@ rotate_visual(struct notcurses* nc, struct ncplane* n, int dy, int dx){
     ncvisual_destroy(ncv);
     return -1;
   }
-  ncplane_erase(n);
+  ncplane_destroy(n);
+  int dimy, dimx;
+  n = notcurses_stddim_yx(nc, &dimy, &dimx);
   bool failed = false;
   const int ROTATIONS = 128;
   timespec_div(&demodelay, ROTATIONS / 8, &scaled);
   struct ncvisual_options vopts = {
-    .n = n,
   };
   for(double i = 0 ; i < ROTATIONS ; ++i){
+    ncplane_erase(n);
     demo_nanosleep(nc, &scaled);
     if(ncvisual_rotate(ncv, M_PI / 2)){
       failed = true;
       break;
     }
-    ncplane_cursor_move_yx(n, 0, 0);
-    if(ncvisual_render(nc, ncv, &vopts) == NULL){
+    int vy, vx, vyscale;
+    ncvisual_geom(nc, ncv, NCBLIT_DEFAULT, &vy, &vx, &vyscale, NULL);
+    struct ncplane* newn;
+    if((newn = ncvisual_render(nc, ncv, &vopts)) == NULL){
       failed = true;
       break;
     }
+    ncplane_move_yx(newn, (dimy - (vy / vyscale)) / 2, (dimx - vx) / 2);
+    vopts.n = newn;
     if(notcurses_render(nc)){
       failed = true;
       break;
     }
   }
+  ncplane_destroy(vopts.n);
   ncvisual_destroy(ncv);
   return failed ? -1 : 0;
 }
@@ -117,7 +124,7 @@ int normal_demo(struct notcurses* nc){
   int r = -1;
   struct ncplane* nstd = notcurses_stddim_yx(nc, &dy, &dx);
   ncplane_erase(nstd);
-  cell c = CELL_SIMPLE_INITIALIZER(' ');
+  cell c = CELL_TRIVIAL_INITIALIZER;
   cell_set_fg_rgb(&c, 0xff, 0xff, 0xff);
   cell_set_bg_rgb(&c, 0xff, 0xff, 0xff);
   ncplane_set_base_cell(nstd, &c);
@@ -191,7 +198,6 @@ int normal_demo(struct notcurses* nc){
   ncplane_set_base_cell(nstd, &c);
   cell_release(nstd, &c);
   bool failed = rotate_visual(nc, n, dy, dx);
-  ncplane_destroy(n);
   return failed ? -1 : 0;
 
 err:

--- a/src/demo/normal.c
+++ b/src/demo/normal.c
@@ -56,26 +56,25 @@ rotate_visual(struct notcurses* nc, struct ncplane* n, int dy, int dx){
   ncplane_erase(n);
   bool failed = false;
   const int ROTATIONS = 128;
-  timespec_div(&demodelay, ROTATIONS, &scaled);
-  struct ncvisual_options vopts = {};
+  timespec_div(&demodelay, ROTATIONS / 8, &scaled);
+  struct ncvisual_options vopts = {
+    .n = n,
+  };
   for(double i = 0 ; i < ROTATIONS ; ++i){
     demo_nanosleep(nc, &scaled);
-    if(ncvisual_rotate(ncv, M_PI / 16)){
+    if(ncvisual_rotate(ncv, M_PI / 2)){
       failed = true;
       break;
     }
     ncplane_cursor_move_yx(n, 0, 0);
-    struct ncplane* newn;
-    if((newn = ncvisual_render(nc, ncv, &vopts)) == NULL){
+    if(ncvisual_render(nc, ncv, &vopts) == NULL){
       failed = true;
       break;
     }
     if(notcurses_render(nc)){
-      ncplane_destroy(newn);
       failed = true;
       break;
     }
-    ncplane_destroy(newn);
   }
   ncvisual_destroy(ncv);
   return failed ? -1 : 0;

--- a/src/demo/normal.c
+++ b/src/demo/normal.c
@@ -57,9 +57,7 @@ rotate_visual(struct notcurses* nc, struct ncplane* n, int dy, int dx){
   bool failed = false;
   const int ROTATIONS = 128;
   timespec_div(&demodelay, ROTATIONS, &scaled);
-  struct ncvisual_options vopts = {
-    .n = n,
-  };
+  struct ncvisual_options vopts = {};
   for(double i = 0 ; i < ROTATIONS ; ++i){
     demo_nanosleep(nc, &scaled);
     if(ncvisual_rotate(ncv, M_PI / 16)){
@@ -67,14 +65,17 @@ rotate_visual(struct notcurses* nc, struct ncplane* n, int dy, int dx){
       break;
     }
     ncplane_cursor_move_yx(n, 0, 0);
-    if(ncvisual_render(nc, ncv, &vopts) == NULL){
+    struct ncplane* newn;
+    if((newn = ncvisual_render(nc, ncv, &vopts)) == NULL){
       failed = true;
       break;
     }
     if(notcurses_render(nc)){
+      ncplane_destroy(newn);
       failed = true;
       break;
     }
+    ncplane_destroy(newn);
   }
   ncvisual_destroy(ncv);
   return failed ? -1 : 0;

--- a/src/demo/normal.c
+++ b/src/demo/normal.c
@@ -152,7 +152,7 @@ int normal_demo(struct notcurses* nc){
         goto err;
       }
     }
-    if(ncblit_rgba(nstd, 0, 0, dx * sizeof(*rgba), rgba, 0, 0, dy, dx) < 0){
+    if(ncplane_blit_rgba(nstd, 0, 0, dx * sizeof(*rgba), NCBLIT_DEFAULT, rgba, 0, 0, dy, dx) < 0){
       goto err;
     }
     if( (r = demo_render(nc)) ){

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -447,26 +447,26 @@ const struct blitset notcurses_blitters[] = {
 // from the upper left by 'placey' and 'placex'. Each row ought occupy
 // 'linesize' bytes (this might be greater than lenx * 4 due to padding). A
 // subregion of the input can be specified with 'begy'x'begx' and 'leny'x'lenx'.
-int ncblit_bgrx(ncplane* nc, int placey, int placex,
-                int linesize, const void* data, int begy, int begx, int leny,
-                int lenx){
-  if(!nc->nc->utf8){
-    return tria_blit_ascii(nc, placey, placex, linesize, data, begy, begx,
-                           leny, lenx, true, false);
+int ncplane_blit_bgrx(ncplane* nc, int placey, int placex, int linesize,
+                      ncblitter_e blitter, const void* data,
+                      int begy, int begx, int leny, int lenx){
+  const struct blitset* bset = lookup_blitset(ncplane_notcurses(nc), blitter, true);
+  if(bset == NULL){
+    return -1;
   }
-  return tria_blit(nc, placey, placex, linesize, data, begy, begx,
-                   leny, lenx, true, false);
+  return bset->blit(nc, placey, placex, linesize, data, begy, begx,
+                    leny, lenx, true, false);
 }
 
-int ncblit_rgba(ncplane* nc, int placey, int placex,
-                int linesize, const void* data, int begy, int begx, int leny,
-                int lenx){
-  if(!nc->nc->utf8){
-    return tria_blit_ascii(nc, placey, placex, linesize, data, begy, begx,
-                           leny, lenx, false, false);
+int ncplane_blit_rgba(ncplane* nc, int placey, int placex, int linesize,
+                      ncblitter_e blitter, const void* data,
+                      int begy, int begx, int leny, int lenx){
+  const struct blitset* bset = lookup_blitset(ncplane_notcurses(nc), blitter, true);
+  if(bset == NULL){
+    return -1;
   }
-  return tria_blit(nc, placey, placex, linesize, data, begy, begx,
-                   leny, lenx, false, false);
+  return bset->blit(nc, placey, placex, linesize, data, begy, begx,
+                    leny, lenx, false, false);
 }
 
 int rgba_blit_dispatch(ncplane* nc, const struct blitset* bset, int placey,

--- a/src/lib/blitset.h
+++ b/src/lib/blitset.h
@@ -5,6 +5,10 @@
 
 static inline const struct blitset*
 lookup_blitset(const struct notcurses* nc, ncblitter_e setid, bool may_degrade) {
+  if(setid == NCBLIT_DEFAULT){
+    setid = NCBLIT_2x1;
+    may_degrade = true;
+  }
   // the only viable blitter in ASCII is NCBLIT_1x1
   if(!notcurses_canutf8(nc) && setid != NCBLIT_1x1){
     if(may_degrade){

--- a/src/lib/ffmpeg.h
+++ b/src/lib/ffmpeg.h
@@ -38,7 +38,7 @@ typedef struct ncvisual_details {
   struct AVCodecParameters* cparams;
   struct AVCodec* subtcodec;
   struct AVPacket* packet;
-  //struct SwsContext* swsctx;
+  struct SwsContext* swsctx;
   AVSubtitle subtitle;
   int stream_index;        // match against this following av_read_frame()
   int sub_stream_index;    // subtitle stream index, can be < 0 if no subtitles
@@ -62,7 +62,7 @@ ncvisual_details_destroy(ncvisual_details* deets) -> void {
   av_frame_free(&deets->frame);
   av_freep(&deets->oframe);
   //avcodec_parameters_free(&ncv->cparams);
-  //sws_freeContext(deets->swsctx);
+  sws_freeContext(deets->swsctx);
   av_packet_free(&deets->packet);
   avformat_close_input(&deets->fmtctx);
   avsubtitle_free(&deets->subtitle);

--- a/src/lib/ffmpeg.h
+++ b/src/lib/ffmpeg.h
@@ -38,7 +38,7 @@ typedef struct ncvisual_details {
   struct AVCodecParameters* cparams;
   struct AVCodec* subtcodec;
   struct AVPacket* packet;
-  struct SwsContext* swsctx;
+  //struct SwsContext* swsctx;
   AVSubtitle subtitle;
   int stream_index;        // match against this following av_read_frame()
   int sub_stream_index;    // subtitle stream index, can be < 0 if no subtitles
@@ -62,7 +62,7 @@ ncvisual_details_destroy(ncvisual_details* deets) -> void {
   av_frame_free(&deets->frame);
   av_freep(&deets->oframe);
   //avcodec_parameters_free(&ncv->cparams);
-  sws_freeContext(deets->swsctx);
+  //sws_freeContext(deets->swsctx);
   av_packet_free(&deets->packet);
   avformat_close_input(&deets->fmtctx);
   avsubtitle_free(&deets->subtitle);

--- a/src/lib/oiio.cpp
+++ b/src/lib/oiio.cpp
@@ -100,6 +100,7 @@ nc_err_e ncvisual_resize(ncvisual* nc, int rows, int cols) {
     nc->rowstride = cols * 4;
     ncvisual_set_data(nc, static_cast<uint32_t*>(ibuf->localpixels()), false);
 //fprintf(stderr, "HAVE SOME NEW DATA: %p\n", ibuf->localpixels());
+    nc->details.ibuf = std::move(ibuf);
   }
   return NCERR_SUCCESS;
 }

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -344,6 +344,7 @@ auto ncvisual_from_rgba(const void* rgba, int rows, int rowstride,
     ncv->cols = cols;
     ncv->rows = rows;
     auto data = static_cast<uint32_t*>(memdup(rgba, rowstride * ncv->rows));
+//fprintf(stderr, "COPY US %zu (%d)\n", rowstride * ncv->rows, ncv->rows);
     if(data == nullptr){
       ncvisual_destroy(ncv);
       return nullptr;
@@ -389,7 +390,7 @@ auto ncvisual_render(notcurses* nc, ncvisual* ncv,
   if(begy < 0 || begx < 0 || lenx < -1 || leny < -1){
     return nullptr;
   }
-//fprintf(stderr, "OUR DATA: %p cols/rows: %d/%d\n", ncv->data, ncv->cols, ncv->rows);
+//fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d\n", ncv->data, ncv->rows, ncv->cols);
   if(ncv->data == nullptr){
     return nullptr;
   }
@@ -441,6 +442,7 @@ auto ncvisual_render(notcurses* nc, ncvisual* ncv,
     }else{
       return nullptr;
     }
+//fprintf(stderr, "PLACING NEW PLANE: %d/%d @ %d/%d\n", disprows, dispcols, placey, placex);
     n = ncplane_new(nc, disprows, dispcols, placey, placex, nullptr);
     if(n == nullptr){
       return nullptr;

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -343,13 +343,12 @@ auto ncvisual_from_rgba(const void* rgba, int rows, int rowstride,
     ncv->rowstride = rowstride;
     ncv->cols = cols;
     ncv->rows = rows;
-//fprintf(stderr, "MADE INITIAL ONE %d/%d\n", disprows, ncv->cols);
     auto data = static_cast<uint32_t*>(memdup(rgba, rowstride * ncv->rows));
     if(data == nullptr){
       ncvisual_destroy(ncv);
       return nullptr;
     }
-//fprintf(stderr, "ROWS: %d STRIDE: %d (%d) COLS: %d\n", rows, rowstride, rowstride / 4, cols);
+fprintf(stderr, "ROWS: %d STRIDE: %d (%d) COLS: %d\n", rows, rowstride, rowstride / 4, cols);
     ncvisual_set_data(ncv, data, true);
     ncvisual_details_seed(ncv);
   }
@@ -485,7 +484,7 @@ auto ncvisual_from_plane(const ncplane* n, int begy, int begx,
   if(leny == -1){
     leny = n->leny - begy;
   }
-  auto* ncv = ncvisual_from_rgba(rgba, leny, lenx * 4, lenx);
+  auto* ncv = ncvisual_from_rgba(rgba, leny * 2, lenx * 4, lenx);
   free(rgba);
   if(ncv == nullptr){
     return nullptr;

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -348,7 +348,7 @@ auto ncvisual_from_rgba(const void* rgba, int rows, int rowstride,
       ncvisual_destroy(ncv);
       return nullptr;
     }
-fprintf(stderr, "ROWS: %d STRIDE: %d (%d) COLS: %d\n", rows, rowstride, rowstride / 4, cols);
+//fprintf(stderr, "ROWS: %d STRIDE: %d (%d) COLS: %d\n", rows, rowstride, rowstride / 4, cols);
     ncvisual_set_data(ncv, data, true);
     ncvisual_details_seed(ncv);
   }
@@ -482,7 +482,7 @@ auto ncvisual_from_plane(const ncplane* n, int begy, int begx,
     lenx = n->lenx - begx;
   }
   if(leny == -1){
-    leny = n->leny - begy;
+    leny = (n->leny - begy);
   }
   auto* ncv = ncvisual_from_rgba(rgba, leny * 2, lenx * 4, lenx);
   free(rgba);

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -272,6 +272,7 @@ rotate_bounding_box(double stheta, double ctheta, int* leny, int* lenx,
 }
 
 auto ncvisual_rotate(ncvisual* ncv, double rads) -> nc_err_e {
+  // done to force conversion into RGBA
   nc_err_e err = ncvisual_resize(ncv, ncv->rows, ncv->cols);
   if(err != NCERR_SUCCESS){
     return err;
@@ -329,7 +330,7 @@ auto ncvisual_rotate(ncvisual* ncv, double rads) -> nc_err_e {
   ncv->cols = bbx;
   ncv->rows = bby;
   ncv->rowstride = bbx * 4;
-  //ncplane_erase(ncv->ncp);
+  ncvisual_details_seed(ncv);
   return NCERR_SUCCESS;
 }
 

--- a/src/poc/rotator.c
+++ b/src/poc/rotator.c
@@ -1,0 +1,81 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <locale.h>
+#include <notcurses/notcurses.h>
+
+static int
+rotate(struct notcurses* nc){
+  const int XSIZE = 16;
+  int dimy, dimx;
+  struct ncplane* n = notcurses_stddim_yx(nc, &dimy, &dimx);
+  if(dimy < XSIZE || dimx < 2){
+    return -1;
+  }
+  int r = 255;
+  int g = 0;
+  int b = 0;
+  for(int x = 0 ; x < XSIZE ; ++x){
+    if(ncplane_set_fg_rgb(n, r, g, b)){
+      return -1;
+    }
+    if(ncplane_set_bg_rgb(n, b, r, g)){
+      return -1;
+    }
+    if(ncplane_putegc_yx(n, dimy / 2, x, "▀", NULL) < 0){
+      return -1;
+    }
+    g += 15;
+    r -= 14;
+  }
+  g = 0;
+  b = 255;
+  for(int x = 0 ; x < XSIZE ; ++x){
+    if(ncplane_set_fg_rgb(n, r, g, b)){
+      return -1;
+    }
+    if(ncplane_set_bg_rgb(n, b, r, g)){
+      return -1;
+    }
+    if(ncplane_putegc_yx(n, dimy / 2 + 1, x, "▄", NULL) < 0){
+      return -1;
+    }
+    g += 14;
+    b -= 15;
+  }
+  notcurses_render(nc);
+  sleep(1);
+
+  // we now have 2 rows of 20 cells each, with gradients. load 'em.
+  uint32_t* rgba = ncplane_rgba(n, dimy / 2, 0, 2, XSIZE);
+  if(rgba == NULL){
+    return -1;
+  }
+  for(int y = 0 ; y < 4 ; ++y){
+    for(int x = 0 ; x < XSIZE ; ++x){
+      fprintf(stderr, "rgba %02d/%02d: %08x\n", y, x, rgba[y * XSIZE + x]);
+    }
+  }
+  ncplane_erase(n);
+  notcurses_render(nc);
+  sleep(1);
+
+  if(ncblit_rgba(n, dimy / 2, XSIZE, XSIZE * 4, rgba, 0, 0, 4, XSIZE) < 0){
+    free(rgba);
+    return -1;
+  }
+  notcurses_render(nc);
+  sleep(1);
+  return 0;
+}
+
+int main(void){
+  setlocale(LC_ALL, "");
+  struct notcurses_options nopts = {
+    .inhibit_alternate_screen = true,
+    .flags = NCOPTION_INHIBIT_SETLOCALE,
+  };
+  struct notcurses* nc = notcurses_init(&nopts, NULL);
+  int r = rotate(nc);
+  r |= notcurses_stop(nc);
+  return r ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/src/poc/rotator.c
+++ b/src/poc/rotator.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <locale.h>
@@ -5,6 +6,10 @@
 
 static int
 rotate(struct notcurses* nc){
+  struct timespec ts = {
+    .tv_sec = 0,
+    .tv_nsec = 250000000,
+  };
   const int XSIZE = 16;
   int dimy, dimx;
   struct ncplane* n = notcurses_stddim_yx(nc, &dimy, &dimx);
@@ -43,7 +48,7 @@ rotate(struct notcurses* nc){
     b -= 15;
   }
   notcurses_render(nc);
-  sleep(1);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
 
   // we now have 2 rows of 20 cells each, with gradients. load 'em.
   uint32_t* rgba = ncplane_rgba(n, dimy / 2, 0, 2, XSIZE);
@@ -59,7 +64,7 @@ rotate(struct notcurses* nc){
   */
   ncplane_erase(n);
   notcurses_render(nc);
-  sleep(1);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
 
   if(ncplane_blit_rgba(n, dimy / 2, XSIZE, XSIZE * 4, NCBLIT_DEFAULT,
                        rgba, 0, 0, 4, XSIZE) < 0){
@@ -67,11 +72,11 @@ rotate(struct notcurses* nc){
     return -1;
   }
   notcurses_render(nc);
-  sleep(1);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
 
   ncplane_erase(n);
   notcurses_render(nc);
-  sleep(1);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
 
   // now promote it to a visual
   struct ncvisual* v = ncvisual_from_rgba(rgba, 4, XSIZE * 4, XSIZE);
@@ -84,7 +89,18 @@ rotate(struct notcurses* nc){
   };
   ncvisual_render(nc, v, &vopts);
   notcurses_render(nc);
-  sleep(1);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
+
+  if(NCERR_SUCCESS != ncvisual_rotate(v, M_PI / 2)){
+    return -1;
+  }
+  ncplane_erase(n);
+  notcurses_render(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
+
+  ncvisual_render(nc, v, &vopts);
+  notcurses_render(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
   return 0;
 }
 

--- a/src/poc/rotator.c
+++ b/src/poc/rotator.c
@@ -86,6 +86,7 @@ rotate(struct notcurses* nc){
   struct ncvisual_options vopts = {
     .x = (dimx - XSIZE) / 2,
     .y = dimy / 2,
+    .n = n,
   };
   ncvisual_render(nc, v, &vopts);
   notcurses_render(nc);
@@ -95,9 +96,14 @@ rotate(struct notcurses* nc){
     return -1;
   }
   ncplane_erase(n);
+  ncvisual_render(nc, v, &vopts);
   notcurses_render(nc);
   clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
 
+  if(NCERR_SUCCESS != ncvisual_rotate(v, M_PI / 4)){
+    return -1;
+  }
+  ncplane_erase(n);
   ncvisual_render(nc, v, &vopts);
   notcurses_render(nc);
   clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;

--- a/src/poc/rotator.c
+++ b/src/poc/rotator.c
@@ -59,7 +59,8 @@ rotate(struct notcurses* nc){
   notcurses_render(nc);
   sleep(1);
 
-  if(ncblit_rgba(n, dimy / 2, XSIZE, XSIZE * 4, rgba, 0, 0, 4, XSIZE) < 0){
+  if(ncplane_blit_rgba(n, dimy / 2, XSIZE, XSIZE * 4, NCBLIT_DEFAULT,
+                       rgba, 0, 0, 4, XSIZE) < 0){
     free(rgba);
     return -1;
   }

--- a/src/poc/rotator.c
+++ b/src/poc/rotator.c
@@ -50,11 +50,13 @@ rotate(struct notcurses* nc){
   if(rgba == NULL){
     return -1;
   }
+  /*
   for(int y = 0 ; y < 4 ; ++y){
     for(int x = 0 ; x < XSIZE ; ++x){
       fprintf(stderr, "rgba %02d/%02d: %08x\n", y, x, rgba[y * XSIZE + x]);
     }
   }
+  */
   ncplane_erase(n);
   notcurses_render(nc);
   sleep(1);
@@ -64,6 +66,23 @@ rotate(struct notcurses* nc){
     free(rgba);
     return -1;
   }
+  notcurses_render(nc);
+  sleep(1);
+
+  ncplane_erase(n);
+  notcurses_render(nc);
+  sleep(1);
+
+  // now promote it to a visual
+  struct ncvisual* v = ncvisual_from_rgba(rgba, 4, XSIZE * 4, XSIZE);
+  if(v == NULL){
+    return -1;
+  }
+  struct ncvisual_options vopts = {
+    .x = (dimx - XSIZE) / 2,
+    .y = dimy / 2,
+  };
+  ncvisual_render(nc, v, &vopts);
   notcurses_render(nc);
   sleep(1);
   return 0;

--- a/src/poc/rotator.c
+++ b/src/poc/rotator.c
@@ -5,6 +5,50 @@
 #include <notcurses/notcurses.h>
 
 static int
+rotate_grad(struct notcurses* nc){
+  struct timespec ts = {
+    .tv_sec = 0,
+    .tv_nsec = 750000000,
+  };
+  int dimy, dimx;
+  struct ncplane* n = notcurses_stddim_yx(nc, &dimy, &dimx);
+  ncplane_cursor_move_yx(n, 0, 0);
+  uint64_t tl = 0, tr = 0, bl = 0, br = 0;
+  channels_set_fg_rgb(&tl, 0, 0, 0);
+  channels_set_fg_rgb(&tr, 0, 0, 0xff);
+  channels_set_fg_rgb(&bl, 0, 0xff, 0);
+  channels_set_fg_rgb(&br, 0, 0xff, 0xff);
+  channels_set_bg_rgb(&tl, 0, 0, 0);
+  channels_set_bg_rgb(&tr, 0, 0xff, 0);
+  channels_set_bg_rgb(&bl, 0, 0, 0xff);
+  channels_set_bg_rgb(&br, 0, 0xff, 0xff);
+  //if(ncplane_gradient(n, "a", 0, tl, tr, bl, br, dimy - 1, dimx - 1) <= 0){
+  if(ncplane_highgradient(n, tl, tr, bl, br, dimy - 1, dimx - 1) <= 0){
+    return -1;
+  }
+  notcurses_render(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);
+  uint32_t* rgba = ncplane_rgba(n, 0, 0, dimy, dimx);
+  if(rgba == NULL){
+    return -1;
+  }
+  ncplane_erase(n);
+  notcurses_render(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
+
+  if(ncplane_blit_rgba(n, 0, 0, dimx * 4, NCBLIT_DEFAULT,
+                       rgba, 0, 0, dimy * 2, dimx) < 0){
+    free(rgba);
+    return -1;
+  }
+  free(rgba);
+  notcurses_render(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
+
+  return 0;
+}
+
+static int
 rotate(struct notcurses* nc){
   struct timespec ts = {
     .tv_sec = 0,
@@ -80,6 +124,7 @@ rotate(struct notcurses* nc){
 
   // now promote it to a visual
   struct ncvisual* v = ncvisual_from_rgba(rgba, 4, XSIZE * 4, XSIZE);
+  free(rgba);
   if(v == NULL){
     return -1;
   }
@@ -92,21 +137,27 @@ rotate(struct notcurses* nc){
   notcurses_render(nc);
   clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
 
-  if(NCERR_SUCCESS != ncvisual_rotate(v, M_PI / 2)){
-    return -1;
+  for(int i = 0 ; i < 4 ; ++i){
+    if(NCERR_SUCCESS != ncvisual_rotate(v, M_PI / 2)){
+      return -1;
+    }
+    ncplane_erase(n);
+    ncvisual_render(nc, v, &vopts);
+    notcurses_render(nc);
+    clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
   }
-  ncplane_erase(n);
-  ncvisual_render(nc, v, &vopts);
-  notcurses_render(nc);
-  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
 
-  if(NCERR_SUCCESS != ncvisual_rotate(v, M_PI / 4)){
-    return -1;
+  for(int i = 0 ; i < 8 ; ++i){
+    if(NCERR_SUCCESS != ncvisual_rotate(v, M_PI / 4)){
+      return -1;
+    }
+    ncplane_erase(n);
+    ncvisual_render(nc, v, &vopts);
+    notcurses_render(nc);
+    clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
   }
-  ncplane_erase(n);
-  ncvisual_render(nc, v, &vopts);
-  notcurses_render(nc);
-  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);;
+
+  ncvisual_destroy(v);
   return 0;
 }
 
@@ -117,7 +168,9 @@ int main(void){
     .flags = NCOPTION_INHIBIT_SETLOCALE,
   };
   struct notcurses* nc = notcurses_init(&nopts, NULL);
-  int r = rotate(nc);
+  int r = 0;
+  r |= rotate(nc);
+  r |= rotate_grad(nc);
   r |= notcurses_stop(nc);
   return r ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/src/poc/rotator.c
+++ b/src/poc/rotator.c
@@ -84,8 +84,8 @@ rotate_grad(struct notcurses* nc){
   for(int i = 0 ; i < 8 ; ++i){
     int vy, vx, scaley, scalex;
     ncvisual_geom(nc, v, NCBLIT_DEFAULT, &vy, &vx, &scaley, &scalex);
-    vopts.x = (dimx - vx) / 2;
-    vopts.y = (dimy * 2 - vy) / 2;
+    vopts.x = (dimx - (vx / scalex)) / 2;
+    vopts.y = (dimy - (vy / scaley)) / 2;
     if(NCERR_SUCCESS != ncvisual_rotate(v, M_PI / 4)){
       return -1;
     }

--- a/src/poc/rotator.c
+++ b/src/poc/rotator.c
@@ -14,15 +14,14 @@ rotate_grad(struct notcurses* nc){
   struct ncplane* n = notcurses_stddim_yx(nc, &dimy, &dimx);
   ncplane_cursor_move_yx(n, 0, 0);
   uint64_t tl = 0, tr = 0, bl = 0, br = 0;
-  channels_set_fg_rgb(&tl, 0, 0, 0);
+  channels_set_fg_rgb(&tl, 0xff, 0, 0);
   channels_set_fg_rgb(&tr, 0, 0, 0xff);
   channels_set_fg_rgb(&bl, 0, 0xff, 0);
   channels_set_fg_rgb(&br, 0, 0xff, 0xff);
-  channels_set_bg_rgb(&tl, 0, 0, 0);
+  channels_set_bg_rgb(&tl, 0xff, 0, 0);
   channels_set_bg_rgb(&tr, 0, 0xff, 0);
   channels_set_bg_rgb(&bl, 0, 0, 0xff);
   channels_set_bg_rgb(&br, 0, 0xff, 0xff);
-  //if(ncplane_gradient(n, "a", 0, tl, tr, bl, br, dimy - 1, dimx - 1) <= 0){
   if(ncplane_highgradient(n, tl, tr, bl, br, dimy - 1, dimx - 1) <= 0){
     return -1;
   }

--- a/src/poc/visual.cpp
+++ b/src/poc/visual.cpp
@@ -53,21 +53,29 @@ int main(int argc, char** argv){
   if(notcurses_render(nc)){
     goto err;
   }
+  vopts.n = NULL;
+  ncplane_destroy(n);
   for(double i = 0 ; i < 256 ; ++i){
     sleep(1);
     if(ncvisual_rotate(ncv, M_PI / 2)){
       failed = true;
       break;
     }
-    ncplane_erase(n);
-    if(ncvisual_render(nc, ncv, &vopts) == nullptr){
+    int vy, vx;
+    ncvisual_geom(nc, ncv, NCBLIT_DEFAULT, &vy, &vx, &scaley, &scalex);
+    vopts.x = (dimx * scalex - vx) / 2;
+    vopts.y = (dimy * scaley - vy) / 2;
+    struct ncplane* newn;
+    if((newn = ncvisual_render(nc, ncv, &vopts)) == nullptr){
       failed = true;
       break;
     }
     if(notcurses_render(nc)){
+      ncplane_destroy(newn);
       failed = true;
       break;
     }
+    ncplane_destroy(newn);
   }
   ncvisual_destroy(ncv);
   return notcurses_stop(nc) || failed ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/src/poc/visual.cpp
+++ b/src/poc/visual.cpp
@@ -57,14 +57,14 @@ int main(int argc, char** argv){
   ncplane_destroy(n);
   for(double i = 0 ; i < 256 ; ++i){
     sleep(1);
-    if(ncvisual_rotate(ncv, M_PI / 2)){
+    if(ncvisual_rotate(ncv, M_PI / ((i / 32) + 2))){
       failed = true;
       break;
     }
     int vy, vx;
     ncvisual_geom(nc, ncv, NCBLIT_DEFAULT, &vy, &vx, &scaley, &scalex);
-    vopts.x = (dimx * scalex - vx) / 2;
-    vopts.y = (dimy * scaley - vy) / 2;
+    vopts.x = (dimx - (vx / scalex)) / 2;
+    vopts.y = (dimy - (vy / scaley)) / 2;
     struct ncplane* newn;
     if((newn = ncvisual_render(nc, ncv, &vopts)) == nullptr){
       failed = true;

--- a/src/poc/visual.cpp
+++ b/src/poc/visual.cpp
@@ -7,6 +7,10 @@
 #include <notcurses/notcurses.h>
 
 int main(int argc, char** argv){
+  struct timespec ts = {
+    .tv_sec = 0,
+    .tv_nsec = 250000000,
+  };
   const char* file = "../data/changes.jpg";
   setlocale(LC_ALL, "");
   if(argc > 2){
@@ -17,6 +21,7 @@ int main(int argc, char** argv){
   }
   notcurses_options opts{};
   opts.inhibit_alternate_screen = true;
+  opts.loglevel = NCLOGLEVEL_TRACE;
   opts.flags = NCOPTION_INHIBIT_SETLOCALE;
   struct notcurses* nc;
   if((nc = notcurses_init(&opts, nullptr)) == nullptr){
@@ -43,7 +48,9 @@ int main(int argc, char** argv){
   if(notcurses_render(nc)){
     goto err;
   }
-  sleep(1);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);
+
+  ncplane_erase(n);
   ncvisual_geom(nc, ncv, NCBLIT_DEFAULT, nullptr, nullptr, &scaley, &scalex);
   ncvisual_resize(ncv, dimy * scaley, dimx * scalex);
   vopts.n = n;
@@ -53,10 +60,12 @@ int main(int argc, char** argv){
   if(notcurses_render(nc)){
     goto err;
   }
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);
+
   vopts.n = NULL;
   ncplane_destroy(n);
   for(double i = 0 ; i < 256 ; ++i){
-    sleep(1);
+    clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);
     if(ncvisual_rotate(ncv, M_PI / ((i / 32) + 2))){
       failed = true;
       break;


### PR DESCRIPTION
* Fix rotation for `oiio` and `ffmpeg` #662 (`ffmpeg` still has a problem rotating rectangular visuals, but this suffices for our needs)
* Fix color byte order for `ncplane_rgba()` #672 
* Always flush after changing cursor status #673 
* `ncblit_rgba()` and `ncblit_bgrx()` -> `ncplane_blit_*`, accept `ncblitter_e` #674 

Added a new POC, `rotator`