### PR TITLE
[C++] API sync

### DIFF
--- a/include/ncpp/Cell.hh
+++ b/include/ncpp/Cell.hh
@@ -161,7 +161,7 @@ namespace ncpp
 			return cell_fg_default_p (&_cell);
 		}
 
-		bool set_fg_alpha (int alpha) noexcept
+		bool set_fg_alpha (unsigned alpha) noexcept
 		{
 			return cell_set_fg_alpha (&_cell, alpha) != -1;
 		}
@@ -171,7 +171,7 @@ namespace ncpp
 			return cell_bg_alpha (&_cell);
 		}
 
-		bool set_bg_alpha (int alpha) noexcept
+		bool set_bg_alpha (unsigned alpha) noexcept
 		{
 			return cell_set_bg_alpha (&_cell, alpha) != -1;
 		}

--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -48,6 +48,11 @@ namespace ncpp
 			return error_guard (ncdirect_fg_rgb (direct, r, g, b), -1);
 		}
 
+		bool fg_palindex (int pidx) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncdirect_fg_palindex (direct, pidx), -1);
+		}
+
 		bool set_bg_default () const NOEXCEPT_MAYBE
 		{
 			return error_guard (ncdirect_bg_default (direct), -1);
@@ -63,6 +68,11 @@ namespace ncpp
 			return error_guard (ncdirect_bg_rgb (direct, r, g, b), -1);
 		}
 
+		bool bg_palindex (int pidx) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncdirect_bg_palindex (direct, pidx), -1);
+		}
+
 		int get_dim_x () const NOEXCEPT_MAYBE
 		{
 			return error_guard (ncdirect_dim_x (direct), -1);
@@ -71,6 +81,11 @@ namespace ncpp
 		int get_dim_y () const NOEXCEPT_MAYBE
 		{
 			return error_guard (ncdirect_dim_y (direct), -1);
+		}
+
+		int get_palette_size () const noexcept
+		{
+			return ncdirect_palette_size (direct);
 		}
 
 		void styles_set (CellStyle stylebits) const noexcept
@@ -126,6 +141,48 @@ namespace ncpp
 		nc_err_e render_image (const char* file, ncalign_e align, ncblitter_e blitter, ncscale_e scale) const noexcept
 		{
 			return ncdirect_render_image (direct, file, align, blitter, scale);
+		}
+
+		bool putstr (uint64_t channels, const char* utf8) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncdirect_putstr (direct, channels, utf8), -1);
+		}
+
+		// TODO: ncdirect_printf_aligned (will need a version which takes vargs)
+
+		int hline_interp (const char* egc, int len, uint64_t h1, uint64_t h2) const noexcept
+		{
+			return ncdirect_hline_interp (direct, egc, len, h1, h2);
+		}
+
+		int vline_interp (const char* egc, int len, uint64_t h1, uint64_t h2) const noexcept
+		{
+			return ncdirect_vline_interp (direct, egc, len, h1, h2);
+		}
+
+		bool box (uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, const wchar_t* wchars, int ylen, int xlen, unsigned ctlword) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncdirect_box (direct, ul, ur, ll, lr, wchars, ylen, xlen, ctlword), -1);
+		}
+
+		bool rounded_box (uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ylen, int xlen, unsigned ctlword) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncdirect_rounded_box (direct, ul, ur, ll, lr, ylen, xlen, ctlword), -1);
+		}
+
+		bool double_box (uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ylen, int xlen, unsigned ctlword) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncdirect_double_box (direct, ul, ur, ll, lr, ylen, xlen, ctlword), -1);
+		}
+
+		bool canopen_images () const noexcept
+		{
+			return ncdirect_canopen_images (direct);
+		}
+
+		bool canutf8 () const noexcept
+		{
+			return ncdirect_canutf8 (direct);
 		}
 
 	private:

--- a/include/ncpp/Menu.hh
+++ b/include/ncpp/Menu.hh
@@ -65,6 +65,11 @@ namespace ncpp
 			return ncmenu_selected (menu, ni);
 		}
 
+		const char* get_mouse_selected (const struct ncinput* click, struct ncinput* ni) const noexcept
+		{
+			return ncmenu_mouse_selected (menu, click, ni);
+		}
+
 		bool offer_input (const struct ncinput* ni) const noexcept
 		{
 			return ncmenu_offer_input (menu, ni);

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -84,6 +84,36 @@ namespace ncpp
 			return notcurses_version ();
 		}
 
+		static void version_components (int* major, int* minor, int* patch, int* tweak) noexcept
+		{
+			notcurses_version_components (major, minor, patch, tweak);
+		}
+
+		static const char* str_blitter (ncblitter_e blitter) noexcept
+		{
+			return notcurses_str_blitter (blitter);
+		}
+
+		static const char* str_scalemode (ncscale_e scalemode) noexcept
+		{
+			return notcurses_str_scalemode (scalemode);
+		}
+
+		static bool lex_margins (const char* op, notcurses_options* opts) NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_lex_margins (op, opts), -1);
+		}
+
+		static bool lex_blitter (const char* op, ncblitter_e* blitter) NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_lex_blitter (op, blitter), -1);
+		}
+
+		static bool lex_scalemode (const char* op, ncscale_e* scalemode) NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_lex_scalemode (op, scalemode), -1);
+		}
+
 		bool stop ();
 
 		bool can_utf8 () const noexcept
@@ -148,6 +178,11 @@ namespace ncpp
 		bool render () const NOEXCEPT_MAYBE
 		{
 			return error_guard (notcurses_render (nc), -1);
+		}
+
+		bool render_to_file (FILE* fp) const NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_render_to_file (nc, fp), -1);
 		}
 
 		void get_term_dim (int *rows, int *cols) const noexcept

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -481,6 +481,24 @@ namespace ncpp
 			return error_guard<int> (ncplane_putwstr_aligned (plane, y, static_cast<ncalign_e>(atype), gclustattr), -1);
 		}
 
+		int putstr_stainable (const char* s) const NOEXCEPT_MAYBE
+		{
+			int ret = ncplane_putstr_stainable (plane, s);
+			return error_guard_cond<int> (ret, ret < 0);
+		}
+
+		int printf_stainable (const char* format, ...) const NOEXCEPT_MAYBE
+			__attribute__ ((format (printf, 2, 3)))
+		{
+			va_list va;
+
+			va_start (va, format);
+			int ret = ncplane_vprintf_stainable (plane, format, va);
+			va_end (va);
+
+			return error_guard<int> (ret, -1);
+		}
+
 		int printf (const char* format, ...) const NOEXCEPT_MAYBE
 			__attribute__ ((format (printf, 2, 3)))
 		{
@@ -515,6 +533,11 @@ namespace ncpp
 			va_end (va);
 
 			return error_guard<int> (ret, -1);
+		}
+
+		int vprintf_stainable (const char* format, va_list ap) const NOEXCEPT_MAYBE
+		{
+			return error_guard<int> (ncplane_vprintf_stainable (plane, format, ap), -1);
 		}
 
 		int vprintf (const char* format, va_list ap) const NOEXCEPT_MAYBE
@@ -691,7 +714,7 @@ namespace ncpp
 			ncplane_set_attr (plane, attrword);
 		}
 
-		bool set_fg_alpha (int alpha) const NOEXCEPT_MAYBE
+		bool set_fg_alpha (unsigned alpha) const NOEXCEPT_MAYBE
 		{
 			return error_guard (ncplane_set_fg_alpha (plane, alpha), -1);
 		}
@@ -701,7 +724,7 @@ namespace ncpp
 			return ncplane_bg_alpha (plane);
 		}
 
-		bool set_bg_alpha (int alpha) const NOEXCEPT_MAYBE
+		bool set_bg_alpha (unsigned alpha) const NOEXCEPT_MAYBE
 		{
 			return error_guard (ncplane_set_bg_alpha (plane, alpha), -1);
 		}

--- a/include/ncpp/Reel.hh
+++ b/include/ncpp/Reel.hh
@@ -116,6 +116,11 @@ namespace ncpp
 			return NcTablet::map_tablet (t, get_notcurses_cpp ());
 		}
 
+		bool offer_input (const struct ncinput* nci) const NOEXCEPT_MAYBE
+		{
+			return error_guard<bool, bool> (ncreel_offer_input (reel, nci), false);
+		}
+
 		Plane* get_plane () const noexcept;
 
 	private:

--- a/include/ncpp/Root.hh
+++ b/include/ncpp/Root.hh
@@ -36,7 +36,7 @@ namespace ncpp {
 		{}
 
 		template<typename TRet = bool, typename TValue = int>
-		TRet error_guard (TValue ret, TValue error_value) const
+		static TRet error_guard (TValue ret, TValue error_value)
 		{
 			static constexpr bool ret_is_bool = std::is_same_v<TRet, bool>;
 
@@ -64,7 +64,7 @@ namespace ncpp {
 		}
 
 		template<typename TRet = bool, typename TValue = int>
-		TRet error_guard_cond ([[maybe_unused]] TValue ret, bool error_value) const
+		static TRet error_guard_cond ([[maybe_unused]] TValue ret, bool error_value)
 		{
 			static constexpr bool ret_is_bool = std::is_same_v<TRet, bool>;
 


### PR DESCRIPTION
Been a while, apologies :)

Added:
  * Direct: fg_palindex (`ncdirect_fg_palindex`)
  * Direct: bg_palindex (`ncdirect_bg_palindex`)
  * Direct: get_palette_size (`ncdirect_palette_size`)
  * Direct: putstr (`ncdirect_putstr`)
  * Direct: hline_interp (`ncdirect_hline_interp`)
  * Direct: vline_interp (`ncdirect_vline_interp`)
  * Direct: box (`ncdirect_box`)
  * Direct: rounded_box (`ncdirect_rounded_box`)
  * Direct: double_box (`ncdirect_double_box`)
  * Direct: canopen_images (`ncdirect_canopen_images`)
  * Direct: canutf8 (`ncdirect_canutf8`)
  * Menu: get_mouse_selected (`ncmenu_mouse_selected`)
  * NotCurses: version_components (`notcurses_version_components`)
  * NotCurses: str_blitter (`notcurses_str_blitter`)
  * NotCurses: str_scalemode (`notcurses_str_scalemode`)
  * NotCurses: lex_margins (`notcurses_lex_margins`)
  * NotCurses: lex_blitter (`notcurses_lex_blitter`)
  * NotCurses: lex_scalemode (`notcurses_lex_scalemode`)
  * NotCurses: render_to_file (`notcurses_render_to_file`)
  * Plane: putstr_stainable (`ncplane_putstr_stainable`)
  * Plane: printf_stainable (`ncplane_printf_stainable`)
  * Plane: vprintf_stainable (`ncplane_vprintf_stainable`)
  * Reel: offer_input (`ncreel_offer_input`)

Changed:
  * Direct: set_fg_alpha uses `unsigned alpha`
  * Direct: set_bg_alpha uses `unsigned alpha`
  * Plane: set_fg_alpha uses `unsigned alpha`
  * Plane: set_bg_alpha uses `unsigned alpha`
  * Root: made `error_guard` and `error_guard_cond` static