### PR TITLE
Bottom out at putegc() rather than putc()

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1626,6 +1626,21 @@ void cell_release(struct ncplane* n, cell* c);
 #define NCSTYLE_PROTECT   0x00010000ul
 #define NCSTYLE_ITALIC    0x01000000ul
 
+// copy the UTF8-encoded EGC out of the cell, whether simple or complex. the
+// result is not tied to the ncplane, and persists across erases / destruction.
+static inline char*
+cell_strdup(const struct ncplane* n, const cell* c){
+  char* ret;
+  if(cell_simple_p(c)){
+    if( (ret = (char*)malloc(2)) ){ // cast is here for C++ clients
+      ret[0] = c->gcluster;
+      ret[1] = '\0';
+    }
+  }else{
+    ret = strdup(cell_extended_gcluster(n, c));
+  }
+  return ret;
+}
 
 // Set the specified style bits for the cell 'c', whether they're actively
 // supported or not.

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -729,7 +729,8 @@ cell_simple_p(const cell* c){
 // is invalidated by any further operation on the plane 'n', so...watch out!
 API const char* cell_extended_gcluster(const struct ncplane* n, const cell* c);
 
-// Extract the EGC from 'c' as a nul-terminated string.
+// copy the UTF8-encoded EGC out of the cell, whether simple or complex. the
+// result is not tied to the ncplane, and persists across erases / destruction.
 static inline char*
 cell_strdup(const struct ncplane* n, const cell* c){
   char* ret;

--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -132,7 +132,7 @@ egcpool_stash(egcpool* pool, const char* egc, size_t ulen){
   do{
     if(egcpool_alloc_justified(pool, len) || searched){
       if(!duplicated){
-        if((duplicated = strdup(egc)) == NULL){
+        if((duplicated = strndup(egc, ulen)) == NULL){
           return -1;
         }
       }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -410,13 +410,6 @@ pool_egc_copy(const egcpool* e, const cell* c){
   return ret;
 }
 
-// copy the UTF8-encoded EGC out of the cell, whether simple or complex. the
-// result is not tied to the ncplane, and persists across erases / destruction.
-static inline char*
-cell_egc_copy(const ncplane* n, const cell* c){
-  return pool_egc_copy(&n->pool, c);
-}
-
 // For our first attempt, O(1) uniform conversion from 8-bit r/g/b down to
 // ~2.4-bit 6x6x6 cube + greyscale (assumed on entry; I know no way to
 // even semi-portably recover the palette) proceeds via: map each 8-bit to

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -284,7 +284,7 @@ TEST_CASE("Wide") {
 
     // should be wide char 1
     REQUIRE(3 == ncplane_at_yx_cell(n_, 0, 0, &c));
-    egc = cell_egc_copy(n_, &c);
+    egc = cell_strdup(n_, &c);
     REQUIRE(egc);
     CHECK(!strcmp("\xe5\x85\xa8", egc));
     CHECK(cell_double_wide_p(&c));
@@ -297,7 +297,7 @@ TEST_CASE("Wide") {
     cell_init(&c);
     // should be wide char 1 right side
     REQUIRE(0 == ncplane_at_yx_cell(n_, 0, 1, &c));
-    egc = cell_egc_copy(n_, &c);
+    egc = cell_strdup(n_, &c);
     REQUIRE(egc);
     CHECK(!strcmp("", egc));
     CHECK(cell_double_wide_p(&c));
@@ -311,7 +311,7 @@ TEST_CASE("Wide") {
 
     // should be wide char 2
     REQUIRE(3 == ncplane_at_yx_cell(n_, 0, 2, &c));
-    egc = cell_egc_copy(n_, &c);
+    egc = cell_strdup(n_, &c);
     REQUIRE(egc);
     CHECK(!strcmp("\xe5\xbd\xa2", egc));
     CHECK(cell_double_wide_p(&c));
@@ -324,7 +324,7 @@ TEST_CASE("Wide") {
     cell_init(&c);
     // should be wide char 2 right side
     CHECK(0 == ncplane_at_yx_cell(n_, 0, 3, &c));
-    egc = cell_egc_copy(n_, &c);
+    egc = cell_strdup(n_, &c);
     REQUIRE(egc);
     CHECK(!strcmp("", egc));
     CHECK(cell_double_wide_p(&c));


### PR DESCRIPTION
Closes #797. `ncplane_putc()` requires setup of a `cell` prior to writing to the plane's cellmatrix, implying two writes to egcpools for each glyph we print. Instead, run everything through `ncplane_putegc()`, thus only requiring a single egcpool hit.