### PR TITLE
Reprogram linux console font for quadblitter #201

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -814,7 +814,7 @@ int get_controlling_tty(void);
   if((nc)->loglevel >= NCLOGLEVEL_ERROR){ \
     nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } }while(0);
 
-#define logwarning(nc, fmt, ...) do{ \
+#define logwarn(nc, fmt, ...) do{ \
   if((nc)->loglevel >= NCLOGLEVEL_WARNING){ \
     nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } }while(0);
 

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -214,6 +214,27 @@ program_line_drawing_chars(const notcurses* nc, struct unimapdesc* map){
 }
 
 static int
+program_block_drawing_chars(const notcurses* nc, struct consolefontdesc* cfd,
+                            struct unimapdesc* map){
+  struct shimmer {
+    int (*glyphfxn)(struct consolefontdesc* cfd, unsigned idx);
+    wchar_t w;
+  } shimmers[] = {
+    { .glyphfxn = shim_upper_half_block, .w = L'▀', },
+    { .glyphfxn = shim_lower_half_block, .w = L'▄', },
+    { .glyphfxn = shim_left_half_block, .w = L'▌', },
+    { .glyphfxn = shim_right_half_block, .w = L'▐', },
+    // FIXME more
+  };
+  int toadd = 0;
+
+  // FIXME need a table of functions + UCS2
+  loginfo(nc, "Successfully added %d kernel font glyph%s\n",
+          toadd, toadd == 1 ? "" : "s");
+  return 0;
+}
+
+static int
 reprogram_linux_font(const notcurses* nc, struct consolefontdesc* cfd,
                      struct unimapdesc* map){
   if(ioctl(nc->ttyfd, GIO_FONTX, cfd)){
@@ -236,11 +257,8 @@ reprogram_linux_font(const notcurses* nc, struct consolefontdesc* cfd,
   if(program_line_drawing_chars(nc, map)){
     return -1;
   }
-  for(unsigned idx = 0 ; idx < map->entry_ct ; ++idx){
-    // FIXME check to see if our desired codepoints already map
-    //  if already declared, trust it?
-    // if not, see if we ought add one or reuse something
-    // if we want to add, find a good place
+  if(program_block_drawing_chars(nc, cfd, map)){
+    return -1;
   }
   return 0;
 }

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -132,6 +132,67 @@ shim_lower_right_quad(struct consolefontdesc* cfd, unsigned idx){
   return 0;
 }
 
+static int
+shim_no_upper_left_quad(struct consolefontdesc* cfd, unsigned idx){
+  unsigned char* glyph = get_glyph(cfd, idx);
+  if(glyph == NULL){
+    return -1;
+  }
+  for(unsigned r = 0 ; r < cfd->charheight / 2 ; ++r, ++glyph){
+    *glyph = 0x0f;
+  }
+  for(unsigned r = cfd->charheight / 2 ; r < cfd->charheight ; ++r, ++glyph){
+    *glyph = 0xff;
+  }
+  return 0;
+}
+
+static int
+shim_no_upper_right_quad(struct consolefontdesc* cfd, unsigned idx){
+  unsigned char* glyph = get_glyph(cfd, idx);
+  if(glyph == NULL){
+    return -1;
+  }
+  for(unsigned r = 0 ; r < cfd->charheight / 2 ; ++r, ++glyph){
+    *glyph = 0xf0;
+  }
+  for(unsigned r = cfd->charheight / 2 ; r < cfd->charheight ; ++r, ++glyph){
+    *glyph = 0xff;
+  }
+  return 0;
+}
+
+static int
+shim_no_lower_left_quad(struct consolefontdesc* cfd, unsigned idx){
+  unsigned char* glyph = get_glyph(cfd, idx);
+  if(glyph == NULL){
+    return -1;
+  }
+  for(unsigned r = 0 ; r < cfd->charheight / 2 ; ++r, ++glyph){
+    *glyph = 0xff;
+  }
+  for(unsigned r = cfd->charheight / 2 ; r < cfd->charheight ; ++r, ++glyph){
+    *glyph = 0x0f;
+  }
+  return 0;
+}
+
+static int
+shim_no_lower_right_quad(struct consolefontdesc* cfd, unsigned idx){
+  unsigned char* glyph = get_glyph(cfd, idx);
+  if(glyph == NULL){
+    return -1;
+  }
+  for(unsigned r = 0 ; r < cfd->charheight / 2 ; ++r, ++glyph){
+    *glyph = 0xff;
+  }
+  for(unsigned r = cfd->charheight / 2 ; r < cfd->charheight ; ++r, ++glyph){
+    *glyph = 0xf0;
+  }
+  return 0;
+}
+
+// P
 // add UCS2 codepoint |w| to |map| for font idx |fidx|
 static int
 add_to_map(const notcurses* nc, struct unimapdesc* map, wchar_t w, unsigned fidx){
@@ -241,6 +302,10 @@ program_block_drawing_chars(const notcurses* nc, struct consolefontdesc* cfd,
     { .glyphfxn = shim_upper_right_quad, .w = L'▝', .found = false, },
     { .glyphfxn = shim_lower_left_quad, .w = L'▖', .found = false, },
     { .glyphfxn = shim_lower_right_quad, .w = L'▗', .found = false, },
+    { .glyphfxn = shim_no_upper_left_quad, .w = L'▟', .found = false, },
+    { .glyphfxn = shim_no_upper_right_quad, .w = L'▙', .found = false, },
+    { .glyphfxn = shim_no_lower_left_quad, .w = L'▜', .found = false, },
+    { .glyphfxn = shim_no_lower_right_quad, .w = L'▛', .found = false, },
   };
   // first, take a pass to see which glyphs we already have
   for(unsigned i = 0 ; i < cfd->charcount ; ++i){

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -192,7 +192,36 @@ shim_no_lower_right_quad(struct consolefontdesc* cfd, unsigned idx){
   return 0;
 }
 
-// P
+static int
+shim_quad_ul_lr(struct consolefontdesc* cfd, unsigned idx){
+  unsigned char* glyph = get_glyph(cfd, idx);
+  if(glyph == NULL){
+    return -1;
+  }
+  for(unsigned r = 0 ; r < cfd->charheight / 2 ; ++r, ++glyph){
+    *glyph = 0xf0;
+  }
+  for(unsigned r = cfd->charheight / 2 ; r < cfd->charheight ; ++r, ++glyph){
+    *glyph = 0x0f;
+  }
+  return 0;
+}
+
+static int
+shim_quad_ll_ur(struct consolefontdesc* cfd, unsigned idx){
+  unsigned char* glyph = get_glyph(cfd, idx);
+  if(glyph == NULL){
+    return -1;
+  }
+  for(unsigned r = 0 ; r < cfd->charheight / 2 ; ++r, ++glyph){
+    *glyph = 0x0f;
+  }
+  for(unsigned r = cfd->charheight / 2 ; r < cfd->charheight ; ++r, ++glyph){
+    *glyph = 0xf0;
+  }
+  return 0;
+}
+
 // add UCS2 codepoint |w| to |map| for font idx |fidx|
 static int
 add_to_map(const notcurses* nc, struct unimapdesc* map, wchar_t w, unsigned fidx){
@@ -306,6 +335,8 @@ program_block_drawing_chars(const notcurses* nc, struct consolefontdesc* cfd,
     { .glyphfxn = shim_no_upper_right_quad, .w = L'▙', .found = false, },
     { .glyphfxn = shim_no_lower_left_quad, .w = L'▜', .found = false, },
     { .glyphfxn = shim_no_lower_right_quad, .w = L'▛', .found = false, },
+    { .glyphfxn = shim_quad_ul_lr, .w = L'▚', .found = false, },
+    { .glyphfxn = shim_quad_ll_ur, .w = L'▞', .found = false, },
   };
   // first, take a pass to see which glyphs we already have
   for(unsigned i = 0 ; i < cfd->charcount ; ++i){

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -78,6 +78,9 @@ shim_upper_left_quad(struct consolefontdesc* cfd, unsigned idx){
   if(glyph == NULL){
     return -1;
   }
+  for(unsigned r = 0 ; r < cfd->charheight / 2 ; ++r, ++glyph){
+    *glyph = 0xf0;
+  }
   for(unsigned r = cfd->charheight / 2 ; r < cfd->charheight ; ++r, ++glyph){
     *glyph = 0;
   }
@@ -234,7 +237,10 @@ program_block_drawing_chars(const notcurses* nc, struct consolefontdesc* cfd,
     { .glyphfxn = shim_lower_half_block, .w = L'▄', .found = false, },
     { .glyphfxn = shim_left_half_block, .w = L'▌', .found = false, },
     { .glyphfxn = shim_right_half_block, .w = L'▐', .found = false, },
-    // FIXME more
+    { .glyphfxn = shim_upper_left_quad, .w = L'▘', .found = false, },
+    { .glyphfxn = shim_upper_right_quad, .w = L'▝', .found = false, },
+    { .glyphfxn = shim_lower_left_quad, .w = L'▖', .found = false, },
+    { .glyphfxn = shim_lower_right_quad, .w = L'▗', .found = false, },
   };
   // first, take a pass to see which glyphs we already have
   for(unsigned i = 0 ; i < cfd->charcount ; ++i){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -735,7 +735,7 @@ get_tty_fd(notcurses* nc, FILE* ttyfp){
   int fd = -1;
   if(ttyfp){
     if((fd = fileno(ttyfp)) < 0){
-      logwarning(nc, "No file descriptor was available in outfp %p\n", ttyfp);
+      logwarn(nc, "No file descriptor was available in outfp %p\n", ttyfp);
     }else{
       if(isatty(fd)){
         fd = dup(fd);
@@ -748,7 +748,7 @@ get_tty_fd(notcurses* nc, FILE* ttyfp){
   if(fd < 0){
     fd = open("/dev/tty", O_RDWR | O_CLOEXEC);
     if(fd < 0){
-      logwarning(nc, "Error opening /dev/tty (%s)\n", strerror(errno));
+      logwarn(nc, "Error opening /dev/tty (%s)\n", strerror(errno));
     }
   }
   return fd;


### PR DESCRIPTION
* Add actual glyphs to console font for various block-drawing characters, lending it the full strength of Quadblitter2 #201 

I've gotta say, this is some awesome work.