### PR TITLE
ncselector_dim_yx: eliminate boundary checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@ rearrangements of Notcurses.
 * 1.6.12 (not yet released)
   * `ncselector_redraw()` and `ncmultiselector_redraw()` no longer call
     `notcurses_render()`. You will need to call `notcurses_render()` for the
-    display to reflect any changes.
+    display to reflect any changes. `ncselector_create` now binds the plane
+    it creates to the plane it was provided, and no longer checks to ensure
+    the widget can be fit within the borders of this binding plane.
 
 * 1.6.11 (2020-08-03)
   * `cell_egc_idx()` is no longer exported; it was never intended to be.

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -191,9 +191,8 @@ ncselector_draw(ncselector* n){
   return 0;
 }
 
-// calculate the necessary dimensions based off properties of the selector and
-// the containing screen FIXME should be based on containing ncplane
-static int
+// calculate the necessary dimensions based off properties of the selector
+static void
 ncselector_dim_yx(notcurses* nc, const ncselector* n, int* ncdimy, int* ncdimx){
   int rows = 0, cols = 0; // desired dimensions
   int dimy, dimx; // dimensions of containing screen
@@ -204,9 +203,6 @@ ncselector_dim_yx(notcurses* nc, const ncselector* n, int* ncdimy, int* ncdimx){
   // we have a top line, a bottom line, two lines of margin, and must be able
   // to display at least one row beyond that, so require five more
   rows += 5;
-  if(rows > dimy){ // insufficient height to display selector
-    return -1;
-  }
   rows += (!n->maxdisplay || n->maxdisplay > n->itemcount ? n->itemcount : n->maxdisplay) - 1; // rows necessary to display all options
   if(rows > dimy){ // claw excess back
     rows = dimy;
@@ -217,11 +213,7 @@ ncselector_dim_yx(notcurses* nc, const ncselector* n, int* ncdimy, int* ncdimx){
   if(n->titlecols + 4 > cols){
     cols = n->titlecols + 4;
   }
-  if(cols > dimx){ // insufficient width to display selector
-    return -1;
-  }
   *ncdimx = cols;
-  return 0;
 }
 
 ncselector* ncselector_create(ncplane* nc, int y, int x, const ncselector_options* opts){
@@ -290,10 +282,8 @@ ncselector* ncselector_create(ncplane* nc, int y, int x, const ncselector_option
     }
   }
   int dimy, dimx;
-  if(ncselector_dim_yx(nc->nc, ns, &dimy, &dimx)){
-    goto freeitems;
-  }
-  if(!(ns->ncp = ncplane_new(nc->nc, dimy, dimx, y, x, NULL))){
+  ncselector_dim_yx(nc->nc, ns, &dimy, &dimx);
+  if(!(ns->ncp = ncplane_bound(nc, dimy, dimx, y, x, NULL))){
     goto freeitems;
   }
   cell_init(&ns->background);
@@ -832,7 +822,7 @@ ncmultiselector* ncmultiselector_create(ncplane* nc, int y, int x,
   if(ncmultiselector_dim_yx(nc->nc, ns, &dimy, &dimx)){
     goto freeitems;
   }
-  if(!(ns->ncp = ncplane_new(nc->nc, dimy, dimx, y, x, NULL))){
+  if(!(ns->ncp = ncplane_bound(nc, dimy, dimx, y, x, NULL))){
     goto freeitems;
   }
   cell_init(&ns->background);


### PR DESCRIPTION
* Eliminate the boundary checks in `ncselector_dim_yx()`; they don't make sense, and are unique among widgets. They would make sense if we were writing directly to the plane we were provided, but we aren't -- we're always creating (and resizing, since #849) the plane to which we draw. This happens to also eliminate some `scan-build` checks that had caught my attention.
* By virtue of eliminating these checks, we can no longer fail out of `ncselector_dim_yx()`, meaning the results can never be undefined.
* Create the new plane with `ncplane_bound()` rather than `ncplane_new()`, to bind it to the provided plane.

@sikfeng , I don't know whether you were running into any problems due to this (it would have required operating with selectors larger than whatever plane you passed to `ncselector_create()`), but i wanted you to be aware of it. your code was fine.