### PR TITLE
add ncmenu_mouse_selected()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ rearrangements of Notcurses.
 
 * 1.6.7 (not yet released)
   * GNU libunistring is now required to build/load Notcurses.
+  * Added `ncmenu_mouse_selection()`. Escape now closes an unrolled menu
+    when processed by `ncmenu_offer_input()`.
 
 * 1.6.6 (2020-07-19)
   * `notcurses-pydemo` is now only installed alongside the Python module,

--- a/doc/man/man3/notcurses_menu.3.md
+++ b/doc/man/man3/notcurses_menu.3.md
@@ -26,7 +26,7 @@ struct ncmenu_section {
 };
 
 #define NCMENU_OPTION_BOTTOM 0x0001 // bottom row (as opposed to top row)
-#define NCMENU_OPTION_HIDING 0x0002 // hide the menu when not being used
+#define NCMENU_OPTION_HIDING 0x0002 // hide the menu when not unrolled
 
 typedef struct ncmenu_options {
   struct ncmenu_section* sections; // 'sectioncount' menu_sections
@@ -53,6 +53,8 @@ typedef struct ncmenu_options {
 
 **const char* ncmenu_selected(const struct ncmenu* n, struct ncinput* ni);**
 
+**const char* ncmenu_mouse_selected(const struct ncmenu* n, const struct ncinput* click, struct ncinput* ni);**
+
 **struct ncplane* ncmenu_plane(struct ncmenu* n);**
 
 **bool ncmenu_offer_input(struct ncmenu* n, const struct ncinput* nc);**
@@ -70,12 +72,20 @@ specified one. **ncmenu_destroy** removes a menu bar, and frees all associated
 resources.
 
 **ncmenu_selected** return the selected item description, or NULL if no section
-is unrolled.
+is unrolled, or no valid item is selected. **ncmenu_mouse_selected** returns
+the item selected by a mouse click (described in **click**), which must be on
+the actively unrolled section. In either case, if there is a shortcut for the
+item and **ni** is not **NULL**, **ni** will be filled in with the shortcut.
 
 The menu can be driven either entirely by the application, via direct calls to
 **ncmenu_previtem**, **ncmenu_prevsection**, and the like, or **struct ncinput**
 objects can be handed to **ncmenu_offer_input**. In the latter case, the menu
-will largely manage itself.
+will largely manage itself. The application must handle item selection (usually
+via the Enter key and/or mouse click) itself, since the menu cannot arbitrarily
+call into the application. **ncmenu_offer_input** will handle clicks to unroll
+menu sections, clicks to dismiss the menu, Escape to dismiss the menu, left
+and right to change menu sections, and up and down to change menu items (these
+latter are only consumed if there is an actively unrolled section).
 
 # RETURN VALUES
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2804,7 +2804,7 @@ struct ncmenu_section {
 };
 
 #define NCMENU_OPTION_BOTTOM 0x0001ull // bottom row (as opposed to top row)
-#define NCMENU_OPTION_HIDING 0x0002ull // hide the menu when not being used
+#define NCMENU_OPTION_HIDING 0x0002ull // hide the menu when not unrolled
 
 typedef struct ncmenu_options {
   struct ncmenu_section* sections; // array of 'sectioncount' menu_sections
@@ -2840,6 +2840,14 @@ API int ncmenu_previtem(struct ncmenu* n);
 // 'ni' is not NULL, and the selected item has a shortcut, 'ni' will be filled
 // in with that shortcut--this can allow faster matching.
 API const char* ncmenu_selected(const struct ncmenu* n, struct ncinput* ni);
+
+// Return the item description corresponding to the mouse click 'click'. The
+// item must be on an actively unrolled section, and the click must be in the
+// area of a valid item. If 'ni' is not NULL, and the selected item has a
+// shortcut, 'ni' will be filled in with the shortcut.
+API const char* ncmenu_mouse_selected(const struct ncmenu* n,
+                                      const struct ncinput* click,
+                                      struct ncinput* ni);
 
 // Return the ncplane backing this ncmenu.
 API struct ncplane* ncmenu_plane(struct ncmenu* n);

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -37,7 +37,6 @@ typedef struct elem {
   struct elem* next;
 } elem;
 
-static bool menu_unrolled;
 static struct ncmenu* menu;
 static struct ncplane* about; // "about" modal popup
 
@@ -162,6 +161,11 @@ bool menu_or_hud_key(struct notcurses *nc, const struct ncinput *ni){
     if(sel == NULL){
       return false;
     }
+  }else if(menu && ni->id == NCKEY_RELEASE){
+    const char* sel = ncmenu_mouse_selected(menu, ni, &tmpni);
+    if(sel == NULL){
+      memcpy(&tmpni, ni, sizeof(tmpni));
+    }
   }else{
     memcpy(&tmpni, ni, sizeof(tmpni));
   }
@@ -198,21 +202,11 @@ bool menu_or_hud_key(struct notcurses *nc, const struct ncinput *ni){
   if(ncmenu_offer_input(menu, ni)){
     return true;
   }else if(ni->id == 'o' && ni->alt && !ni->ctrl){
-    if(ncmenu_unroll(menu, 0) == 0){
-      menu_unrolled = true;
-    }
+    ncmenu_unroll(menu, 0);
     return true;
   }else if(ni->id == 'h' && ni->alt && !ni->ctrl){
-    if(ncmenu_unroll(menu, 2) == 0){
-      menu_unrolled = true;
-    }
+    ncmenu_unroll(menu, 2);
     return true;
-  }else if(ni->id == '\x1b'){
-    if(menu_unrolled){
-      ncmenu_rollup(menu);
-      menu_unrolled = false;
-      return true;
-    }
   }
   return false;
 }

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -511,6 +511,38 @@ const char* ncmenu_selected(const ncmenu* n, ncinput* ni){
   return sec->items[itemidx].desc;
 }
 
+const char* ncmenu_mouse_selected(const ncmenu* n, const ncinput* click,
+                                  ncinput* ni){
+  if(click->id != NCKEY_RELEASE){
+    return NULL;
+  }
+  int y, x, dimy, dimx;
+  struct ncplane* nc = n->ncp;
+  y = click->y;
+  x = click->x;
+  ncplane_dim_yx(nc, &dimy, &dimx);
+  if(!ncplane_translate_abs(nc, &y, &x)){
+    return NULL;
+  }
+  // FIXME section_x() works only off the section header lenghts, meaning that
+  // if we click an item outside of those columns covered by the header, it will
+  // read as a -1 from section_x(). we want to instead get the unrolled section,
+  // find its boundaries, and verify that we are within them.
+  int i = section_x(n, x);
+  if(i < 0 || i != n->unrolledsection){
+    return NULL;
+  }
+  const struct ncmenu_int_section* sec = &n->sections[n->unrolledsection];
+  if(y < 2 || y - 2 >= sec->itemcount){
+    return NULL;
+  }
+  const int itemidx = y - 2;
+  if(ni){
+    memcpy(ni, &sec->items[itemidx].shortcut, sizeof(*ni));
+  }
+  return sec->items[itemidx].desc;
+}
+
 bool ncmenu_offer_input(ncmenu* n, const ncinput* nc){
   // we can't actually select menu items in this function, since we need to
   // invoke an arbitrary function as a result.

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -512,6 +512,8 @@ const char* ncmenu_selected(const ncmenu* n, ncinput* ni){
 }
 
 bool ncmenu_offer_input(ncmenu* n, const ncinput* nc){
+  // we can't actually select menu items in this function, since we need to
+  // invoke an arbitrary function as a result.
   if(nc->id == NCKEY_RELEASE){
     int y, x, dimy, dimx;
     y = nc->y;
@@ -554,10 +556,8 @@ bool ncmenu_offer_input(ncmenu* n, const ncinput* nc){
     }
     return true;
   }else if(nc->id == 0x1b){
-    if(n->unrolledsection){
-      ncmenu_rollup(n);
-      return true;
-    }
+    ncmenu_rollup(n);
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
Add `ncmenu_mouse_selected()`, allowing menu users to pass a mouse click through and get any menu item selected by it. Closes #819.