### PR TITLE
rust: generate direct mode bindings #853

### DIFF
--- a/rust/libnotcurses-sys/src/lib.rs
+++ b/rust/libnotcurses-sys/src/lib.rs
@@ -95,10 +95,20 @@ mod tests {
                 margin_r: 0,
                 margin_b: 0,
                 margin_l: 0,
-                flags: NCOPTION_NO_ALTERNATE_SCREEN as u64,
+                flags: (NCOPTION_NO_ALTERNATE_SCREEN | NCOPTION_INHIBIT_SETLOCALE) as u64,
             };
             let nc = notcurses_init(&opts, std::ptr::null_mut());
             notcurses_stop(nc);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn create_direct_context() {
+        unsafe {
+            let _ = libc::setlocale(libc::LC_ALL, std::ffi::CString::new("").unwrap().as_ptr());
+            let nc = ncdirect_init(std::ptr::null_mut(), std::ptr::null_mut());
+            ncdirect_stop(nc);
         }
     }
 

--- a/rust/libnotcurses-sys/wrapper.h
+++ b/rust/libnotcurses-sys/wrapper.h
@@ -1,1 +1,2 @@
 #include <notcurses/notcurses.h>
+#include <notcurses/direct.h>


### PR DESCRIPTION
When we split direct.h out from notcurses.h, I forgot to add
the new header file to the bindgen-rs includes. I've added
it, and also added a simple directmode unit test.

Closes #853. Thanks @joseluis for reporting this issue!