### PR TITLE
refactor test module

### DIFF
--- a/rust/notcurses/src/lib.rs
+++ b/rust/notcurses/src/lib.rs
@@ -12,7 +12,10 @@ pub fn render(_n: *mut ffi::notcurses) -> std::result::Result<(), std::io::Error
     unsafe {
         let r = ffi::notcurses_render(_n);
         if r != 0 {
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, "error rendering"));
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "error rendering",
+            ));
         }
         Ok(())
     }
@@ -38,8 +41,21 @@ mod tests {
     use all_asserts;
     use serial_test::serial; // serialize tests w/ ffi::notcurses_init()
 
-    extern {
+    extern "C" {
         static stdout: *mut ffi::_IO_FILE;
+    }
+
+    fn opts() -> ffi::notcurses_options {
+        ffi::notcurses_options {
+            loglevel: 0,
+            termtype: std::ptr::null(),
+            renderfp: std::ptr::null_mut(),
+            margin_t: 0,
+            margin_r: 0,
+            margin_b: 0,
+            margin_l: 0,
+            flags: ffi::NCOPTION_NO_ALTERNATE_SCREEN as u64 | ffi::NCOPTION_SUPPRESS_BANNERS as u64,
+        }
     }
 
     #[test]
@@ -47,17 +63,7 @@ mod tests {
     fn create_context() {
         unsafe {
             let _ = libc::setlocale(libc::LC_ALL, std::ffi::CString::new("").unwrap().as_ptr());
-            let opts: ffi::notcurses_options = ffi::notcurses_options {
-                loglevel: 0,
-                termtype: std::ptr::null(),
-                renderfp: std::ptr::null_mut(),
-                margin_t: 0,
-                margin_r: 0,
-                margin_b: 0,
-                margin_l: 0,
-                flags: ffi::NCOPTION_NO_ALTERNATE_SCREEN as u64,
-            };
-            let nc = ffi::notcurses_init(&opts, stdout);
+            let nc = ffi::notcurses_init(&opts(), stdout);
             assert_ne!(std::ptr::null(), nc);
             let mut dimy = 0;
             let mut dimx = 0;
@@ -73,7 +79,7 @@ mod tests {
     fn stdplane_dims() {
         unsafe {
             let _ = libc::setlocale(libc::LC_ALL, std::ffi::CString::new("").unwrap().as_ptr());
-            let nc = ffi::notcurses_init(std::ptr::null(), stdout);
+            let nc = ffi::notcurses_init(&opts(), stdout);
             assert_ne!(std::ptr::null(), nc);
             let mut dimsy = 0;
             let mut dimsx = 0;


### PR DESCRIPTION
- new function for creating the notcurses options for tests
- hide the initial statistics for cleaner test output
- reformat file with rustfmt