### PR TITLE
ncplane_puttext() work for longer lines

### DIFF
--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -57,7 +57,7 @@ static struct ncmselector_item mselect_items[] = {
 
 static struct ncmultiselector*
 multiselector_demo(struct ncplane* n, struct ncplane* under, int dimx,
-                   int y, pthread_mutex_t* lock, int* res){
+                   int y, pthread_mutex_t* lock, int* ret){
   struct notcurses* nc = ncplane_notcurses(n);
   ncmultiselector_options mopts = {
     .maxdisplay = 8,
@@ -89,20 +89,38 @@ multiselector_demo(struct ncplane* n, struct ncplane* under, int dimx,
   pthread_mutex_unlock(lock);
   ncinput ni;
   for(int i = -length + 1 ; i < dimx - (length + 1) ; ++i){
-    if( (*res = locked_demo_render(nc, lock)) ){
-      ncmultiselector_destroy(mselector);
-      return NULL;
-    }
-    ncplane_move_yx(mplane, y, i);
-    char32_t wc = demo_getc(nc, &swoopdelay, &ni);
-    if(wc == (char32_t)-1){
-      ncmultiselector_destroy(mselector);
-      return NULL;
-    }else if(wc){
-      ncmultiselector_offer_input(mselector, &ni);
-    }
+    struct timespec now, deadline;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    ns_to_timespec(timespec_to_ns(&swoopdelay) + timespec_to_ns(&now), &deadline);
+    do{
+      pthread_mutex_lock(lock);
+        *ret = demo_render(nc);
+        ncplane_move_yx(mplane, y, i);
+      pthread_mutex_unlock(lock);
+      if(*ret){
+        ncmultiselector_destroy(mselector);
+        return NULL;
+      }
+      struct timespec iterdelay;
+      ns_to_timespec(timespec_subtract_ns(&deadline, &now), &iterdelay);
+      char32_t wc = demo_getc(nc, &iterdelay, &ni);
+      if(wc == (char32_t)-1){
+        ncmultiselector_destroy(mselector);
+        return NULL;
+      }else if(wc){
+        pthread_mutex_lock(lock);
+          ncmultiselector_offer_input(mselector, &ni);
+          *ret = demo_render(nc);
+        pthread_mutex_unlock(lock);
+        if(*ret){
+          ncmultiselector_destroy(mselector);
+          return NULL;
+        }
+      }
+      clock_gettime(CLOCK_MONOTONIC, &now);
+    }while(timespec_to_ns(&now) < timespec_to_ns(&deadline));
   }
-  if( (*res = locked_demo_render(nc, lock)) ){
+  if( (*ret = locked_demo_render(nc, lock)) ){
     ncmultiselector_destroy(mselector);
     return NULL;
   }

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -291,6 +291,7 @@ reader_thread(void* vmarsh){
   // we usually won't be done rendering the text before reaching our target row
   size_t textpos = 0;
   int ret;
+  const int MAXTOWRITE = 8;
   while(textpos < textlen || y > targrow){
     pthread_mutex_lock(lock);
       if( (ret = demo_render(nc)) ){
@@ -305,12 +306,14 @@ reader_thread(void* vmarsh){
         --y;
       }
       ncplane_move_yx(rplane, y, x);
-      size_t towrite = strlen(text + textpos);
-      //size_t towrite = strcspn(text + textpos, " \t\n") + 1;
+      size_t towrite = strcspn(text + textpos, " \t\n") + 1;
+      if(towrite > MAXTOWRITE){
+        towrite = MAXTOWRITE;
+      }
       if(towrite){
         char* duped = strndup(text + textpos, towrite);
         size_t bytes;
-        if(ncplane_puttext(rplane, -1, NCALIGN_LEFT, duped, &bytes) < 0 || bytes != towrite){
+        if(ncplane_puttext(rplane, -1, NCALIGN_LEFT, duped, &bytes) < 0 || bytes != strlen(duped)){
           free(duped);
           return THREAD_RETURN_NEGATIVE;
         }

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -287,8 +287,10 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np, int xoff){
       ncdirect_bg(n, channels_bg(channels));
 //fprintf(stderr, "%03d/%03d [%s] (%03dx%03d)\n", y, x, egc, dimy, dimx);
       if(fprintf(n->ttyfp, "%s", strlen(egc) == 0 ? " " : egc) < 0){
+        free(egc);
         return -1;
       }
+      free(egc);
     }
     if(dimx < totx){
       ncdirect_bg_default(n);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -781,29 +781,40 @@ int get_controlling_tty(void);
 
 // logging
 #define logerror(nc, fmt, ...) do{ \
-  if((nc)->loglevel >= NCLOGLEVEL_ERROR){ \
-    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } }while(0);
+  if(nc){ if((nc)->loglevel >= NCLOGLEVEL_ERROR){ \
+    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+}while(0);
 
 #define logwarn(nc, fmt, ...) do{ \
-  if((nc)->loglevel >= NCLOGLEVEL_WARNING){ \
-    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } }while(0);
+  if(nc){ if((nc)->loglevel >= NCLOGLEVEL_WARNING){ \
+    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+}while(0);
 
 #define loginfo(nc, fmt, ...) do{ \
-  if((nc)->loglevel >= NCLOGLEVEL_INFO){ \
-    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } }while(0);
+  if(nc){ if((nc)->loglevel >= NCLOGLEVEL_INFO){ \
+    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+}while(0);
 
 #define logverbose(nc, fmt, ...) do{ \
-  if((nc)->loglevel >= NCLOGLEVEL_VERBOSE){ \
-    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } }while(0);
+  if(nc){ if((nc)->loglevel >= NCLOGLEVEL_VERBOSE){ \
+    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+}while(0);
 
 #define logdebug(nc, fmt, ...) do{ \
-  if((nc)->loglevel >= NCLOGLEVEL_DEBUG){ \
-    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } }while(0);
+  if(nc){ if((nc)->loglevel >= NCLOGLEVEL_DEBUG){ \
+    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+}while(0);
 
 #define logtrace(nc, fmt, ...) do{ \
-  if((nc)->loglevel >= NCLOGLEVEL_TRACE){ \
-    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } }while(0);
-
+  if(nc){ if((nc)->loglevel >= NCLOGLEVEL_TRACE){ \
+    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+}while(0);
 
 // Convert a notcurses log level to some multimedia library equivalent.
 int ffmpeg_log_level(ncloglevel_e level);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -795,26 +795,22 @@ int get_controlling_tty(void);
 #define loginfo(nc, fmt, ...) do{ \
   if(nc){ if((nc)->loglevel >= NCLOGLEVEL_INFO){ \
     nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
-  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
-}while(0);
+  } }while(0);
 
 #define logverbose(nc, fmt, ...) do{ \
   if(nc){ if((nc)->loglevel >= NCLOGLEVEL_VERBOSE){ \
     nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
-  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
-}while(0);
+  } }while(0);
 
 #define logdebug(nc, fmt, ...) do{ \
   if(nc){ if((nc)->loglevel >= NCLOGLEVEL_DEBUG){ \
     nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
-  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
-}while(0);
+  } }while(0);
 
 #define logtrace(nc, fmt, ...) do{ \
   if(nc){ if((nc)->loglevel >= NCLOGLEVEL_TRACE){ \
     nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
-  }else{ fprintf(stderr, "%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
-}while(0);
+  } }while(0);
 
 // Convert a notcurses log level to some multimedia library equivalent.
 int ffmpeg_log_level(ncloglevel_e level);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -65,6 +65,9 @@ typedef struct ncplane {
   cell* fb;              // "framebuffer" of character cells
   int logrow;            // logical top row, starts at 0, add one for each scroll
   int x, y;              // current cursor location within this plane
+  // ncplane_yx() etc. use coordinates relative to the plane to which this
+  // plane is bound, but absx/absy are always relative to the terminal origin.
+  // they must thus be translated by any such function.
   int absx, absy;        // origin of the plane relative to the screen
   int lenx, leny;        // size of the plane, [0..len{x,y}) is addressable
   struct ncplane* above; // plane above us, NULL if we're on top

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1715,7 +1715,6 @@ overlong_word(const char* text, int dimx){
 
 // FIXME probably best to use u8_wordbreaks() and get all wordbreaks at once...
 int ncplane_puttext(ncplane* n, int y, ncalign_e align, const char* text, size_t* bytes){
-fprintf(stderr, "SHITFAYRE %s\n", text);
   int totalcols = 0;
   // save the beginning for diagnostic
   const char* beginning = text;
@@ -1738,7 +1737,7 @@ fprintf(stderr, "SHITFAYRE %s\n", text);
     // not a space, it won't be printed, and we carry the word forward.
     // FIXME what ought be done with \n or multiple spaces?
     while(*text && x <= dimx){
-fprintf(stderr, "laying out [%s] at %d <= %d, %zu\n", linestart, x, dimx, text - linestart);
+//fprintf(stderr, "laying out [%s] at %d <= %d, %zu\n", linestart, x, dimx, text - linestart);
       wchar_t w;
       size_t consumed = mbrtowc(&w, text, MB_CUR_MAX, &mbstate);
       if(consumed == (size_t)-2 || consumed == (size_t)-1){
@@ -1749,7 +1748,7 @@ fprintf(stderr, "laying out [%s] at %d <= %d, %zu\n", linestart, x, dimx, text -
         return -1;
       }
       if(iswordbreak(w)){
-fprintf(stderr, "wordbreak [%lc] at %d\n", w, x);
+//fprintf(stderr, "wordbreak [%lc] at %d\n", w, x);
         if(x == 0){
           text += consumed;
           linestart = text;
@@ -1760,7 +1759,7 @@ fprintf(stderr, "wordbreak [%lc] at %d\n", w, x);
         }
       }
       width = wcwidth(w);
-fprintf(stderr, "have char %lc (%d) (%zu)\n", w, width, text - linestart);
+//fprintf(stderr, "have char %lc (%d) (%zu)\n", w, width, text - linestart);
       if(width < 0){
         width = 0;
       }
@@ -1770,7 +1769,7 @@ fprintf(stderr, "have char %lc (%d) (%zu)\n", w, width, text - linestart);
       x += width;
       text += consumed;
     }
-fprintf(stderr, "OUT! %s %zu %d\n", linestart, text - linestart, x);
+//fprintf(stderr, "OUT! %s %zu %d\n", linestart, text - linestart, x);
     bool overlong = false; // ugh
     // if we have no breaker, we got a single word that was longer than our
     // line. print what we can and move along. if *text is nul, we're done.
@@ -1785,12 +1784,12 @@ fprintf(stderr, "OUT! %s %zu %d\n", linestart, text - linestart, x);
         breaker = text;
         breakercol = dimx;
         overlong = true;
-fprintf(stderr, "NEW BREAKER: %s\n", breaker);
+//fprintf(stderr, "NEW BREAKER: %s\n", breaker);
       }
     }
     // if the most recent breaker was the last column, it doesn't really count
     if(breakercol == dimx - 1){
-fprintf(stderr, "END OF THE LINE. breakercol: %d -> %d breakerdiff: %zu\n", breakercol, dimx, breaker - linestart);
+//fprintf(stderr, "END OF THE LINE. breakercol: %d -> %d breakerdiff: %zu\n", breakercol, dimx, breaker - linestart);
       breakercol = dimx;
       ++breaker; // FIXME need to advance # of bytes in the UTF8 breaker, not 1
     }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1757,7 +1757,7 @@ puttext_premove(ncplane* n, const char* text){
       text += consumed;
     }
   }
-  if(breaker == NULL){
+  if(*text && breaker == NULL){
 //fprintf(stderr, "ADVANCING DA FOKKER, JA\n");
     if(n->scrolling){
       scroll_down(n);
@@ -1770,6 +1770,9 @@ puttext_premove(ncplane* n, const char* text){
 
 // FIXME probably best to use u8_wordbreaks() and get all wordbreaks at once...
 int ncplane_puttext(ncplane* n, int y, ncalign_e align, const char* text, size_t* bytes){
+  if(bytes){
+    *bytes = 0;
+  }
   int totalcols = 0;
   // save the beginning for diagnostic
   const char* beginning = text;

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -566,6 +566,9 @@ tighten_reel(ncreel* r){
       }
     }
   }
+  if(!top || !bottom){
+    return 0;
+  }
   return trim_reel_overhang(r, top, bottom);
 }
 

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -313,9 +313,7 @@ TEST_CASE("TextLayout") {
     const int READER_ROWS = 8;
     const char text[] =
       "Notcurses provides several widgets to quickly build vivid TUIs.\n\n"
-      "This NCReader widget facilitates free-form text entry complete with readline-style bindings. "
-      "NCSelector allows a single option to be selected from a list. "
-      "NCMultiselector allows 0..n options to be selected from a list of n items. "
+      "This NCReader widget facilitates free-form text entry complete with readline-style bindings. " "NCSelector allows a single option to be selected from a list. " "NCMultiselector allows 0..n options to be selected from a list of n items. "
       "NCFdplane streams a file descriptor, while NCSubproc spawns a subprocess and streams its output. "
       "A variety of plots are supported, and menus can be placed along the top and/or bottom of any plane.\n\n"
       "Widgets can be controlled with the keyboard and/or mouse. They are implemented atop ncplanes, and these planes can be manipulated like all others.";
@@ -348,7 +346,6 @@ TEST_CASE("TextLayout") {
       "Widgets can be controlled with the keyboard and/or mouse. They are implemented atop ncplanes, and these planes can be manipulated like all others.";
     auto sp = ncplane_new(nc_, READER_ROWS, READER_COLS, 0, 0, nullptr);
     REQUIRE(sp);
-    ncplane_set_scrolling(sp, true);
     size_t bytes;
     ncplane_home(sp);
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, text, &bytes));

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -284,6 +284,34 @@ TEST_CASE("TextLayout") {
     ncplane_destroy(sp);
   }
 
+  SUBCASE("LayoutZooText") {
+    // straight from the zoo demo, which didn't work at first
+    const int READER_COLS = 64;
+    const int READER_ROWS = 8;
+    const char text[] =
+      "Notcurses provides several widgets to quickly build vivid TUIs.\n\n"
+      "This NCReader widget facilitates free-form text entry complete with readline-style bindings. "
+      "NCSelector allows a single option to be selected from a list. "
+      "NCMultiselector allows 0..n options to be selected from a list of n items. "
+      "NCFdplane streams a file descriptor, while NCSubproc spawns a subprocess and streams its output. "
+      "A variety of plots are supported, and menus can be placed along the top and/or bottom of any plane.\n\n"
+      "Widgets can be controlled with the keyboard and/or mouse. They are implemented atop ncplanes, and these planes can be manipulated like all others.";
+    auto sp = ncplane_new(nc_, READER_ROWS, READER_COLS, 0, 0, nullptr);
+    REQUIRE(sp);
+    ncplane_set_scrolling(sp, true);
+    size_t bytes;
+    ncplane_home(sp);
+    CHECK(0 < ncplane_puttext(sp, -1, NCALIGN_LEFT, text, &bytes));
+    CHECK(bytes == strlen(text));
+    CHECK(0 == notcurses_render(nc_));
+sleep(5);
+    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    REQUIRE(line);
+fprintf(stderr, "RESULT: %s\n", line);
+    free(line);
+    ncplane_destroy(sp);
+  }
+
   CHECK(0 == notcurses_stop(nc_));
 
 }

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -301,7 +301,35 @@ TEST_CASE("TextLayout") {
     ncplane_set_scrolling(sp, true);
     size_t bytes;
     ncplane_home(sp);
-    CHECK(0 < ncplane_puttext(sp, -1, NCALIGN_LEFT, text, &bytes));
+    CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, text, &bytes));
+    CHECK(bytes == strlen(text));
+    CHECK(0 == notcurses_render(nc_));
+sleep(5);
+    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    REQUIRE(line);
+fprintf(stderr, "RESULT: %s\n", line);
+    free(line);
+    ncplane_destroy(sp);
+  }
+
+  SUBCASE("LayoutZooTextNoScroll") {
+    // straight from the zoo demo, which didn't work at first
+    const int READER_COLS = 64;
+    const int READER_ROWS = 15;
+    const char text[] =
+      "Notcurses provides several widgets to quickly build vivid TUIs.\n\n"
+      "This NCReader widget facilitates free-form text entry complete with readline-style bindings. "
+      "NCSelector allows a single option to be selected from a list. "
+      "NCMultiselector allows 0..n options to be selected from a list of n items. "
+      "NCFdplane streams a file descriptor, while NCSubproc spawns a subprocess and streams its output. "
+      "A variety of plots are supported, and menus can be placed along the top and/or bottom of any plane.\n\n"
+      "Widgets can be controlled with the keyboard and/or mouse. They are implemented atop ncplanes, and these planes can be manipulated like all others.";
+    auto sp = ncplane_new(nc_, READER_ROWS, READER_COLS, 0, 0, nullptr);
+    REQUIRE(sp);
+    ncplane_set_scrolling(sp, true);
+    size_t bytes;
+    ncplane_home(sp);
+    CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, text, &bytes));
     CHECK(bytes == strlen(text));
     CHECK(0 == notcurses_render(nc_));
 sleep(5);


### PR DESCRIPTION
* The `zoo` demo made manifest that we had some serious problems handling sequences of longer lines in `ncplane_puttext()`. This remedies most of the problems, though it's not yet perfect. #871
* Guard `notcurses*` for `NULL` in `log*()` #878 #879 
* Fix memory leak in `ncdirect_dump_plane()`