### PR TITLE
New reel layout algorithm #818

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.11.4)
 project(notcurses VERSION 1.6.11
   DESCRIPTION "UI for modern terminal emulators"
   HOMEPAGE_URL "https://nick-black.com/dankwiki/index.php/notcurses"

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ rearrangements of Notcurses.
     display to reflect any changes. `ncselector_create` now binds the plane
     it creates to the plane it was provided, and no longer checks to ensure
     the widget can be fit within the borders of this binding plane.
+  * Added `ncplane_new_named()`, `ncplane_bound_named()`, and
+    `ncplane_aligned_named()`. These would be the defaults, but I didn't want
+    to break existing code. They might become the defaults by 2.0. Names are
+    used only for debugging (`notcurses_debug()`) at this time.
   * Added `ncplane_parent()` and `ncplane_parent_const()` for accessing the
     plane to which a plane is bound.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ rearrangements of Notcurses.
     display to reflect any changes. `ncselector_create` now binds the plane
     it creates to the plane it was provided, and no longer checks to ensure
     the widget can be fit within the borders of this binding plane.
+  * Added `ncplane_parent()` and `ncplane_parent_const()` for accessing the
+    plane to which a plane is bound.
 
 * 1.6.11 (2020-08-03)
   * `cell_egc_idx()` is no longer exported; it was never intended to be.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@ This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
 * 1.6.12 (not yet released)
+  * `ncreel`s `tabletcb` callback function semantics are radically simplified.
+    No more worrying about borders that might or might not have been drawn;
+    simply fill up the plane that you're handed. This eliminates four of the
+    seven arguments to these callbacks. I hope the inconvenience of adapting
+    them is worth the elimination of complexity therein; I obviously think
+    it is =].
   * `ncselector_redraw()` and `ncmultiselector_redraw()` no longer call
     `notcurses_render()`. You will need to call `notcurses_render()` for the
     display to reflect any changes. `ncselector_create` now binds the plane

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ that fine library.
 ## Requirements
 
 * (build) A C11 and a C++17 compiler
-* (build) CMake 3.14.0+
+* (build) CMake 3.11.4+
 * (build+runtime) From NCURSES: terminfo 6.1+
 * (build+runtime) GNU libunistring 0.9.10+
 * (OPTIONAL) (build+runtime) From QR-Code-generator: [libqrcodegen](https://github.com/nayuki/QR-Code-generator) 1.5.0+

--- a/USAGE.md
+++ b/USAGE.md
@@ -617,15 +617,30 @@ quickly reset the `ncplane`, use `ncplane_erase()`.
 struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols,
                             int yoff, int xoff, void* opaque);
 
-// Create a new ncplane aligned relative to 'n'.
-struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols,
-                                int yoff, ncalign_e align, void* opaque);
+// Create a named plane ala ncplane_new(). Names are only used for debugging.
+struct ncplane* ncplane_new_named(struct notcurses* nc, int rows, int cols,
+                                  int yoff, int xoff, void* opaque,
+                                  const char* name);
 
 // Create a plane bound to plane 'n'. Being bound to 'n' means that 'yoff' and
 // 'xoff' are interpreted relative to that plane's origin, and that if that
 // plane is moved later, this new plane is moved by the same amount.
 struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols,
                               int yoff, int xoff, void* opaque);
+
+// Create a named plane ala ncplane_bound(). Names are used only for debugging.
+struct ncplane* ncplane_bound_named(struct ncplane* n, int rows, int cols,
+                                    int yoff, int xoff, void* opaque,
+                                    const char* name);
+
+// Create a plane bound to 'n', and aligned relative to it using 'align'.
+struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols,
+                                int yoff, ncalign_e align, void* opaque);
+
+// Create a named plane ala ncplane_aligned(). Names are used only for debugging.
+struct ncplane* ncplane_aligned_named(struct ncplane* n, int rows, int cols,
+                                      int yoff, ncalign_e align,
+                                      void* opaque, const char* name);
 
 // Plane 'n' will be unbound from its parent plane, if it is currently bound,
 // and will be made a bound child of 'newparent', if 'newparent' is not NULL.

--- a/USAGE.md
+++ b/USAGE.md
@@ -536,7 +536,7 @@ typedef struct ncinput {
 // be NULL. Returns 0 on a timeout. If an event is processed, the return value
 // is the 'id' field from that event. 'ni' may be NULL.
 char32_t notcurses_getc(struct notcurses* n, const struct timespec* ts,
-                            sigset_t* sigmask, ncinput* ni);
+                        sigset_t* sigmask, ncinput* ni);
 
 // 'ni' may be NULL if the caller is uninterested in event details. If no event
 // is ready, returns 0.
@@ -699,7 +699,7 @@ It is an error to invoke these functions on the standard plane.
 // Essentially, the kept material does not move. It serves to anchor the
 // resized plane. If there is no kept material, the plane can move freely.
 int ncplane_resize(struct ncplane* n, int keepy, int keepx, int keepleny,
-                       int keeplenx, int yoff, int xoff, int ylen, int xlen);
+                   int keeplenx, int yoff, int xoff, int ylen, int xlen);
 
 // Resize the plane, retaining what data we can (everything, unless we're
 // shrinking in some dimension). Keep the origin where it is.
@@ -1038,10 +1038,10 @@ ncplane_putwstr(struct ncplane* n, const wchar_t* gclustarr){
 
 // The ncplane equivalents of printf(3) and vprintf(3).
 int ncplane_vprintf_aligned(struct ncplane* n, int y, ncalign_e align,
-                                const char* format, va_list ap);
+                            const char* format, va_list ap);
 
 int ncplane_vprintf_yx(struct ncplane* n, int y, int x,
-                           const char* format, va_list ap);
+                       const char* format, va_list ap);
 
 static inline int
 ncplane_vprintf(struct ncplane* n, const char* format, va_list ap){
@@ -1119,7 +1119,7 @@ on both sides. Boxes allow fairly detailed specification of how they're drawn.
 // number of cells drawn on success. On error, return the negative number of
 // cells drawn.
 int ncplane_hline_interp(struct ncplane* n, const cell* c, int len,
-                             uint64_t c1, uint64_t c2);
+                         uint64_t c1, uint64_t c2);
 
 static inline int
 ncplane_hline(struct ncplane* n, const cell* c, int len){
@@ -1127,7 +1127,7 @@ ncplane_hline(struct ncplane* n, const cell* c, int len){
 }
 
 int ncplane_vline_interp(struct ncplane* n, const cell* c, int len,
-                             uint64_t c1, uint64_t c2);
+                         uint64_t c1, uint64_t c2);
 
 static inline int
 ncplane_vline(struct ncplane* n, const cell* c, int len){
@@ -1165,9 +1165,8 @@ ncplane_vline(struct ncplane* n, const cell* c, int len){
 #define NCBOXCORNER_SHIFT 8u
 
 int ncplane_box(struct ncplane* n, const cell* ul, const cell* ur,
-                    const cell* ll, const cell* lr, const cell* hline,
-                    const cell* vline, int ystop, int xstop,
-                    unsigned ctlword);
+                const cell* ll, const cell* lr, const cell* hline,
+                const cell* vline, int ystop, int xstop, unsigned ctlword);
 
 // Draw a box with its upper-left corner at the current cursor position, having
 // dimensions 'ylen'x'xlen'. See ncplane_box() for more information. The
@@ -1323,13 +1322,13 @@ typedef int (*fadecb)(struct notcurses* nc, struct ncplane* ncp,
 // modification (if the terminal uses a palette, our ability to fade planes is
 // limited, and affected by the complexity of the rest of the screen).
 int ncplane_fadeout(struct ncplane* n, const struct timespec* ts,
-                        fadecb fader, void* curry);
+                    fadecb fader, void* curry);
 
 // Fade the ncplane in over the specified time. Load the ncplane with the
 // target cells without rendering, then call this function. When it's done, the
 // ncplane will have reached the target levels, starting from zeroes.
 int ncplane_fadein(struct ncplane* n, const struct timespec* ts,
-                       fadecb fader, void* curry);
+                   fadecb fader, void* curry);
 
 // Rather than the simple ncplane_fade{in/out}(), ncfadectx_setup() can be
 // Pulse the plane in and out until the callback returns non-zero, relying on
@@ -1381,8 +1380,6 @@ int ncblit_rgba(const void* data, int linesize,
 int ncblit_bgrx(const void* data, int linesize,
                 const struct ncvisual_options* vopts);
 ```
-
-
 
 ### Plane channels API
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -631,6 +631,10 @@ struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols,
 // and will be made a bound child of 'newparent', if 'newparent' is not NULL.
 struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparent);
 
+// Get the plane to which the plane 'n' is bound, if any.
+struct ncplane* ncplane_parent(struct ncplane* n);
+const struct ncplane* ncplane_parent_const(const struct ncplane* n);
+
 // Duplicate an existing ncplane. The new plane will have the same geometry,
 // will duplicate all content, and will start with the same rendering state.
 struct ncplane* ncplane_dup(struct ncplane* n, void* opaque);

--- a/doc/man/man1/notcurses-demo.1.md
+++ b/doc/man/man1/notcurses-demo.1.md
@@ -55,7 +55,7 @@ At any time, press 'q' to quit. The demo is best run in at least an 80x45 termin
 
 **-d delaymult**: Apply a non-negative rational multiplier to the standard delay of 1s.
 
-**-l loglevel**: Log everything (high log level) or nothing (log level 0) to stderr.
+**-l loglevel**: Log everything (log level 8) or nothing (log level 0) to stderr.
 
 **-f renderfile**: Render each frame to **renderfile** in addition to the screen.
 

--- a/doc/man/man1/notcurses-ncreel.1.md
+++ b/doc/man/man1/notcurses-ncreel.1.md
@@ -8,7 +8,7 @@ notcurses-ncreel - Experiment with ncreels
 
 # SYNOPSIS
 
-**notcurses-ncreel** [**-t tabletbordermask**] [**-b bordermask**] [**-ob bottomoffset**] [**-ot topoffset**] [**-ol leftoffset**] [**-or rightoffset**]
+**notcurses-ncreel** [**-t tabletbordermask**] [**-b bordermask**] [**-ob bottomoffset**] [**-ot topoffset**] [**-ol leftoffset**] [**-or rightoffset**] [**-ln**]
 
 # DESCRIPTION
 
@@ -17,6 +17,8 @@ program open, press 'a' to create a new tablet, or 'd' to delete the focused
 tablet (if one exists). 'q' quits at any time.
 
 # OPTIONS
+
+**-l loglevel**: Log everything (log level 8) or nothing (log level 0) to stderr.
 
 # NOTES
 

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -12,11 +12,17 @@ notcurses_plane - operations on ncplanes
 
 **struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque);**
 
+**struct ncplane* ncplane_new_named(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);**
+
 **struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque);**
 
-**struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparent);**
+**struct ncplane* ncplane_bound_named(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);**
 
 **struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque);**
+
+**struct ncplane* ncplane_aligned_named(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque, const char* name);**
+
+**struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparent);**
 
 **struct ncplane* ncplane_dup(struct ncplane* n, void* opaque);**
 

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -26,6 +26,10 @@ notcurses_plane - operations on ncplanes
 
 **void ncplane_yx(const struct ncplane* n, int* restrict y, int* restrict x);**
 
+**struct ncplane* ncplane_parent(struct ncplane* n);**
+
+**const struct ncplane* ncplane_parent_const(const struct ncplane* n);**
+
 **int ncplane_set_base_cell(struct ncplane* ncp, const cell* c);**
 
 **int ncplane_set_base(struct ncplane* ncp, const char* egc, uint32_t attrword, uint64_t channels);**

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2463,18 +2463,10 @@ API struct ncreel* ncreel_create(struct ncplane* nc, const ncreel_options* popts
 API struct ncplane* ncreel_plane(struct ncreel* pr);
 
 // Tablet draw callback, provided a tablet (from which the ncplane and userptr
-// may be extracted), and a bool indicating whether output ought be clipped at
-// the top (true) or bottom (false).
-//
-// Regarding clipping: it is possible that the tablet is only partially
-// displayed on the screen. If so, it is either partially present on the top of
-// the screen, or partially present at the bottom. In the former case, the top
-// is clipped (cliptop will be true), and output must start from the end. In
-// the latter case, cliptop is false, and output must start from the beginning.
-//
-// Returns the number of lines of output, which ought be less than or equal to
-// maxy - begy, and non-negative (negative values might be used in the future).
-typedef int (*tabletcb)(struct nctablet* t, bool cliptop);
+// may be extracted), and a bool indicating whether output ought be drawn from
+// the top (true) or bottom (false). Returns non-negative count of output lines,
+// which must be less than or equal to ncplane_dim_y(nctablet_plane(t)).
+typedef int (*tabletcb)(struct nctablet* t, bool drawfromtop);
 
 // Add a new nctablet to the provided ncreel, having the callback object
 // opaque. Neither, either, or both of after and before may be specified. If

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1222,7 +1222,7 @@ API char* ncplane_contents(const struct ncplane* nc, int begy, int begx,
 // Manipulate the opaque user pointer associated with this plane.
 // ncplane_set_userptr() returns the previous userptr after replacing
 // it with 'opaque'. the others simply return the userptr.
-API void* ncplane_set_userptr(struct ncplane* n, void* opaque);
+API void* ncplane_set_userptR(STRUCT Ncplane* n, void* opaque);
 API void* ncplane_userptr(struct ncplane* n);
 
 API void ncplane_center_abs(const struct ncplane* n, int* RESTRICT y,

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1141,6 +1141,10 @@ API int ncplane_move_yx(struct ncplane* n, int y, int x);
 // which it is bound (if it is bound to a plane).
 API void ncplane_yx(const struct ncplane* n, int* RESTRICT y, int* RESTRICT x);
 
+// Get the plane to which the plane 'n' is bound, if any.
+API struct ncplane* ncplane_parent(struct ncplane* n);
+API const struct ncplane* ncplane_parent_const(const struct ncplane* n);
+
 // Splice ncplane 'n' out of the z-buffer, and reinsert it at the top or bottom.
 API void ncplane_move_top(struct ncplane* n);
 API void ncplane_move_bottom(struct ncplane* n);

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1222,7 +1222,7 @@ API char* ncplane_contents(const struct ncplane* nc, int begy, int begx,
 // Manipulate the opaque user pointer associated with this plane.
 // ncplane_set_userptr() returns the previous userptr after replacing
 // it with 'opaque'. the others simply return the userptr.
-API void* ncplane_set_userptR(STRUCT Ncplane* n, void* opaque);
+API void* ncplane_set_userptr(struct ncplane* n, void* opaque);
 API void* ncplane_userptr(struct ncplane* n);
 
 API void ncplane_center_abs(const struct ncplane* n, int* RESTRICT y,
@@ -2463,22 +2463,18 @@ API struct ncreel* ncreel_create(struct ncplane* nc, const ncreel_options* popts
 API struct ncplane* ncreel_plane(struct ncreel* pr);
 
 // Tablet draw callback, provided a tablet (from which the ncplane and userptr
-// may be extracted), the first column that may be used, the first row that may
-// be used, the first column that may not be used, the first row that may not
-// be used, and a bool indicating whether output ought be clipped at the top
-// (true) or bottom (false). Rows and columns are zero-indexed, and both are
-// relative to the tablet's plane.
+// may be extracted), and a bool indicating whether output ought be clipped at
+// the top (true) or bottom (false).
 //
 // Regarding clipping: it is possible that the tablet is only partially
 // displayed on the screen. If so, it is either partially present on the top of
 // the screen, or partially present at the bottom. In the former case, the top
-// is clipped (cliptop will be true), and output ought start from the end. In
-// the latter case, cliptop is false, and output ought start from the beginning.
+// is clipped (cliptop will be true), and output must start from the end. In
+// the latter case, cliptop is false, and output must start from the beginning.
 //
 // Returns the number of lines of output, which ought be less than or equal to
 // maxy - begy, and non-negative (negative values might be used in the future).
-typedef int (*tabletcb)(struct nctablet* t, int begx, int begy, int maxx,
-                        int maxy, bool cliptop);
+typedef int (*tabletcb)(struct nctablet* t, bool cliptop);
 
 // Add a new nctablet to the provided ncreel, having the callback object
 // opaque. Neither, either, or both of after and before may be specified. If

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -984,14 +984,30 @@ API char* notcurses_at_yx(struct notcurses* nc, int yoff, int xoff,
 API struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols,
                                 int yoff, int xoff, void* opaque);
 
-API struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols,
-                                    int yoff, ncalign_e align, void* opaque);
+// Create a named plane ala ncplane_new(). Names are only used for debugging.
+API struct ncplane* ncplane_new_named(struct notcurses* nc, int rows, int cols,
+                                      int yoff, int xoff, void* opaque,
+                                      const char* name);
 
 // Create a plane bound to plane 'n'. Being bound to 'n' means that 'yoff' and
 // 'xoff' are interpreted relative to that plane's origin, and that if that
 // plane is moved later, this new plane is moved by the same amount.
 API struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols,
                                   int yoff, int xoff, void* opaque);
+
+// Create a named plane ala ncplane_bound(). Names are used only for debugging.
+API struct ncplane* ncplane_bound_named(struct ncplane* n, int rows, int cols,
+                                        int yoff, int xoff, void* opaque,
+                                        const char* name);
+
+// Create a plane bound to 'n', and aligned relative to it using 'align'.
+API struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols,
+                                    int yoff, ncalign_e align, void* opaque);
+
+// Create a named plane ala ncplane_aligned(). Names are used only for debugging.
+API struct ncplane* ncplane_aligned_named(struct ncplane* n, int rows, int cols,
+                                          int yoff, ncalign_e align,
+                                          void* opaque, const char* name);
 
 // Plane 'n' will be unbound from its parent plane, if it is currently bound,
 // and will be made a bound child of 'newparent', if 'newparent' is not NULL.

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -96,15 +96,18 @@ int ncplane_base(struct ncplane* ncp, cell* c);
 struct ncplane* notcurses_top(struct notcurses* n);
 void notcurses_drop_planes(struct notcurses* nc);
 int notcurses_refresh(struct notcurses* n, int* restrict y, int* restrict x);
-struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque);
-struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque);
 struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparent);
 typedef enum {
   NCALIGN_LEFT,
   NCALIGN_CENTER,
   NCALIGN_RIGHT,
 } ncalign_e;
+struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque);
+struct ncplane* ncplane_new_named(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);
+struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque);
+struct ncplane* ncplane_bound_named(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);
 struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque);
+struct ncplane* ncplane_aligned_named(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque, const char* name);
 unsigned notcurses_supported_styles(const struct notcurses* nc);
 int notcurses_palette_size(const struct notcurses* nc);
 bool notcurses_cantruecolor(const struct notcurses* nc);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -510,6 +510,8 @@ int ncdirect_double_box(struct ncdirect* n, uint64_t ul, uint64_t ur, uint64_t l
 bool ncdirect_canopen_images(const struct ncdirect* n);
 bool ncdirect_canutf8(const struct ncdirect* n);
 nc_err_e ncdirect_render_image(struct ncdirect* n, const char* filename, ncalign_e align, ncblitter_e blitter, ncscale_e scale);
+struct ncplane* ncplane_parent(struct ncplane* n);
+const struct ncplane* ncplane_parent_const(const struct ncplane* n);
 """)
 
 if __name__ == "__main__":

--- a/src/demo/reel.c
+++ b/src/demo/reel.c
@@ -102,7 +102,10 @@ tabletdown(struct ncplane* w, int maxy, tabletctx* tctx, unsigned rgb){
   cell c = CELL_TRIVIAL_INITIALIZER;
   int y;
   int maxx = ncplane_dim_x(w) - 1;
-  for(y = 0 ; y <= maxy && y < tctx->lines ; ++y, rgb += 16){
+  if(maxy > tctx->lines){
+    maxy = tctx->lines;
+  }
+  for(y = 0 ; y <= maxy ; ++y, rgb += 16){
     snprintf(cchbuf, sizeof(cchbuf) / sizeof(*cchbuf), "%x", y % 16);
     cell_load(w, &c, cchbuf);
     if(cell_set_fg_rgb(&c, (rgb >> 16u) % 0xffu, (rgb >> 8u) % 0xffu, rgb % 0xffu)){
@@ -182,7 +185,10 @@ tablet_thread(void* vtabletctx){
     pthread_mutex_lock(&renderlock);
     if(nctablet_ncplane(tctx->t)){
       ncreel_redraw(tctx->pr);
-      demo_render(ncplane_notcurses(nctablet_ncplane(tctx->t)));
+      auto tplane = nctablet_ncplane(tctx->t);
+      if(tplane){
+        demo_render(ncplane_notcurses(tplane));
+      }
     }
     pthread_mutex_unlock(&renderlock);
   }

--- a/src/demo/reel.c
+++ b/src/demo/reel.c
@@ -185,7 +185,7 @@ tablet_thread(void* vtabletctx){
     pthread_mutex_lock(&renderlock);
     if(nctablet_ncplane(tctx->t)){
       ncreel_redraw(tctx->pr);
-      auto tplane = nctablet_ncplane(tctx->t);
+      struct ncplane* tplane = nctablet_ncplane(tctx->t);
       if(tplane){
         demo_render(ncplane_notcurses(tplane));
       }

--- a/src/demo/reel.c
+++ b/src/demo/reel.c
@@ -64,25 +64,25 @@ kill_active_tablet(struct ncreel* pr, tabletctx** tctx){
 // partially off-screen), but also leave unused space at the end (since
 // wresize() only keeps the top and left on a shrink).
 static int
-tabletup(struct ncplane* w, int begx, int begy, int maxx, int maxy,
-         tabletctx* tctx, int rgb){
+tabletup(struct ncplane* w, int maxy, tabletctx* tctx, int rgb){
   char cchbuf[2];
   cell c = CELL_TRIVIAL_INITIALIZER;
   int y, idx;
   idx = tctx->lines;
-  if(maxy - begy > tctx->lines){
-    maxy -= (maxy - begy - tctx->lines);
+  int maxx = ncplane_dim_x(w) - 1;
+  if(maxy > tctx->lines){
+    maxy = tctx->lines;
   }
 /*fprintf(stderr, "-OFFSET BY %d (%d->%d)\n", maxy - begy - tctx->lines,
         maxy, maxy - (maxy - begy - tctx->lines));*/
-  for(y = maxy ; y >= begy ; --y, rgb += 16){
+  for(y = maxy ; y >= 0 ; --y, rgb += 16){
     snprintf(cchbuf, sizeof(cchbuf) / sizeof(*cchbuf), "%x", idx % 16);
     cell_load(w, &c, cchbuf);
     if(cell_set_fg_rgb(&c, (rgb >> 16u) % 0xffu, (rgb >> 8u) % 0xffu, rgb % 0xffu)){
       return -1;
     }
     int x;
-    for(x = begx ; x <= maxx ; ++x){
+    for(x = 0 ; x <= maxx ; ++x){
       if(ncplane_putc_yx(w, y, x, &c) <= 0){
         return -1;
       }
@@ -97,57 +97,55 @@ tabletup(struct ncplane* w, int begx, int begy, int maxx, int maxy,
 }
 
 static int
-tabletdown(struct ncplane* w, int begx, int begy, int maxx, int maxy,
-           tabletctx* tctx, unsigned rgb){
+tabletdown(struct ncplane* w, int maxy, tabletctx* tctx, unsigned rgb){
   char cchbuf[2];
   cell c = CELL_TRIVIAL_INITIALIZER;
   int y;
-  for(y = begy ; y <= maxy ; ++y, rgb += 16){
-    if(y - begy >= tctx->lines){
-      break;
-    }
+  int maxx = ncplane_dim_x(w) - 1;
+  for(y = 0 ; y <= maxy && y < tctx->lines ; ++y, rgb += 16){
     snprintf(cchbuf, sizeof(cchbuf) / sizeof(*cchbuf), "%x", y % 16);
     cell_load(w, &c, cchbuf);
     if(cell_set_fg_rgb(&c, (rgb >> 16u) % 0xffu, (rgb >> 8u) % 0xffu, rgb % 0xffu)){
       return -1;
     }
     int x;
-    for(x = begx ; x <= maxx ; ++x){
+    for(x = 0 ; x <= maxx ; ++x){
       if(ncplane_putc_yx(w, y, x, &c) <= 0){
         return -1;
       }
     }
     cell_release(w, &c);
   }
-  return y - begy;
+  return y;
 }
 
 static int
-tabletdraw(struct nctablet* t, int begx, int begy, int maxx, int maxy, bool cliptop){
+tabletdraw(struct nctablet* t, bool cliptop){
   struct ncplane* p = nctablet_ncplane(t);
   tabletctx* tctx = nctablet_userptr(t);
   pthread_mutex_lock(&tctx->lock);
   unsigned rgb = tctx->rgb;
   int ll;
+  int maxy = ncplane_dim_y(p);
   if(cliptop){
-    ll = tabletup(p, begx, begy, maxx, maxy, tctx, rgb);
+    ll = tabletup(p, maxy, tctx, rgb);
   }else{
-    ll = tabletdown(p, begx, begy, maxx, maxy, tctx, rgb);
+    ll = tabletdown(p, maxy, tctx, rgb);
   }
   ncplane_set_fg_rgb(p, 242, 242, 242);
   if(ll){
-    int summaryy = begy;
+    int summaryy = 0;
     if(cliptop){
-      if(ll == maxy - begy + 1){
+      if(ll == maxy + 1){
         summaryy = ll - 1;
       }else{
         summaryy = ll;
       }
     }
     ncplane_styles_on(p, NCSTYLE_BOLD);
-    if(ncplane_printf_yx(p, summaryy, begx, "[#%u %d line%s %u/%u] ",
+    if(ncplane_printf_yx(p, summaryy, 0, "[#%u %d line%s %u available] ",
                          tctx->id, tctx->lines, tctx->lines == 1 ? "" : "s",
-                         begy, maxy) < 0){
+                         maxy) < 0){
       pthread_mutex_unlock(&tctx->lock);
       return -1;
     }

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -6,9 +6,9 @@ void notcurses_debug(notcurses* nc, FILE* debugfp){
   int planeidx = 0;
   fprintf(debugfp, "*************************** notcurses debug state *****************************\n");
   while(n){
-    fprintf(debugfp, "%04d off y: %3d x: %3d geom y: %3d x: %3d curs y: %3d x: %3d %06llx %.8s\n",
+    fprintf(debugfp, "%04d off y: %3d x: %3d geom y: %3d x: %3d curs y: %3d x: %3d %p %.8s\n",
             planeidx, n->absy, n->absx, n->leny, n->lenx, n->y, n->x,
-            (uintptr_t)n % 0x100000000ull, n->name ? n->name : "");
+            n, n->name ? n->name : "");
     if(n->boundto || n->bnext || n->bprev || n->blist){
       fprintf(debugfp, " bound %p -> %p <- %p binds %p\n",
               n->boundto, n->bnext, n->bprev, n->blist);

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -10,7 +10,7 @@ void notcurses_debug(notcurses* nc, FILE* debugfp){
             planeidx, n->absy, n->absx, n->leny, n->lenx, n->y, n->x,
             n, n->name ? n->name : "");
     if(n->boundto || n->bnext || n->bprev || n->blist){
-      fprintf(debugfp, " bound %p -> %p <- %p binds %p\n",
+      fprintf(debugfp, " bound %p → %p ← %p binds %p\n",
               n->boundto, n->bnext, n->bprev, n->blist);
     }
     if(n->bnext == n || n->boundto == n || n->blist == n){

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -117,6 +117,32 @@ typedef struct renderstate {
   bool defaultelidable;
 } renderstate;
 
+// Tablets are the toplevel entitites within an ncreel. Each corresponds to
+// a single, distinct ncplane.
+typedef struct nctablet {
+  ncplane* p;                  // border plane, NULL when offscreen
+  ncplane* cbp;                // data plane, NULL when offscreen
+  struct nctablet* next;
+  struct nctablet* prev;
+  tabletcb cbfxn;              // application callback to draw cbp
+  void* curry;                 // application data provided to cbfxn
+} nctablet;
+
+typedef struct ncreel {
+  ncplane* p;           // ncplane this ncreel occupies, under tablets
+  // doubly-linked list, a circular one when infinity scrolling is in effect.
+  // points at the focused tablet (when at least one tablet exists, one must be
+  // focused). it will be visibly focused following the next redraw.
+  nctablet* tablets;
+  nctablet* vft;        // the visibly-focused tablet
+  enum {
+    LASTDIRECTION_UP,
+    LASTDIRECTION_DOWN,
+  } direction;          // last direction of travel
+  int tabletcount;      // could be derived, but we keep it o(1)
+  ncreel_options ropts; // copied in ncreel_create()
+} ncreel;
+
 // ncmenu_item and ncmenu_section have internal and (minimal) external forms
 typedef struct ncmenu_int_item {
   char* desc;           // utf-8 menu item, NULL for horizontal separator

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -795,6 +795,9 @@ cell_nobackground_p(const cell* c){
   return c->channels & CELL_NOBACKGROUND_MASK;
 }
 
+// Destroy a plane and all its bound descendants.
+int ncplane_genocide(ncplane *ncp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -297,11 +297,13 @@ void free_plane(ncplane* p){
 ncplane* ncplane_create(notcurses* nc, ncplane* n, int rows, int cols,
                         int yoff, int xoff, void* opaque, const char* name){
   if(rows <= 0 || cols <= 0){
+    logerror(nc, "Won't create denormalized plane (r=%d, c=%d)\n", rows, cols);
     return NULL;
   }
   ncplane* p = malloc(sizeof(*p));
   size_t fbsize = sizeof(*p->fb) * (rows * cols);
   if((p->fb = malloc(fbsize)) == NULL){
+    logerror(nc, "Error allocating cellmatrix (r=%d, c=%d)\n", rows, cols);
     free(p);
     return NULL;
   }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -348,6 +348,7 @@ ncplane* ncplane_create(notcurses* nc, ncplane* n, int rows, int cols,
   }else{
     p->below = NULL;
   }
+  loginfo(nc, "Created new %dx%d plane @ %dx%d\n", rows, cols, yoff, xoff);
   return p;
 }
 
@@ -562,22 +563,6 @@ int ncplane_resize(ncplane* n, int keepy, int keepx, int keepleny,
                                  yoff, xoff, ylen, xlen);
 }
 
-int ncplane_genocide(ncplane *ncp){
-  if(ncp == NULL){
-    return 0;
-  }
-  if(ncp->nc->stdplane == ncp){
-    logerror(ncp->nc, "Won't destroy standard plane\n");
-    return -1;
-  }
-  int ret = 0;
-  while(ncp->blist){
-    ret |= ncplane_genocide(ncp->blist);
-  }
-  ret |= ncplane_destroy(ncp);
-  return ret;
-}
-
 int ncplane_destroy(ncplane* ncp){
   if(ncp == NULL){
     return 0;
@@ -611,6 +596,22 @@ int ncplane_destroy(ncplane* ncp){
     bound = tmp;
   }
   free_plane(ncp);
+  return ret;
+}
+
+int ncplane_genocide(ncplane *ncp){
+  if(ncp == NULL){
+    return 0;
+  }
+  if(ncp->nc->stdplane == ncp){
+    logerror(ncp->nc, "Won't destroy standard plane\n");
+    return -1;
+  }
+  int ret = 0;
+  while(ncp->blist){
+    ret |= ncplane_genocide(ncp->blist);
+  }
+  ret |= ncplane_destroy(ncp);
   return ret;
 }
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -374,14 +374,30 @@ ncplane* ncplane_new(notcurses* nc, int rows, int cols, int yoff, int xoff, void
   return ncplane_create(nc, NULL, rows, cols, yoff, xoff, opaque, NULL);
 }
 
+ncplane* ncplane_new_named(notcurses* nc, int rows, int cols, int yoff,
+                           int xoff, void* opaque, const char* name){
+  return ncplane_create(nc, NULL, rows, cols, yoff, xoff, opaque, name);
+}
+
 ncplane* ncplane_bound(ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque){
   return ncplane_create(n->nc, n, rows, cols, yoff, xoff, opaque, NULL);
+}
+
+ncplane* ncplane_bound_named(ncplane* n, int rows, int cols, int yoff, int xoff,
+                             void* opaque, const char* name){
+  return ncplane_create(n->nc, n, rows, cols, yoff, xoff, opaque, name);
 }
 
 ncplane* ncplane_aligned(ncplane* n, int rows, int cols, int yoff,
                          ncalign_e align, void* opaque){
   return ncplane_create(n->nc, n, rows, cols, yoff,
                         ncplane_align(n, align, cols), opaque, NULL);
+}
+
+ncplane* ncplane_aligned_named(ncplane* n, int rows, int cols, int yoff,
+                               ncalign_e align, void* opaque, const char* name){
+  return ncplane_create(n->nc, n, rows, cols, yoff,
+                        ncplane_align(n, align, cols), opaque, name);
 }
 
 void ncplane_home(ncplane* n){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2201,6 +2201,14 @@ const notcurses* ncplane_notcurses_const(const ncplane* n){
   return n->nc;
 }
 
+ncplane* ncplane_parent(ncplane* n){
+  return n->boundto;
+}
+
+const ncplane* ncplane_parent_const(const ncplane* n){
+  return n->boundto;
+}
+
 ncplane* ncplane_reparent(ncplane* n, ncplane* newparent){
   if(n == n->nc->stdplane){
     return NULL; // can't reparent standard plane

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -587,53 +587,6 @@ tighten_reel(ncreel* r){
   return 0;
 }
 
-// debugging
-bool ncreel_validate(const ncreel* n){
-  if(n->tablets == NULL){
-    return true;
-  }
-  const nctablet* t = n->tablets;
-  int cury = -1;
-  bool wentaround = false;
-  do{
-    const ncplane* np = t->p;
-    if(np){
-      int y, x;
-      ncplane_yx(np, &y, &x);
-//fprintf(stderr, "forvart: %p (%p) @ %d\n", t, np, y);
-      if(y < cury){
-        if(wentaround){
-          return false;
-        }
-        wentaround = true;
-      }else if(y == cury){
-        return false;
-      }
-      cury = y;
-    }
-  }while((t = t->next) != n->tablets);
-  cury = INT_MAX;
-  wentaround = false;
-  do{
-    const ncplane* np = t->p;
-    if(np){
-      int y, x;
-      ncplane_yx(np, &y, &x);
-//fprintf(stderr, "backwards: %p (%p) @ %d\n", t, np, y);
-      if(y > cury){
-        if(wentaround){
-          return false;
-        }
-        wentaround = true;
-      }else if(y == cury){
-        return false;
-      }
-      cury = y;
-    }
-  }while((t = t->prev) != n->tablets);
-  return true;
-}
-
 // destroy all existing tablet planes pursuant to redraw
 static void
 clean_reel(ncreel* r){
@@ -696,9 +649,6 @@ int ncreel_redraw(ncreel* nr){
   }
   tighten_reel(nr);
 //fprintf(stderr, "DONE ARRANGING\n");
-  if(!ncreel_validate(nr)){
-    return -1;
-  }
   return 0;
 }
 

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -209,7 +209,7 @@ static int
 tablet_geom(const ncreel* nr, nctablet* t, int* begx, int* begy,
             int* lenx, int* leny, int frontiertop, int frontierbottom,
             direction_e direction){
-fprintf(stderr, "jigsawing %p with %d/%d dir %d\n", t, frontiertop, frontierbottom, direction);
+//fprintf(stderr, "jigsawing %p with %d/%d dir %d\n", t, frontiertop, frontierbottom, direction);
   *begy = 0;
   *begx = 0;
   ncplane_dim_yx(nr->p, leny, lenx);
@@ -259,18 +259,18 @@ ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiertop,
                    int frontierbottom, direction_e direction){
   assert(!t->p);
   if(t->p || t->cbp){
-fprintf(stderr, "already drew %p: %p %p\n", t, t->p, t->cbp);
+//fprintf(stderr, "already drew %p: %p %p\n", t, t->p, t->cbp);
     return -1;
   }
   int lenx, leny, begy, begx;
   if(tablet_geom(nr, t, &begx, &begy, &lenx, &leny, frontiertop, frontierbottom, direction)){
-fprintf(stderr, "no room: %p base %d/%d len %d/%d dir %d\n", t, begy, begx, leny, lenx, direction);
+//fprintf(stderr, "no room: %p base %d/%d len %d/%d dir %d\n", t, begy, begx, leny, lenx, direction);
     return -1;
   }
 fprintf(stderr, "tplacement: %p base %d/%d len %d/%d frontiery %d %d dir %d\n", t, begy, begx, leny, lenx, frontiertop, frontierbottom, direction);
-  ncplane* fp = ncplane_bound(nr->p, leny, lenx, begy, begx, NULL);
+  ncplane* fp = ncplane_bound_named(nr->p, leny, lenx, begy, begx, NULL, "tab");
   if((t->p = fp) == NULL){
-fprintf(stderr, "failure creating border plane %d %d %d %d\n", leny, lenx, begy, begx);
+//fprintf(stderr, "failure creating border plane %d %d %d %d\n", leny, lenx, begy, begx);
     return -1;
   }
   // we allow the callback to use a bound plane that lives above our border
@@ -289,9 +289,9 @@ fprintf(stderr, "failure creating border plane %d %d %d %d\n", leny, lenx, begy,
     ++cbx;
   }
   if(cbleny - cby + 1 > 0){
-    t->cbp = ncplane_bound(t->p, cbleny - cby + 1, cblenx - cbx + 1, cby, cbx, NULL);
+    t->cbp = ncplane_bound_named(t->p, cbleny - cby + 1, cblenx - cbx + 1, cby, cbx, NULL, "tdat");
     if(t->cbp == NULL){
-fprintf(stderr, "failure creating data plane %d %d %d %d\n", cbleny - cby + 1, cblenx - cbx + 1, cby, cbx);
+//fprintf(stderr, "failure creating data plane %d %d %d %d\n", cbleny - cby + 1, cblenx - cbx + 1, cby, cbx);
       ncplane_destroy(t->p);
       t->p = NULL;
       return -1;
@@ -477,18 +477,18 @@ clean_reel(ncreel* r){
   nctablet* vft = r->vft;
   if(vft){
     for(nctablet* n = vft->next ; n->p && n != vft ; n = n->next){
-fprintf(stderr, "CLEANING NEXT: %p (%p)\n", n, n->p);
+//fprintf(stderr, "CLEANING NEXT: %p (%p)\n", n, n->p);
       ncplane_genocide(n->p);
       n->p = NULL;
       n->cbp = NULL;
     }
     for(nctablet* n = vft->prev ; n->p && n != vft ; n = n->prev){
-fprintf(stderr, "CLEANING PREV: %p (%p)\n", n, n->p);
+//fprintf(stderr, "CLEANING PREV: %p (%p)\n", n, n->p);
       ncplane_genocide(n->p);
       n->p = NULL;
       n->cbp = NULL;
     }
-fprintf(stderr, "CLEANING VFT: %p (%p)\n", vft, vft->p);
+//fprintf(stderr, "CLEANING VFT: %p (%p)\n", vft, vft->p);
     ncplane_genocide(vft->p);
     vft->p = NULL;
     vft->cbp = NULL;
@@ -549,11 +549,11 @@ fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy
   }
   clean_reel(nr);
   if(focused){
-fprintf(stderr, "drawing focused tablet %p dir: %d fulcrum: %d!\n", focused, nr->direction, fulcrum);
+//fprintf(stderr, "drawing focused tablet %p dir: %d fulcrum: %d!\n", focused, nr->direction, fulcrum);
     if(ncreel_draw_tablet(nr, focused, fulcrum, fulcrum, DIRECTION_DOWN)){
       return -1;
     }
-fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused->p, nr->direction);
+//fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused->p, nr->direction);
     nctablet* otherend = focused;
     int frontiertop, frontierbottom;
     ncplane_yx(nr->tablets->p, &frontiertop, NULL);
@@ -575,9 +575,9 @@ fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused-
     if(otherend == NULL){
       return -1;
     }
-notcurses_debug(nr->p->nc, stderr);
+//notcurses_debug(nr->p->nc, stderr);
     tighten_reel(nr);
-notcurses_debug(nr->p->nc, stderr);
+//notcurses_debug(nr->p->nc, stderr);
   }
   nr->vft = nr->tablets; // update the visually-focused tablet pointer
 //fprintf(stderr, "DONE ARRANGING\n");

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -716,7 +716,7 @@ int ncreel_del(ncreel* nr, struct nctablet* t){
   }
   t->next->prev = t->prev;
   if(t->p){
-    ncplane_destroy(t->p);
+    ncplane_genocide(t->p);
   }
   free(t);
   --nr->tabletcount;
@@ -730,7 +730,6 @@ int ncreel_destroy(ncreel* nreel){
     while( (t = nreel->tablets) ){
       ncreel_del(nreel, t);
     }
-    ncplane_destroy(nreel->p);
     free(nreel);
   }
   return ret;

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -289,7 +289,7 @@ fprintf(stderr, "already drew %p: %p %p\n", t, t->p, t->cbp);
 fprintf(stderr, "no room: %p base %d/%d len %d/%d dir %d\n", t, begy, begx, leny, lenx, direction);
     return -1;
   }
-fprintf(stderr, "tplacement: %p base %d/%d len %d/%d frontiery %d %d dir %d\n", t, begy, begx, leny, lenx, frontiertop, frontierbottom, direction);
+//fprintf(stderr, "tplacement: %p base %d/%d len %d/%d frontiery %d %d dir %d\n", t, begy, begx, leny, lenx, frontiertop, frontierbottom, direction);
   ncplane* fp = ncplane_bound(nr->p, leny, lenx, begy, begx, NULL);
   if((t->p = fp) == NULL){
 fprintf(stderr, "failure creating border plane %d %d %d %d\n", leny, lenx, begy, begx);
@@ -313,19 +313,18 @@ fprintf(stderr, "failure creating border plane %d %d %d %d\n", leny, lenx, begy,
   if(cbleny - cby + 1 > 0){
     t->cbp = ncplane_bound(t->p, cbleny - cby + 1, cblenx - cbx + 1, cby, cbx, NULL);
     if(t->cbp == NULL){
-  fprintf(stderr, "failure creating data plane %d %d %d %d\n", cbleny - cby + 1, cblenx - cbx + 1, cby, cbx);
+fprintf(stderr, "failure creating data plane %d %d %d %d\n", cbleny - cby + 1, cblenx - cbx + 1, cby, cbx);
       ncplane_destroy(t->p);
       t->p = NULL;
       return -1;
     }
     ncplane_move_above(t->cbp, t->p);
-  // fprintf(stderr, "calling! lenx/leny: %d/%d cbx/cby: %d/%d cblenx/cbleny: %d/%d dir: %d\n",
-  //    lenx, leny, cbx, cby, cblenx, cbleny, direction);
+// fprintf(stderr, "calling! lenx/leny: %d/%d cbx/cby: %d/%d cblenx/cbleny: %d/%d dir: %d\n", lenx, leny, cbx, cby, cblenx, cbleny, direction);
     int ll = t->cbfxn(t, direction == DIRECTION_DOWN);
-  fprintf(stderr, "RETURNRETURNRETURN %p %d (%d, %d, %d) DIR %d\n", t, ll, cby, cbleny, leny, direction);
+fprintf(stderr, "RETURNRETURNRETURN %p %d (%d, %d, %d) DIR %d\n", t, ll, cby, cbleny, leny, direction);
     if(ll != cbleny - cby + 1){
       int diff = (cbleny - cby + 1) - ll;
-  fprintf(stderr, "resizing data plane %d->%d\n", cbleny - cby + 1, ll);
+fprintf(stderr, "resizing data plane %d->%d\n", cbleny - cby + 1, ll);
       ncplane_resize_simple(t->cbp, ll, cblenx - cbx + 1);
       ncplane_resize_simple(t->p, leny - diff, lenx);
       // We needn't move the resized plane if drawing down, or the focused plane.
@@ -338,10 +337,10 @@ fprintf(stderr, "failure creating border plane %d %d %d %d\n", leny, lenx, begy,
           frontiertop += (leny - ll);
         }
         ncplane_move_yx(fp, frontiertop, begx);
-  fprintf(stderr, "moved to frontiertop %d\n", frontiertop);
+fprintf(stderr, "moved to frontiertop %d\n", frontiertop);
       }else if(direction == DIRECTION_UP){
         ncplane_move_yx(fp, begy + diff, begx);
-  fprintf(stderr, "MOVEDOWN from %d to %d\n", begy, begy + diff);
+fprintf(stderr, "MOVEDOWN from %d to %d\n", begy, begy + diff);
       }
     }
   }
@@ -420,6 +419,7 @@ tighten_reel_down(ncreel* r, int ybot){
     }
     cury = ybot - ylen;
     ncplane_move_yx(cur->p, cury, curx);
+fprintf(stderr, "tightened %p down to %d\n", cur, cury);
     ybot = cury - 1;
     if((cur = cur->prev) == r->tablets){
       break;
@@ -462,6 +462,7 @@ fprintf(stderr, "tightening it up\n");
     ncplane_yx(cur->p, &cury, &curx);
     if(cury != expected){
       if(ncplane_move_yx(cur->p, expected, curx)){
+fprintf(stderr, "tightened %p up to %d\n", cur, expected);
         return -1;
       }
     }else{
@@ -525,7 +526,7 @@ fprintf(stderr, "CLEANING VFT: %p (%p)\n", vft, vft->p);
 // place relative to the new focus; they could otherwise pivot around the new
 // focus, if we're not filling out the reel.
 int ncreel_redraw(ncreel* nr){
-//fprintf(stderr, "--------> BEGIN REDRAW <--------\n");
+fprintf(stderr, "\n--------> BEGIN REDRAW <--------\n");
   nctablet* focused = nr->tablets;
   int fulcrum; // target line
   if(nr->direction == DIRECTION_UP){
@@ -544,7 +545,7 @@ fprintf(stderr, "case i fulcrum %d\n", fulcrum);
 fprintf(stderr, "case i fulcrum %d (%d %d) %p %p\n", fulcrum, focy, vfty, focused, nr->vft);
       }else{
         ncplane_yx(focused->p, &fulcrum, NULL); // case iii
-fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p\n", fulcrum, focy, vfty, focused, nr->vft);
+fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy, vfty, focused, nr->vft, nr->direction);
       }
     }
   }else{
@@ -563,7 +564,7 @@ fprintf(stderr, "case ii fulcrum %d\n", fulcrum);
 fprintf(stderr, "case ii fulcrum %d (%d %d) %p %p\n", fulcrum, focy, vfty, focused, nr->vft);
       }else{
         ncplane_yx(focused->p, &fulcrum, NULL); // case iii
-fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p\n", fulcrum, focy, vfty, focused, nr->vft);
+fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy, vfty, focused, nr->vft, nr->direction);
       }
     }
   }

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -217,7 +217,7 @@ fprintf(stderr, "jigsawing %p with %d/%d dir %d\n", t, frontiertop, frontierbott
     if(direction == DIRECTION_UP){
       return -1;
     }
-    frontierbottom = 0;
+    frontiertop = 0;
   }
   if(frontierbottom >= *leny){
     if(direction == DIRECTION_DOWN){
@@ -267,7 +267,7 @@ fprintf(stderr, "already drew %p: %p %p\n", t, t->p, t->cbp);
 fprintf(stderr, "no room: %p base %d/%d len %d/%d dir %d\n", t, begy, begx, leny, lenx, direction);
     return -1;
   }
-//fprintf(stderr, "tplacement: %p base %d/%d len %d/%d frontiery %d %d dir %d\n", t, begy, begx, leny, lenx, frontiertop, frontierbottom, direction);
+fprintf(stderr, "tplacement: %p base %d/%d len %d/%d frontiery %d %d dir %d\n", t, begy, begx, leny, lenx, frontiertop, frontierbottom, direction);
   ncplane* fp = ncplane_bound(nr->p, leny, lenx, begy, begx, NULL);
   if((t->p = fp) == NULL){
 fprintf(stderr, "failure creating border plane %d %d %d %d\n", leny, lenx, begy, begx);

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -511,7 +511,7 @@ fprintf(stderr, "\n--------> BEGIN REDRAW <--------\n");
     // case i iff the last direction was UP, and either the focused tablet is
     // not visible, or below the visibly-focused tablet, or there is no
     // visibly-focused tablet.
-    if((focused && !focused->p) || !nr->vft){
+    if(!focused || !focused->p || !nr->vft){
       fulcrum = 0;
 fprintf(stderr, "case i fulcrum %d\n", fulcrum);
     }else{
@@ -530,11 +530,12 @@ fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy
     // case ii iff the last direction was DOWN, and either the focused tablet
     // is not visible, or above the visibly-focused tablet, or there is no
     // visibly-focused tablet.
-    if((focused && !focused->p) || !nr->vft){
+    if(!focused || !focused->p || !nr->vft){
       fulcrum = ncplane_dim_y(nr->p) - 1;
 fprintf(stderr, "case ii fulcrum %d\n", fulcrum);
     }else{
       int focy, vfty;
+fprintf(stderr, "focused: %p\n", focused);
       ncplane_yx(focused->p, &focy, NULL);
       ncplane_yx(nr->vft->p, &vfty, NULL);
       if(focy < vfty){
@@ -692,6 +693,9 @@ int ncreel_del(ncreel* nr, struct nctablet* t){
     }
     // FIXME ought set direction based on actual location of replacement t
     nr->direction = LASTDIRECTION_DOWN;
+  }
+  if(nr->vft == t){
+    nr->vft = NULL;
   }
   t->next->prev = t->prev;
   if(t->p){

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -575,6 +575,7 @@ fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused-
     if(otherend == NULL){
       return -1;
     }
+notcurses_debug(nr->p->nc, stderr);
     tighten_reel(nr);
 fprintf(stderr, "done tightening\n");
   }

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -730,6 +730,7 @@ int ncreel_destroy(ncreel* nreel){
     while( (t = nreel->tablets) ){
       ncreel_del(nreel, t);
     }
+    ncplane_destroy(nreel->p);
     free(nreel);
   }
   return ret;

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -299,10 +299,10 @@ fprintf(stderr, "tplacement: %p base %d/%d len %d/%d frontiery %d %d dir %d\n", 
     ncplane_move_above(t->cbp, t->p);
 // fprintf(stderr, "calling! lenx/leny: %d/%d cbx/cby: %d/%d cblenx/cbleny: %d/%d dir: %d\n", lenx, leny, cbx, cby, cblenx, cbleny, direction);
     int ll = t->cbfxn(t, direction == DIRECTION_DOWN);
-fprintf(stderr, "RETURNRETURNRETURN %p %d (%d, %d, %d) DIR %d\n", t, ll, cby, cbleny, leny, direction);
+//fprintf(stderr, "RETURNRETURNRETURN %p %d (%d, %d, %d) DIR %d\n", t, ll, cby, cbleny, leny, direction);
     if(ll != cbleny - cby + 1){
       int diff = (cbleny - cby + 1) - ll;
-fprintf(stderr, "resizing data plane %d->%d\n", cbleny - cby + 1, ll);
+//fprintf(stderr, "resizing data plane %d->%d\n", cbleny - cby + 1, ll);
       ncplane_resize_simple(t->cbp, ll, cblenx - cbx + 1);
       ncplane_resize_simple(t->p, leny - diff, lenx);
       // We needn't move the resized plane if drawing down, or the focused plane.
@@ -315,10 +315,10 @@ fprintf(stderr, "resizing data plane %d->%d\n", cbleny - cby + 1, ll);
           frontiertop += (leny - ll);
         }
         ncplane_move_yx(fp, frontiertop, begx);
-fprintf(stderr, "moved to frontiertop %d\n", frontiertop);
+//fprintf(stderr, "moved to frontiertop %d\n", frontiertop);
       }else if(direction == DIRECTION_UP){
         ncplane_move_yx(fp, begy + diff, begx);
-fprintf(stderr, "MOVEDOWN from %d to %d\n", begy, begy + diff);
+//fprintf(stderr, "MOVEDOWN from %d to %d\n", begy, begy + diff);
       }
     }
   }
@@ -332,7 +332,7 @@ fprintf(stderr, "MOVEDOWN from %d to %d\n", begy, begy + diff);
 static nctablet*
 draw_following_tablets(const ncreel* nr, nctablet* otherend,
                        int frontiertop, int* frontierbottom){
-fprintf(stderr, "following otherend: %p ->p: %p %d/%d\n", otherend, otherend->p, frontiertop, *frontierbottom);
+//fprintf(stderr, "following otherend: %p ->p: %p %d/%d\n", otherend, otherend->p, frontiertop, *frontierbottom);
   nctablet* working = nr->tablets->next;
   const int maxx = ncplane_dim_y(nr->p) - 1;
   // move down past the focused tablet, filling up the reel to the bottom
@@ -342,7 +342,7 @@ fprintf(stderr, "following otherend: %p ->p: %p %d/%d\n", otherend, otherend->p,
     }
 //fprintf(stderr, "following otherend: %p ->p: %p\n", otherend, otherend->p);
     // modify frontier based off the one we're at
-fprintf(stderr, "EASTBOUND AND DOWN: %p->%p %d %d\n", working, working->next, frontiertop, *frontierbottom);
+//fprintf(stderr, "EASTBOUND AND DOWN: %p->%p %d %d\n", working, working->next, frontiertop, *frontierbottom);
     if(ncreel_draw_tablet(nr, working, frontiertop, *frontierbottom, DIRECTION_DOWN)){
       return NULL;
     }
@@ -352,7 +352,7 @@ fprintf(stderr, "EASTBOUND AND DOWN: %p->%p %d %d\n", working, working->next, fr
     *frontierbottom += ncplane_dim_y(working->p) + 1;
     working = working->next;
   }
-fprintf(stderr, "done with prevs: %p->%p %d %d\n", working, working->prev, frontiertop, *frontierbottom);
+//fprintf(stderr, "done with prevs: %p->%p %d %d\n", working, working->prev, frontiertop, *frontierbottom);
   return working;
 }
 

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -566,18 +566,18 @@ fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused-
       }
       otherend = draw_following_tablets(nr, otherend, frontiertop, &frontierbottom);
     }else{ // DIRECTION_UP
-      otherend = draw_following_tablets(nr, otherend, frontiertop, &frontierbottom);
+      otherend = draw_previous_tablets(nr, otherend, &frontiertop, frontierbottom);
       if(otherend == NULL){
         return -1;
       }
-      otherend = draw_previous_tablets(nr, otherend, &frontiertop, frontierbottom);
+      otherend = draw_following_tablets(nr, otherend, frontiertop, &frontierbottom);
     }
     if(otherend == NULL){
       return -1;
     }
 notcurses_debug(nr->p->nc, stderr);
     tighten_reel(nr);
-fprintf(stderr, "done tightening\n");
+notcurses_debug(nr->p->nc, stderr);
   }
   nr->vft = nr->tablets; // update the visually-focused tablet pointer
 //fprintf(stderr, "DONE ARRANGING\n");

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -362,13 +362,13 @@ static nctablet*
 draw_previous_tablets(const ncreel* nr, nctablet* otherend,
                       int* frontiertop, int frontierbottom){
   nctablet* upworking = nr->tablets->prev;
-fprintf(stderr, "preceding %p otherend: %p ->p: %p frontiers: %d %d\n", upworking, otherend, otherend->p, *frontiertop, frontierbottom);
+//fprintf(stderr, "preceding %p otherend: %p ->p: %p frontiers: %d %d\n", upworking, otherend, otherend->p, *frontiertop, frontierbottom);
   // modify frontier based off the one we're at
   while(*frontiertop >= 0 && (upworking != otherend || !otherend->p)){
     if(upworking->p){
       break;
     }
-fprintf(stderr, "MOVIN' ON UP: %p->%p %d %d\n", upworking, upworking->prev, *frontiertop, frontierbottom);
+//fprintf(stderr, "MOVIN' ON UP: %p->%p %d %d\n", upworking, upworking->prev, *frontiertop, frontierbottom);
     if(ncreel_draw_tablet(nr, upworking, *frontiertop, frontierbottom, DIRECTION_UP)){
       return NULL;
     }
@@ -378,7 +378,7 @@ fprintf(stderr, "MOVIN' ON UP: %p->%p %d %d\n", upworking, upworking->prev, *fro
     *frontiertop -= ncplane_dim_y(upworking->p) + 1;
     upworking = upworking->prev;
   }
-fprintf(stderr, "done with prevs: %p->%p %d %d\n", upworking, upworking->prev, *frontiertop, frontierbottom);
+//fprintf(stderr, "done with prevs: %p->%p %d %d\n", upworking, upworking->prev, *frontiertop, frontierbottom);
   return upworking;
 }
 
@@ -452,6 +452,7 @@ fprintf(stderr, "bot: %dx%d @ %d, maxy: %d\n", ylen, xlen, y, maxy);
 fprintf(stderr, "TRIMMED bottom %p from %d to %d (%d)\n", bottom->p, ylen, ynew, maxy - boty);
     }
   }
+fprintf(stderr, "finished trimming\n");
   return 0;
 }
 
@@ -627,11 +628,11 @@ fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy
   }
   clean_reel(nr);
   if(focused){
-//fprintf(stderr, "drawing focused tablet %p dir: %d fulcrum: %d!\n", focused, nr->direction, fulcrum);
+fprintf(stderr, "drawing focused tablet %p dir: %d fulcrum: %d!\n", focused, nr->direction, fulcrum);
     if(ncreel_draw_tablet(nr, focused, fulcrum, fulcrum, DIRECTION_DOWN)){
       return -1;
     }
-//fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused->p, nr->direction);
+fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused->p, nr->direction);
     nctablet* otherend = focused;
     int frontiertop, frontierbottom;
     ncplane_yx(nr->tablets->p, &frontiertop, NULL);
@@ -775,7 +776,7 @@ int ncreel_del(ncreel* nr, struct nctablet* t){
     nr->direction = LASTDIRECTION_DOWN;
   }
   if(nr->vft == t){
-    nr->vft = NULL;
+    clean_reel(nr); // maybe just make nr->tablets the vft?
   }
   t->next->prev = t->prev;
   if(t->p){

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -446,7 +446,10 @@ fprintf(stderr, "bot: %dx%d @ %d, maxy: %d\n", ylen, xlen, y, maxy);
           ncplane_genocide(bottom->cbp);
           bottom->cbp = NULL;
         }else{
-          // FIXME resize cbp
+          ncplane_dim_yx(bottom->cbp, &ylen, &xlen);
+          if(ncplane_resize(bottom->cbp, 0, 0, ynew - 1, xlen, 0, 0, ynew - 1, xlen)){
+            return -1;
+          }
         }
       }
 fprintf(stderr, "TRIMMED bottom %p from %d to %d (%d)\n", bottom->p, ylen, ynew, maxy - boty);

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -267,7 +267,7 @@ ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiertop,
 //fprintf(stderr, "no room: %p base %d/%d len %d/%d dir %d\n", t, begy, begx, leny, lenx, direction);
     return -1;
   }
-fprintf(stderr, "tplacement: %p base %d/%d len %d/%d frontiery %d %d dir %d\n", t, begy, begx, leny, lenx, frontiertop, frontierbottom, direction);
+//fprintf(stderr, "tplacement: %p base %d/%d len %d/%d frontiery %d %d dir %d\n", t, begy, begx, leny, lenx, frontiertop, frontierbottom, direction);
   ncplane* fp = ncplane_bound_named(nr->p, leny, lenx, begy, begx, NULL, "tab");
   if((t->p = fp) == NULL){
 //fprintf(stderr, "failure creating border plane %d %d %d %d\n", leny, lenx, begy, begx);
@@ -391,15 +391,15 @@ trim_reel_overhang(ncreel* r, nctablet* top, nctablet* bottom){
   assert(bottom);
   assert(bottom->p);
   int y;
-fprintf(stderr, "trimming: top %p bottom %p\n", top->p, bottom->p);
+//fprintf(stderr, "trimming: top %p bottom %p\n", top->p, bottom->p);
   ncplane_yx(top->p, &y, NULL);
   int ylen, xlen;
   ncplane_dim_yx(top->p, &ylen, &xlen);
   const int miny = !(r->ropts.bordermask & NCBOXMASK_TOP);
   int boty = y + ylen - 1;
-fprintf(stderr, "top: %dx%d @ %d, miny: %d\n", ylen, xlen, y, miny);
+//fprintf(stderr, "top: %dx%d @ %d, miny: %d\n", ylen, xlen, y, miny);
   if(boty < miny){
-fprintf(stderr, "NUKING top!\n");
+//fprintf(stderr, "NUKING top!\n");
     ncplane_genocide(top->p);
     top->p = NULL;
     top->cbp = NULL;
@@ -420,17 +420,23 @@ fprintf(stderr, "NUKING top!\n");
           ncplane_genocide(top->cbp);
           top->cbp = NULL;
         }else{
-          // FIXME resize cbp
+          ncplane_dim_yx(top->cbp, &ylen, &xlen);
+          if(ncplane_resize(top->cbp, miny - y, 0, ynew - 1, xlen, 0, 0, ynew - 1, xlen)){
+            return -1;
+          }
+          int x;
+          ncplane_yx(top->cbp, &y, &x);
+          ncplane_move_yx(top->cbp, y - 1, x);
         }
       }
-fprintf(stderr, "TRIMMED top %p from %d to %d (%d)\n", top->p, ylen, ynew, y - miny);
+//fprintf(stderr, "TRIMMED top %p from %d to %d (%d)\n", top->p, ylen, ynew, y - miny);
     }
   }
   ncplane_dim_yx(bottom->p, &ylen, &xlen);
   ncplane_yx(bottom->p, &y, NULL);
   const int maxy = ncplane_dim_y(r->p) - (1 + !(r->ropts.bordermask & NCBOXMASK_BOTTOM));
   boty = y + ylen - 1;
-fprintf(stderr, "bot: %dx%d @ %d, maxy: %d\n", ylen, xlen, y, maxy);
+//fprintf(stderr, "bot: %dx%d @ %d, maxy: %d\n", ylen, xlen, y, maxy);
   if(maxy < boty){
     const int ynew = ylen - (boty - maxy);
     if(ynew <= 0){
@@ -452,10 +458,10 @@ fprintf(stderr, "bot: %dx%d @ %d, maxy: %d\n", ylen, xlen, y, maxy);
           }
         }
       }
-fprintf(stderr, "TRIMMED bottom %p from %d to %d (%d)\n", bottom->p, ylen, ynew, maxy - boty);
+//fprintf(stderr, "TRIMMED bottom %p from %d to %d (%d)\n", bottom->p, ylen, ynew, maxy - boty);
     }
   }
-fprintf(stderr, "finished trimming\n");
+//fprintf(stderr, "finished trimming\n");
   return 0;
 }
 
@@ -491,7 +497,7 @@ tighten_reel_down(ncreel* r, int ybot){
 // FIXME could pass top/bottom in directly, available as otherend
 static int
 tighten_reel(ncreel* r){
-fprintf(stderr, "tightening it up\n");
+//fprintf(stderr, "tightening it up\n");
   nctablet* top = r->tablets;
   nctablet* cur = top;
   int ytop = INT_MAX;
@@ -519,7 +525,7 @@ fprintf(stderr, "tightening it up\n");
     ncplane_yx(cur->p, &cury, &curx);
     if(cury != expected){
       if(ncplane_move_yx(cur->p, expected, curx)){
-fprintf(stderr, "tightened %p up to %d\n", cur, expected);
+//fprintf(stderr, "tightened %p up to %d\n", cur, expected);
         return -1;
       }
     }else{
@@ -586,7 +592,7 @@ clean_reel(ncreel* r){
 // place relative to the new focus; they could otherwise pivot around the new
 // focus, if we're not filling out the reel.
 int ncreel_redraw(ncreel* nr){
-fprintf(stderr, "\n--------> BEGIN REDRAW <--------\n");
+//fprintf(stderr, "\n--------> BEGIN REDRAW <--------\n");
   nctablet* focused = nr->tablets;
   int fulcrum; // target line
   if(nr->direction == LASTDIRECTION_UP){
@@ -595,17 +601,17 @@ fprintf(stderr, "\n--------> BEGIN REDRAW <--------\n");
     // visibly-focused tablet.
     if(!focused || !focused->p || !nr->vft){
       fulcrum = 0;
-fprintf(stderr, "case i fulcrum %d\n", fulcrum);
+//fprintf(stderr, "case i fulcrum %d\n", fulcrum);
     }else{
       int focy, vfty;
       ncplane_yx(focused->p, &focy, NULL);
       ncplane_yx(nr->vft->p, &vfty, NULL);
       if(focy > vfty){
         fulcrum = 0;
-fprintf(stderr, "case i fulcrum %d (%d %d) %p %p\n", fulcrum, focy, vfty, focused, nr->vft);
+//fprintf(stderr, "case i fulcrum %d (%d %d) %p %p\n", fulcrum, focy, vfty, focused, nr->vft);
       }else{
         ncplane_yx(focused->p, &fulcrum, NULL); // case iii
-fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy, vfty, focused, nr->vft, nr->direction);
+//fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy, vfty, focused, nr->vft, nr->direction);
       }
     }
   }else{
@@ -614,28 +620,28 @@ fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy
     // visibly-focused tablet.
     if(!focused || !focused->p || !nr->vft){
       fulcrum = ncplane_dim_y(nr->p) - 1;
-fprintf(stderr, "case ii fulcrum %d\n", fulcrum);
+//fprintf(stderr, "case ii fulcrum %d\n", fulcrum);
     }else{
       int focy, vfty;
-fprintf(stderr, "focused: %p\n", focused);
+//fprintf(stderr, "focused: %p\n", focused);
       ncplane_yx(focused->p, &focy, NULL);
       ncplane_yx(nr->vft->p, &vfty, NULL);
       if(focy < vfty){
         fulcrum = ncplane_dim_y(nr->p) - 1;
-fprintf(stderr, "case ii fulcrum %d (%d %d) %p %p\n", fulcrum, focy, vfty, focused, nr->vft);
+//fprintf(stderr, "case ii fulcrum %d (%d %d) %p %p\n", fulcrum, focy, vfty, focused, nr->vft);
       }else{
         ncplane_yx(focused->p, &fulcrum, NULL); // case iii
-fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy, vfty, focused, nr->vft, nr->direction);
+//fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy, vfty, focused, nr->vft, nr->direction);
       }
     }
   }
   clean_reel(nr);
   if(focused){
-fprintf(stderr, "drawing focused tablet %p dir: %d fulcrum: %d!\n", focused, nr->direction, fulcrum);
+//fprintf(stderr, "drawing focused tablet %p dir: %d fulcrum: %d!\n", focused, nr->direction, fulcrum);
     if(ncreel_draw_tablet(nr, focused, fulcrum, fulcrum, DIRECTION_DOWN)){
       return -1;
     }
-fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused->p, nr->direction);
+//fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused->p, nr->direction);
     nctablet* otherend = focused;
     int frontiertop, frontierbottom;
     ncplane_yx(nr->tablets->p, &frontiertop, NULL);
@@ -657,8 +663,10 @@ fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused-
     if(otherend == NULL){
       return -1;
     }
-notcurses_debug(nr->p->nc, stderr);
-    tighten_reel(nr);
+//notcurses_debug(nr->p->nc, stderr);
+    if(tighten_reel(nr)){
+      return -1;
+    }
 //notcurses_debug(nr->p->nc, stderr);
   }
   nr->vft = nr->tablets; // update the visually-focused tablet pointer
@@ -818,7 +826,7 @@ nctablet* ncreel_focused(ncreel* nr){
 nctablet* ncreel_next(ncreel* nr){
   if(nr->tablets){
     nr->tablets = nr->tablets->next;
-fprintf(stderr, "---------------> moved to next, %p to %p <----------\n", nr->tablets->prev, nr->tablets);
+//fprintf(stderr, "---------------> moved to next, %p to %p <----------\n", nr->tablets->prev, nr->tablets);
     nr->direction = LASTDIRECTION_DOWN;
   }
   return nr->tablets;
@@ -827,7 +835,7 @@ fprintf(stderr, "---------------> moved to next, %p to %p <----------\n", nr->ta
 nctablet* ncreel_prev(ncreel* nr){
   if(nr->tablets){
     nr->tablets = nr->tablets->prev;
-fprintf(stderr, "----------------> moved to prev, %p to %p <----------\n", nr->tablets->next, nr->tablets);
+//fprintf(stderr, "----------------> moved to prev, %p to %p <----------\n", nr->tablets->next, nr->tablets);
     nr->direction = LASTDIRECTION_UP;
   }
   return nr->tablets;

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -550,32 +550,33 @@ fprintf(stderr, "case iii fulcrum %d (%d %d) %p %p lastdir: %d\n", fulcrum, focy
   clean_reel(nr);
   if(focused){
 fprintf(stderr, "drawing focused tablet %p dir: %d fulcrum: %d!\n", focused, nr->direction, fulcrum);
-    if(ncreel_draw_tablet(nr, focused, fulcrum, fulcrum, DIRECTION_DOWN) == 0){
+    if(ncreel_draw_tablet(nr, focused, fulcrum, fulcrum, DIRECTION_DOWN)){
+      return -1;
+    }
 fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused->p, nr->direction);
-      nctablet* otherend = focused;
-      int frontiertop, frontierbottom;
-      ncplane_yx(nr->tablets->p, &frontiertop, NULL);
-      frontierbottom = frontiertop + ncplane_dim_y(nr->tablets->p) + 1;
-      frontiertop -= 2;
-      if(nr->direction == LASTDIRECTION_DOWN){
-        otherend = draw_previous_tablets(nr, otherend, &frontiertop, frontierbottom);
-        if(otherend == NULL){
-          return -1;
-        }
-        otherend = draw_following_tablets(nr, otherend, frontiertop, &frontierbottom);
-      }else{ // DIRECTION_UP
-        otherend = draw_following_tablets(nr, otherend, frontiertop, &frontierbottom);
-        if(otherend == NULL){
-          return -1;
-        }
-        otherend = draw_previous_tablets(nr, otherend, &frontiertop, frontierbottom);
-      }
+    nctablet* otherend = focused;
+    int frontiertop, frontierbottom;
+    ncplane_yx(nr->tablets->p, &frontiertop, NULL);
+    frontierbottom = frontiertop + ncplane_dim_y(nr->tablets->p) + 1;
+    frontiertop -= 2;
+    if(nr->direction == LASTDIRECTION_DOWN){
+      otherend = draw_previous_tablets(nr, otherend, &frontiertop, frontierbottom);
       if(otherend == NULL){
         return -1;
       }
-      tighten_reel(nr);
-fprintf(stderr, "done tightening\n");
+      otherend = draw_following_tablets(nr, otherend, frontiertop, &frontierbottom);
+    }else{ // DIRECTION_UP
+      otherend = draw_following_tablets(nr, otherend, frontiertop, &frontierbottom);
+      if(otherend == NULL){
+        return -1;
+      }
+      otherend = draw_previous_tablets(nr, otherend, &frontiertop, frontierbottom);
     }
+    if(otherend == NULL){
+      return -1;
+    }
+    tighten_reel(nr);
+fprintf(stderr, "done tightening\n");
   }
   nr->vft = nr->tablets; // update the visually-focused tablet pointer
 //fprintf(stderr, "DONE ARRANGING\n");

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -349,7 +349,7 @@ fprintf(stderr, "EASTBOUND AND DOWN: %p->%p %d %d\n", working, working->next, fr
     if(working == otherend){
       otherend = otherend->next;
     }
-    *frontierbottom += ncplane_dim_y(working->p) + 2;
+    *frontierbottom += ncplane_dim_y(working->p) + 1;
     working = working->next;
   }
 fprintf(stderr, "done with prevs: %p->%p %d %d\n", working, working->prev, frontiertop, *frontierbottom);

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -355,7 +355,7 @@ ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiery, int direction){
   bool cbdir = (nr->tablets != t && direction == DIRECTION_UP) ? true : false;
 // fprintf(stderr, "calling! lenx/leny: %d/%d cbx/cby: %d/%d cbmaxx/cbmaxy: %d/%d dir: %d\n",
 //    lenx, leny, cbx, cby, cbmaxx, cbmaxy, direction);
-  int ll = t->cbfxn(t, cbx, cby, cbmaxx, cbmaxy, cbdir);
+  int ll = t->cbfxn(t, cbdir);
 //fprintf(stderr, "RETURNRETURNRETURN %p %d (%d, %d, %d) DIR %d\n", t, ll, cby, cbmaxy, leny, direction);
   if(ll != leny){
     if(ll == leny - 1){ // only has one border visible (partially off-screen)

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -44,8 +44,9 @@ typedef enum {
 // Second rule: if there must be 2+ consecutive lines of blank space, they must
 //             all be at the bottom of the reel (connect and anchor the reel).
 // Third rule: the focused tablet gets all the space it can use.
-// Fourth rule: the focused tablet should remain where it is across redraws,
-//              except as necessary to accommodate the prior rules.
+// Fourth rule: thou shalt never wrap a tablet [across a border]
+// Fifth rule: the focused tablet should remain where it is across redraws,
+//             except as necessary to accommodate the prior rules.
 //
 // At any ncreel_redraw(), you can make three types of moves:
 //
@@ -77,7 +78,7 @@ typedef enum {
 //
 // We otherwise have case iii. The focused tablet must be on-screen (if it was
 // off-screen, we matched one of case i or case ii). We want to draw it as near
-// to its current position as possible, subject to the first three Rules.
+// to its current position as possible, subject to the first four Rules.
 //
 // ncreel_redraw() thus starts by determining the case. This must be done
 // before any changes are made to the arrangement. It then clears the reel.
@@ -271,18 +272,15 @@ tablet_columns(const ncreel* nr, nctablet* t, int* begx, int* begy,
   return 0;
 }
 
-// Draw the specified tablet, if possible. DIRECTION_UP means we're
-// laying out towards the top. DIRECTION_DOWN means towards the bottom. 0
-// means this is the focused tablet, always the first one to be drawn.
-// frontiery is the line on which we're placing the tablet (in the case of the
-// focused window, this is only an ideal, subject to change). For direction
-// greater than or equal to 0, it's the top line of the tablet. For direction
-// less than 0, it's the bottom line. Gives the tablet all possible space to
-// work with (i.e. up to the edge we're approaching, or the entire panel for
-// the focused tablet). If the callback uses less space, shrinks the panel back
-// down before displaying it. Destroys any panel if it ought be hidden.
+// Draw the specified tablet, if possible. DIRECTION_UP means we're laying out
+// bottom-to-top. DIRECTION_DOWN means top-to-bottom. 'frontiery' is the line
+// to which we'll be fitting the tablet (our last row for DIRECTION_UP, and our
+// first row for DIRECTION_DOWN). Gives the tablet all possible space to work
+// with (i.e. up through the edge we're approaching, or the entire reel for
+// the focused tablet). If the callback uses less space, shrinks the panel to
+// that size before displaying it.
 static int
-ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiery, int direction){
+ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiery, direction_e direction){
   int lenx, leny, begy, begx;
   ncplane* fp = t->p;
   if(tablet_columns(nr, t, &begx, &begy, &lenx, &leny, frontiery, direction)){

--- a/src/ncreel/main.cpp
+++ b/src/ncreel/main.cpp
@@ -181,6 +181,7 @@ int main(int argc, char** argv){
   int margin_r = ncopts.margin_r;
   int margin_b = ncopts.margin_b;
   ncopts.margin_t = ncopts.margin_l = ncopts.margin_r = ncopts.margin_b = 0;
+  ncopts.loglevel = NCLOGLEVEL_VERBOSE;
   auto nc = notcurses_init(&ncopts, NULL);
   if(nc == nullptr){
     return EXIT_FAILURE;

--- a/src/ncreel/main.cpp
+++ b/src/ncreel/main.cpp
@@ -40,13 +40,8 @@ class TabletCtx {
     inline static int class_idx = 0;
 };
 
-int tabletfxn(struct nctablet* _t, int begx, int begy, int maxx, int maxy,
-              bool cliptop){
-  (void)begx;
-  (void)begy;
-  (void)maxx;
-  (void)maxy;
-  (void)cliptop;
+int tabletfxn(struct nctablet* _t, bool cliptop){
+  (void)cliptop; // FIXME
   NcTablet *t = NcTablet::map_tablet (_t);
   Plane* p = t->get_plane();
   auto tctx = t->get_userptr<TabletCtx>();

--- a/src/ncreel/main.cpp
+++ b/src/ncreel/main.cpp
@@ -60,6 +60,7 @@ void usage(const char* argv0, std::ostream& c, int status){
   c << "usage: " << argv0 << " [ -h ] | options\n"
     << " -b bordermask: hex ncreel border mask (0x0..0xf)\n"
     << " -m margin(s): margin(s) around the reel\n"
+    << " -ln: logging level, higher n for more output (0 ≤ n ≤ 8)\n"
     << " -t tabletmask: hex tablet border mask (0x0..0xf)" << std::endl;
   exit(status);
 }
@@ -70,9 +71,19 @@ void parse_args(int argc, char** argv, struct notcurses_options* opts,
     { .name = nullptr, .has_arg = 0, .flag = nullptr, .val = 0, },
   };
   int c;
-  while((c = getopt_long(argc, argv, "b:t:m:h", longopts, nullptr)) != -1){
+  while((c = getopt_long(argc, argv, "l:b:t:m:h", longopts, nullptr)) != -1){
     switch(c){
-      case 'b':{
+      case 'l':{
+        int loglevel;
+        std::stringstream s(optarg);
+        s >> loglevel;
+        opts->loglevel = static_cast<ncloglevel_e>(loglevel);
+        if(opts->loglevel < NCLOGLEVEL_SILENT || opts->loglevel > NCLOGLEVEL_TRACE){
+          fprintf(stderr, "Invalid log level: %d\n", opts->loglevel);
+          usage(argv[0], std::cerr, EXIT_FAILURE);
+        }
+        break;
+      }case 'b':{
         std::stringstream ss;
         ss << std::hex << optarg;
         ss >> ropts->bordermask;
@@ -181,7 +192,6 @@ int main(int argc, char** argv){
   int margin_r = ncopts.margin_r;
   int margin_b = ncopts.margin_b;
   ncopts.margin_t = ncopts.margin_l = ncopts.margin_r = ncopts.margin_b = 0;
-  ncopts.loglevel = NCLOGLEVEL_VERBOSE;
   auto nc = notcurses_init(&ncopts, NULL);
   if(nc == nullptr){
     return EXIT_FAILURE;

--- a/src/ncreel/main.cpp
+++ b/src/ncreel/main.cpp
@@ -41,7 +41,6 @@ class TabletCtx {
 };
 
 int tabletfxn(struct nctablet* _t, bool cliptop){
-  (void)cliptop; // FIXME
   NcTablet *t = NcTablet::map_tablet (_t);
   Plane* p = t->get_plane();
   auto tctx = t->get_userptr<TabletCtx>();

--- a/src/ncreel/main.cpp
+++ b/src/ncreel/main.cpp
@@ -41,6 +41,7 @@ class TabletCtx {
 };
 
 int tabletfxn(struct nctablet* _t, bool cliptop){
+  (void)cliptop;
   NcTablet *t = NcTablet::map_tablet (_t);
   Plane* p = t->get_plane();
   auto tctx = t->get_userptr<TabletCtx>();

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -13,7 +13,7 @@ auto cbfxn(struct nctablet* t, bool toptobottom) -> int {
   (void)toptobottom;
   int* userptr = static_cast<int*>(nctablet_userptr(t));
   int y;
-  ncplane_yx(ncplane_parent(nctablet_ncplane(t)), &y, NULL);
+  ncplane_yx(nctablet_ncplane(t), &y, NULL);
   *userptr += y;
   return 4;
 }
@@ -257,22 +257,26 @@ TEST_CASE("Reels") {
       CHECK_EQ(0, notcurses_render(nc_));
       CHECK(ncreel_validate(nr));
     }
+    int expectedy = 1;
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      //CHECK_GT(-1, order[n]);
+      CHECK_LE(0, order[n]);
       int y;
       ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
-      // FIXME
+      CHECK(y == expectedy);
+      expectedy += 7;
     }
     ncreel_next(nr);
     CHECK(tabs[1] == nr->tablets);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
+    expectedy = 1;
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      //CHECK_EQ(2 - n + 1, order[n]);
+      CHECK_LE(1, order[n]);
       int y;
       ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
-      // FIXME
+      CHECK(y == expectedy);
+      expectedy += 7;
     }
     ncreel_next(nr);
     CHECK(tabs[2] == nr->tablets);

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -1,10 +1,8 @@
 #include "main.h"
 #include <iostream>
 
-auto panelcb(struct nctablet* t, int begx, int begy, int maxx, int maxy, bool cliptop) -> int {
+auto panelcb(struct nctablet* t, bool cliptop) -> int {
   CHECK(nctablet_ncplane(t));
-  CHECK(begx < maxx);
-  CHECK(begy < maxy);
   CHECK(!nctablet_userptr(t));
   CHECK(!cliptop);
   // FIXME verify geometry is as expected

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -56,9 +56,9 @@ TEST_CASE("Reels") {
     struct ncreel* nr = ncreel_create(n_, &r);
     REQUIRE(nr);
     CHECK(!ncreel_next(nr));
-    // CHECK_EQ(0, ncreel_validate(n_, pr));
+    CHECK_EQ(0, ncreel_redraw(nr));
     CHECK(!ncreel_prev(nr));
-    // CHECK_EQ(0, ncreel_validate(n_, pr));
+    CHECK_EQ(0, ncreel_redraw(nr));
   }
 
   SUBCASE("OneTablet") {
@@ -67,9 +67,9 @@ TEST_CASE("Reels") {
     REQUIRE(nr);
     struct nctablet* t = ncreel_add(nr, nullptr, nullptr, panelcb, nullptr);
     REQUIRE(t);
-    // CHECK_EQ(0, ncreel_validate(n_, pr));
+    CHECK_EQ(0, ncreel_redraw(nr));
     CHECK(0 == ncreel_del(nr, t));
-    // CHECK_EQ(0, ncreel_validate(n_, pr));
+    CHECK_EQ(0, ncreel_redraw(nr));
   }
 
   SUBCASE("MovementWithOneTablet") {
@@ -78,13 +78,13 @@ TEST_CASE("Reels") {
     REQUIRE(nr);
     struct nctablet* t = ncreel_add(nr, nullptr, nullptr, panelcb, nullptr);
     REQUIRE(t);
-    // CHECK_EQ(0, ncreel_validate(n_, pr));
+    CHECK_EQ(0, ncreel_redraw(nr));
     CHECK(ncreel_next(nr));
-    // CHECK_EQ(0, ncreel_validate(n_, pr));
+    CHECK_EQ(0, ncreel_redraw(nr));
     CHECK(ncreel_prev(nr));
-    // CHECK_EQ(0, ncreel_validate(n_, pr));
+    CHECK_EQ(0, ncreel_redraw(nr));
     CHECK(0 == ncreel_del(nr, t));
-    // CHECK_EQ(0, ncreel_validate(n_, pr));
+    CHECK_EQ(0, ncreel_redraw(nr));
   }
 
   SUBCASE("DeleteActiveTablet") {

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -12,12 +12,10 @@ auto panelcb(struct nctablet* t, bool toptobottom) -> int {
 auto cbfxn(struct nctablet* t, bool toptobottom) -> int {
   (void)toptobottom;
   int* userptr = static_cast<int*>(nctablet_userptr(t));
-  REQUIRE(userptr);
-  CHECK(0 == *userptr);
   int y;
   ncplane_yx(nctablet_ncplane(t), &y, NULL);
-  *userptr = y;
-  return 0;
+  *userptr += y;
+  return 4;
 }
 
 // debugging

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -13,6 +13,7 @@ auto cbfxn(struct nctablet* t, bool toptobottom) -> int {
   (void)toptobottom;
   int* userptr = static_cast<int*>(nctablet_userptr(t));
   int y;
+fprintf(stderr, "WRITEBACK CBFXN: %d %d\n", *userptr, y);
   ncplane_yx(nctablet_ncplane(t), &y, NULL);
   *userptr += y;
   return 4;
@@ -246,15 +247,32 @@ TEST_CASE("Reels") {
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
-    int order[3] = {};
+    int order[3];
+    for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
+      order[n] = -1;
+    }
     ncreel_add(nr, nullptr, nullptr, cbfxn, &order[0]);
     ncreel_add(nr, nullptr, nullptr, cbfxn, &order[1]);
     ncreel_add(nr, nullptr, nullptr, cbfxn, &order[2]);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
-    for(int& n : order){
-      CHECK(1 == order[n]);
+    for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
+      CHECK_EQ(0, order[n]);
+    }
+    ncreel_next(nr);
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
+    for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
+      CHECK_EQ(1, order[n]);
+    }
+    ncreel_next(nr);
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
+    for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
+      CHECK_EQ(2, order[n]);
     }
   }
 

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -257,52 +257,55 @@ TEST_CASE("Reels") {
       CHECK_EQ(0, notcurses_render(nc_));
       CHECK(ncreel_validate(nr));
     }
-    int t0y;
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_GT(-1, order[n]);
+      //CHECK_GT(-1, order[n]);
       int y;
       ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
       // FIXME
     }
     ncreel_next(nr);
     CHECK(tabs[1] == nr->tablets);
-    ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[0])), &t0y, nullptr);
-    CHECK(1 == t0y);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(2 - n + 1, order[n]);
+      //CHECK_EQ(2 - n + 1, order[n]);
+      int y;
+      ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
+      // FIXME
     }
     ncreel_next(nr);
     CHECK(tabs[2] == nr->tablets);
-    ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[0])), &t0y, nullptr);
-    CHECK(1 == t0y);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(2 - n + 2, order[n]);
+      //CHECK_EQ(2 - n + 2, order[n]);
+      int y;
+      ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
+      // FIXME
     }
     ncreel_prev(nr);
     CHECK(tabs[1] == nr->tablets);
-    ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[0])), &t0y, nullptr);
-    CHECK(1 == t0y);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(2 - n + 3, order[n]);
+      //CHECK_EQ(2 - n + 3, order[n]);
+      int y;
+      ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
+      // FIXME
     }
     ncreel_prev(nr);
-    ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[0])), &t0y, nullptr);
-    CHECK(1 == t0y);
     CHECK(tabs[0] == nr->tablets);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(2 - n + 4, order[n]);
+      //CHECK_EQ(2 - n + 4, order[n]);
+      int y;
+      ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
+      // FIXME
     }
   }
 

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -258,10 +258,16 @@ TEST_CASE("Reels") {
       CHECK_EQ(0, notcurses_render(nc_));
       CHECK(ncreel_validate(nr));
     }
+    int t0y;
+    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
+    CHECK(1 == t0y);
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
       CHECK_EQ(2 - n, order[n]);
     }
     ncreel_next(nr);
+    CHECK(tabs[1] == nr->tablets);
+    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
+    CHECK(1 == t0y);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
@@ -269,6 +275,9 @@ TEST_CASE("Reels") {
       CHECK_EQ(2 - n + 1, order[n]);
     }
     ncreel_next(nr);
+    CHECK(tabs[2] == nr->tablets);
+    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
+    CHECK(1 == t0y);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
@@ -276,6 +285,9 @@ TEST_CASE("Reels") {
       CHECK_EQ(2 - n + 2, order[n]);
     }
     ncreel_prev(nr);
+    CHECK(tabs[1] == nr->tablets);
+    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
+    CHECK(1 == t0y);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
@@ -283,6 +295,9 @@ TEST_CASE("Reels") {
       CHECK_EQ(2 - n + 3, order[n]);
     }
     ncreel_prev(nr);
+    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
+    CHECK(1 == t0y);
+    CHECK(tabs[0] == nr->tablets);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -13,8 +13,7 @@ auto cbfxn(struct nctablet* t, bool toptobottom) -> int {
   (void)toptobottom;
   int* userptr = static_cast<int*>(nctablet_userptr(t));
   int y;
-fprintf(stderr, "WRITEBACK CBFXN: %d %d\n", *userptr, y);
-  ncplane_yx(nctablet_ncplane(t), &y, NULL);
+  ncplane_yx(ncplane_parent(nctablet_ncplane(t)), &y, NULL);
   *userptr += y;
   return 4;
 }
@@ -259,14 +258,15 @@ TEST_CASE("Reels") {
       CHECK(ncreel_validate(nr));
     }
     int t0y;
-    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
-    CHECK(1 == t0y);
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(2 - n, order[n]);
+      CHECK_GT(-1, order[n]);
+      int y;
+      ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
+      // FIXME
     }
     ncreel_next(nr);
     CHECK(tabs[1] == nr->tablets);
-    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
+    ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[0])), &t0y, nullptr);
     CHECK(1 == t0y);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
@@ -276,7 +276,7 @@ TEST_CASE("Reels") {
     }
     ncreel_next(nr);
     CHECK(tabs[2] == nr->tablets);
-    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
+    ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[0])), &t0y, nullptr);
     CHECK(1 == t0y);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
@@ -286,7 +286,7 @@ TEST_CASE("Reels") {
     }
     ncreel_prev(nr);
     CHECK(tabs[1] == nr->tablets);
-    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
+    ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[0])), &t0y, nullptr);
     CHECK(1 == t0y);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
@@ -295,7 +295,7 @@ TEST_CASE("Reels") {
       CHECK_EQ(2 - n + 3, order[n]);
     }
     ncreel_prev(nr);
-    ncplane_yx(nctablet_ncplane(tabs[0]), &t0y, nullptr);
+    ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[0])), &t0y, nullptr);
     CHECK(1 == t0y);
     CHECK(tabs[0] == nr->tablets);
     CHECK_EQ(0, ncreel_redraw(nr));

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -251,9 +251,12 @@ TEST_CASE("Reels") {
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
       order[n] = -1;
     }
-    ncreel_add(nr, nullptr, nullptr, cbfxn, &order[0]);
-    ncreel_add(nr, nullptr, nullptr, cbfxn, &order[1]);
-    ncreel_add(nr, nullptr, nullptr, cbfxn, &order[2]);
+    auto t0 = ncreel_add(nr, nullptr, nullptr, cbfxn, &order[0]);
+    REQUIRE(t0);
+    auto t1 = ncreel_add(nr, nullptr, nullptr, cbfxn, &order[1]);
+    REQUIRE(t1);
+    auto t2 = ncreel_add(nr, nullptr, nullptr, cbfxn, &order[2]);
+    REQUIRE(t2);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
@@ -273,6 +276,20 @@ TEST_CASE("Reels") {
     CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
       CHECK_EQ(2, order[n]);
+    }
+    ncreel_prev(nr);
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
+    for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
+      CHECK_EQ(3, order[n]);
+    }
+    ncreel_prev(nr);
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
+    for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
+      CHECK_EQ(4, order[n]);
     }
   }
 

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -248,48 +248,46 @@ TEST_CASE("Reels") {
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
     int order[3];
+    nctablet* tabs[3];
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
       order[n] = -1;
+      tabs[n] = ncreel_add(nr, nullptr, nullptr, cbfxn, &order[n]);
+      REQUIRE(tabs[n]);
+      CHECK(tabs[0] == nr->tablets);
+      CHECK_EQ(0, ncreel_redraw(nr));
+      CHECK_EQ(0, notcurses_render(nc_));
+      CHECK(ncreel_validate(nr));
     }
-    auto t0 = ncreel_add(nr, nullptr, nullptr, cbfxn, &order[0]);
-    REQUIRE(t0);
-    auto t1 = ncreel_add(nr, nullptr, nullptr, cbfxn, &order[1]);
-    REQUIRE(t1);
-    auto t2 = ncreel_add(nr, nullptr, nullptr, cbfxn, &order[2]);
-    REQUIRE(t2);
-    CHECK_EQ(0, ncreel_redraw(nr));
-    CHECK_EQ(0, notcurses_render(nc_));
-    CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(0, order[n]);
+      CHECK_EQ(2 - n, order[n]);
     }
     ncreel_next(nr);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(1, order[n]);
+      CHECK_EQ(2 - n + 1, order[n]);
     }
     ncreel_next(nr);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(2, order[n]);
+      CHECK_EQ(2 - n + 2, order[n]);
     }
     ncreel_prev(nr);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(3, order[n]);
+      CHECK_EQ(2 - n + 3, order[n]);
     }
     ncreel_prev(nr);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
-      CHECK_EQ(4, order[n]);
+      CHECK_EQ(2 - n + 4, order[n]);
     }
   }
 

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -1,10 +1,10 @@
 #include "main.h"
 #include <iostream>
 
-auto panelcb(struct nctablet* t, bool cliptop) -> int {
+auto panelcb(struct nctablet* t, bool toptobottom) -> int {
   CHECK(nctablet_ncplane(t));
   CHECK(!nctablet_userptr(t));
-  CHECK(!cliptop);
+  CHECK(toptobottom);
   // FIXME verify geometry is as expected
   return 0;
 }
@@ -83,6 +83,7 @@ TEST_CASE("Reels") {
     r.flags = NCREEL_OPTION_INFINITESCROLL | NCREEL_OPTION_CIRCULAR;
     struct ncreel* nr = ncreel_create(n_, &r);
     REQUIRE(nr);
+    CHECK(ncreel_validate(nr));
     REQUIRE(0 == ncreel_destroy(nr));
   }
 
@@ -103,9 +104,11 @@ TEST_CASE("Reels") {
     CHECK(!ncreel_next(nr));
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
     CHECK(!ncreel_prev(nr));
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
   }
 
   SUBCASE("OneTablet") {
@@ -116,9 +119,11 @@ TEST_CASE("Reels") {
     REQUIRE(t);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
     CHECK(0 == ncreel_del(nr, t));
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
   }
 
   SUBCASE("MovementWithOneTablet") {
@@ -128,12 +133,20 @@ TEST_CASE("Reels") {
     struct nctablet* t = ncreel_add(nr, nullptr, nullptr, panelcb, nullptr);
     REQUIRE(t);
     CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
     CHECK(ncreel_next(nr));
     CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
     CHECK(ncreel_prev(nr));
     CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
     CHECK(0 == ncreel_del(nr, t));
     CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
   }
 
   SUBCASE("DeleteActiveTablet") {
@@ -143,6 +156,9 @@ TEST_CASE("Reels") {
     struct nctablet* t = ncreel_add(nr, nullptr, nullptr, panelcb, nullptr);
     REQUIRE(t);
     CHECK(0 == ncreel_del(nr, ncreel_focused(nr)));
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
   }
 
   SUBCASE("NoBorder") {
@@ -151,6 +167,9 @@ TEST_CASE("Reels") {
                     NCBOXMASK_TOP | NCBOXMASK_BOTTOM;
     struct ncreel* nr = ncreel_create(n_, &r);
     REQUIRE(nr);
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
   }
 
   SUBCASE("BadBorderBitsRejected") {
@@ -166,6 +185,9 @@ TEST_CASE("Reels") {
                     NCBOXMASK_TOP | NCBOXMASK_BOTTOM;
     struct ncreel* nr = ncreel_create(n_, &r);
     REQUIRE(nr);
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
   }
 
   SUBCASE("NoTopBottomBorder") {
@@ -173,6 +195,9 @@ TEST_CASE("Reels") {
     r.bordermask = NCBOXMASK_TOP | NCBOXMASK_BOTTOM;
     struct ncreel* nr = ncreel_create(n_, &r);
     REQUIRE(nr);
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
   }
 
   SUBCASE("NoSideBorders") {
@@ -180,6 +205,9 @@ TEST_CASE("Reels") {
     r.bordermask = NCBOXMASK_LEFT | NCBOXMASK_RIGHT;
     struct ncreel* nr = ncreel_create(n_, &r);
     REQUIRE(nr);
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
   }
 
   SUBCASE("BadTabletBorderBitsRejected") {
@@ -194,7 +222,14 @@ TEST_CASE("Reels") {
     channels_set_bg_alpha(&r.bgchannel, 3);
     struct ncreel* nr = ncreel_create(n_, &r);
     REQUIRE(nr);
-    // FIXME
+    CHECK_EQ(0, ncreel_redraw(nr));
+    CHECK_EQ(0, notcurses_render(nc_));
+    CHECK(ncreel_validate(nr));
+  }
+
+  // Layout tests. Add some tablets, move around, and verify that they all
+  // have the expected locations/contents/geometries.
+  SUBCASE("ThreeCycleDown") {
   }
 
   CHECK(0 == notcurses_stop(nc_));

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -283,33 +283,39 @@ TEST_CASE("Reels") {
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
+    expectedy = 1;
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
       //CHECK_EQ(2 - n + 2, order[n]);
       int y;
       ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
-      // FIXME
+      CHECK(y == expectedy);
+      expectedy += 7;
     }
     ncreel_prev(nr);
     CHECK(tabs[1] == nr->tablets);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
+    expectedy = 1;
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
       //CHECK_EQ(2 - n + 3, order[n]);
       int y;
       ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
-      // FIXME
+      CHECK(y == expectedy);
+      expectedy += 7;
     }
     ncreel_prev(nr);
     CHECK(tabs[0] == nr->tablets);
     CHECK_EQ(0, ncreel_redraw(nr));
     CHECK_EQ(0, notcurses_render(nc_));
     CHECK(ncreel_validate(nr));
+    expectedy = 1;
     for(size_t n = 0 ; n < sizeof(order) / sizeof(*order) ; ++n){
       //CHECK_EQ(2 - n + 4, order[n]);
       int y;
       ncplane_yx(ncplane_parent(nctablet_ncplane(tabs[n])), &y, nullptr);
-      // FIXME
+      CHECK(y == expectedy);
+      expectedy += 7;
     }
   }
 


### PR DESCRIPTION
* New reel layout algorithm based on trimming and sifting. Fixes the original issue of #818, though I'm not marking that bug fixed until I've resolved the little issues remaining with this one.
* Back off CMake version dependency, see if we can get by with 3.11.4 for EPEL8 #851 
* Simplify tablet drawing tremendously by separating tablet border and data planes. Callbacks no longer need worry about the borders; they can simply fill the plane they're handed. #833 
* Improve `notcurses_debug()` a bit
* Add `ncplane_new_named()` and friends to expose plane naming to the user.
* Add internal `ncplane_genocide()` to kill a plane and all its bound descendents
* New industrial-strength ncreel unit testing
* `notcurses-ncreel` now accepts `-ln` for log level n
* Add `ncplane_parent()` and `ncplane_parent_const()`