### PR TITLE
ncdirect_render_image(): add alignment, fix corner cases #759

### DIFF
--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -122,9 +122,9 @@ namespace ncpp
 			return error_guard (ncdirect_cursor_disable (direct), -1);
 		}
 
-		nc_err_e render_image (const char* file, ncblitter_e blitter, ncscale_e scale) const noexcept
+		nc_err_e render_image (const char* file, ncalign_e align, ncblitter_e blitter, ncscale_e scale) const noexcept
 		{
-			return ncdirect_render_image (direct, file, blitter, scale);
+			return ncdirect_render_image (direct, file, align, blitter, scale);
 		}
 
 	private:

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -154,7 +154,8 @@ API int ncdirect_printf_aligned(struct ncdirect* n, int y, ncalign_e align,
 // // be arbitrarily many rows -- the output will scroll -- but will only occupy
 // // the column of the cursor, and those to the right.
 API nc_err_e ncdirect_render_image(struct ncdirect* n, const char* filename,
-                                   ncblitter_e blitter, ncscale_e scale);
+                                   ncalign_e align, ncblitter_e blitter,
+                                   ncscale_e scale);
 
 // Clear the screen.
 API int ncdirect_clear(struct ncdirect* nc);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -506,7 +506,7 @@ int ncdirect_cursor_up(struct ncdirect* nc, int num);
 int ncdirect_cursor_left(struct ncdirect* nc, int num);
 int ncdirect_cursor_right(struct ncdirect* nc, int num);
 int ncdirect_cursor_down(struct ncdirect* nc, int num);
-nc_err_e ncdirect_render_image(struct ncdirect* n, const char* filename, ncblitter_e blitter, ncscale_e scale);
+nc_err_e ncdirect_render_image(struct ncdirect* n, const char* filename, ncalign_e align, ncblitter_e blitter, ncscale_e scale);
 """)
 
 if __name__ == "__main__":

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -405,7 +405,8 @@ display_thread(void* vmarshal){
   drawpalette(m->nc);
   if(m->dinfo){
     if(m->dinfo->logofile){
-      if(ncdirect_render_image(m->nc, m->dinfo->logofile, NCBLIT_2x2,
+      if(ncdirect_render_image(m->nc, m->dinfo->logofile,
+                               NCALIGN_CENTER, NCBLIT_2x2,
                                NCSCALE_SCALE) != NCERR_SUCCESS){
         return NULL;
       }

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -280,6 +280,7 @@ quadrant_blit(ncplane* nc, int placey, int placex, int linesize,
   int dimy, dimx, x, y;
   int total = 0; // number of cells written
   ncplane_dim_yx(nc, &dimy, &dimx);
+//fprintf(stderr, "quadblitter %dx%d -> %d/%d+%d/%d\n", leny, lenx, dimy, dimx, placey, placex);
   // FIXME not going to necessarily be safe on all architectures hrmmm
   const unsigned char* dat = data;
   int visy = begy;

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -67,10 +67,10 @@ int ncdirect_cursor_down(ncdirect* nc, int num){
 }
 
 int ncdirect_clear(ncdirect* nc){
-  if(!nc->tcache.clear){
+  if(!nc->tcache.clearscr){
     return -1; // FIXME scroll output off the screen
   }
-  return term_emit("clear", nc->tcache.clear, nc->ttyfp, true);
+  return term_emit("clear", nc->tcache.clearscr, nc->ttyfp, true);
 }
 
 int ncdirect_dim_x(const ncdirect* nc){

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -288,20 +288,14 @@ nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncblitter_e blitte
   if(ncv == NULL){
     return ret;
   }
-  int begy, begx;
 //fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d\n", ncv->data, ncv->rows, ncv->cols);
-  if(ncdirect_cursor_yx(n, &begy, &begx)){
-    ncvisual_destroy(ncv);
-    return NCERR_SYSTEM;
-  }
-//fprintf(stderr, "INITIAL CURSOR: %d/%d\n", begy, begx);
   int leny = ncv->rows; // we allow it to freely scroll
-  int lenx = ncv->cols - begx;
+  int lenx = ncv->cols;
   if(leny == 0 || lenx == 0){
     ncvisual_destroy(ncv);
     return NCERR_DECODE;
   }
-//fprintf(stderr, "render %d/%d to %dx%d+%dx%d scaling: %d\n", ncv->rows, ncv->cols, begy, begx, leny, lenx, scale);
+//fprintf(stderr, "render %d/%d to %d+%dx%d scaling: %d\n", ncv->rows, ncv->cols, leny, lenx, scale);
   auto bset = rgba_blitter_low(n->utf8, scale, true, blitter);
   if(!bset){
     return NCERR_INVALID_ARG;
@@ -312,14 +306,13 @@ nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncblitter_e blitte
   if(scale != NCSCALE_NONE){
     dispcols *= encoding_x_scale(bset);
     disprows *= encoding_y_scale(bset);
-    dispcols -= begx;
     if(scale == NCSCALE_SCALE){
       scale_visual(ncv, &disprows, &dispcols);
     }
   }
   leny = (leny / (double)ncv->rows) * ((double)disprows);
   lenx = (lenx / (double)ncv->cols) * ((double)dispcols);
-//fprintf(stderr, "render: %dx%d:%d+%d of %d/%d stride %u %p\n", begy, begx, leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
+//fprintf(stderr, "render: %d+%d of %d/%d stride %u %p\n", leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
   struct ncplane* faken = ncplane_create(NULL, NULL,
                                          disprows / encoding_y_scale(bset),
                                          dispcols,// / encoding_x_scale(bset),

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -431,6 +431,10 @@ ncdirect* ncdirect_init(const char* termtype, FILE* outfp){
     delete(ret);
     return NULL;
   }
+  if(ncvisual_init(ffmpeg_log_level(NCLOGLEVEL_SILENT))){
+    delete(ret);
+    return NULL;
+  }
   if(interrogate_terminfo(&ret->tcache)){
     delete(ret);
     return NULL;

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -244,6 +244,23 @@ int ncdirect_cursor_pop(ncdirect* n){
   return term_emit("rc", n->tcache.rc, n->ttyfp, false);
 }
 
+static inline int
+ncdirect_align(const struct ncdirect* n, ncalign_e align, int c){
+  if(align == NCALIGN_LEFT){
+    return 0;
+  }
+  int cols = ncdirect_dim_x(n);
+  if(c > cols){
+    return 0;
+  }
+  if(align == NCALIGN_CENTER){
+    return (cols - c) / 2;
+  }else if(align == NCALIGN_RIGHT){
+    return cols - c;
+  }
+  return INT_MAX;
+}
+
 static int
 ncdirect_dump_plane(ncdirect* n, const ncplane* np, int xoff){
   const int totx = ncdirect_dim_x(n);
@@ -334,7 +351,8 @@ nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncalign_e align,
     return NCERR_SYSTEM;
   }
   ncvisual_destroy(ncv);
-  int xoff = 0;
+  int xoff = ncdirect_align(n, align, lenx / encoding_x_scale(bset));
+fprintf(stderr, "XOFF: %d lenx: %d dispcols: %d\n", xoff, lenx, dispcols);
   if(ncdirect_dump_plane(n, faken, xoff)){
     return NCERR_SYSTEM;
   }
@@ -353,23 +371,6 @@ int ncdirect_fg_palindex(ncdirect* nc, int pidx){
 
 int ncdirect_bg_palindex(ncdirect* nc, int pidx){
   return term_emit("setab", tiparm(nc->tcache.setab, pidx), nc->ttyfp, false);
-}
-
-static inline int
-ncdirect_align(const struct ncdirect* n, ncalign_e align, int c){
-  if(align == NCALIGN_LEFT){
-    return 0;
-  }
-  int cols = ncdirect_dim_x(n);
-  if(c > cols){
-    return 0;
-  }
-  if(align == NCALIGN_CENTER){
-    return (cols - c) / 2;
-  }else if(align == NCALIGN_RIGHT){
-    return cols - c;
-  }
-  return INT_MAX;
 }
 
 int ncdirect_vprintf_aligned(ncdirect* n, int y, ncalign_e align, const char* fmt, va_list ap){

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -282,7 +282,8 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np){
   return 0;
 }
 
-nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncblitter_e blitter, ncscale_e scale){
+nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncalign_e align,
+                               ncblitter_e blitter, ncscale_e scale){
   nc_err_e ret;
   struct ncvisual* ncv = ncvisual_from_file(file, &ret);
   if(ncv == NULL){

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -250,7 +250,6 @@ typedef struct tinfo {
   char* italoff;  // CELL_STYLE_ITALIC (disable)
   char* initc;    // set a palette entry's RGB value
   char* oc;       // restore original colors
-  char* clear;    // clear the screen
   char* clearscr; // erase screen and home cursor
   char* cleareol; // clear to end of line
   char* clearbol; // clear to beginning of line

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -814,6 +814,9 @@ int get_controlling_tty(void);
   if((nc)->loglevel >= NCLOGLEVEL_INFO){ \
     nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } }while(0);
 
+// Convert a notcurses log level to some multimedia library equivalent.
+int ffmpeg_log_level(ncloglevel_e level);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -614,9 +614,8 @@ void notcurses_reset_stats(notcurses* nc, ncstats* stats){
   stash_stats(nc);
 }
 
-// Convert a notcurses log level to its ffmpeg equivalent.
-static int
-ffmpeg_log_level(ncloglevel_e level){
+// Convert a notcurses log level to some multimedia library equivalent.
+int ffmpeg_log_level(ncloglevel_e level){
 #ifdef USE_FFMPEG
   switch(level){
     case NCLOGLEVEL_SILENT: return AV_LOG_QUIET;

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -16,12 +16,10 @@ int main(void){
     return EXIT_FAILURE;
   }
   sleep(1);
-  printf("\n");
   if(ncdirect_render_image(n, "../data/changes.jpg", NCBLIT_DEFAULT, NCSCALE_SCALE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   sleep(1);
-  printf("\n");
   if(ncdirect_render_image(n, "../data/warmech.bmp", NCBLIT_DEFAULT, NCSCALE_NONE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -17,11 +17,17 @@ int main(void){
     return EXIT_FAILURE;
   }
   sleep(1);
+  if(ncdirect_clear(n)){
+    return EXIT_FAILURE;
+  }
   if(ncdirect_render_image(n, "../data/changes.jpg", NCALIGN_CENTER,
                            NCBLIT_DEFAULT, NCSCALE_SCALE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   sleep(1);
+  if(ncdirect_clear(n)){
+    return EXIT_FAILURE;
+  }
   if(ncdirect_render_image(n, "../data/warmech.bmp", NCALIGN_RIGHT,
                            NCBLIT_DEFAULT, NCSCALE_NONE) != NCERR_SUCCESS){
     return EXIT_FAILURE;

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -16,19 +16,39 @@ int main(void){
                            NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
-  sleep(1);
-  /*if(ncdirect_clear(n)){
+  if(ncdirect_render_image(n, "../data/normal.png", NCALIGN_CENTER,
+                           NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
     return EXIT_FAILURE;
-  }*/
+  }
+  if(ncdirect_render_image(n, "../data/normal.png", NCALIGN_RIGHT,
+                           NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
+    return EXIT_FAILURE;
+  }
+  sleep(1);
+  if(ncdirect_clear(n)){
+    return EXIT_FAILURE;
+  }
+  if(ncdirect_render_image(n, "../data/changes.jpg", NCALIGN_LEFT,
+                           NCBLIT_DEFAULT, NCSCALE_SCALE) != NCERR_SUCCESS){
+    return EXIT_FAILURE;
+  }
   if(ncdirect_render_image(n, "../data/changes.jpg", NCALIGN_CENTER,
                            NCBLIT_DEFAULT, NCSCALE_SCALE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
-  sleep(1);
-  /*if(ncdirect_clear(n)){
+  if(ncdirect_render_image(n, "../data/changes.jpg", NCALIGN_RIGHT,
+                           NCBLIT_DEFAULT, NCSCALE_SCALE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
-  }*/
+  }
+  sleep(1);
+  if(ncdirect_clear(n)){
+    return EXIT_FAILURE;
+  }
   if(ncdirect_render_image(n, "../data/warmech.bmp", NCALIGN_RIGHT,
+                           NCBLIT_DEFAULT, NCSCALE_NONE) != NCERR_SUCCESS){
+    return EXIT_FAILURE;
+  }
+  if(ncdirect_render_image(n, "../data/warmech.bmp", NCALIGN_LEFT,
                            NCBLIT_DEFAULT, NCSCALE_NONE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -17,17 +17,17 @@ int main(void){
     return EXIT_FAILURE;
   }
   sleep(1);
-  if(ncdirect_clear(n)){
+  /*if(ncdirect_clear(n)){
     return EXIT_FAILURE;
-  }
+  }*/
   if(ncdirect_render_image(n, "../data/changes.jpg", NCALIGN_CENTER,
                            NCBLIT_DEFAULT, NCSCALE_SCALE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   sleep(1);
-  if(ncdirect_clear(n)){
+  /*if(ncdirect_clear(n)){
     return EXIT_FAILURE;
-  }
+  }*/
   if(ncdirect_render_image(n, "../data/warmech.bmp", NCALIGN_RIGHT,
                            NCBLIT_DEFAULT, NCSCALE_NONE) != NCERR_SUCCESS){
     return EXIT_FAILURE;

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -12,15 +12,18 @@ int main(void){
   if((n = ncdirect_init(NULL, stdout)) == NULL){
     return EXIT_FAILURE;
   }
-  if(ncdirect_render_image(n, "../data/normal.png", NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
+  if(ncdirect_render_image(n, "../data/normal.png", NCALIGN_LEFT,
+                           NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   sleep(1);
-  if(ncdirect_render_image(n, "../data/changes.jpg", NCBLIT_DEFAULT, NCSCALE_SCALE) != NCERR_SUCCESS){
+  if(ncdirect_render_image(n, "../data/changes.jpg", NCALIGN_CENTER,
+                           NCBLIT_DEFAULT, NCSCALE_SCALE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   sleep(1);
-  if(ncdirect_render_image(n, "../data/warmech.bmp", NCBLIT_DEFAULT, NCSCALE_NONE) != NCERR_SUCCESS){
+  if(ncdirect_render_image(n, "../data/warmech.bmp", NCALIGN_RIGHT,
+                           NCBLIT_DEFAULT, NCSCALE_NONE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   if(ncdirect_stop(n)){

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -16,7 +16,13 @@ int main(void){
     return EXIT_FAILURE;
   }
   sleep(1);
-  if(ncdirect_render_image(n, "../data/changes.jpg", NCBLIT_DEFAULT, NCSCALE_STRETCH) != NCERR_SUCCESS){
+  printf("\n");
+  if(ncdirect_render_image(n, "../data/changes.jpg", NCBLIT_DEFAULT, NCSCALE_SCALE) != NCERR_SUCCESS){
+    return EXIT_FAILURE;
+  }
+  sleep(1);
+  printf("\n");
+  if(ncdirect_render_image(n, "../data/warmech.bmp", NCBLIT_DEFAULT, NCSCALE_NONE) != NCERR_SUCCESS){
     return EXIT_FAILURE;
   }
   if(ncdirect_stop(n)){


### PR DESCRIPTION
* Add an `ncalign_e` argument to `ncdirect_render_image()`, use `NCALIGN_CENTER` in `ncneofetch`
* Update C++ wrapper
* Update Python wrapper
* Fix `NCSCALE_NONE` case
* Fix various corner cases related to various image X terminal geometries #759
* Call `ffmpeg_init()` from `ncdirect_init()` to silence error messages
* Fix `ncdirect_clear()` by eliminating obsolete member from `ncdirect`