### PR TITLE
ncplane_puttext improvements + unit tests

### DIFF
--- a/doc/man/index.html
+++ b/doc/man/index.html
@@ -14,14 +14,15 @@
 </script>
 </head>
 <body>
-  <font size="+2">
   <center>
+    <h2>
     <a href="https://github.com/dankamongmen/notcurses">github</a><span>	</span>
     <a href="https://nick-black.com/htp-notcurses.pdf">book</a><span>	</span>
     <a href="https://nick-black.com/dankwiki/index.php/Notcurses">dankwiki</a>
-    <a href="html/index.html">doxygen</a></h2>
+    <a href="html/index.html">doxygen</a>
+    <a href="https://drone.dsscaw.com:4443/dankamongmen/notcurses/">drone</a>
+    </h2>
   </center>
-  </font>
   <hr>
   <h1><a href="https://nick-black.com/dankwiki/index.php/Notcurses">notcurses</a> man pages (v1.6.6)</h1>
   <a href="notcurses.3.html">notcurses(3)</a>—a blingful TUI library<br/>

--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -84,9 +84,11 @@ utf8_egc_len(const char* gcluster, int* colcount){
         if(*colcount){ // this must be starting a new EGC, exit and do not claim
           break;
         }
-        if(cols < 0 && iswspace(wc)){ // newline or tab
+        if(cols < 0){
+          if(iswspace(wc)){ // newline or tab
+            return ret + 1;
+          }
           cols = 0;
-          return ret + 1;
         }
         *colcount += cols;
       }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1671,7 +1671,7 @@ int ncplane_puttext(ncplane* n, int y, ncalign_e align, const char* text, size_t
     // not a space, it won't be printed, and we carry the word forward.
     // FIXME what ought be done with \n or multiple spaces?
     while(*text && x <= dimx){
-//fprintf(stderr, "laying out [%s] at %d (%d)\n", linestart, x, dimx);
+fprintf(stderr, "laying out [%s] at %d <= %d, %zu\n", linestart, x, dimx, text - linestart);
       wchar_t w;
       size_t consumed = mbrtowc(&w, text, MB_CUR_MAX, &mbstate);
       if(consumed == (size_t)-2 || consumed == (size_t)-1){
@@ -1692,7 +1692,7 @@ int ncplane_puttext(ncplane* n, int y, ncalign_e align, const char* text, size_t
         }
       }
       width = wcwidth(w);
-//fprintf(stderr, "have non-wordbreak char %lc (%d)\n", w, width);
+fprintf(stderr, "have char %lc (%d)\n", w, width);
       if(width < 0){
         width = 0;
       }
@@ -1702,8 +1702,8 @@ int ncplane_puttext(ncplane* n, int y, ncalign_e align, const char* text, size_t
       x += width;
       text += consumed;
     }
-//fprintf(stderr, "OUT! %s %zu\n", linestart, text - linestart);
-    int carrycols = 0;
+fprintf(stderr, "OUT! %s %zu\n", linestart, text - linestart);
+    int carrybytes = 0;
     bool overlong = false; // ugh
     // if we have no breaker, we got a single word that was longer than our
     // line. print what we can and move along. if *text is nul, we're done.
@@ -1716,17 +1716,17 @@ int ncplane_puttext(ncplane* n, int y, ncalign_e align, const char* text, size_t
       if(overlong_word(breaker + 1, dimx)){
         breaker = text;
         overlong = true;
-//fprintf(stderr, "NEW BREAKER: %s\n", breaker);
+fprintf(stderr, "NEW BREAKER: %s\n", breaker);
       }else{
-        carrycols = text - breaker;
+        carrybytes = text - breaker;
       }
     }
-//fprintf(stderr, "exited at %d (%d) %zu looking at [%.*s]\n", x, dimx, breaker - linestart, (int)(breaker - linestart), linestart);
+fprintf(stderr, "exited at %d (%d) %zu looking at [%.*s]\n", x, dimx, breaker - linestart, (int)(breaker - linestart), linestart);
     if(breaker != linestart){
       totalcols += x;
       const int xpos = ncplane_align(n, align, x);
       // blows out if we supply a y beyond leny
-//fprintf(stderr, "y: %d %ld %.*s\n", y, breaker - linestart, (int)(breaker - linestart), linestart);
+fprintf(stderr, "y: %d %ld %.*s\n", y, breaker - linestart, (int)(breaker - linestart), linestart);
       if(ncplane_putnstr_yx(n, y, xpos, breaker - linestart, linestart) <= 0){ 
         if(bytes){
           *bytes = linestart - beginning;
@@ -1734,7 +1734,7 @@ int ncplane_puttext(ncplane* n, int y, ncalign_e align, const char* text, size_t
         return -1;
       }
     }
-    x = carrycols;
+    x = carrybytes;
     if(breaker == text || overlong){
       linestart = breaker;
     }else{
@@ -2458,7 +2458,7 @@ int ncplane_putnstr_aligned(struct ncplane* n, int y, ncalign_e align, size_t s,
 
 int ncplane_putnstr_yx(struct ncplane* n, int y, int x, size_t s, const char* gclusters){
   int ret = 0;
-//fprintf(stderr, "PUT %zu at %d/%d [%.*s]\n", s, y, x, (int)s, gclusters);
+fprintf(stderr, "PUT %zu at %d/%d [%.*s]\n", s, y, x, (int)s, gclusters);
   // FIXME speed up this blissfully naive solution
   while((size_t)ret < s && *gclusters){
     int wcs;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1721,7 +1721,7 @@ fprintf(stderr, "NEW BREAKER: %s\n", breaker);
         carrycols = text - breaker;
       }
     }
-fprintf(stderr, "exited at %d (%d) looking at [%.*s]\n", x, dimx, (int)(breaker - linestart), linestart);
+fprintf(stderr, "exited at %d (%d) %zu looking at [%.*s]\n", x, dimx, breaker - linestart, (int)(breaker - linestart), linestart);
     if(breaker != linestart){
       totalcols += (breaker - linestart);
       const int xpos = ncplane_align(n, align, x);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1722,6 +1722,12 @@ int ncplane_puttext(ncplane* n, int y, ncalign_e align, const char* text, size_t
 //fprintf(stderr, "NEW BREAKER: %s\n", breaker);
       }
     }
+    // if the most recent breaker was the last column, it doesn't really count
+    if(breakercol == dimx - 1){
+//fprintf(stderr, "END OF THE LINE. breakercol: %d -> %d breakerdiff: %zu\n", breakercol, dimx, breaker - linestart);
+      breakercol = dimx;
+      ++breaker; // FIXME need to advance # of bytes in the UTF8 breaker, not 1
+    }
 //fprintf(stderr, "exited at %d (%d) %zu looking at [%.*s]\n", x, dimx, breaker - linestart, (int)(breaker - linestart), linestart);
     if(breaker != linestart){
       totalcols += breakercol;
@@ -1734,14 +1740,16 @@ int ncplane_puttext(ncplane* n, int y, ncalign_e align, const char* text, size_t
         }
         return -1;
       }
+      text = breaker;
     }
-//fprintf(stderr, "x gets breakercol: %d\n", breakercol);
-    x = breakercol;
+//fprintf(stderr, "x gets %d\n", dimx == breakercol ? 0 : breakercol);
+    x = 0;
     if(breaker == text || overlong){
       linestart = breaker;
     }else{
       linestart = breaker + 1;
     }
+    // FIXME does this print a bottom line with breakers twice?
     if(y >= 0 && ++y >= dimy){
       if(n->scrolling){
         if(ncplane_putsimple_yx(n, -1, -1, '\n') < 0){

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -594,10 +594,8 @@ bool ncreel_validate(const ncreel* n){
 // destroy all existing tablet planes pursuant to redraw
 static void
 clean_reel(ncreel* r){
-  nctablet* focused = r->tablets;
-  nctablet* cur = focused;
   if(r->tablets){
-    cur = r->tablets->next;
+    nctablet* cur = r->tablets->next;
     while(cur && cur != r->tablets){// && cur->p){
 //fprintf(stderr, "CLEANING: %p (%p)\n", cur, cur->p);
       if(cur->p){

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -1021,7 +1021,7 @@ int notcurses_render_to_file(struct notcurses* nc, FILE* fp){
   }
   fclose(out);
   free(rastered);
-  return 0;
+  return ret;
 }
 
 

--- a/tests/Exceptions.cpp
+++ b/tests/Exceptions.cpp
@@ -5,18 +5,23 @@ using namespace ncpp;
 
 TEST_CASE("Exceptions") {
 
+  notcurses_options nopts{};
+  nopts.flags = NCOPTION_SUPPRESS_BANNERS |
+                NCOPTION_INHIBIT_SETLOCALE;
+  nopts.loglevel = NCLOGLEVEL_VERBOSE;
+
   SUBCASE("GetInstance") {
     CHECK_THROWS_AS(NotCurses::get_instance(), invalid_state_error);
   }
 
   SUBCASE("ResetStats") {
-    NotCurses nc;
+    NotCurses nc{ nopts };
     CHECK_THROWS_AS(nc.reset_stats(nullptr), invalid_argument);
   }
 
   // ncpp only allows one notcurses object at a time (why?)
   SUBCASE("OnlyOneNotCurses") {
-    NotCurses nc;
+    NotCurses nc{ nopts };
     std::unique_ptr<NotCurses> nc2;
     // FIXME attempts to match ::init_error have failed thus far :/
     CHECK_THROWS(nc2.reset(new NotCurses()));

--- a/tests/Ncpp.cpp
+++ b/tests/Ncpp.cpp
@@ -6,17 +6,21 @@ using namespace ncpp;
 TEST_CASE("Ncpp"
           * doctest::description("Basic C++ wrapper tests")) {
 
+  notcurses_options nopts{};
+  nopts.flags = NCOPTION_SUPPRESS_BANNERS |
+                NCOPTION_INHIBIT_SETLOCALE;
+
   // we ought be able to construct a NotCurses object with a nullptr FILE
   // or even just no argument (decays to nullptr).
   SUBCASE("ConstructNotCurses") {
-    NotCurses nc;
+    NotCurses nc{ nopts };
     CHECK(!NotCurses::is_notcurses_stopped(&nc));
     CHECK(nc.stop());
     CHECK(NotCurses::is_notcurses_stopped(&nc));
   }
 
   SUBCASE("ConstructNotCursesNullFILE") {
-    NotCurses ncnull(nullptr);
+    NotCurses ncnull{ nopts, nullptr };
     CHECK(!NotCurses::is_notcurses_stopped(&ncnull));
     CHECK(ncnull.stop());
     CHECK(NotCurses::is_notcurses_stopped(&ncnull));
@@ -24,17 +28,17 @@ TEST_CASE("Ncpp"
 
   // we ought be able to get a new NotCurses object after stop()ping one.
   SUBCASE("ConstructNotCursesTwice") {
-    NotCurses nc;
+    NotCurses nc{ nopts };
     CHECK(nc.stop());
     CHECK(NotCurses::is_notcurses_stopped(&nc));
-    NotCurses ncnull(nullptr);
+    NotCurses ncnull{ nopts, nullptr };
     CHECK(!NotCurses::is_notcurses_stopped(&ncnull));
     CHECK(ncnull.stop());
     CHECK(NotCurses::is_notcurses_stopped(&ncnull));
   }
 
   SUBCASE("StdPlane") {
-    NotCurses nc;
+    NotCurses nc{ nopts };
     auto std1 = nc.get_stdplane();
     CHECK(nullptr != std1);
     int y, x;
@@ -46,19 +50,19 @@ TEST_CASE("Ncpp"
   }
 
   SUBCASE("Debug") { // just test to ensure it doesn't coredump
-    NotCurses nc;
+    NotCurses nc{ nopts };
     nc.debug(stderr);
     CHECK(nc.stop());
   }
 
   SUBCASE("GetPaletteSize") {
-    NotCurses nc;
+    NotCurses nc{ nopts };
     CHECK(0 < nc.get_palette_size());
     CHECK(nc.stop());
   }
 
   SUBCASE("VisualFromFile") {
-    NotCurses nc;
+    NotCurses nc{ nopts };
     if(nc.can_open_images()){
       nc_err_e err;
       {
@@ -70,7 +74,7 @@ TEST_CASE("Ncpp"
   }
 
   SUBCASE("VisualFromRGBA") {
-    NotCurses nc;
+    NotCurses nc{ nopts };
     uint32_t rgba[] = {
       0x4080c0ff,
       0x105090ff,
@@ -83,7 +87,7 @@ TEST_CASE("Ncpp"
   }
 
   SUBCASE("VisualFromPlane") {
-    NotCurses nc;
+    NotCurses nc{ nopts };
     {
       auto n = nc.get_stdplane();
       REQUIRE(n);

--- a/tests/Ncpp.cpp
+++ b/tests/Ncpp.cpp
@@ -9,6 +9,7 @@ TEST_CASE("Ncpp"
   notcurses_options nopts{};
   nopts.flags = NCOPTION_SUPPRESS_BANNERS |
                 NCOPTION_INHIBIT_SETLOCALE;
+  nopts.loglevel = NCLOGLEVEL_VERBOSE;
 
   // we ought be able to construct a NotCurses object with a nullptr FILE
   // or even just no argument (decays to nullptr).

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -90,13 +90,13 @@ TEST_CASE("TextLayout") {
     auto sp = ncplane_new(nc_, 2, 6, 0, 0, nullptr);
     REQUIRE(sp);
     size_t bytes;
-    const char boundstr[] = "a 血的神 m公";
+    const char boundstr[] = "a 血的神";
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
     char* line = ncplane_contents(sp, 0, 0, -1, -1);
     REQUIRE(line);
-    CHECK(0 == strcmp(line, "a 血的神 m公"));
+    CHECK(0 == strcmp(line, "a血的神"));
     free(line);
     ncplane_destroy(sp);
   }

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -118,6 +118,23 @@ TEST_CASE("TextLayout") {
     ncplane_destroy(sp);
   }
 
+  // a long word (one requiring a split no matter what) ought not force the
+  // next line, but instead be printed where it starts
+  SUBCASE("LayoutTransPlanarWide") {
+    auto sp = ncplane_new(nc_, 2, 8, 0, 0, nullptr);
+    REQUIRE(sp);
+    size_t bytes;
+    const char boundstr[] = "1 我能吞下玻璃";
+    CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, boundstr, &bytes));
+    CHECK(0 == notcurses_render(nc_));
+    CHECK(bytes == strlen(boundstr));
+    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    REQUIRE(line);
+    CHECK(0 == strcmp(line, "1 我能吞下玻璃"));
+    free(line);
+    ncplane_destroy(sp);
+  }
+
   SUBCASE("LayoutLeadingSpaces") {
     auto sp = ncplane_new(nc_, 3, 10, 0, 0, nullptr);
     REQUIRE(sp);

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -112,7 +112,6 @@ TEST_CASE("TextLayout") {
     CHECK(bytes == strlen(boundstr));
     char* line = ncplane_contents(sp, 0, 0, -1, -1);
     REQUIRE(line);
-fprintf(stderr, "LINE: [%s]\n", line);
     CHECK(0 == strcmp(line, "my thermonucleararms"));
     free(line);
     ncplane_destroy(sp);
@@ -183,7 +182,6 @@ fprintf(stderr, "LINE: [%s]\n", line);
   }
 
   // create a plane of two rows, and exactly fill both, with no spaces
-/*
   SUBCASE("LayoutFillsPlaneNoSpaces") {
     auto sp = ncplane_new(nc_, 2, 6, 0, 0, nullptr);
     REQUIRE(sp);
@@ -194,16 +192,14 @@ fprintf(stderr, "LINE: [%s]\n", line);
     CHECK(bytes == strlen(boundstr));
     char* line = ncplane_contents(sp, 0, 0, -1, -1);
     REQUIRE(line);
-fprintf(stderr, "LINE: [%s]\n", line);
     CHECK(0 == strcmp(line, "0123456789AB"));
     free(line);
     ncplane_destroy(sp);
   }
-*/
 
   // create a plane of two rows, and exactly fill both with wide chars
   SUBCASE("LayoutFillsPlaneWide") {
-    auto sp = ncplane_new(nc_, 2, 7, 0, 0, nullptr);
+    auto sp = ncplane_new(nc_, 2, 6, 0, 0, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "我能吞 下玻璃";

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -203,16 +203,16 @@ fprintf(stderr, "LINE: [%s]\n", line);
 
   // create a plane of two rows, and exactly fill both with wide chars
   SUBCASE("LayoutFillsPlaneWide") {
-    auto sp = ncplane_new(nc_, 2, 8, 0, 0, nullptr);
+    auto sp = ncplane_new(nc_, 2, 7, 0, 0, nullptr);
     REQUIRE(sp);
     size_t bytes;
-    const char boundstr[] = "我能吞 下玻 璃";
+    const char boundstr[] = "我能吞 下玻璃";
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
     char* line = ncplane_contents(sp, 0, 0, -1, -1);
     REQUIRE(line);
-    CHECK(0 == strcmp(line, "我能吞下玻 璃"));
+    CHECK(0 == strcmp(line, "我能吞下玻璃"));
     free(line);
     ncplane_destroy(sp);
   }

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -85,6 +85,22 @@ TEST_CASE("TextLayout") {
     ncplane_destroy(sp);
   }
 
+  // lay out text where a wide word crosses the boundary
+  SUBCASE("LayoutCrossBoundaryWide") {
+    auto sp = ncplane_new(nc_, 2, 6, 0, 0, nullptr);
+    REQUIRE(sp);
+    size_t bytes;
+    const char boundstr[] = "a 血的神 m公";
+    CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, boundstr, &bytes));
+    CHECK(0 == notcurses_render(nc_));
+    CHECK(bytes == strlen(boundstr));
+    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    REQUIRE(line);
+    CHECK(0 == strcmp(line, "a 血的神 m公"));
+    free(line);
+    ncplane_destroy(sp);
+  }
+
   // a long word (one requiring a split no matter what) ought not force the
   // next line, but instead be printed where it starts
   SUBCASE("LayoutTransPlanar") {

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -112,6 +112,7 @@ TEST_CASE("TextLayout") {
     CHECK(bytes == strlen(boundstr));
     char* line = ncplane_contents(sp, 0, 0, -1, -1);
     REQUIRE(line);
+fprintf(stderr, "LINE: [%s]\n", line);
     CHECK(0 == strcmp(line, "my thermonucleararms"));
     free(line);
     ncplane_destroy(sp);
@@ -177,6 +178,39 @@ TEST_CASE("TextLayout") {
     char* line = ncplane_contents(sp, 0, 0, -1, -1);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "quantum ballsscratchy no?!"));
+    free(line);
+    ncplane_destroy(sp);
+  }
+
+  // create a plane of two rows, and exactly fill both with wide chars
+  SUBCASE("LayoutFillsPlaneNoSpaces") {
+    auto sp = ncplane_new(nc_, 2, 6, 0, 0, nullptr);
+    REQUIRE(sp);
+    size_t bytes;
+    const char boundstr[] = "0123456789AB";
+    CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
+    CHECK(0 == notcurses_render(nc_));
+    CHECK(bytes == strlen(boundstr));
+    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    REQUIRE(line);
+fprintf(stderr, "LINE: [%s]\n", line);
+    CHECK(0 == strcmp(line, "0123456789AB"));
+    free(line);
+    ncplane_destroy(sp);
+  }
+
+  // create a plane of two rows, and exactly fill both with wide chars
+  SUBCASE("LayoutFillsPlaneWide") {
+    auto sp = ncplane_new(nc_, 2, 8, 0, 0, nullptr);
+    REQUIRE(sp);
+    size_t bytes;
+    const char boundstr[] = "我能吞 下玻 璃";
+    CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
+    CHECK(0 == notcurses_render(nc_));
+    CHECK(bytes == strlen(boundstr));
+    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    REQUIRE(line);
+    CHECK(0 == strcmp(line, "我能吞下玻 璃"));
     free(line);
     ncplane_destroy(sp);
   }

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -182,7 +182,8 @@ fprintf(stderr, "LINE: [%s]\n", line);
     ncplane_destroy(sp);
   }
 
-  // create a plane of two rows, and exactly fill both with wide chars
+  // create a plane of two rows, and exactly fill both, with no spaces
+/*
   SUBCASE("LayoutFillsPlaneNoSpaces") {
     auto sp = ncplane_new(nc_, 2, 6, 0, 0, nullptr);
     REQUIRE(sp);
@@ -198,6 +199,7 @@ fprintf(stderr, "LINE: [%s]\n", line);
     free(line);
     ncplane_destroy(sp);
   }
+*/
 
   // create a plane of two rows, and exactly fill both with wide chars
   SUBCASE("LayoutFillsPlaneWide") {

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -20,7 +20,7 @@ TEST_CASE("TextLayout") {
     CHECK(bytes == strlen(str));
     char* line = ncplane_contents(sp, 0, 0, 2, 20);
     REQUIRE(line);
-    CHECK(0 == strcmp(line, "this is going to bebroken up"));
+    CHECK(0 == strcmp(line, "this is going to be broken up"));
     free(line);
     ncplane_destroy(sp);
   }
@@ -34,7 +34,7 @@ TEST_CASE("TextLayout") {
     CHECK(bytes == strlen(str));
     char* line = ncplane_contents(sp, 0, 0, 2, 20);
     REQUIRE(line);
-    CHECK(0 == strcmp(line, "this is going to bebroken up"));
+    CHECK(0 == strcmp(line, "this is going to be broken up"));
     free(line);
     ncplane_destroy(sp);
   }
@@ -48,7 +48,7 @@ TEST_CASE("TextLayout") {
     CHECK(bytes == strlen(str));
     char* line = ncplane_contents(sp, 0, 0, 2, 20);
     REQUIRE(line);
-    CHECK(0 == strcmp(line, "this is going to bebroken up"));
+    CHECK(0 == strcmp(line, "this is going to be broken up"));
     free(line);
     ncplane_destroy(sp);
   }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -17,7 +17,6 @@ auto testing_notcurses() -> struct notcurses* {
   notcurses_options nopts{};
   nopts.loglevel = NCLOGLEVEL_VERBOSE;
   nopts.flags = NCOPTION_SUPPRESS_BANNERS
-                | NCOPTION_NO_ALTERNATE_SCREEN
                 | NCOPTION_INHIBIT_SETLOCALE;
   auto nc = notcurses_init(&nopts, nullptr);
   return nc;


### PR DESCRIPTION
Add a number of unit tests to `layout.cpp`, exercising `ncplane_puttext()`. These tests include several wide glyph cases, and another case which was discovered while writing them. Numerous layout bugs have been fixed. Closes #815 .