### PR TITLE
Add ncreader with pianoplayer text to the zoo demo #835

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.6.10 (not yet released)
+  * The `egc` member of `ncreader_options` is now `const`.
+
 * 1.6.9 (2020-07-26)
   * No user-visible changes.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -2267,7 +2267,7 @@ typedef struct ncreader_options {
   uint64_t echannels; // channels used for empty space
   uint32_t tattrword; // attributes used for input
   uint32_t eattrword; // attributes used for empty space
-  char* egc;          // egc used for empty space
+  const char* egc;    // egc used for empty space
   int physrows;
   int physcols;
   bool scroll; // allow more than the physical area's worth of input

--- a/doc/man/man3/notcurses_reader.3.md
+++ b/doc/man/man3/notcurses_reader.3.md
@@ -24,7 +24,7 @@ typedef struct ncreader_options {
   uint64_t echannels; // channels used for empty space
   uint32_t tattrword; // attributes used for input
   uint32_t eattrword; // attributes used for empty space
-  char* egc;          // egc used for empty space
+  const char* egc;    // egc used for empty space
   int physrows;
   int physcols;
   unsigned flags;     // bitfield over NCREADER_OPTION_*

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3000,7 +3000,7 @@ typedef struct ncreader_options {
   uint64_t echannels; // channels used for empty space
   uint32_t tattrword; // attributes used for input
   uint32_t eattrword; // attributes used for empty space
-  char* egc;          // egc used for empty space
+  const char* egc;    // egc used for empty space
   int physrows;
   int physcols;
   uint64_t flags;     // bitfield of NCREADER_OPTION_*

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -259,10 +259,13 @@ reader_demo(struct notcurses* nc, pthread_t* tid, pthread_mutex_t* lock){
   const int READER_COLS = 40;
   const int READER_ROWS = 8;
   ncreader_options nopts = {
+    .echannels = CHANNELS_RGB_INITIALIZER(0x20, 0, 0xe0, 0, 0, 0),
+    .egc = "░",
     .physcols = READER_COLS,
     .physrows = READER_ROWS,
-    .egc = "░",
+    // FIXME .flags = NCREADER_OPTION_VERSCROLL,
   };
+  channels_set_bg_alpha(&nopts.echannels, CELL_ALPHA_BLEND);
   const int x = ncplane_align(std, NCALIGN_CENTER, nopts.physcols);
   if((marsh->reader = ncreader_create(std, dimy, x, &nopts)) == NULL){
     free(marsh);

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -229,7 +229,9 @@ reader_thread(void* vmarsh){
   struct timespec rowdelay;
   ncplane_yx(rplane, &y, &x);
   int targrow = y / 2;
-  timespec_div(&demodelay, y - targrow, &rowdelay);
+  // the other widgets divide the movement range by 3 (and thus take about 3
+  // demodelays to transit). take about 4 demodelays to rise to midscreen.
+  timespec_div(&demodelay, (y - targrow) / 4, &rowdelay);
   while(y > targrow){
     // FIXME add text
     pthread_mutex_lock(lock);
@@ -259,6 +261,7 @@ reader_demo(struct notcurses* nc, pthread_t* tid, pthread_mutex_t* lock){
   ncreader_options nopts = {
     .physcols = READER_COLS,
     .physrows = READER_ROWS,
+    .egc = "░",
   };
   const int x = ncplane_align(std, NCALIGN_CENTER, nopts.physcols);
   if((marsh->reader = ncreader_create(std, dimy, x, &nopts)) == NULL){

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -219,12 +219,12 @@ static void*
 reader_thread(void* vmarsh){
   // FIXME use ncplane_puttext() to handle word breaking; this is ugly
   const char text[] =
-    "Notcurses provides widgets to quickly build vivid TUIs.\n"
+    "Notcurses provides several widgets to quickly build vivid TUIs.\n\n"
     "This ncreader widget facilitates free-form text entry complete with readline-style bindings. "
     "The ncselector allows a single option to be selected from a list. "
     "The ncmultiselector allows 0..n options to be selected from a list of n items. "
     "The ncfdplane allows a file descriptor to be streamed to a plane. The ncsubproc spawns a subprocess and streams its output to a plane. "
-    "Menus can be placed along the top and/or bottom of any plane. "
+    "Menus can be placed along the top and/or bottom of any plane.\n\n"
     "Widgets can be controlled with the keyboard and/or mouse. They are implemented atop ncplanes, and these planes can be manipulated like all others.";
   const size_t textlen = strlen(text);
   read_marshal* marsh = vmarsh;
@@ -238,8 +238,9 @@ reader_thread(void* vmarsh){
   ncplane_yx(rplane, &y, &x);
   int targrow = y / 2;
   // the other widgets divide the movement range by 3 (and thus take about 3
-  // demodelays to transit). take about 4 demodelays to rise to midscreen.
-  timespec_div(&demodelay, (y - targrow) / 4, &rowdelay);
+  // demodelays to transit). take about 3 demodelays to rise to midscreen. this
+  // also affects the "typing" speed.
+  timespec_div(&demodelay, (y - targrow) / 3, &rowdelay);
   // we usually won't be done rendering the text before reaching our target row
   size_t textpos = 0;
   const int TOWRITEMAX = 4; // FIXME throw in some jitter!

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2329,6 +2329,7 @@ uint32_t* ncplane_rgba(const ncplane* nc, ncblitter_e blit,
   return ret;
 }
 
+// return a heap-allocated copy of the contents
 char* ncplane_contents(const ncplane* nc, int begy, int begx, int leny, int lenx){
   if(begy < 0 || begx < 0){
     logerror(nc->nc, "Beginning coordinates (%d/%d) below 0\n", begy, begx);

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -758,6 +758,7 @@ stage_cursor(notcurses* nc, FILE* out, int y, int x){
 
 // True if the cell does not generate background pixels. Only the FULL BLOCK
 // glyph has this property, AFAIK.
+// FIXME also shaded blocks! ░ etc
 // FIXME set a bit, doing this at load time
 static inline bool
 cell_nobackground_p(const egcpool* e, const cell* c){

--- a/src/poc/reader.cpp
+++ b/src/poc/reader.cpp
@@ -21,7 +21,7 @@ auto main() -> int {
   ncreader_options opts{};
   opts.physrows = dimy / 8;
   opts.physcols = dimx / 2;
-  opts.egc = strdup("░");
+  opts.egc = "░";
   // FIXME c++ is crashing
   //Reader nr(nc, 0, 0, &opts);
   auto nr = ncreader_create(**n, 2, 2, &opts);


### PR DESCRIPTION
* Fix the display delays in `zoo` to properly incorporate `-d` multiples
* Add an `ncreader` widget, scroll it up from the bottom, and pianoplay text into it summarizing widgets