### PR TITLE
[C++] API sync

### DIFF
--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -122,6 +122,11 @@ namespace ncpp
 			return error_guard (ncdirect_cursor_disable (direct), -1);
 		}
 
+		nc_err_e render_image (const char* file, ncblitter_e blitter, ncscale_e scale) const noexcept
+		{
+			return ncdirect_render_image (direct, file, blitter, scale);
+		}
+
 	private:
 		ncdirect *direct;
 	};

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -111,6 +111,11 @@ namespace ncpp
 			return notcurses_canchangecolor (nc);
 		}
 
+		bool can_truecolor () const noexcept
+		{
+			return notcurses_cantruecolor (nc);
+		}
+
 		void get_stats (ncstats *stats) const noexcept
 		{
 			if (stats == nullptr)

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -285,6 +285,11 @@ namespace ncpp
 			return reparent (const_cast<Plane*>(&newparent));
 		}
 
+		void home () const noexcept
+		{
+			ncplane_home (plane);
+		}
+
 		bool move (int y, int x) const NOEXCEPT_MAYBE
 		{
 			return error_guard (ncplane_move_yx (plane, y, x), -1);
@@ -614,6 +619,16 @@ namespace ncpp
 		bool perimeter (const Cell &ul, const Cell &ur, const Cell &ll, const Cell &lr, const Cell &hline, const Cell &vline, unsigned ctlword) const NOEXCEPT_MAYBE
 		{
 			return error_guard (ncplane_perimeter (plane, ul, ur, ll, lr, hline, vline, ctlword), -1);
+		}
+
+		bool perimeter_rounded (uint32_t attrword, uint64_t channels, unsigned ctlword) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncplane_perimeter_rounded (plane, attrword, channels, ctlword), -1);
+		}
+
+		bool perimeter_double (uint32_t attrword, uint64_t channels, unsigned ctlword) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncplane_perimeter_double (plane, attrword, channels, ctlword), -1);
 		}
 
 		int polyfill (int y, int x, const Cell& c) const NOEXCEPT_MAYBE
@@ -1031,6 +1046,16 @@ namespace ncpp
 		{
 			int ret = ncplane_qrcode (plane, blitter, ymax, xmax, data, len);
 			return error_guard_cond<int> (ret, ret < 0);
+		}
+
+		bool is_fg_default () const noexcept
+		{
+			return ncplane_fg_default_p (plane);
+		}
+
+		bool is_bg_default () const noexcept
+		{
+			return ncplane_bg_default_p (plane);
 		}
 
 	protected:

--- a/include/ncpp/Plot.hh
+++ b/include/ncpp/Plot.hh
@@ -18,7 +18,7 @@ namespace ncpp
 		static constexpr bool is_uint64 = std::is_same_v<TCoord,uint64_t>;
 
 	public:
-		bool add_sample(TCoord x, TCoord y) const NOEXCEPT_MAYBE
+		bool add_sample (uint64_t x, TCoord y) const NOEXCEPT_MAYBE
 		{
 			int ret;
 
@@ -31,7 +31,7 @@ namespace ncpp
 			return error_guard (ret, -1);
 		}
 
-		bool set_sample(TCoord x, TCoord y) const NOEXCEPT_MAYBE
+		bool set_sample (uint64_t x, TCoord y) const NOEXCEPT_MAYBE
 		{
 			int ret;
 
@@ -40,6 +40,19 @@ namespace ncpp
 			} else {
 				ret = nduplot_set_sample (plot, x, y);
 			}
+			return error_guard (ret, -1);
+		}
+
+		bool sample (uint64_t x, TCoord* y) const NOEXCEPT_MAYBE
+		{
+			int ret;
+
+			if constexpr (is_double) {
+				ret = ncdplot_sample (plot, x, y);
+			} else {
+				ret = ncuplot_sample (plot, x, y);
+			}
+
 			return error_guard (ret, -1);
 		}
 

--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -92,6 +92,11 @@ namespace ncpp
 			return error_guard<int> (ncvisual_polyfill_yx (visual, y, x, rgba), -1);
 		}
 
+		bool geom (const struct ncvisual_options *vopts, int *y, int *x, int *toy, int *tox) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncvisual_geom (get_notcurses (), visual, vopts, y, x, toy, tox), -1);
+		}
+
 		bool at (int y, int x, uint32_t* pixel) const
 		{
 			if (pixel == nullptr)


### PR DESCRIPTION
Added:
  * Direct: render_image (`ncdirect_render_image`)
  * NotCurses: can_truecolor (`notcurses_cantruecolor`)
  * Plane: home (`ncplane_home`)
  * Plane: perimeter_rounded (`ncplane_perimeter_rounded`)
  * Plane: perimeter_double (`ncplane_perimeter_double`)
  * Plane: is_fg_default (`ncplane_fg_default_p`)
  * Plane: is_bg_default (`ncplane_bg_default_p`)
  * Plot: sample (`nc{d,u}plot_sample`)
  * Visual: geom (`ncvisual_geom`)

Fixed:
  * Plot: {set,add}_sample - `x` coord is always `uint64_t`