### PR TITLE
[C++] Actually use compilation options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,6 @@ set(NCPP_COMPILE_OPTIONS
   -Wnull-dereference
   -Wmisleading-indentation
   -Wunused
-  -Wpedantic
   -Wsuggest-override
   -Wno-c99-extensions
   -fno-strict-aliasing
@@ -281,7 +280,6 @@ set(NCPP_COMPILE_OPTIONS
   -finline-limit=300
   -fstack-protector
   -fno-rtti
-  -fno-exceptions
   -fpic
   )
 
@@ -294,12 +292,12 @@ set(NCPP_COMPILE_DEFINITIONS_PRIVATE
 
 target_compile_options(notcurses++
   PRIVATE
-  ${NCPP_COMPILLE_OPTIONS}
+  ${NCPP_COMPILE_OPTIONS}
   )
 
 target_compile_options(notcurses++-static
   PRIVATE
-  ${NCPP_COMPILLE_OPTIONS}
+  ${NCPP_COMPILE_OPTIONS}
   )
 
 target_compile_definitions(notcurses++


### PR DESCRIPTION
Fixes: https://github.com/dankamongmen/notcurses/issues/722

`-Wpedantic` is dropped because C code uses designated structure
initializers which are available in C++20 onward (and we use C++17
ATM). Once we switch to C++20 we should re-enable the flag.

`-fno-exceptions` is dropped because we do have exceptions, so...