### PR TITLE
ncneofetch: reimplement with ncdirect #750

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,10 +568,6 @@ add_test(
   NAME rgbbg
   COMMAND rgbbg
 )
-add_test(
-  NAME ncneofetch
-  COMMAND ncneofetch
-)
 endif()
 
 # pkg-config support

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # notcurses
-blingful TUI library for modern terminal emulators. definitely not curses.
+
+a blingful TUI/character graphics library for modern terminal emulators.
 
 * **What it is**: a library facilitating complex TUIs on modern terminal
-    emulators, supporting vivid colors and Unicode to the maximum degree
-    possible. Many tasks delegated to Curses can be achieved using Notcurses
-    (and vice versa).
+    emulators, supporting vivid colors, multimedia, and Unicode to the maximum
+    degree possible. [things](https://www.youtube.com/watch?v=b4lmMADP1lA) can
+    be done with Notcurses than simply can't be done with NCURSES.
 
 * **What it is not**: a source-compatible X/Open Curses implementation, nor a
     replacement for NCURSES on existing systems.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 # notcurses
 blingful TUI library for modern terminal emulators. definitely not curses.
 
+* **What it is**: a library facilitating complex TUIs on modern terminal
+    emulators, supporting vivid colors and Unicode to the maximum degree
+    possible. Many tasks delegated to Curses can be achieved using Notcurses
+    (and vice versa).
+
+* **What it is not**: a source-compatible X/Open Curses implementation, nor a
+    replacement for NCURSES on existing systems.
+
 * birthed screaming into this world by [nick black](https://nick-black.com/dankwiki/index.php/Hack_on) (<nickblack@linux.com>)
 * C++ wrappers by [marek habersack](http://twistedcode.net/blog/) (<grendel@twistedcode.net>)
 
 for more information, see [dankwiki](https://nick-black.com/dankwiki/index.php/Notcurses)
-and the [man pages](https://notcurses.com/notcurses). There's also a reference
-[in this repo](USAGE.md).
-
-In addition, there is
-[Doxygen](https://nick-black.com/notcurses/html/) output. There is a [mailing
-list](https://groups.google.com/forum/#!forum/notcurses) which can be reached
+and the [man pages](https://notcurses.com/notcurses). there's also a reference
+[in this repo](USAGE.md). in addition, there is
+[Doxygen](https://nick-black.com/notcurses/html/) output. there is a
+[mailing list](https://groups.google.com/forum/#!forum/notcurses) which can be reached
 via notcurses@googlegroups.com.
 
 I wrote a coherent [guidebook](https://nick-black.com/htp-notcurses.pdf), which
@@ -46,14 +52,6 @@ and the FreeBSD [Ports Collection](https://www.freshports.org/devel/notcurses/).
   * [Thanks](#thanks)
 
 ## Introduction
-
-* **What it is**: a library facilitating complex TUIs on modern terminal
-    emulators, supporting vivid colors and Unicode to the maximum degree
-    possible. Many tasks delegated to Curses can be achieved using Notcurses
-    (and vice versa).
-
-* **What it is not**: a source-compatible X/Open Curses implementation, nor a
-    replacement for NCURSES on existing systems.
 
 Notcurses abandons the X/Open Curses API bundled as part of the Single UNIX
 Specification. The latter shows its age, and seems not capable of making use of

--- a/doc/man/man3/notcurses_directmode.3.md
+++ b/doc/man/man3/notcurses_directmode.3.md
@@ -12,6 +12,8 @@ ncdirect_init - minimal notcurses instances for styling text
 
 **struct ncdirect* ncdirect_init(const char* termtype, FILE* fp);**
 
+**int ncdirect_palette_size(const struct ncdirect* nc);**
+
 **int ncdirect_bg_rgb8(struct ncdirect* nc, unsigned r, unsigned g, unsigned b);**
 
 **int ncdirect_fg_rgb8(struct ncdirect* nc, unsigned r, unsigned g, unsigned b);**
@@ -51,6 +53,8 @@ ncdirect_init - minimal notcurses instances for styling text
 **int ncdirect_cursor_right(struct ncdirect* nc, int num);**
 
 **int ncdirect_cursor_down(struct ncdirect* nc, int num);**
+
+**int ncdirect_putc(struct ncdirect* nc, uint64_t channels, const char* egc);**
 
 **nc_err_e ncdirect_render_image(struct ncdirect* n, const char* filename, ncblitter_e blitter, ncscale_e scale);**
 

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -488,6 +488,8 @@ int ncplane_qrcode(struct ncplane* n, ncblitter_e blitter, int* ymax, int* xmax,
 struct ncdirect* ncdirect_init(const char* termtype, FILE* fp);
 int ncdirect_bg_rgb(struct ncdirect* n, unsigned r, unsigned g, unsigned b);
 int ncdirect_fg_rgb(struct ncdirect* n, unsigned r, unsigned g, unsigned b);
+int ncdirect_palette_size(const struct ncdirect* nc);
+int ncdirect_putc(struct ncdirect* nc, uint64_t channels, const char* egc);
 int ncdirect_fg(struct ncdirect* n, unsigned rgb);
 int ncdirect_bg(struct ncdirect* n, unsigned rgb);
 int ncdirect_styles_set(struct ncdirect* n, unsigned stylebits);

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -269,13 +269,22 @@ drawpalette(struct ncdirect* nc){
 
 static int
 infoplane(struct ncdirect* nc, const fetched_info* fi){
-  const int planeheight = 8;
   const int planewidth = 60;
+  const int infox = (ncdirect_dim_x(nc) - planewidth) / 2;
+  if(infox < 0){
+    return -1;
+  }
+  printf("\n");
   ncdirect_fg_rgb(nc, 0xd0, 0xd0, 0xd0);
   ncdirect_bg_rgb(nc, 0x50, 0x50, 0x50);
   ncdirect_styles_on(nc, NCSTYLE_UNDERLINE);
+  if(ncdirect_cursor_move_yx(nc, -1, infox + 1) < 0){
+    return -1;
+  }
+  if(printf("%s %s", fi->kernel, fi->kernver) < 0){
+    return -1;
+  }
   /*
-  ncplane_printf_aligned(infop, 1, NCALIGN_LEFT, " %s %s", fi->kernel, fi->kernver);
   if(fi->distro_pretty){
     ncplane_printf_aligned(infop, 1, NCALIGN_RIGHT, "%s ", fi->distro_pretty);
   }
@@ -341,6 +350,11 @@ infoplane(struct ncdirect* nc, const fetched_info* fi){
     return -1;
   }
   */
+  ncdirect_fg_default(nc);
+  ncdirect_bg_default(nc);
+  if(printf("\n") < 0){
+    return -1;
+  }
   return 0;
 }
 
@@ -398,12 +412,9 @@ ncneofetch(struct ncdirect* nc){
   fetch_x_props(&fi);
   fetch_cpu_info(&fi);
   sem_wait(&display_marshal.sem);
-  /*if(infoplane(nc, &fi)){
+  if(infoplane(nc, &fi)){
     return -1;
   }
-  if(notcurses_render(nc)){
-    return -1;
-  }*/
   return 0;
 }
 

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -257,7 +257,7 @@ drawpalette(struct ncdirect* nc){
         return -1;
       }
     }
-    if(ncdirect_bg_palindex(nc, 0)){
+    if(ncdirect_bg_default(nc)){
       return -1;
     }
     if(putchar('\n') == EOF){
@@ -267,29 +267,28 @@ drawpalette(struct ncdirect* nc){
   return 0;
 }
 
-static int
+/*static int
 infoplane(struct ncdirect* nc, const fetched_info* fi){
+  // FIXME look for an area without background logo in it. pick the one
+  // closest to the center horizontally, and lowest vertically. if none
+  // can be found, just center it on the bottom as we do now
+  const int dimy = ncdirect_dim_y(nc);
+  const int planeheight = 8;
   const int planewidth = 60;
-  const int infox = (ncdirect_dim_x(nc) - planewidth) / 2;
-  if(infox < 0){
+  struct ncplane* infop = ncplane_aligned(notcurses_stdplane(nc),
+                                          planeheight, planewidth,
+                                          dimy - (planeheight + 1),
+                                          NCALIGN_CENTER, NULL);
+  if(infop == NULL){
     return -1;
   }
-  printf("\n");
-  ncdirect_fg_rgb(nc, 0xd0, 0xd0, 0xd0);
-  ncdirect_bg_rgb(nc, 0x50, 0x50, 0x50);
-  ncdirect_styles_set(nc, NCSTYLE_UNDERLINE);
-  if(ncdirect_cursor_move_yx(nc, -1, infox) < 0){
-    return -1;
-  }
-  int r = printf(" %s %s", fi->kernel, fi->kernver);
-  if(r < 0){
-    return -1;
-  }
+  ncplane_set_fg_rgb(infop, 0xd0, 0xd0, 0xd0);
+  ncplane_set_attr(infop, NCSTYLE_UNDERLINE);
+  ncplane_printf_aligned(infop, 1, NCALIGN_LEFT, " %s %s", fi->kernel, fi->kernver);
   if(fi->distro_pretty){
-    printf("%*s ", planewidth - r, fi->distro_pretty);
+    ncplane_printf_aligned(infop, 1, NCALIGN_RIGHT, "%s ", fi->distro_pretty);
   }
-  ncdirect_styles_set(nc, NCSTYLE_NONE);
-  /*
+  ncplane_set_attr(infop, NCSTYLE_NONE);
 #ifdef __linux__
   struct sysinfo sinfo;
   sysinfo(&sinfo);
@@ -350,14 +349,11 @@ infoplane(struct ncdirect* nc, const fetched_info* fi){
                             fi->username, fi->hostname) < 0){
     return -1;
   }
-  */
-  ncdirect_fg_default(nc);
-  ncdirect_bg_default(nc);
-  if(printf("\n") < 0){
-    return -1;
-  }
+  channels_set_fg_rgb(&channels, 0, 0, 0);
+  channels_set_bg_rgb(&channels, 0x50, 0x50, 0x50);
+  ncplane_set_base(infop, " ", 0, channels);
   return 0;
-}
+}*/
 
 struct marshal {
   struct ncdirect* nc;
@@ -413,9 +409,12 @@ ncneofetch(struct ncdirect* nc){
   fetch_x_props(&fi);
   fetch_cpu_info(&fi);
   sem_wait(&display_marshal.sem);
-  if(infoplane(nc, &fi)){
+  /*if(infoplane(nc, &fi)){
     return -1;
   }
+  if(notcurses_render(nc)){
+    return -1;
+  }*/
   return 0;
 }
 

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -221,17 +221,6 @@ get_kernel(fetched_info* fi){
   return NCNEO_UNKNOWN;
 }
 
-static int
-display(struct ncdirect* nc, const distro_info* dinfo){
-  if(dinfo->logofile){
-    // FIXME should be NCSCALE_SCALE, not _STRETCH
-    if(ncdirect_render_image(nc, dinfo->logofile, NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
-      return -1;
-    }
-  }
-  return 0;
-}
-
 static const distro_info*
 freebsd_ncneofetch(fetched_info* fi){
   static const distro_info fbsd = {
@@ -378,7 +367,12 @@ display_thread(void* vmarshal){
   struct marshal* m = vmarshal;
   drawpalette(m->nc);
   if(m->dinfo){
-    display(m->nc, m->dinfo);
+    if(m->dinfo->logofile){
+      if(ncdirect_render_image(m->nc, m->dinfo->logofile, NCBLIT_2x2,
+                               NCSCALE_SCALE) != NCERR_SUCCESS){
+        return NULL;
+      }
+    }
   }
   sem_post(&m->sem);
   pthread_detach(pthread_self());

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -221,40 +221,16 @@ get_kernel(fetched_info* fi){
   return NCNEO_UNKNOWN;
 }
 
-// writes the first row drawn to |*drawrow|
-/*
-static struct ncplane*
-display(struct ncdirect* nc, const distro_info* dinfo, int* drawrow){
+static int
+display(struct ncdirect* nc, const distro_info* dinfo){
   if(dinfo->logofile){
-    int dimy, dimx;
-    nc_err_e err;
-    struct ncvisual* ncv = ncvisual_from_file(dinfo->logofile, &err);
-    if(ncv == NULL){
-      fprintf(stderr, "Error opening logo file at %s\n", dinfo->logofile);
-      return NULL;
+    // FIXME should be NCSCALE_SCALE, not _STRETCH
+    if(ncdirect_render_image(nc, dinfo->logofile, NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
+      return -1;
     }
-    struct ncvisual_options vopts = {
-      .scaling = NCSCALE_SCALE,
-      .blitter = NCBLIT_2x2,
-      .n = notcurses_stddim_yx(nc, &dimy, &dimx),
-    };
-    int y, x, scaley, scalex;
-    ncvisual_geom(nc, ncv, &vopts, &y, &x, &scaley, &scalex);
-    if(y / scaley < dimy){
-      vopts.y = (dimy - (y + (scaley - 1)) / scaley) / 2;
-    }
-    if(x / scalex < dimx){
-      vopts.x = (dimx - (x + (scalex - 1)) / scalex) / 2;
-    }
-    *drawrow = vopts.y;
-    if(ncvisual_render(nc, ncv, &vopts) == NULL){
-      ncvisual_destroy(ncv);
-      return NULL;
-    }
-    ncvisual_destroy(ncv);
   }
   return 0;
-}*/
+}
 
 static const distro_info*
 freebsd_ncneofetch(fetched_info* fi){
@@ -402,7 +378,7 @@ display_thread(void* vmarshal){
   struct marshal* m = vmarshal;
   drawpalette(m->nc);
   if(m->dinfo){
-    // FIXME display(m->nc, m->dinfo, &yoff);
+    display(m->nc, m->dinfo);
   }
   sem_post(&m->sem);
   pthread_detach(pthread_self());

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -277,18 +277,19 @@ infoplane(struct ncdirect* nc, const fetched_info* fi){
   printf("\n");
   ncdirect_fg_rgb(nc, 0xd0, 0xd0, 0xd0);
   ncdirect_bg_rgb(nc, 0x50, 0x50, 0x50);
-  ncdirect_styles_on(nc, NCSTYLE_UNDERLINE);
-  if(ncdirect_cursor_move_yx(nc, -1, infox + 1) < 0){
+  ncdirect_styles_set(nc, NCSTYLE_UNDERLINE);
+  if(ncdirect_cursor_move_yx(nc, -1, infox) < 0){
     return -1;
   }
-  if(printf("%s %s", fi->kernel, fi->kernver) < 0){
+  int r = printf(" %s %s", fi->kernel, fi->kernver);
+  if(r < 0){
     return -1;
   }
-  /*
   if(fi->distro_pretty){
-    ncplane_printf_aligned(infop, 1, NCALIGN_RIGHT, "%s ", fi->distro_pretty);
+    printf("%*s ", planewidth - r, fi->distro_pretty);
   }
-  ncplane_set_attr(infop, NCSTYLE_NONE);
+  ncdirect_styles_set(nc, NCSTYLE_NONE);
+  /*
 #ifdef __linux__
   struct sysinfo sinfo;
   sysinfo(&sinfo);

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -245,7 +245,6 @@ drawpalette(struct ncdirect* nc){
     if(ncdirect_cursor_move_yx(nc, -1, (dimx - 64) / 2)){
       return -1;
     }
-    // FIXME move to center
     for(int x = (dimx - 64) / 2 ; x < dimx / 2 + 32 ; ++x){
       const int truex = x - (dimx - 64) / 2;
       if(y * 64 + truex >= psize){

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -267,23 +267,14 @@ drawpalette(struct ncdirect* nc){
   return 0;
 }
 
-/*static int
+static int
 infoplane(struct ncdirect* nc, const fetched_info* fi){
-  // FIXME look for an area without background logo in it. pick the one
-  // closest to the center horizontally, and lowest vertically. if none
-  // can be found, just center it on the bottom as we do now
-  const int dimy = ncdirect_dim_y(nc);
   const int planeheight = 8;
   const int planewidth = 60;
-  struct ncplane* infop = ncplane_aligned(notcurses_stdplane(nc),
-                                          planeheight, planewidth,
-                                          dimy - (planeheight + 1),
-                                          NCALIGN_CENTER, NULL);
-  if(infop == NULL){
-    return -1;
-  }
-  ncplane_set_fg_rgb(infop, 0xd0, 0xd0, 0xd0);
-  ncplane_set_attr(infop, NCSTYLE_UNDERLINE);
+  ncdirect_fg_rgb(nc, 0xd0, 0xd0, 0xd0);
+  ncdirect_bg_rgb(nc, 0x50, 0x50, 0x50);
+  ncdirect_styles_on(nc, NCSTYLE_UNDERLINE);
+  /*
   ncplane_printf_aligned(infop, 1, NCALIGN_LEFT, " %s %s", fi->kernel, fi->kernver);
   if(fi->distro_pretty){
     ncplane_printf_aligned(infop, 1, NCALIGN_RIGHT, "%s ", fi->distro_pretty);
@@ -349,11 +340,9 @@ infoplane(struct ncdirect* nc, const fetched_info* fi){
                             fi->username, fi->hostname) < 0){
     return -1;
   }
-  channels_set_fg_rgb(&channels, 0, 0, 0);
-  channels_set_bg_rgb(&channels, 0x50, 0x50, 0x50);
-  ncplane_set_base(infop, " ", 0, channels);
+  */
   return 0;
-}*/
+}
 
 struct marshal {
   struct ncdirect* nc;

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -369,6 +369,7 @@ display_thread(void* vmarshal){
     if(m->dinfo->logofile){
       if(ncdirect_render_image(m->nc, m->dinfo->logofile, NCBLIT_2x2,
                                NCSCALE_SCALE) != NCERR_SUCCESS){
+        sem_post(&m->sem);
         return NULL;
       }
     }

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -302,7 +302,7 @@ quadrant_blit(ncplane* nc, int placey, int placex, int linesize,
       if(visy < begy + leny - 1){
         rgbbase_bl = dat + (linesize * (visy + 1)) + (visx * bpp / CHAR_BIT);
       }
-//fprintf(stderr, "[%04d/%04d] bpp: %d lsize: %d %02x %02x %02x %02x\n", y, x, bpp, linesize, rgbbase_up[0], rgbbase_up[1], rgbbase_up[2], rgbbase_up[3]);
+//fprintf(stderr, "[%04d/%04d] bpp: %d lsize: %d %02x %02x %02x %02x\n", y, x, bpp, linesize, rgbbase_tl[0], rgbbase_tr[1], rgbbase_bl[2], rgbbase_br[3]);
       cell* c = ncplane_cell_ref_yx(nc, y, x);
       c->channels = 0;
       c->attrword = 0;

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -388,8 +388,11 @@ int ncdirect_vprintf_aligned(ncdirect* n, int y, ncalign_e align, const char* fm
     free(r);
     return -1;
   }
-  int ret = vprintf(fmt, ap);
+  int ret = puts(r);
   free(r);
+  if(ret == EOF){
+    return -1;
+  }
   return ret;
 }
 

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -275,7 +275,7 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np){
     // not have it when using 2x1 (we insert blank lines otherwise). don't paper
     // over it with a conditional, but instead get to the bottom of this FIXME.
     ncdirect_cursor_left(n, dimx);
-    ncdirect_cursor_down(n, 1);
+    //ncdirect_cursor_down(n, 1);
   }
   return 0;
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -268,9 +268,10 @@ typedef struct tinfo {
 typedef struct ncdirect {
   int attrword;              // current styles
   palette256 palette;        // 256-indexed palette can be used instead of/with RGB
-  FILE* ttyfp;               // FILE* for controlling tty
+  FILE* ttyfp;               // FILE* for output tty
+  int ctermfd;               // fd for controlling terminal
   tinfo tcache;              // terminfo cache
-  uint16_t fgrgb, bgrgb;     // last RGB values of foreground/background
+  unsigned fgrgb, bgrgb;     // last RGB values of foreground/background
   bool fgdefault, bgdefault; // are FG/BG currently using default colors?
   bool utf8;                 // are we using utf-8 encoding, as hoped?
 } ncdirect;
@@ -780,6 +781,9 @@ nc_err_e ncvisual_blit(struct ncvisual* ncv, int rows, int cols,
                        int leny, int lenx, bool blendcolors);
 
 void nclog(const char* fmt, ...);
+
+// get a file descriptor for the controlling tty device, -1 on error
+int get_controlling_tty(void);
 
 // logging
 #define logerror(nc, fmt, ...) do{ \

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -769,6 +769,9 @@ ncplane* ncplane_create(notcurses* nc, ncplane* n, int rows, int cols,
                         int yoff, int xoff, void* opaque);
 void free_plane(ncplane* p);
 
+// heap-allocated formatted output
+char* ncplane_vprintf_prep(const char* format, va_list ap);
+
 // Resize the provided ncviusal to the specified 'rows' x 'cols', but do not
 // change the internals of the ncvisual. Uses oframe.
 nc_err_e ncvisual_blit(struct ncvisual* ncv, int rows, int cols,

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -631,44 +631,6 @@ ffmpeg_log_level(ncloglevel_e level){
 #endif
 }
 
-ncdirect* ncdirect_init(const char* termtype, FILE* outfp){
-  if(outfp == NULL){
-    outfp = stdout;
-  }
-  ncdirect* ret = malloc(sizeof(*ret));
-  if(ret == NULL){
-    return ret;
-  }
-  ret->ttyfp = outfp;
-  memset(&ret->palette, 0, sizeof(ret->palette));
-  int ttyfd = fileno(ret->ttyfp);
-  if(ttyfd < 0){
-    fprintf(stderr, "No file descriptor was available in outfp %p\n", outfp);
-    free(ret);
-    return NULL;
-  }
-  int termerr;
-  if(setupterm(termtype, ttyfd, &termerr) != OK){
-    fprintf(stderr, "Terminfo error %d (see terminfo(3ncurses))\n", termerr);
-    free(ret);
-    return NULL;
-  }
-  if(interrogate_terminfo(&ret->tcache)){
-    free(ret);
-    return NULL;
-  }
-  ret->fgdefault = ret->bgdefault = true;
-  ret->fgrgb = ret->bgrgb = 0;
-  ncdirect_styles_set(ret, 0);
-  const char* encoding = nl_langinfo(CODESET);
-  if(encoding && strcmp(encoding, "UTF-8") == 0){
-    ret->utf8 = true;
-  }else if(encoding && strcmp(encoding, "ANSI_X3.4-1968") == 0){
-    ret->utf8 = false;
-  }
-  return ret;
-}
-
 // unless the suppress_banner flag was set, print some version information and
 // (if applicable) warnings to stdout. we are not yet on the alternate screen.
 static void

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1404,9 +1404,8 @@ unsigned ncplane_styles(const ncplane* n){
 
 // i hate the big allocation and two copies here, but eh what you gonna do?
 // well, for one, we don't need the huge allocation FIXME
-static char*
-ncplane_vprintf_prep(ncplane* n, const char* format, va_list ap){
-  const size_t size = n->lenx + 1; // healthy estimate, can embiggen below
+char* ncplane_vprintf_prep(const char* format, va_list ap){
+  const size_t size = BUFSIZ; // healthy estimate, can embiggen below
   char* buf = malloc(size);
   if(buf == NULL){
     return NULL;
@@ -1434,7 +1433,7 @@ ncplane_vprintf_prep(ncplane* n, const char* format, va_list ap){
 }
 
 int ncplane_vprintf_yx(ncplane* n, int y, int x, const char* format, va_list ap){
-  char* r = ncplane_vprintf_prep(n, format, ap);
+  char* r = ncplane_vprintf_prep(format, ap);
   if(r == NULL){
     return -1;
   }
@@ -1445,7 +1444,7 @@ int ncplane_vprintf_yx(ncplane* n, int y, int x, const char* format, va_list ap)
 
 int ncplane_vprintf_aligned(ncplane* n, int y, ncalign_e align,
                             const char* format, va_list ap){
-  char* r = ncplane_vprintf_prep(n, format, ap);
+  char* r = ncplane_vprintf_prep(format, ap);
   if(r == NULL){
     return -1;
   }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -748,6 +748,10 @@ int ncdirect_styles_set(ncdirect* n, unsigned stylebits){
                        n->tcache.italics, n->tcache.italoff);
 }
 
+int ncdirect_palette_size(const ncdirect* nc){
+  return nc->tcache.colors;
+}
+
 int ncdirect_fg_default(ncdirect* nc){
   if(term_emit("op", nc->tcache.op, nc->ttyfp, false) == 0){
     nc->fgdefault = true;


### PR DESCRIPTION
By using `ncdirect` rather than full `notcurses` for most of `ncneofetch`, we're able to execute in less than a full terminal, naturally scrolling, and otherwise working like `neofetch`. This also strengthens the `ncdirect` API significantly. Closes #750.