### PR TITLE
First go at ncdirect_render_image() #725

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.5.4 (not yet released)
+  * `ncdirect_render_image()` has been added, allowing images (but not
+    videos or animated images) to be rendered directly into the standard I/O
+    streams. It begins drawing from the current cursor position, running
+    through the right-hand side of the screen, and scrolling as much content
+    as is necessary.
+
 * 1.5.3 (2020-06-28)
   * The default blitter when `NCSCALE_STRETCH` is used is now `NCBLIT_2x2`,
     replacing `NCBLIT_2x1`. It is not the default for `NCSCALE_NONE` and

--- a/include/notcurses/ncerrs.h
+++ b/include/notcurses/ncerrs.h
@@ -16,6 +16,8 @@ typedef enum {
   NCERR_NOMEM = ENOMEM,
   NCERR_EOF = 0x20464f45, // matches AVERROR_EOF
   NCERR_DECODE,
+  NCERR_SYSTEM,
+  NCERR_INVALID_ARG,
   NCERR_UNIMPLEMENTED,
 } nc_err_e;
 
@@ -26,6 +28,8 @@ nc_strerror(nc_err_e ncerr){
     case NCERR_NOMEM: return strerror(ENOMEM);
     case NCERR_EOF: return "end of file";
     case NCERR_DECODE: return "error decoding";
+    case NCERR_SYSTEM: return "system error";
+    case NCERR_INVALID_ARG: return "invalid argument";
     case NCERR_UNIMPLEMENTED: return "feature not available";
   };
   return "unknown error";

--- a/src/lib/blitset.h
+++ b/src/lib/blitset.h
@@ -27,38 +27,6 @@ lookup_blitset(bool utf8, ncblitter_e setid, bool may_degrade) {
   return NULL;
 }
 
-static inline ncblitter_e
-ncvisual_default_blitter(bool canutf8) {
-  if(canutf8){
-    // FIXME probably want 2x2, at least for images larger than plane
-    return NCBLIT_2x1;
-  }
-  return NCBLIT_1x1;
-}
-
-// RGBA visuals all use NCBLIT_2x1 by default (or NCBLIT_1x1 if not in
-// UTF-8 mode), but an alternative can be specified.
-static inline const struct blitset*
-rgba_blitter(bool utf8, ncblitter_e setid, bool maydegrade) {
-  const struct blitset* bset;
-  if(setid != NCBLIT_DEFAULT){
-    bset = lookup_blitset(utf8, setid, maydegrade);
-  }else{
-    bset = lookup_blitset(utf8, ncvisual_default_blitter(utf8), maydegrade);
-  }
-  if(bset && !bset->blit){ // FIXME remove this once all blitters are enabled
-    bset = NULL;
-  }
-  return bset;
-}
-
-// convenience wrapper around rgba_blitter()
-static inline const struct blitset*
-ncv_rgba_blitter(bool utf8, const struct ncvisual_options* opts) {
-  const bool maydegrade = !(opts && (opts->flags & NCVISUAL_OPTION_NODEGRADE));
-  return rgba_blitter(utf8, opts ? opts->blitter : NCBLIT_DEFAULT, maydegrade);
-}
-
 // number of pixels that map to a single cell, height-wise
 static inline int
 encoding_y_scale(const struct blitset* bset) {
@@ -69,6 +37,44 @@ encoding_y_scale(const struct blitset* bset) {
 static inline int
 encoding_x_scale(const struct blitset* bset) {
   return bset->width;
+}
+
+static inline ncblitter_e
+ncvisual_default_blitter(bool utf8, ncscale_e scale) {
+  if(utf8){
+    // NCBLIT_2x2 is better image quality, especially for large images, but
+    // it's not the general default because it doesn't preserve aspect ratio.
+    // NCSCALE_STRETCH throws away aspect ratio, and can safely use NCBLIT_2x2.
+    if(scale == NCSCALE_STRETCH){
+      return NCBLIT_2x2;
+    }
+    return NCBLIT_2x1;
+  }
+  return NCBLIT_1x1;
+}
+
+static inline const struct blitset*
+rgba_blitter_low(bool utf8, ncscale_e scale, bool maydegrade, ncblitter_e blitrec) {
+  const struct blitset* bset;
+  if(blitrec != NCBLIT_DEFAULT){
+    bset = lookup_blitset(utf8, blitrec, maydegrade);
+  }else{
+    bset = lookup_blitset(utf8, ncvisual_default_blitter(utf8, scale), maydegrade);
+  }
+  if(bset && !bset->blit){ // FIXME remove this once all blitters are enabled
+    bset = NULL;
+  }
+  return bset;
+}
+
+// RGBA visuals all use NCBLIT_2x1 by default (or NCBLIT_1x1 if not in
+// UTF-8 mode), but an alternative can be specified.
+static inline const struct blitset*
+rgba_blitter(const struct notcurses* nc, const struct ncvisual_options* opts) {
+  const bool maydegrade = !(opts && (opts->flags & NCVISUAL_OPTION_NODEGRADE));
+  const ncscale_e scale = opts ? opts->scaling : NCSCALE_NONE;
+  return rgba_blitter_low(notcurses_canutf8(nc), scale, maydegrade,
+                          opts ? opts->blitter : NCBLIT_DEFAULT);
 }
 
 #endif

--- a/src/lib/blitset.h
+++ b/src/lib/blitset.h
@@ -4,13 +4,13 @@
 #include "notcurses/notcurses.h"
 
 static inline const struct blitset*
-lookup_blitset(const struct notcurses* nc, ncblitter_e setid, bool may_degrade) {
+lookup_blitset(bool utf8, ncblitter_e setid, bool may_degrade) {
   if(setid == NCBLIT_DEFAULT){
     setid = NCBLIT_2x1;
     may_degrade = true;
   }
   // the only viable blitter in ASCII is NCBLIT_1x1
-  if(!notcurses_canutf8(nc) && setid != NCBLIT_1x1){
+  if(!utf8 && setid != NCBLIT_1x1){
     if(may_degrade){
       setid = NCBLIT_1x1;
     }else{
@@ -25,6 +25,50 @@ lookup_blitset(const struct notcurses* nc, ncblitter_e setid, bool may_degrade) 
     ++bset;
   }
   return NULL;
+}
+
+static inline ncblitter_e
+ncvisual_default_blitter(bool canutf8) {
+  if(canutf8){
+    // FIXME probably want 2x2, at least for images larger than plane
+    return NCBLIT_2x1;
+  }
+  return NCBLIT_1x1;
+}
+
+// RGBA visuals all use NCBLIT_2x1 by default (or NCBLIT_1x1 if not in
+// UTF-8 mode), but an alternative can be specified.
+static inline const struct blitset*
+rgba_blitter(bool utf8, ncblitter_e setid, bool maydegrade) {
+  const struct blitset* bset;
+  if(setid != NCBLIT_DEFAULT){
+    bset = lookup_blitset(utf8, setid, maydegrade);
+  }else{
+    bset = lookup_blitset(utf8, ncvisual_default_blitter(utf8), maydegrade);
+  }
+  if(bset && !bset->blit){ // FIXME remove this once all blitters are enabled
+    bset = NULL;
+  }
+  return bset;
+}
+
+// convenience wrapper around rgba_blitter()
+static inline const struct blitset*
+ncv_rgba_blitter(bool utf8, const struct ncvisual_options* opts) {
+  const bool maydegrade = !(opts && (opts->flags & NCVISUAL_OPTION_NODEGRADE));
+  return rgba_blitter(utf8, opts ? opts->blitter : NCBLIT_DEFAULT, maydegrade);
+}
+
+// number of pixels that map to a single cell, height-wise
+static inline int
+encoding_y_scale(const struct blitset* bset) {
+  return bset->height;
+}
+
+// number of pixels that map to a single cell, width-wise
+static inline int
+encoding_x_scale(const struct blitset* bset) {
+  return bset->width;
 }
 
 #endif

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -195,6 +195,12 @@ int ncdirect_cursor_yx(ncdirect* n, int* y, int* x){
     fprintf(stderr, "Couldn't restore terminal mode on %d (%s)\n",
             infd, strerror(errno)); // don't return error for this
   }
+  if(y){
+    --*y;
+  }
+  if(x){
+    --*x;
+  }
   return ret;
 }
 
@@ -227,11 +233,12 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np){
       ncdirect_fg(n, channels_fg(channels));
       ncdirect_bg(n, channels_bg(channels));
 //    fprintf(stderr, "%03d/%03d [%s]\n", y, x, egc);
-      if(printf("%s", egc) < 0){
+      if(printf("%s", strlen(egc) == 0 ? " " : egc) < 0){
         return -1;
       }
     }
-    putchar('\n');
+    ncdirect_cursor_down(n, 1);
+    ncdirect_cursor_left(n, dimx);
   }
   return 0;
 }
@@ -248,6 +255,7 @@ nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncblitter_e blitte
     ncvisual_destroy(ncv);
     return NCERR_SYSTEM;
   }
+//fprintf(stderr, "INITIAL CURSOR: %d/%d\n", begy, begx);
   int leny = ncv->rows; // we allow it to freely scroll
   int lenx = ncv->cols - begx;
   if(leny == 0 || lenx == 0){
@@ -272,7 +280,7 @@ nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncblitter_e blitte
   }
   leny = (leny / (double)ncv->rows) * ((double)disprows);
   lenx = (lenx / (double)ncv->cols) * ((double)dispcols);
-fprintf(stderr, "render: %dx%d:%d+%d of %d/%d stride %u %p\n", begy, begx, leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
+//fprintf(stderr, "render: %dx%d:%d+%d of %d/%d stride %u %p\n", begy, begx, leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
   struct ncplane* faken = ncplane_create(NULL, NULL, disprows, dispcols, 0, 0, NULL);
   if(faken == NULL){
     return NCERR_NOMEM;

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -226,6 +226,7 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np){
       }
       ncdirect_fg(n, channels_fg(channels));
       ncdirect_bg(n, channels_bg(channels));
+//    fprintf(stderr, "%03d/%03d [%s]\n", y, x, egc);
       if(printf("%s", egc) < 0){
         return -1;
       }
@@ -259,8 +260,8 @@ nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncblitter_e blitte
     return NCERR_INVALID_ARG;
   }
   int disprows, dispcols;
-  dispcols = ncdirect_dim_x(n);
   disprows = ncdirect_dim_y(n);
+  dispcols = ncdirect_dim_x(n);
   if(scale != NCSCALE_NONE){
     dispcols *= encoding_x_scale(bset);
     disprows *= encoding_y_scale(bset);
@@ -271,13 +272,13 @@ nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncblitter_e blitte
   }
   leny = (leny / (double)ncv->rows) * ((double)disprows);
   lenx = (lenx / (double)ncv->cols) * ((double)dispcols);
-//fprintf(stderr, "render: %dx%d:%d+%d of %d/%d stride %u %p\n", begy, begx, leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
+fprintf(stderr, "render: %dx%d:%d+%d of %d/%d stride %u %p\n", begy, begx, leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
   struct ncplane* faken = ncplane_create(NULL, NULL, disprows, dispcols, 0, 0, NULL);
   if(faken == NULL){
     return NCERR_NOMEM;
   }
   if(ncvisual_blit(ncv, disprows, dispcols, faken, bset,
-                   begy, begx, begy, begx, leny, lenx,
+                   0, 0, 0, 0, leny, lenx,
                    false)){
     ncvisual_destroy(ncv);
     free_plane(faken);

--- a/src/lib/ffmpeg.cpp
+++ b/src/lib/ffmpeg.cpp
@@ -416,9 +416,9 @@ nc_err_e ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
   int stride = 0;
   AVFrame* sframe = nullptr;
   const int targformat = AV_PIX_FMT_RGBA;
-//fprintf(stderr, "got format: %d want format: %d\n", inframe->format, targformat);
+fprintf(stderr, "got format: %d want format: %d\n", inframe->format, targformat);
   if(inframe && (cols != inframe->width || rows != inframe->height || inframe->format != targformat)){
-//fprintf(stderr, "resize+render: %d/%d->%d/%d (%dX%d @ %dX%d, %d/%d)\n", inframe->height, inframe->width, rows, cols, begy, begx, placey, placex, leny, lenx);
+fprintf(stderr, "resize+render: %d/%d->%d/%d (%dX%d @ %dX%d, %d/%d)\n", inframe->height, inframe->width, rows, cols, begy, begx, placey, placex, leny, lenx);
     sframe = av_frame_alloc();
     if(sframe == nullptr){
 //fprintf(stderr, "Couldn't allocate output frame for scaled frame\n");
@@ -461,9 +461,10 @@ nc_err_e ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
     stride = ncv->rowstride;
     data = ncv->data;
   }
-//fprintf(stderr, "place: %d/%d rows/cols: %d/%d %d/%d+%d/%d\n", placey, placex, rows, cols, begy, begx, leny, lenx);
+fprintf(stderr, "place: %d/%d rows/cols: %d/%d %d/%d+%d/%d\n", placey, placex, rows, cols, begy, begx, leny, lenx);
   if(rgba_blit_dispatch(n, bset, placey, placex, stride, data, begy, begx,
                         leny, lenx, blendcolors) <= 0){
+fprintf(stderr, "rgba dispatch failed!\n");
     if(sframe){
       av_freep(sframe->data);
       av_freep(&sframe);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -272,6 +272,7 @@ typedef struct ncdirect {
   tinfo tcache;              // terminfo cache
   uint16_t fgrgb, bgrgb;     // last RGB values of foreground/background
   bool fgdefault, bgdefault; // are FG/BG currently using default colors?
+  bool utf8;                 // are we using utf-8 encoding, as hoped?
 } ncdirect;
 
 typedef struct notcurses {
@@ -760,6 +761,13 @@ calc_gradient_channels(uint64_t* channels, uint64_t ul, uint64_t ur,
     channels_set_bg_default(channels);
   }
 }
+
+// Resize the provided ncviusal to the specified 'rows' x 'cols', but do not
+// change the internals of the ncvisual. Uses oframe.
+nc_err_e ncvisual_blit(struct ncvisual* ncv, int rows, int cols,
+                       ncplane* n, const struct blitset* bset,
+                       int placey, int placex, int begy, int begx,
+                       int leny, int lenx, bool blendcolors);
 
 void nclog(const char* fmt, ...);
 

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -762,6 +762,13 @@ calc_gradient_channels(uint64_t* channels, uint64_t ul, uint64_t ur,
   }
 }
 
+// ncdirect needs to "fake" an isolated ncplane as a drawing surface for
+// ncvisual_render(), and thus calls these low-level internal functions.
+// they are not for general use -- check ncplane_new() and ncplane_destroy().
+ncplane* ncplane_create(notcurses* nc, ncplane* n, int rows, int cols,
+                        int yoff, int xoff, void* opaque);
+void free_plane(ncplane* p);
+
 // Resize the provided ncviusal to the specified 'rows' x 'cols', but do not
 // change the internals of the ncvisual. Uses oframe.
 nc_err_e ncvisual_blit(struct ncvisual* ncv, int rows, int cols,

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -653,6 +653,12 @@ ncdirect* ncdirect_init(const char* termtype, FILE* outfp){
   ret->fgdefault = ret->bgdefault = true;
   ret->fgrgb = ret->bgrgb = 0;
   ncdirect_styles_set(ret, 0);
+  const char* encoding = nl_langinfo(CODESET);
+  if(encoding && strcmp(encoding, "UTF-8") == 0){
+    ret->utf8 = true;
+  }else if(encoding && strcmp(encoding, "ANSI_X3.4-1968") == 0){
+    ret->utf8 = false;
+  }
   return ret;
 }
 

--- a/src/lib/visual-details.h
+++ b/src/lib/visual-details.h
@@ -15,8 +15,7 @@
 typedef struct ncvisual_details {
 } ncvisual_details;
 
-static inline auto
-ncvisual_details_init(ncvisual_details* deets) -> nc_err_e {
+static inline auto ncvisual_details_init(ncvisual_details* deets) -> nc_err_e {
   (void)deets;
   return NCERR_SUCCESS;
 }

--- a/src/lib/visual-details.h
+++ b/src/lib/visual-details.h
@@ -58,4 +58,14 @@ ncvisual_set_data(ncvisual* ncv, uint32_t* data, bool owned) -> void {
   ncv->owndata = owned;
 }
 
+static inline void
+scale_visual(const ncvisual* ncv, int* disprows, int* dispcols) {
+  float xratio = (float)(*dispcols) / ncv->cols;
+  if(xratio * ncv->rows > *disprows){
+    xratio = (float)(*disprows) / ncv->rows;
+  }
+  *disprows = xratio * (ncv->rows);
+  *dispcols = xratio * (ncv->cols);
+}
+
 #endif

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -4,13 +4,6 @@
 #include "visual-details.h"
 #include "internal.h"
 
-// Resize the provided ncviusal to the specified 'rows' x 'cols', but do not
-// change the internals of the ncvisual. Uses oframe.
-nc_err_e ncvisual_blit(struct ncvisual* ncv, int rows, int cols,
-                       ncplane* n, const struct blitset* bset,
-                       int placey, int placex, int begy, int begx,
-                       int leny, int lenx, bool blendcolors);
-
 // ncv constructors other than ncvisual_from_file() need to set up the
 // AVFrame* 'frame' according to their own data, which is assumed to
 // have been prepared already in 'ncv'.
@@ -449,7 +442,7 @@ auto ncvisual_render(notcurses* nc, ncvisual* ncv,
   if(begx + lenx > ncv->cols || begy + leny > ncv->rows){
     return nullptr;
   }
-  auto bset = rgba_blitter(nc, vopts);
+  auto bset = rgba_blitter(notcurses_canutf8(nc), vopts);
   if(!bset){
     return nullptr;
   }

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -1,4 +1,5 @@
 #include <locale.h>
+#include <unistd.h>
 #include <notcurses/notcurses.h>
 
 // can we leave what was already on the screen there? (narrator: it seems not)
@@ -12,6 +13,10 @@ int main(void){
     return EXIT_FAILURE;
   }
   if(ncdirect_render_image(n, "../data/warmech.bmp", NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
+    return EXIT_FAILURE;
+  }
+  sleep(1);
+  if(ncdirect_render_image(n, "../data/worldmap.png", NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   if(ncdirect_stop(n)){

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -1,0 +1,21 @@
+#include <locale.h>
+#include <notcurses/notcurses.h>
+
+// can we leave what was already on the screen there? (narrator: it seems not)
+int main(void){
+  if(!setlocale(LC_ALL, "")){
+    fprintf(stderr, "Couldn't set locale\n");
+    return EXIT_FAILURE;
+  }
+  struct ncdirect* n; // see bug #391
+  if((n = ncdirect_init(NULL, stdout)) == NULL){
+    return EXIT_FAILURE;
+  }
+  if(ncdirect_render_image(n, "../data/warmech.bmp", NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
+    return EXIT_FAILURE;
+  }
+  if(ncdirect_stop(n)){
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -12,11 +12,11 @@ int main(void){
   if((n = ncdirect_init(NULL, stdout)) == NULL){
     return EXIT_FAILURE;
   }
-  if(ncdirect_render_image(n, "../data/warmech.bmp", NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
+  if(ncdirect_render_image(n, "../data/normal.png", NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   sleep(1);
-  if(ncdirect_render_image(n, "../data/worldmap.png", NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
+  if(ncdirect_render_image(n, "../data/changes.jpg", NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   if(ncdirect_stop(n)){


### PR DESCRIPTION
Add `ncdirect_render_image()` and the `vizdirect` PoC to drive it. This required a disgusting hack whereby `ncplane_create()` and `free_plane()` are exposed to `ncdirect`, and we fake an "isolated" `ncplane` for rendering in `ncvisual_render()`. It's gross, but it appears to work, at least for the test cases I've thrown at it. Probably will need some corner cases cleaned up, but this ought be good enough for an `ncdirect`-based ncneofetch.