### PR TITLE
Highcontrast: reapply any covering blends following computation #748

### DIFF
--- a/doc/release-checklist.md
+++ b/doc/release-checklist.md
@@ -70,6 +70,13 @@
   * Test that package builds with `makepkg`
   * `git commit -a`
 
+### Alpine
+
+* Update version in `APKBUILD`
+  * Run `abuild checksum` to get new checksums
+  * `abuild -r` to test `APKBUILD`
+  * create merge request
+
 ### FreeBSD
 
 * Update svn checkout of Ports tree: `cd /usr/ports && svn up`

--- a/src/demo/normal.c
+++ b/src/demo/normal.c
@@ -221,7 +221,7 @@ int normal_demo(struct notcurses* nc){
   if(notcurses_canutf8(nc)){
     ncplane_erase(nstd);
     ncplane_home(n);
-    if(rotate_plane(nc, n)){
+    if( (r = rotate_plane(nc, n)) ){
       goto err;
     }
   }

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -110,6 +110,145 @@ TEST_CASE("Cell") {
     CHECK(!cell_bg_default_p(&c));
   }
 
+  // white on a black background ought be unmolested for highcontrast
+  SUBCASE("HighContrastWhiteOnBlackBackground"){
+    cell c = CELL_SIMPLE_INITIALIZER('+');
+    CHECK(0 == cell_set_fg_rgb(&c, 0xff, 0xff, 0xff));
+    CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
+    CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
+    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    REQUIRE(nullptr != np);
+    CHECK(1 == ncplane_putc(np, &c));
+    cell_load_simple(np, &c, '*');
+    CHECK(0 == cell_set_bg_rgb(&c, 0x0, 0x0, 0x0));
+    CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
+    CHECK(1 == ncplane_putc(n_, &c));
+    CHECK(0 == notcurses_render(nc_));
+    uint64_t channels, underchannels, overchannels;
+    auto egc = notcurses_at_yx(nc_, 0, 0, nullptr, &channels);
+    REQUIRE(nullptr != egc);
+    auto negc = ncplane_at_yx(n_, 0, 0, nullptr, &underchannels);
+    REQUIRE(nullptr != negc);
+    auto topegc = ncplane_at_yx(np, 0, 0, nullptr, &overchannels);
+    REQUIRE(nullptr != topegc);
+    CHECK(channels_bg(channels) == channels_bg(underchannels));
+    CHECK(channels_fg(channels) == channels_fg(overchannels));
+    free(topegc);
+    free(negc);
+    free(egc);
+  }
+
+  // white on a white background ought be changed for highcontrast
+  SUBCASE("HighContrastWhiteOnWhiteBackground"){
+    cell c = CELL_SIMPLE_INITIALIZER('+');
+    CHECK(0 == cell_set_fg_rgb(&c, 0xff, 0xff, 0xff));
+    CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
+    CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
+    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    REQUIRE(nullptr != np);
+    CHECK(1 == ncplane_putc(np, &c));
+    cell_load_simple(np, &c, '*');
+    CHECK(0 == cell_set_bg_rgb(&c, 0xff, 0xff, 0xff));
+    CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
+    CHECK(1 == ncplane_putc(n_, &c));
+    CHECK(0 == notcurses_render(nc_));
+    uint64_t channels, underchannels, overchannels;
+    auto egc = notcurses_at_yx(nc_, 0, 0, nullptr, &channels);
+    REQUIRE(nullptr != egc);
+    auto negc = ncplane_at_yx(n_, 0, 0, nullptr, &underchannels);
+    REQUIRE(nullptr != negc);
+    auto topegc = ncplane_at_yx(np, 0, 0, nullptr, &overchannels);
+    REQUIRE(nullptr != topegc);
+    CHECK(channels_bg(channels) == channels_bg(underchannels));
+    CHECK(channels_fg(channels) < channels_fg(overchannels));
+    free(topegc);
+    free(negc);
+    free(egc);
+  }
+
+  // black on a black background must be changed for highcontrast
+  SUBCASE("HighContrastBlackOnBlackBackground"){
+    cell c = CELL_SIMPLE_INITIALIZER('+');
+    CHECK(0 == cell_set_fg_rgb(&c, 0x0, 0x0, 0x0));
+    CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
+    CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
+    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    REQUIRE(nullptr != np);
+    CHECK(1 == ncplane_putc(np, &c));
+    CHECK(0 == cell_set_bg_rgb(&c, 0x0, 0x0, 0x0));
+    CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
+    CHECK(1 == ncplane_putc(n_, &c));
+    CHECK(0 == notcurses_render(nc_));
+    uint64_t channels, underchannels, overchannels;
+    auto egc = notcurses_at_yx(nc_, 0, 0, nullptr, &channels);
+    REQUIRE(nullptr != egc);
+    auto negc = ncplane_at_yx(n_, 0, 0, nullptr, &underchannels);
+    REQUIRE(nullptr != negc);
+    auto topegc = ncplane_at_yx(np, 0, 0, nullptr, &overchannels);
+    REQUIRE(nullptr != topegc);
+    CHECK(channels_bg(channels) == channels_bg(underchannels));
+    CHECK(channels_fg(channels) > channels_fg(overchannels));
+    free(topegc);
+    free(negc);
+    free(egc);
+  }
+
+  // black on a white background ought be unmolested for highcontrast
+  SUBCASE("HighContrastBlackOnWhiteBackground"){
+    cell c = CELL_SIMPLE_INITIALIZER('+');
+    CHECK(0 == cell_set_fg_rgb(&c, 0x0, 0x0, 0x0));
+    CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
+    CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
+    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    REQUIRE(nullptr != np);
+    CHECK(1 == ncplane_putc(np, &c));
+    CHECK(0 == cell_set_bg_rgb(&c, 0xff, 0xff, 0xff));
+    CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
+    CHECK(1 == ncplane_putc(n_, &c));
+    CHECK(0 == notcurses_render(nc_));
+    uint64_t channels, underchannels, overchannels;
+    auto egc = notcurses_at_yx(nc_, 0, 0, nullptr, &channels);
+    REQUIRE(nullptr != egc);
+    auto negc = ncplane_at_yx(n_, 0, 0, nullptr, &underchannels);
+    REQUIRE(nullptr != negc);
+    auto topegc = ncplane_at_yx(np, 0, 0, nullptr, &overchannels);
+    REQUIRE(nullptr != topegc);
+    CHECK(channels_bg(channels) == channels_bg(underchannels));
+    CHECK(channels_fg(channels) == channels_fg(overchannels));
+    free(topegc);
+    free(negc);
+    free(egc);
+  }
+
+  // high contrast ought only be activated relevant to the background equal to
+  // or below them, not above.
+  SUBCASE("HighContrastBelowOnly"){
+    cell c = CELL_SIMPLE_INITIALIZER('+');
+    // top has a background of white
+    CHECK(0 == cell_set_bg_rgb(&c, 0xff, 0xff, 0xff));
+    CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_TRANSPARENT));
+    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    REQUIRE(nullptr != np);
+    CHECK(1 == ncplane_putc(np, &c));
+    // bottom has white foreground + HIGHCONTRAST, should remain white
+    CHECK(0 == cell_set_fg_rgb(&c, 0xff, 0xff, 0xff));
+    CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_TRANSPARENT));
+    CHECK(1 == ncplane_putc(n_, &c));
+    CHECK(0 == notcurses_render(nc_));
+    uint64_t channels, underchannels, overchannels;
+    auto egc = notcurses_at_yx(nc_, 0, 0, nullptr, &channels);
+    REQUIRE(nullptr != egc);
+    auto negc = ncplane_at_yx(n_, 0, 0, nullptr, &underchannels);
+    REQUIRE(nullptr != negc);
+    auto topegc = ncplane_at_yx(np, 0, 0, nullptr, &overchannels);
+    REQUIRE(nullptr != topegc);
+    CHECK(channels_bg(channels) == channels_bg(overchannels));
+    CHECK(channels_fg(channels) == channels_fg(underchannels));
+    free(topegc);
+    free(negc);
+    free(egc);
+  }
+
   // common teardown
   CHECK(0 == notcurses_stop(nc_));
 }

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -133,6 +133,7 @@ TEST_CASE("Cell") {
     REQUIRE(nullptr != topegc);
     CHECK(channels_bg(channels) == channels_bg(underchannels));
     CHECK(channels_fg(channels) == channels_fg(overchannels));
+    ncplane_destroy(np);
     free(topegc);
     free(negc);
     free(egc);
@@ -161,6 +162,7 @@ TEST_CASE("Cell") {
     REQUIRE(nullptr != topegc);
     CHECK(channels_bg(channels) == channels_bg(underchannels));
     CHECK(channels_fg(channels) < channels_fg(overchannels));
+    ncplane_destroy(np);
     free(topegc);
     free(negc);
     free(egc);
@@ -175,6 +177,7 @@ TEST_CASE("Cell") {
     auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
+    cell_load_simple(np, &c, '*');
     CHECK(0 == cell_set_bg_rgb(&c, 0x0, 0x0, 0x0));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
     CHECK(1 == ncplane_putc(n_, &c));
@@ -188,6 +191,7 @@ TEST_CASE("Cell") {
     REQUIRE(nullptr != topegc);
     CHECK(channels_bg(channels) == channels_bg(underchannels));
     CHECK(channels_fg(channels) > channels_fg(overchannels));
+    ncplane_destroy(np);
     free(topegc);
     free(negc);
     free(egc);
@@ -202,6 +206,7 @@ TEST_CASE("Cell") {
     auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
+    cell_load_simple(np, &c, '*');
     CHECK(0 == cell_set_bg_rgb(&c, 0xff, 0xff, 0xff));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
     CHECK(1 == ncplane_putc(n_, &c));
@@ -215,6 +220,7 @@ TEST_CASE("Cell") {
     REQUIRE(nullptr != topegc);
     CHECK(channels_bg(channels) == channels_bg(underchannels));
     CHECK(channels_fg(channels) == channels_fg(overchannels));
+    ncplane_destroy(np);
     free(topegc);
     free(negc);
     free(egc);
@@ -223,16 +229,18 @@ TEST_CASE("Cell") {
   // high contrast ought only be activated relevant to the background equal to
   // or below them, not above.
   SUBCASE("HighContrastBelowOnly"){
-    cell c = CELL_SIMPLE_INITIALIZER('+');
+    cell c = CELL_TRIVIAL_INITIALIZER;
     // top has a background of white
     CHECK(0 == cell_set_bg_rgb(&c, 0xff, 0xff, 0xff));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_TRANSPARENT));
     auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
+    cell_load_simple(n_, &c, '*');
     // bottom has white foreground + HIGHCONTRAST, should remain white
-    CHECK(0 == cell_set_fg_rgb(&c, 0xff, 0xff, 0xff));
-    CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_TRANSPARENT));
+    CHECK(0 == cell_set_fg_rgb(&c, 0xff, 0x0, 0xff));
+    CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
+    cell_set_bg_default(&c);
     CHECK(1 == ncplane_putc(n_, &c));
     CHECK(0 == notcurses_render(nc_));
     uint64_t channels, underchannels, overchannels;

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -251,7 +251,7 @@ TEST_CASE("Cell") {
     auto topegc = ncplane_at_yx(np, 0, 0, nullptr, &overchannels);
     REQUIRE(nullptr != topegc);
     CHECK(channels_bg(channels) == channels_bg(overchannels));
-    CHECK(channels_fg(channels) == channels_fg(underchannels));
+    CHECK(channels_fg(channels) < channels_fg(underchannels));
     free(topegc);
     free(negc);
     free(egc);


### PR DESCRIPTION
When we have `CELL_ALPHA_HIGHCONTRAST` in play in the foreground, we recompute the foreground following cell solution using the solved background. That's fine and dandy, but we ought reshade based on any overlaying translucency. Stash the foreground RGB and blendcount upon noting highcontrast, and reapply at the end. #748 

Also carries a few fixes for the `normal` demo, which was reporting user-requested aborts as internal failures. #802 