### PR TITLE
GNU libunistring for word breaking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,18 +79,24 @@ elseif(${USE_OIIO})
 pkg_check_modules(OIIO REQUIRED OpenImageIO>=2.1)
 endif()
 find_library(MATH_LIBRARIES m)
-# don't cache this, or installing it requires clearing the cache to be found
+if(${USE_DOCTEST})
+find_package(doctest 2.3.5 REQUIRED)
+endif()
+
+# don't cache these, or installing them requires clearing the cache to be found.
+# this is going to be true for anything lacking pkg-config/CMake support.
 unset(HAVE_QRCODEGEN_H CACHE)
-check_include_file("qrcodegen/qrcodegen.h" HAVE_QRCODEGEN_H)
+check_include_file("uniwbrk.h" HAVE_UNISTRING_H)
+if(NOT "${HAVE_UNISTRING_H}")
+  message(FATAL_ERROR "Couldn't find uniwbrk.h from GNU libunistring")
+endif()
 if("${USE_QRCODEGEN}")
+check_include_file("qrcodegen/qrcodegen.h" HAVE_QRCODEGEN_H)
 if(NOT "${HAVE_QRCODEGEN_H}")
   message(FATAL_ERROR "USE_QRCODEGEN is active, but couldn't find qrcodegen.h")
 endif()
 endif()
 find_library(LIBRT rt)
-if(${USE_DOCTEST})
-find_package(doctest 2.3.5 REQUIRED)
-endif()
 
 # libnotcurses (core shared library and static library)
 file(GLOB NCSRCS CONFIGURE_DEPENDS src/lib/*.c src/lib/*.cpp)
@@ -129,6 +135,7 @@ target_link_libraries(notcurses
   PRIVATE
     "${TERMINFO_LIBRARIES}"
     "${LIBRT}"
+    unistring
   PUBLIC
     Threads::Threads
 )
@@ -136,6 +143,7 @@ target_link_libraries(notcurses-static
   PRIVATE
     "${TERMINFO_STATIC_LIBRARIES}"
     "${LIBRT}"
+    unistring
   PUBLIC
     Threads::Threads
 )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.6.7 (not yet released)
+  * GNU libunistring is now required to build/load Notcurses.
+
 * 1.6.6 (2020-07-19)
   * `notcurses-pydemo` is now only installed alongside the Python module,
     using setuptools. CMake no longer installs it.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ that fine library.
 * (build) A C11 and a C++17 compiler
 * (build) CMake 3.14.0+
 * (build+runtime) From NCURSES: terminfo 6.1+
+* (build+runtime) GNU libunistring 0.9.10+
 * (OPTIONAL) (build+runtime) From QR-Code-generator: [libqrcodegen](https://github.com/nayuki/QR-Code-generator) 1.5.0+
 * (OPTIONAL) (build+runtime) From [FFmpeg](https://www.ffmpeg.org/): libswscale 5.0+, libavformat 57.0+, libavutil 56.0+
 * (OPTIONAL) (build+runtime) [OpenImageIO](https://github.com/OpenImageIO/oiio) 2.15.0+

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -6,9 +6,9 @@ void notcurses_debug(notcurses* nc, FILE* debugfp){
   int planeidx = 0;
   fprintf(debugfp, "*************************** notcurses debug state *****************************\n");
   while(n){
-    fprintf(debugfp, "%04d off y: %3d x: %3d geom y: %3d x: %3d curs y: %3d x: %3d %s %p\n",
+    fprintf(debugfp, "%04d off y: %3d x: %3d geom y: %3d x: %3d curs y: %3d x: %3d %06llx %.8s\n",
             planeidx, n->absy, n->absx, n->leny, n->lenx, n->y, n->x,
-            n == notcurses_stdplane_const(nc) ? "std" : "   ", n);
+            (uintptr_t)n % 0x100000000ull, n->name ? n->name : "");
     if(n->boundto || n->bnext || n->bprev || n->blist){
       fprintf(debugfp, " bound %p -> %p <- %p binds %p\n",
               n->boundto, n->bnext, n->bprev, n->blist);

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -341,7 +341,7 @@ nc_err_e ncdirect_render_image(ncdirect* n, const char* file, ncalign_e align,
   struct ncplane* faken = ncplane_create(nullptr, nullptr,
                                          disprows / encoding_y_scale(bset),
                                          dispcols / encoding_x_scale(bset),
-                                         0, 0, nullptr);
+                                         0, 0, nullptr, nullptr);
   if(faken == nullptr){
     return NCERR_NOMEM;
   }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -80,6 +80,7 @@ typedef struct ncplane {
   cell basecell;         // cell written anywhere that fb[i].gcluster == 0
   struct notcurses* nc;  // notcurses object of which we are a part
   bool scrolling;        // is scrolling enabled? always disabled by default
+  char* name;            // used only for debugging
 } ncplane;
 
 #include "blitset.h"
@@ -782,7 +783,7 @@ calc_gradient_channels(uint64_t* channels, uint64_t ul, uint64_t ur,
 // ncvisual_render(), and thus calls these low-level internal functions.
 // they are not for general use -- check ncplane_new() and ncplane_destroy().
 ncplane* ncplane_create(notcurses* nc, ncplane* n, int rows, int cols,
-                        int yoff, int xoff, void* opaque);
+                        int yoff, int xoff, void* opaque, const char* name);
 void free_plane(ncplane* p);
 
 // heap-allocated formatted output

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -498,6 +498,7 @@ TEST_CASE("NCPlane") {
     ncplane_cursor_yx(n_, &y, &x);
     REQUIRE(1 == y);
     REQUIRE(dimx == x);
+    // this ought not print anything, since we're at the end of the row
     REQUIRE(0 == ncplane_putstr(n_, STR3));
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_at_cursor_cell(n_, &testcell)); // want first char of STR1
@@ -534,6 +535,7 @@ TEST_CASE("NCPlane") {
     ncplane_cursor_yx(n_, &y, &x);
     REQUIRE(1 == y);
     REQUIRE(dimx == x);
+    // this ought not print anything, since we're at the end of the row
     REQUIRE(0 == ncplane_putstr(n_, STR3));
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_at_cursor_cell(n_, &testcell)); // want first char of STR1


### PR DESCRIPTION
We now use GNU libunistring for word breaking in `ncplane_puttext()`'s layout engine #772.
Print the plane name in `notcurses_debug()` output #780.