### PR TITLE
add the new 'z'oo demo (widgets) #628

### DIFF
--- a/doc/man/man1/notcurses-demo.1.md
+++ b/doc/man/man1/notcurses-demo.1.md
@@ -45,6 +45,7 @@ The demonstrations include (see NOTES below):
 * (w)hiteout—a great Nothing slowly robs the world of color
 * (x)ray—stimulate a logo with energy
 * (y)ield—the best laid schemes o' mice an'men gang aft agley
+* (z)oo—see the marvelous widgets of the notcurses world
 
 At any time, press 'q' to quit. The demo is best run in at least an 80x45 terminal.
 
@@ -73,7 +74,7 @@ At any time, press 'q' to quit. The demo is best run in at least an 80x45 termin
 **-V**: Print the program name and version, and exit with success.
 
 demospec: Select which demos to run, and what order to run them in. The
-default is **ixeaydthnbcmgrwuvlsfjqo**. See above for a list of demos.
+default is **ixezaydthnbcmgrwuvlsfjqo**. See above for a list of demos.
 
 Default margins are all 0, and thus the full screen will be rendered. Using
 **-m**, margins can be supplied. Provide a single number to set all four margins

--- a/doc/man/man3/notcurses_multiselector.3.md
+++ b/doc/man/man3/notcurses_multiselector.3.md
@@ -50,7 +50,7 @@ typedef struct ncmultiselector_options {
 
 **bool ncmultiselector_offer_input(struct ncmultiselector* n, const struct ncinput* nc);**
 
-**void ncmultiselector_destroy(struct ncmultiselector* n, char** item);**
+**void ncmultiselector_destroy(struct ncmultiselector* n);**
 
 # DESCRIPTION
 

--- a/include/ncpp/MultiSelector.hh
+++ b/include/ncpp/MultiSelector.hh
@@ -38,7 +38,7 @@ namespace ncpp
 		~MultiSelector ()
 		{
 			if (!is_notcurses_stopped ())
-				ncmultiselector_destroy (multiselector, nullptr);
+				ncmultiselector_destroy (multiselector);
 		}
 
 		bool offer_input (const struct ncinput *ni) const noexcept

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2773,7 +2773,7 @@ API struct ncplane* ncmultiselector_plane(struct ncmultiselector* n);
 API bool ncmultiselector_offer_input(struct ncmultiselector* n, const struct ncinput* nc);
 
 // Destroy the ncmultiselector.
-API void ncmultiselector_destroy(struct ncmultiselector* n, char** item);
+API void ncmultiselector_destroy(struct ncmultiselector* n);
 
 // Menus. Horizontal menu bars are supported, on the top and/or bottom rows.
 // If the menu bar is longer than the screen, it will be only partially

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -359,7 +359,7 @@ struct ncmultiselector* ncmultiselector_create(struct ncplane* n, int y, int x, 
 int ncmultiselector_selected(struct ncmultiselector* n, bool* selected, unsigned count);
 struct ncplane* ncmultiselector_plane(struct ncmultiselector* n);
 bool ncmultiselector_offer_input(struct ncmultiselector* n, const struct ncinput* nc);
-void ncmultiselector_destroy(struct ncmultiselector* n, char** item);
+void ncmultiselector_destroy(struct ncmultiselector* n);
 struct ncmenu_item {
   char* desc;           // utf-8 menu item, NULL for horizontal separator
   ncinput shortcut;     // shortcut, all should be distinct

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -118,11 +118,16 @@ usage(const char* exe, int status){
   fprintf(out, " -p: data file path (default: %s)\n", NOTCURSES_SHARE);
   fprintf(out, " -m: margin, or 4 comma-separated margins\n");
   fprintf(out, "\nspecify demos via their first letter. repetitions are allowed.\n");
-  fprintf(out, "default spec: %s\n", DEFAULT_DEMO);
+  fprintf(out, "default spec: %s\n\n", DEFAULT_DEMO);
   int printed = 0;
   for(size_t i = 0 ; i < sizeof(demos) / sizeof(*demos) ; ++i){
     if(demos[i].name){
-      fprintf(out, "%*.*s", 10, 10, demos[i].name);
+      if(printed % 6 == 0){
+        fprintf(out, " ");
+      }
+      // U+24D0: CIRCLED LATIN SMALL LETTER A
+      fprintf(out, "%lc ", *demos[i].name - 'a' + 0x24d0);
+      fprintf(out, "%-*.*s", 8, 8, demos[i].name + 1);
       if(++printed % 6 == 0){
         fprintf(out, "\n");
       }
@@ -197,7 +202,12 @@ handle_opts(int argc, char** argv, notcurses_options* opts, bool* ignore_failure
   *json_output = NULL;
   int c;
   memset(opts, 0, sizeof(*opts));
-  while((c = getopt(argc, argv, "VhickJ:l:r:d:f:p:m:")) != EOF){
+  const struct option longopts[] = {
+    { .name = "help", .has_arg = 0, .flag = NULL, .val = 'h', },
+    { .name = NULL, .has_arg = 0, .flag = NULL, .val = 0, },
+  };
+  int lidx;
+  while((c = getopt_long(argc, argv, "VhickJ:l:r:d:f:p:m:", longopts, &lidx)) != EOF){
     switch(c){
       case 'h':
         usage(*argv, EXIT_SUCCESS);

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -20,7 +20,7 @@ static int democount;
 static demoresult* results;
 static char *datadir = NOTCURSES_SHARE;
 
-static const char DEFAULT_DEMO[] = "ixeaydthnbcmgrwuvlsfjqo";
+static const char DEFAULT_DEMO[] = "ixezaydthnbcmgrwuvlsfjqo";
 
 atomic_bool interrupted = ATOMIC_VAR_INIT(false);
 // checked following demos, whether aborted, failed, or otherwise
@@ -99,7 +99,7 @@ static struct {
   { "whiteout", witherworm_demo, false, },
   { "xray", xray_demo, false, },
   { "yield", yield_demo, false, },
-  { NULL, NULL, false, }, // zoo
+  { "zoo", zoo_demo, false, },
 };
 
 static void

--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -53,6 +53,7 @@ int eagle_demo(struct notcurses* nc);
 int reel_demo(struct notcurses* nc);
 int xray_demo(struct notcurses* nc);
 int luigi_demo(struct notcurses* nc);
+int zoo_demo(struct notcurses* nc);
 int intro(struct notcurses* nc);
 int outro(struct notcurses* nc);
 

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -12,11 +12,37 @@ static struct ncselector_item select_items[] = {
 #undef SITEM
 };
 
+static struct ncmselector_item mselect_items[] = {
+  { "Pa231", "Protactinium-231 (162kg)", .selected = false, },
+  { "U233", "Uranium-233 (15kg)", .selected = false, },
+  { "U235", "Uranium-235 (50kg)", .selected = false, },
+  { "Np236", "Neptunium-236 (7kg)", .selected = false, },
+  { "Np237", "Neptunium-237 (60kg)", .selected = false, },
+  { "Pu238", "Plutonium-238 (10kg)", .selected = false, },
+  { "Pu239", "Plutonium-239 (10kg)", .selected = false, },
+  { "Pu240", "Plutonium-240 (40kg)", .selected = false, },
+  { "Pu241", "Plutonium-241 (13kg)", .selected = false, },
+  { "Am241", "Americium-241 (100kg)", .selected = false, },
+  { "Pu242", "Plutonium-242 (100kg)", .selected = false, },
+  { "Am242", "Americium-242 (18kg)", .selected = false, },
+  { "Am243", "Americium-243 (155kg)", .selected = false, },
+  { "Cm243", "Curium-243 (10kg)", .selected = false, },
+  { "Cm244", "Curium-244 (30kg)", .selected = false, },
+  { "Cm245", "Curium-245 (13kg)", .selected = false, },
+  { "Cm246", "Curium-246 (84kg)", .selected = false, },
+  { "Cm247", "Curium-247 (7kg)", .selected = false, },
+  { "Bk247", "Berkelium-247 (10kg)", .selected = false, },
+  { "Cf249", "Californium-249 (6kg)", .selected = false, },
+  { "Cf251", "Californium-251 (9kg)", .selected = false, },
+  { NULL, NULL, .selected = false, },
+};
+
 static struct ncmultiselector*
 multiselector_demo(struct notcurses* nc, struct ncplane* n, int dimx, int y){
   ncmultiselector_options mopts = {
     .maxdisplay = 8,
     .title = "multi-item selector",
+    .items = mselect_items,
   };
   channels_set_fg(&mopts.boxchannels, 0x20e040);
   channels_set_fg(&mopts.opchannels, 0xe08040);
@@ -84,7 +110,6 @@ int zoo_demo(struct notcurses* nc){
   struct ncmultiselector* mselector = NULL;
   struct ncplane* n = notcurses_stddim_yx(nc, NULL, &dimx);
   ncselector_options sopts = {
-    .maxdisplay = 4,
     .title = "single-item selector",
     .items = select_items,
   };
@@ -121,6 +146,7 @@ int zoo_demo(struct notcurses* nc){
   if(mselector == NULL){
     goto err;
   }
+  demo_nanosleep(nc, &demodelay);
   ncselector_destroy(selector, NULL);
   ncmultiselector_destroy(mselector);
   DEMO_RENDER(nc);

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -1,20 +1,75 @@
 #include "demo.h"
 
+static struct ncmultiselector*
+multiselector_demo(struct notcurses* nc, struct ncplane* n, int dimx, int y){
+  ncmultiselector_options mopts = {
+    .maxdisplay = 8,
+    .title = "multi-item selector",
+  };
+  channels_set_fg(&mopts.boxchannels, 0x20e040);
+  channels_set_fg(&mopts.opchannels, 0xe08040);
+  channels_set_fg(&mopts.descchannels, 0x80e040);
+  channels_set_bg(&mopts.opchannels, 0);
+  channels_set_bg(&mopts.descchannels, 0);
+  channels_set_fg(&mopts.footchannels, 0xe00040);
+  channels_set_fg(&mopts.titlechannels, 0xffff80);
+  channels_set_fg(&mopts.bgchannels, 0x002000);
+  channels_set_bg(&mopts.bgchannels, 0x002000);
+  channels_set_fg_alpha(&mopts.bgchannels, CELL_ALPHA_BLEND);
+  channels_set_bg_alpha(&mopts.bgchannels, CELL_ALPHA_BLEND);
+  struct ncmultiselector* mselector = ncmultiselector_create(n, y, 0, &mopts);
+  if(mselector == NULL){
+    return NULL;
+  }
+  struct ncplane* mplane = ncmultiselector_plane(mselector);
+  struct timespec swoopdelay;
+  timespec_div(&demodelay, dimx / 3, &swoopdelay);
+  int length = ncplane_dim_x(mplane);
+  for(int i = 0 ; i < dimx - (length + 1) ; ++i){
+    if(demo_render(nc)){
+      ncmultiselector_destroy(mselector);
+      return NULL;
+    }
+    ncplane_move_yx(mplane, y, i);
+    demo_nanosleep(nc, &swoopdelay);
+  }
+  return mselector;
+}
+
 int zoo_demo(struct notcurses* nc){
-  struct ncplane* n = notcurses_stdplane(nc);
+  int dimx;
+  struct ncplane* n = notcurses_stddim_yx(nc, NULL, &dimx);
   ncselector_options sopts = {
     .maxdisplay = 4,
     .title = "single-item selector",
   };
-  struct ncselector* selector = ncselector_create(n, 1, 1, &sopts);
+  channels_set_fg(&sopts.boxchannels, 0x20e040);
+  channels_set_fg(&sopts.opchannels, 0xe08040);
+  channels_set_fg(&sopts.descchannels, 0x80e040);
+  channels_set_bg(&sopts.opchannels, 0);
+  channels_set_bg(&sopts.descchannels, 0);
+  channels_set_fg(&sopts.footchannels, 0xe00040);
+  channels_set_fg(&sopts.titlechannels, 0xffff80);
+  channels_set_fg(&sopts.bgchannels, 0x002000);
+  channels_set_bg(&sopts.bgchannels, 0x002000);
+  channels_set_fg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
+  channels_set_bg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
+  struct ncselector* selector = ncselector_create(n, 2, dimx, &sopts);
   if(selector == NULL){
     return -1;
   }
-  DEMO_RENDER(nc);
-  // FIXME swoop a selector in from the right
-  demo_nanosleep(nc, &demodelay);
+  struct ncplane* splane = ncselector_plane(selector);
+  struct timespec swoopdelay;
+  timespec_div(&demodelay, dimx / 3, &swoopdelay);
+  for(int i = dimx - 1 ; i > 1 ; --i){
+    DEMO_RENDER(nc);
+    ncplane_move_yx(splane, 2, i);
+    demo_nanosleep(nc, &swoopdelay);
+  }
+  struct ncmultiselector* mselector;
+  mselector = multiselector_demo(nc, n, dimx, 8); // FIXME calculate from splane
   ncselector_destroy(selector, NULL);
-  // FIXME swoop a multiselector in from the left
+  ncmultiselector_destroy(mselector);
   DEMO_RENDER(nc);
   return 0;
 }

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -1,8 +1,20 @@
 #include "demo.h"
 
 int zoo_demo(struct notcurses* nc){
+  struct ncplane* n = notcurses_stdplane(nc);
+  ncselector_options sopts = {
+    .maxdisplay = 4,
+    .title = "single-item selector",
+  };
+  struct ncselector* selector = ncselector_create(n, 1, 1, &sopts);
+  if(selector == NULL){
+    return -1;
+  }
+  DEMO_RENDER(nc);
   // FIXME swoop a selector in from the right
+  demo_nanosleep(nc, &demodelay);
+  ncselector_destroy(selector, NULL);
   // FIXME swoop a multiselector in from the left
-  (void)nc; // FIXME
+  DEMO_RENDER(nc);
   return 0;
 }

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -1,0 +1,8 @@
+#include "demo.h"
+
+int zoo_demo(struct notcurses* nc){
+  // FIXME swoop a selector in from the right
+  // FIXME swoop a multiselector in from the left
+  (void)nc; // FIXME
+  return 0;
+}

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -48,8 +48,32 @@ multiselector_demo(struct notcurses* nc, struct ncplane* n, int dimx, int y){
   return mselector;
 }
 
+static int
+draw_background(struct notcurses* nc){
+  if(notcurses_canopen_images(nc)){
+    struct ncplane* n = notcurses_stdplane(nc);
+    nc_err_e err;
+    struct ncvisual* ncv = ncvisual_from_file("../data/changes.jpg", &err);
+    if(!ncv){
+      return -1;
+    }
+    struct ncvisual_options vopts = {
+      .scaling = NCSCALE_STRETCH,
+      .n = n,
+    };
+    if(ncvisual_render(nc, ncv, &vopts) == NULL){
+      ncvisual_destroy(ncv);
+      return -1;
+    }
+  }
+  return 0;
+}
+
 int zoo_demo(struct notcurses* nc){
   int dimx;
+  if(draw_background(nc)){
+    return -1;
+  }
   struct ncplane* n = notcurses_stddim_yx(nc, NULL, &dimx);
   ncselector_options sopts = {
     .maxdisplay = 4,

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -1,5 +1,16 @@
 #include "demo.h"
 
+// we list all distributions on which notcurses is known to exist
+static struct ncselector_item select_items[] = {
+#define SITEM(short, long) { short, long, 0, 0, }
+  SITEM("fbsd", "FreeBSD"),
+  SITEM("deb", "Debian Unstable Linux"),
+  SITEM("rpm", "Fedora Rawhide Linux"),
+  SITEM("pac", "Arch Linux"),
+  SITEM("apk", "Alpine Edge Linux"),
+#undef SITEM
+};
+
 static struct ncmultiselector*
 multiselector_demo(struct notcurses* nc, struct ncplane* n, int dimx, int y){
   ncmultiselector_options mopts = {
@@ -42,6 +53,8 @@ int zoo_demo(struct notcurses* nc){
   ncselector_options sopts = {
     .maxdisplay = 4,
     .title = "single-item selector",
+    .items = select_items,
+    .itemcount = sizeof(select_items) / sizeof(*select_items),
   };
   channels_set_fg(&sopts.boxchannels, 0x20e040);
   channels_set_fg(&sopts.opchannels, 0xe08040);

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -8,6 +8,7 @@ static struct ncselector_item select_items[] = {
   SITEM("rpm", "Fedora Rawhide Linux"),
   SITEM("pac", "Arch Linux"),
   SITEM("apk", "Alpine Edge Linux"),
+  SITEM(NULL, NULL),
 #undef SITEM
 };
 
@@ -54,7 +55,6 @@ int zoo_demo(struct notcurses* nc){
     .maxdisplay = 4,
     .title = "single-item selector",
     .items = select_items,
-    .itemcount = sizeof(select_items) / sizeof(*select_items),
   };
   channels_set_fg(&sopts.boxchannels, 0x20e040);
   channels_set_fg(&sopts.opchannels, 0xe08040);

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -763,12 +763,8 @@ freeitems:
   return NULL;
 }
 
-void ncmultiselector_destroy(ncmultiselector* n, char** item){
+void ncmultiselector_destroy(ncmultiselector* n){
   if(n){
-    if(item){
-      *item = n->items[n->current].option;
-      n->items[n->current].option = NULL;
-    }
     while(n->itemcount--){
       free(n->items[n->itemcount].option);
       free(n->items[n->itemcount].desc);

--- a/src/poc/multiselect.c
+++ b/src/poc/multiselect.c
@@ -36,8 +36,8 @@ run_mselect(struct notcurses* nc, struct ncmultiselector* ns){
   while((keypress = notcurses_getc_blocking(nc, &ni)) != (char32_t)-1){
     if(!ncmultiselector_offer_input(ns, &ni)){
       switch(keypress){
-        case NCKEY_ENTER: ncmultiselector_destroy(ns, NULL); return;
-        case 'M': case 'J': if(ni.ctrl){ ncmultiselector_destroy(ns, NULL); return; }
+        case NCKEY_ENTER: ncmultiselector_destroy(ns); return;
+        case 'M': case 'J': if(ni.ctrl){ ncmultiselector_destroy(ns); return; }
       }
       if(keypress == 'q'){
         break;
@@ -45,7 +45,7 @@ run_mselect(struct notcurses* nc, struct ncmultiselector* ns){
     }
     notcurses_render(nc);
   }
-  ncmultiselector_destroy(ns, NULL);
+  ncmultiselector_destroy(ns);
 }
 
 int main(void){


### PR DESCRIPTION
The long-planned 'z'oo demo, showing off the `ncselector` and `ncmultiselector` widgets. We'll likely extend and improve this, but it's a sufficient MVP. This also nicely closes off our table of demos at 6x4 =].