### PR TITLE
Eliminate partially-drawn tablets #818

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -174,53 +174,6 @@ typedef struct ncmenu {
   bool bottom;              // are we on the bottom (vs top)?
 } ncmenu;
 
-typedef struct ncselector {
-  ncplane* ncp;                  // backing ncplane
-  unsigned selected;             // index of selection
-  unsigned startdisp;            // index of first option displayed
-  unsigned maxdisplay;           // max number of items to display, 0 -> no limit
-  int longop;                    // columns occupied by longest option
-  int longdesc;                  // columns occupied by longest description
-  struct ncselector_item* items; // list of items and descriptions, heap-copied
-  unsigned itemcount;            // number of pairs in 'items'
-  char* title;                   // can be NULL, in which case there's no riser
-  int titlecols;                 // columns occupied by title
-  char* secondary;               // can be NULL
-  int secondarycols;             // columns occupied by secondary
-  char* footer;                  // can be NULL
-  int footercols;                // columns occupied by footer
-  cell background;               // background, used in body only
-  uint64_t opchannels;           // option channels
-  uint64_t descchannels;         // description channels
-  uint64_t titlechannels;        // title channels
-  uint64_t footchannels;         // secondary and footer channels
-  uint64_t boxchannels;          // border channels
-  int uarrowy, darrowy, arrowx;// location of scrollarrows, even if not present
-} ncselector;
-
-typedef struct ncmultiselector {
-  ncplane* ncp;                   // backing ncplane
-  unsigned current;               // index of highlighted item
-  unsigned startdisp;             // index of first option displayed
-  unsigned maxdisplay;            // max number of items to display, 0 -> no limit
-  int longitem;                   // columns occupied by longest item
-  struct ncmselector_item* items; // items, descriptions, and statuses, heap-copied
-  unsigned itemcount;             // number of pairs in 'items'
-  char* title;                    // can be NULL, in which case there's no riser
-  int titlecols;                  // columns occupied by title
-  char* secondary;                // can be NULL
-  int secondarycols;              // columns occupied by secondary
-  char* footer;                   // can be NULL
-  int footercols;                 // columns occupied by footer
-  cell background;                // background, used in body only
-  uint64_t opchannels;            // option channels
-  uint64_t descchannels;          // description channels
-  uint64_t titlechannels;         // title channels
-  uint64_t footchannels;          // secondary and footer channels
-  uint64_t boxchannels;           // border channels
-  int uarrowy, darrowy, arrowx;   // location of scrollarrows, even if not present
-} ncmultiselector;
-
 // terminfo cache
 typedef struct tinfo {
   int colors;     // number of colors terminfo reported usable for this screen

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -1,5 +1,52 @@
 #include "internal.h"
 
+typedef struct ncselector {
+  ncplane* ncp;                  // backing ncplane
+  unsigned selected;             // index of selection
+  unsigned startdisp;            // index of first option displayed
+  unsigned maxdisplay;           // max number of items to display, 0 -> no limit
+  int longop;                    // columns occupied by longest option
+  int longdesc;                  // columns occupied by longest description
+  struct ncselector_item* items; // list of items and descriptions, heap-copied
+  unsigned itemcount;            // number of pairs in 'items'
+  char* title;                   // can be NULL, in which case there's no riser
+  int titlecols;                 // columns occupied by title
+  char* secondary;               // can be NULL
+  int secondarycols;             // columns occupied by secondary
+  char* footer;                  // can be NULL
+  int footercols;                // columns occupied by footer
+  cell background;               // background, used in body only
+  uint64_t opchannels;           // option channels
+  uint64_t descchannels;         // description channels
+  uint64_t titlechannels;        // title channels
+  uint64_t footchannels;         // secondary and footer channels
+  uint64_t boxchannels;          // border channels
+  int uarrowy, darrowy, arrowx;// location of scrollarrows, even if not present
+} ncselector;
+
+typedef struct ncmultiselector {
+  ncplane* ncp;                   // backing ncplane
+  unsigned current;               // index of highlighted item
+  unsigned startdisp;             // index of first option displayed
+  unsigned maxdisplay;            // max number of items to display, 0 -> no limit
+  int longitem;                   // columns occupied by longest item
+  struct ncmselector_item* items; // items, descriptions, and statuses, heap-copied
+  unsigned itemcount;             // number of pairs in 'items'
+  char* title;                    // can be NULL, in which case there's no riser
+  int titlecols;                  // columns occupied by title
+  char* secondary;                // can be NULL
+  int secondarycols;              // columns occupied by secondary
+  char* footer;                   // can be NULL
+  int footercols;                 // columns occupied by footer
+  cell background;                // background, used in body only
+  uint64_t opchannels;            // option channels
+  uint64_t descchannels;          // description channels
+  uint64_t titlechannels;         // title channels
+  uint64_t footchannels;          // secondary and footer channels
+  uint64_t boxchannels;           // border channels
+  int uarrowy, darrowy, arrowx;   // location of scrollarrows, even if not present
+} ncmultiselector;
+
 // ideal body width given the ncselector's items and secondary/footer
 static int
 ncselector_body_width(const ncselector* n){


### PR DESCRIPTION
This represents an improvement on the reel-drawing algorithm, which seems to eliminate the partially-drawn tablets described in #818. This still isn't a perfect solution, but it's partially there. The full solution is outlined in new comments.