### PR TITLE
Glyph transparency in selector backgrounds #847

### DIFF
--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -254,7 +254,7 @@ ncselector* ncselector_create(ncplane* nc, int y, int x, const ncselector_option
   channels_set_fg_alpha(&transchan, CELL_ALPHA_TRANSPARENT);
   channels_set_bg_alpha(&transchan, CELL_ALPHA_TRANSPARENT);
   ncplane_set_base(ns->ncp, "", 0, transchan);
-  if(cell_prime(ns->ncp, &ns->background, " ", 0, opts->bgchannels) < 0){
+  if(cell_prime(ns->ncp, &ns->background, "", 0, opts->bgchannels) < 0){
     ncplane_destroy(ns->ncp);
     goto freeitems;
   }
@@ -762,7 +762,7 @@ ncmultiselector* ncmultiselector_create(ncplane* nc, int y, int x,
   channels_set_fg_alpha(&transchan, CELL_ALPHA_TRANSPARENT);
   channels_set_bg_alpha(&transchan, CELL_ALPHA_TRANSPARENT);
   ncplane_set_base(ns->ncp, "", 0, transchan);
-  if(cell_prime(ns->ncp, &ns->background, " ", 0, opts->bgchannels) < 0){
+  if(cell_prime(ns->ncp, &ns->background, "", 0, opts->bgchannels) < 0){
     ncplane_destroy(ns->ncp);
     goto freeitems;
   }


### PR DESCRIPTION
Now that we have true glyph transparency (since 1.6.0 or so), we can have a clear selector/multiselector. This allows any background to be seen in full resolution.