### PR TITLE
Inlined EGCs #830

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ steps:
     - cd build
     - cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MULTIMEDIA=none ..
     - make
-    - env TERM=xterm make test
+    - env TERM=xterm make test || env TERM=xterm ./notcurses-tester -p ../data
 ---
 kind: pipeline
 type: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: debian-unstable
 
 steps:
 - name: debian-build
-  image: dankamongmen/unstable_builder:2020-07-13a
+  image: dankamongmen/unstable_builder:2020-08-14a
   commands:
     - export LANG=en_US.UTF-8
     - apt-get install -y libunistring-dev
@@ -21,7 +21,7 @@ name: ubuntu-focal
 
 steps:
 - name: ubuntu-build
-  image: dankamongmen/focal:2020-07-13a
+  image: dankamongmen/focal:2020-08-14a
   commands:
     - export LANG=en_US.UTF-8
     - apt-get install -y libunistring-dev
@@ -37,7 +37,7 @@ name: fedora-rawhide
 
 steps:
 - name: fedora-rawhide
-  image: dankamongmen/fedora33:2020-07-13a
+  image: dankamongmen/fedora33:2020-08-14a
   commands:
     - export LANG=en_US.UTF-8
     - dnf install -y libunistring-devel

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ steps:
     - cd build
     - cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MULTIMEDIA=none ..
     - make
-    - env TERM=xterm make test || env TERM=xterm ./notcurses-tester -p ../data
+    - env TERM=xterm make test
 ---
 kind: pipeline
 type: docker

--- a/README.md
+++ b/README.md
@@ -372,6 +372,12 @@ If things break or seem otherwise lackluster, **please** consult the
 * *Q:* Do you support [musl](https://musl.libc.org/)?
 * *A:* I try to! You'll need at least 1.20.
 
+* *Q:* I only seem to blit in ASCII.
+* *A:* `setlocale(3)` has not been called, or your `LANG` environment variable is underdefined or incorrectly defined, or the necessary locale is not present on your machine.
+
+* *Q:* I pretty much always need an `ncplane` when using a `cell`. Why doesn't the latter hold a point to the former?
+* *A:* Besides the massive redundancy this would entail, `cell` needs to remain as small as possible, and you almost always have the `ncplane` handy if you've got a reference to a valid `cell` anyway.
+
 ## Supplemental material
 
 ### Useful links

--- a/USAGE.md
+++ b/USAGE.md
@@ -1513,7 +1513,7 @@ useful to use a `cell` when the same styling is used in a discontinuous manner.
 //
 // Each cell occupies 16 static bytes (128 bits). The surface is thus ~1.6MB
 // for a (pretty large) 500x200 terminal. At 80x43, it's less than 64KB.
-// Dynamic requirements can add up to 32MB to an ncplane, but such large pools
+// Dynamic requirements can add up to 16MB to an ncplane, but such large pools
 // are unlikely in common use.
 //
 // We implement some small alpha compositing. Foreground and background both
@@ -1536,7 +1536,7 @@ useful to use a `cell` when the same styling is used in a discontinuous manner.
 typedef struct cell {
   // These 32 bits are either a single-byte, single-character grapheme cluster
   // (values 0--0x7f), or an offset into a per-ncplane attached pool of
-  // varying-length UTF-8 grapheme clusters. This pool may thus be up to 32MB.
+  // varying-length UTF-8 grapheme clusters. This pool may thus be up to 16MB.
   uint32_t gcluster;          // 4B -> 4B
   // NCSTYLE_* attributes (16 bits) + 8 foreground palette index bits + 8
   // background palette index bits. palette index bits are used only if the

--- a/doc/man/man1/notcurses-demo.1.md
+++ b/doc/man/man1/notcurses-demo.1.md
@@ -74,7 +74,7 @@ At any time, press 'q' to quit. The demo is best run in at least an 80x45 termin
 **-V**: Print the program name and version, and exit with success.
 
 demospec: Select which demos to run, and what order to run them in. The
-default is **ixezaydthnbcmgrwuvlsfjqo**. See above for a list of demos.
+default is **ixezydthnbcmgarwuvlsfjqo**. See above for a list of demos.
 
 Default margins are all 0, and thus the full screen will be rendered. Using
 **-m**, margins can be supplied. Provide a single number to set all four margins

--- a/include/notcurses/endianness.h
+++ b/include/notcurses/endianness.h
@@ -1,0 +1,43 @@
+#ifndef NOTCURSES_ENDIANNESS
+#define NOTCURSES_ENDIANNESS
+
+// We would just use ntohl() and friends, except we need them in both a
+// (1) compile-time and (2) C++ enum context. They're not permitted as
+// C++ enum initializers. Thus this sorry affair.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum ncendianness_t {
+  NC_BIGENDIAN = 0x00000001llu,
+  NC_LITENDIAN = 0x01000000llu,
+};
+
+// Sprinkle parentheses of salt and recite the ancient incantation...
+#ifdef __BIG_ENDIAN__
+enum { NC_ENDIANNESS = NC_BIGENDIAN };
+#else
+#ifdef __LITTLE_ENDIAN__
+enum { NC_ENDIANNESS = NC_LITENDIAN };
+#else
+#ifdef BSD
+#include <sys/endian.h>
+#else
+#include <endian.h>
+#endif
+#if __BYTE_ORDER == __BIG_ENDIAN
+enum { NC_ENDIANNESS = NC_BIGENDIAN };
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+enum { NC_ENDIANNESS = NC_LITENDIAN };
+#else
+#error "Couldn't determine endianness"
+#endif
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/notcurses/endianness.h
+++ b/include/notcurses/endianness.h
@@ -17,9 +17,11 @@ enum ncendianness_t {
 // Sprinkle parentheses of salt and recite the ancient incantation...
 #ifdef __BIG_ENDIAN__
 enum { NC_ENDIANNESS = NC_BIGENDIAN };
+#define NC_LITTLEENDIAN 0
 #else
 #ifdef __LITTLE_ENDIAN__
 enum { NC_ENDIANNESS = NC_LITENDIAN };
+#define NC_LITTLEENDIAN 1
 #else
 #ifdef BSD
 #include <sys/endian.h>
@@ -28,8 +30,10 @@ enum { NC_ENDIANNESS = NC_LITENDIAN };
 #endif
 #if __BYTE_ORDER == __BIG_ENDIAN
 enum { NC_ENDIANNESS = NC_BIGENDIAN };
+#define NC_LITTLEENDIAN 0
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
 enum { NC_ENDIANNESS = NC_LITENDIAN };
+#define NC_LITTLEENDIAN 1
 #else
 #error "Couldn't determine endianness"
 #endif

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -15,6 +15,7 @@
 #include <stdbool.h>
 #include <notcurses/nckeys.h>
 #include <notcurses/ncerrs.h>
+#include <notcurses/endianness.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -570,6 +571,9 @@ API int cell_duplicate(struct ncplane* n, cell* targ, const cell* c);
 // Release resources held by the cell 'c'.
 API void cell_release(struct ncplane* n, cell* c);
 
+// We want the 2 bytes at the highest address of a 32-bit word, so that the
+// octet adjacent to g->clusters is left undisturbed as zero.
+#ifdef NC_BIGENDIAN
 #define NCSTYLE_MASK      0x0000fffful
 #define NCSTYLE_STANDOUT  0x00000080ul
 #define NCSTYLE_UNDERLINE 0x00000040ul
@@ -580,6 +584,18 @@ API void cell_release(struct ncplane* n, cell* c);
 #define NCSTYLE_INVIS     0x00000002ul
 #define NCSTYLE_PROTECT   0x00000001ul
 #define NCSTYLE_ITALIC    0x00000100ul
+#else
+#define NCSTYLE_MASK      0xffff0000ul
+#define NCSTYLE_STANDOUT  0x00800000ul
+#define NCSTYLE_UNDERLINE 0x00400000ul
+#define NCSTYLE_REVERSE   0x00200000ul
+#define NCSTYLE_BLINK     0x00100000ul
+#define NCSTYLE_DIM       0x00080000ul
+#define NCSTYLE_BOLD      0x00040000ul
+#define NCSTYLE_INVIS     0x00020000ul
+#define NCSTYLE_PROTECT   0x00010000ul
+#define NCSTYLE_ITALIC    0x01000000ul
+#endif
 #define NCSTYLE_NONE      0
 
 // Set the specified style bits for the cell 'c', whether they're actively

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -664,9 +664,9 @@ static inline char*
 cell_strdup(const struct ncplane* n, const cell* c){
   char* ret;
   if(cell_simple_p(c)){
-    if( (ret = (char*)malloc(2)) ){ // cast is here for C++ clients
-      ret[0] = c->gcluster;
-      ret[1] = '\0';
+    if( (ret = (char*)malloc(sizeof(c->gcluster) + 1)) ){ // cast is here for C++ clients
+      memset(ret, 0, sizeof(c->gcluster) + 1);
+      memcpy(ret, &c->gcluster, sizeof(c->gcluster));
     }
   }else{
     ret = strdup(cell_extended_gcluster(n, c));

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -587,30 +587,21 @@ API void cell_release(struct ncplane* n, cell* c);
 
 // We want the 2 bytes at the highest address of a 32-bit word, so that the
 // octet adjacent to g->clusters is left undisturbed as zero.
-#ifdef NC_BIGENDIAN
-#define NCSTYLE_MASK      0x0000fffful
-#define NCSTYLE_STANDOUT  0x00000080ul
-#define NCSTYLE_UNDERLINE 0x00000040ul
-#define NCSTYLE_REVERSE   0x00000020ul
-#define NCSTYLE_BLINK     0x00000010ul
-#define NCSTYLE_DIM       0x00000008ul
-#define NCSTYLE_BOLD      0x00000004ul
-#define NCSTYLE_INVIS     0x00000002ul
-#define NCSTYLE_PROTECT   0x00000001ul
-#define NCSTYLE_ITALIC    0x00000100ul
-#else
-#define NCSTYLE_MASK      0xffff0000ul
-#define NCSTYLE_STANDOUT  0x00800000ul
-#define NCSTYLE_UNDERLINE 0x00400000ul
-#define NCSTYLE_REVERSE   0x00200000ul
-#define NCSTYLE_BLINK     0x00100000ul
-#define NCSTYLE_DIM       0x00080000ul
-#define NCSTYLE_BOLD      0x00040000ul
-#define NCSTYLE_INVIS     0x00020000ul
-#define NCSTYLE_PROTECT   0x00010000ul
-#define NCSTYLE_ITALIC    0x01000000ul
-#endif
+#ifdef NC_LITTLEENDIAN
+#define NCSTYLE_MASK      (0x0000fffful << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_STANDOUT  (0x00000080ul << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_UNDERLINE (0x00000040ul << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_REVERSE   (0x00000020ul << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_BLINK     (0x00000010ul << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_DIM       (0x00000008ul << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_BOLD      (0x00000004ul << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_INVIS     (0x00000002ul << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_PROTECT   (0x00000001ul << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_ITALIC    (0x00000100ul << (16u * !NC_LITTLEENDIAN))
 #define NCSTYLE_NONE      0
+#else
+#error "Groping blindly through an uncaring universe, I know not my endianness"
+#endif
 
 // Set the specified style bits for the cell 'c', whether they're actively
 // supported or not.

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -678,30 +678,22 @@ cell_wide_left_p(const cell* c){
   return cell_double_wide_p(c) && c->gcluster;
 }
 
-// Is the cell simple (a lone ASCII character, encoded as such)?
+// Is the cell simple (a UTF8-encoded EGC of four bytes or fewer)?
 static inline bool
 cell_simple_p(const cell* c){
   return (c->gcluster >> 24u) != 0x01;
 }
 
 // return a pointer to the NUL-terminated EGC referenced by 'c'. this pointer
-// is invalidated by any further operation on the plane 'n', so...watch out!
+// can be invalidated by any further operation on the plane 'n', so...watch out!
+// works on both simple and non-simple cells.
 API const char* cell_extended_gcluster(const struct ncplane* n, const cell* c);
 
 // copy the UTF8-encoded EGC out of the cell, whether simple or complex. the
 // result is not tied to the ncplane, and persists across erases / destruction.
 static inline char*
 cell_strdup(const struct ncplane* n, const cell* c){
-  char* ret;
-  if(cell_simple_p(c)){
-    if( (ret = (char*)malloc(sizeof(c->gcluster) + 1)) ){ // cast is here for C++ clients
-      memset(ret, 0, sizeof(c->gcluster) + 1);
-      memcpy(ret, &c->gcluster, sizeof(c->gcluster));
-    }
-  }else{
-    ret = strdup(cell_extended_gcluster(n, c));
-  }
-  return ret;
+  return strdup(cell_extended_gcluster(n, c));
 }
 
 // Extract the three elements of a cell.

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -588,16 +588,16 @@ API void cell_release(struct ncplane* n, cell* c);
 // We want the 2 bytes at the highest address of a 32-bit word, so that the
 // octet adjacent to g->clusters is left undisturbed as zero.
 #ifdef NC_LITTLEENDIAN
-#define NCSTYLE_MASK      (0x0000fffful << (16u * !NC_LITTLEENDIAN))
-#define NCSTYLE_STANDOUT  (0x00000080ul << (16u * !NC_LITTLEENDIAN))
-#define NCSTYLE_UNDERLINE (0x00000040ul << (16u * !NC_LITTLEENDIAN))
-#define NCSTYLE_REVERSE   (0x00000020ul << (16u * !NC_LITTLEENDIAN))
-#define NCSTYLE_BLINK     (0x00000010ul << (16u * !NC_LITTLEENDIAN))
-#define NCSTYLE_DIM       (0x00000008ul << (16u * !NC_LITTLEENDIAN))
-#define NCSTYLE_BOLD      (0x00000004ul << (16u * !NC_LITTLEENDIAN))
-#define NCSTYLE_INVIS     (0x00000002ul << (16u * !NC_LITTLEENDIAN))
-#define NCSTYLE_PROTECT   (0x00000001ul << (16u * !NC_LITTLEENDIAN))
-#define NCSTYLE_ITALIC    (0x00000100ul << (16u * !NC_LITTLEENDIAN))
+#define NCSTYLE_MASK      (0x0000fffful << (16u * NC_LITTLEENDIAN))
+#define NCSTYLE_STANDOUT  (0x00000080ul << (16u * NC_LITTLEENDIAN))
+#define NCSTYLE_UNDERLINE (0x00000040ul << (16u * NC_LITTLEENDIAN))
+#define NCSTYLE_REVERSE   (0x00000020ul << (16u * NC_LITTLEENDIAN))
+#define NCSTYLE_BLINK     (0x00000010ul << (16u * NC_LITTLEENDIAN))
+#define NCSTYLE_DIM       (0x00000008ul << (16u * NC_LITTLEENDIAN))
+#define NCSTYLE_BOLD      (0x00000004ul << (16u * NC_LITTLEENDIAN))
+#define NCSTYLE_INVIS     (0x00000002ul << (16u * NC_LITTLEENDIAN))
+#define NCSTYLE_PROTECT   (0x00000001ul << (16u * NC_LITTLEENDIAN))
+#define NCSTYLE_ITALIC    (0x00000100ul << (16u * NC_LITTLEENDIAN))
 #define NCSTYLE_NONE      0
 #else
 #error "Groping blindly through an uncaring universe, I know not my endianness"

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -20,7 +20,7 @@ static int democount;
 static demoresult* results;
 static char *datadir = NOTCURSES_SHARE;
 
-static const char DEFAULT_DEMO[] = "ixezaydthnbcmgrwuvlsfjqo";
+static const char DEFAULT_DEMO[] = "ixezydthnbcmgarwuvlsfjqo";
 
 atomic_bool interrupted = ATOMIC_VAR_INIT(false);
 // checked following demos, whether aborted, failed, or otherwise

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -28,7 +28,7 @@ static int plot_pos_y;
 
 // how many columns for runtime?
 #define HUD_ROWS (3 + 2) // 2 for borders
-static const int HUD_COLS = 30 + 2; // 2 for borders
+static const int HUD_COLS = 24 + 2; // 2 for borders
 
 typedef struct elem {
   char* name;
@@ -304,11 +304,11 @@ hud_print_finished(elem* list){
       if(ncplane_printf_yx(hud, line, 1, "%d", e->frames) < 0){
         return -1;
       }
-      if(ncplane_printf_yx(hud, line, 7, "%ju.%02jus", e->totalns / GIG,
-                           (e->totalns % GIG) / (GIG / 100)) < 0){
+      if(ncplane_printf_yx(hud, line, 7, "%ju.%03jus", e->totalns / GIG,
+                           (e->totalns % GIG) / 1000000) < 0){
         return -1;
       }
-      if(ncplane_putstr_yx(hud, line, 18, e->name) < 0){
+      if(ncplane_putstr_yx(hud, line, 16, e->name) < 0){
         return -1;
       }
     }
@@ -504,11 +504,11 @@ int demo_render(struct notcurses* nc){
     if(ncplane_printf_yx(hud, 1, 1, "%d", elems->frames) < 0){
       return -1;
     }
-    if(ncplane_printf_yx(hud, 1, 7, "%ju.%02jus",
-                         ns / GIG, (ns % GIG) / (GIG / 100)) < 0){
+    if(ncplane_printf_yx(hud, 1, 7, "%ju.%03jus", ns / GIG,
+                         (ns % GIG) / 1000000) < 0){
       return -1;
     }
-    if(ncplane_putstr_yx(hud, 1, 18, elems->name) < 0){
+    if(ncplane_putstr_yx(hud, 1, 16, elems->name) < 0){
       return -1;
     }
   }

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -51,9 +51,9 @@ static int
 hud_standard_bg(struct ncplane* n){
   uint64_t channels = 0;
   channels_set_fg_alpha(&channels, CELL_ALPHA_BLEND);
-  channels_set_fg_rgb(&channels, 0xff, 0xff, 0xff);
+  channels_set_fg_rgb(&channels, 0x80, 0x80, 0x80);
   channels_set_bg_alpha(&channels, CELL_ALPHA_BLEND);
-  channels_set_bg_rgb(&channels, 0xff, 0xff, 0xff);
+  channels_set_bg_rgb(&channels, 0x80, 0x80, 0x80);
   if(ncplane_set_base(n, "", 0, channels) >= 0){
     return -1;
   }
@@ -298,7 +298,7 @@ hud_print_finished(elem* list){
       ncplane_base(hud, &c);
       ncplane_set_bg(hud, cell_bg(&c));
       ncplane_set_bg_alpha(hud, CELL_ALPHA_BLEND);
-      ncplane_set_fg(hud, 0);
+      ncplane_set_fg(hud, 0xffffff);
       ncplane_set_fg_alpha(hud, CELL_ALPHA_OPAQUE);
       cell_release(hud, &c);
       if(ncplane_printf_yx(hud, line, 1, "%d", e->frames) < 0){
@@ -498,7 +498,7 @@ int demo_render(struct notcurses* nc){
     ncplane_base(hud, &c);
     ncplane_set_bg(hud, cell_bg(&c));
     ncplane_set_bg_alpha(hud, CELL_ALPHA_BLEND);
-    ncplane_set_fg(hud, 0x002080);
+    ncplane_set_fg(hud, 0x80d0ff);
     ncplane_set_fg_alpha(hud, CELL_ALPHA_OPAQUE);
     cell_release(hud, &c);
     if(ncplane_printf_yx(hud, 1, 1, "%d", elems->frames) < 0){

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -28,7 +28,7 @@ static int plot_pos_y;
 
 // how many columns for runtime?
 #define HUD_ROWS (3 + 2) // 2 for borders
-static const int HUD_COLS = 24 + 2; // 2 for borders
+static const int HUD_COLS = 23 + 2; // 2 for borders
 
 typedef struct elem {
   char* name;

--- a/src/demo/intro.c
+++ b/src/demo/intro.c
@@ -103,9 +103,16 @@ int intro(struct notcurses* nc){
   ncplane_set_fg_rgb(ncp, 0xff, 0xff, 0xff);
   int major, minor, patch, tweak;
   notcurses_version_components(&major, &minor, &patch, &tweak);
-  if(ncplane_printf_aligned(ncp, rows / 2, NCALIGN_CENTER, "notcurses %d.%d.%d.%d. press 'q' to quit.",
-                            major, minor, patch, tweak) < 0){
-    return -1;
+  if(tweak){
+    if(ncplane_printf_aligned(ncp, rows / 2, NCALIGN_CENTER, "notcurses %d.%d.%d.%d. press 'q' to quit.",
+                              major, minor, patch, tweak) < 0){
+      return -1;
+    }
+  }else{
+    if(ncplane_printf_aligned(ncp, rows / 2, NCALIGN_CENTER, "notcurses %d.%d.%d. press 'q' to quit.",
+                              major, minor, patch) < 0){
+      return -1;
+    }
   }
   ncplane_styles_off(ncp, NCSTYLE_BOLD);
   const wchar_t wstr[] = L"▏▁ ▂ ▃ ▄ ▅ ▆ ▇ █ █ ▇ ▆ ▅ ▄ ▃ ▂ ▁▕";

--- a/src/demo/trans.c
+++ b/src/demo/trans.c
@@ -28,7 +28,6 @@ static struct ncplane*
 legend(struct notcurses* nc, const char* msg){
   int dimx, dimy;
   notcurses_term_dim_yx(nc, &dimy, &dimx);
-  // FIXME replace with ncplane_new_aligned()
   struct ncplane* n = ncplane_aligned(notcurses_stdplane(nc), 3,
                                       strlen(msg) + 4, 3,
                                       NCALIGN_CENTER, NULL);
@@ -39,9 +38,15 @@ legend(struct notcurses* nc, const char* msg){
   cell_set_fg_rgb(&c, 0, 0, 0); // darken surrounding characters by half
   cell_set_fg_alpha(&c, CELL_ALPHA_BLEND);
   cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT); // don't touch background
-  ncplane_set_base_cell(n, &c);
-  ncplane_set_fg(n, 0xd78700);
-  ncplane_set_bg(n, 0);
+  if(ncplane_set_base_cell(n, &c)){
+    ncplane_destroy(n);
+    return NULL;
+  }
+  if(ncplane_set_fg(n, 0xd78700) || ncplane_set_bg(n, 0)){
+    ncplane_destroy(n);
+    return NULL;
+  }
+  ncplane_styles_on(n, NCSTYLE_BOLD | NCSTYLE_ITALIC);
   if(ncplane_printf_aligned(n, 1, NCALIGN_CENTER, " %s ", msg) < 0){
     ncplane_destroy(n);
     return NULL;

--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -249,7 +249,7 @@ egcpool_dump(egcpool* pool){
 // unsafe results if called on a simple cell.
 static inline uint32_t
 cell_egc_idx(const cell* c){
-  return c->gcluster - 0x80;
+  return c->gcluster & 0x00fffffflu;
 }
 
 __attribute__ ((__returns_nonnull__)) static inline const char*

--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -255,6 +255,7 @@ cell_egc_idx(const cell* c){
 // only applies to complex cells, do not use on simple cells
 __attribute__ ((__returns_nonnull__)) static inline const char*
 egcpool_extended_gcluster(const egcpool* pool, const cell* c) {
+  assert(!cell_simple_p(c));
   uint32_t idx = cell_egc_idx(c);
   return pool->pool + idx;
 }

--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -252,6 +252,7 @@ cell_egc_idx(const cell* c){
   return c->gcluster & 0x00fffffflu;
 }
 
+// only applies to complex cells, do not use on simple cells
 __attribute__ ((__returns_nonnull__)) static inline const char*
 egcpool_extended_gcluster(const egcpool* pool, const cell* c) {
   uint32_t idx = cell_egc_idx(c);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -571,8 +571,8 @@ static inline void
 pool_release(egcpool* pool, cell* c){
   if(!cell_simple_p(c)){
     egcpool_release(pool, cell_egc_idx(c));
+    c->gcluster = 0; // don't subject ourselves to double-release problems
   }
-  c->gcluster = 0; // don't subject ourselves to double-release problems
 }
 
 // Duplicate one cell onto another, possibly crossing ncplanes.

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -385,9 +385,9 @@ static inline char*
 pool_egc_copy(const egcpool* e, const cell* c){
   char* ret;
   if(cell_simple_p(c)){
-    if( (ret = (char*)malloc(2)) ){
-      ret[0] = c->gcluster;
-      ret[1] = '\0';
+    if( (ret = (char*)malloc(sizeof(c->gcluster) + 1)) ){
+      memset(ret, 0, sizeof(c->gcluster) + 1);
+      memcpy(ret, &c->gcluster, sizeof(c->gcluster));
     }
   }else{
     ret = strdup(egcpool_extended_gcluster(e, c));
@@ -599,7 +599,7 @@ cell_duplicate_far(egcpool* tpool, cell* targ, const ncplane* splane, const cell
   targ->channels = c->channels;
   if(cell_simple_p(c)){
     targ->gcluster = c->gcluster;
-    return !!c->gcluster;
+    return strnlen((char*)&c->gcluster, sizeof(c->gcluster));
   }
   assert(splane);
   const char* egc = extended_gcluster(splane, c);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -608,7 +608,7 @@ cell_duplicate_far(egcpool* tpool, cell* targ, const ncplane* splane, const cell
   if(eoffset < 0){
     return -1;
   }
-  targ->gcluster = eoffset + 0x80;
+  targ->gcluster = 0x01000000ul + eoffset;
   return ulen;
 }
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -724,7 +724,9 @@ init_banner(const notcurses* nc){
   if(!nc->suppress_banner){
     char prefixbuf[BPREFIXSTRLEN + 1];
     term_fg_palindex(nc, stdout, nc->tcache.colors <= 256 ? 50 % nc->tcache.colors : 0x20e080);
-    printf("\n notcurses %s by nick black et al", notcurses_version());
+    // FIXME do runtime detection of endianness, ensure it matches compile time
+    printf("\n notcurses %s %s by nick black et al", notcurses_version(),
+           (int)NC_ENDIANNESS == (int)NC_BIGENDIAN ? "BE" : "LE");
     term_fg_palindex(nc, stdout, nc->tcache.colors <= 256 ? 12 % nc->tcache.colors : 0x2080e0);
     printf("\n  %d rows, %d columns (%sB), %d colors (%s)\n"
            "  compiled with gcc-%s\n"

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1377,7 +1377,6 @@ cell_load_direct(ncplane* n, cell* c, const char* gcluster, int bytes, int cols)
   }
   if(bytes <= 4){
     cell_release(n, c);
-    c->channels &= ~CELL_WIDEASIAN_MASK;
     c->gcluster = 0;
     memcpy(&c->gcluster, gcluster, bytes);
     return bytes;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1377,7 +1377,7 @@ cell_load_direct(ncplane* n, cell* c, const char* gcluster, int bytes, int cols)
     return bytes;
   }
   // FIXME also shaded blocks! ░ etc. are there combined EGCs involving these?
-  if(strncmp(gcluster, "\xe2\x96\x88", 3)){
+  if(strcmp(gcluster, "\xe2\x96\x88")){
     c->channels &= ~CELL_NOBACKGROUND_MASK;
     if(cols < 2){
       c->channels &= ~CELL_WIDEASIAN_MASK;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1187,7 +1187,10 @@ int ncplane_base(ncplane* ncp, cell* c){
 }
 
 const char* cell_extended_gcluster(const ncplane* n, const cell* c){
-  return extended_gcluster(n, c);
+  if(cell_simple_p(c)){
+    return (const char*)&c->gcluster;
+  }
+  return egcpool_extended_gcluster(&n->pool, c);
 }
 
 // 'n' ends up above 'above'

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -510,8 +510,7 @@ term_putc(FILE* out, const egcpool* e, const cell* c){
       return -1;
     }
   }else{
-    const char* ext = egcpool_extended_gcluster(e, c);
-    if(ncfputs(ext, out) == EOF){
+    if(ncfputs(egcpool_extended_gcluster(e, c), out) == EOF){
       return -1;
     }
   }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -505,7 +505,7 @@ term_putc(FILE* out, const egcpool* e, const cell* c){
       if(ncfputc(' ', out) == EOF){
         return -1;
       }
-    }else if(fprintf(out, "%.4s", (const char*)&c->gcluster) < 0){
+    }else if(ncfputs((const char*)&c->gcluster, out) == EOF){
       return -1;
     }
   }else{

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -501,6 +501,7 @@ static int
 term_putc(FILE* out, const egcpool* e, const cell* c){
   if(cell_simple_p(c)){
 //fprintf(stderr, "[%.4s] %08x\n", (const char*)&c->gcluster, c->gcluster); }
+    // FIXME pretty sure we need 0xff000000llu + 24-rshift on big-endian, fuck
     if(c->gcluster == 0 || iscntrl(c->gcluster & 0xffu)){
       if(ncfputc(' ', out) == EOF){
         return -1;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -601,6 +601,9 @@ static const char* NUMBERS[] = {
 
 static inline int
 term_esc_rgb(FILE* out, bool foreground, unsigned r, unsigned g, unsigned b){
+  assert(r < 256);
+  assert(g < 256);
+  assert(b < 256);
   // The correct way to do this is using tiparm+tputs, but doing so (at least
   // as of terminfo 6.1.20191019) both emits ~3% more bytes for a run of 'rgb'
   // and gives rise to some corrupted cells (possibly due to special handling of

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -500,16 +500,12 @@ ncfputc(char c, FILE* out){
 static int
 term_putc(FILE* out, const egcpool* e, const cell* c){
   if(cell_simple_p(c)){
-    if(c->gcluster == 0 || iscntrl(c->gcluster)){
-// fprintf(stderr, "[ ]\n");
-      if(ncfputc(' ', out) == EOF){
-        return -1;
-      }
-    }else{
-//fprintf(stderr, "[%c]\n", c->gcluster);
-      if(ncfputc(c->gcluster, out) == EOF){
-        return -1;
-      }
+    char egc[5];
+    memset(egc, 0, sizeof(egc));
+    memcpy(egc, &c->gcluster, sizeof(c->gcluster));
+//fprintf(stderr, "[%ls]\n", egc);
+    if(ncfputs(egc, out) == EOF){
+      return -1;
     }
   }else{
     const char* ext = egcpool_extended_gcluster(e, c);

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -500,11 +500,8 @@ ncfputc(char c, FILE* out){
 static int
 term_putc(FILE* out, const egcpool* e, const cell* c){
   if(cell_simple_p(c)){
-    char egc[5];
-    memset(egc, 0, sizeof(egc));
-    memcpy(egc, &c->gcluster, sizeof(c->gcluster));
 //fprintf(stderr, "[%ls]\n", egc);
-    if(ncfputs(egc, out) == EOF){
+    if(fprintf(out, "%.4s", (const char*)&c->gcluster) < 0){
       return -1;
     }
   }else{

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -500,13 +500,16 @@ ncfputc(char c, FILE* out){
 static int
 term_putc(FILE* out, const egcpool* e, const cell* c){
   if(cell_simple_p(c)){
-//fprintf(stderr, "[%ls]\n", egc);
-    if(fprintf(out, "%.4s", (const char*)&c->gcluster) < 0){
+//fprintf(stderr, "[%.4s] %08x\n", (const char*)&c->gcluster, c->gcluster); }
+    if(c->gcluster == 0 || iscntrl(c->gcluster & 0xffu)){
+      if(ncfputc(' ', out) == EOF){
+        return -1;
+      }
+    }else if(fprintf(out, "%.4s", (const char*)&c->gcluster) < 0){
       return -1;
     }
   }else{
     const char* ext = egcpool_extended_gcluster(e, c);
-// fprintf(stderr, "[%s]\n", ext);
     if(ncfputs(ext, out) == EOF){
       return -1;
     }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -606,8 +606,8 @@ term_esc_rgb(FILE* out, bool foreground, unsigned r, unsigned g, unsigned b){
   assert(b < 256);
   // The correct way to do this is using tiparm+tputs, but doing so (at least
   // as of terminfo 6.1.20191019) both emits ~3% more bytes for a run of 'rgb'
-  // and gives rise to some corrupted cells (possibly due to special handling of
-  // values < 256; I'm not at this time sure). So we just cons up our own.
+  // and gives rise to some inaccurate colors (possibly due to special handling
+  // of values < 256; I'm not at this time sure). So we just cons up our own.
   /*if(esc == 4){
     return term_emit("setab", tiparm(nc->setab, (int)((r << 16u) | (g << 8u) | b)), out, false);
   }else if(esc == 3){

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -1074,16 +1074,10 @@ int notcurses_render(notcurses* nc){
 // result is not tied to the ncplane, and persists across erases / destruction.
 static inline char*
 pool_egc_copy(const egcpool* e, const cell* c){
-  char* ret;
   if(cell_simple_p(c)){
-    if( (ret = (char*)malloc(sizeof(c->gcluster) + 1)) ){
-      memset(ret, 0, sizeof(c->gcluster) + 1);
-      memcpy(ret, &c->gcluster, sizeof(c->gcluster));
-    }
-  }else{
-    ret = strdup(egcpool_extended_gcluster(e, c));
+    return strdup((const char*)&c->gcluster);
   }
-  return ret;
+  return strdup(egcpool_extended_gcluster(e, c));
 }
 
 char* notcurses_at_yx(notcurses* nc, int yoff, int xoff, uint32_t* attrword, uint64_t* channels){

--- a/src/poc/sgr-direct.c
+++ b/src/poc/sgr-direct.c
@@ -4,8 +4,7 @@
 #include <assert.h>
 #include <notcurses/direct.h>
 
-int main(int argc, char** argv){
-  (void)argc;
+int main(void){
   if(!setlocale(LC_ALL, "")){
     return EXIT_FAILURE;
   }

--- a/src/poc/sgr.c
+++ b/src/poc/sgr.c
@@ -44,8 +44,8 @@ int main(int argc, char** argv){
     fprintf(stderr, "Couldn't get terminfo entry for sgr\n");
     return EXIT_FAILURE;
   }
-  int sgrs[8] = { 0 };
-  int pivot = sizeof(sgrs) / sizeof(*sgrs);
+  int sgrs[9] = { 0 };
+  int pivot = 8;
   if(DISABLE_ALTCHARSET){
     --pivot;
   }
@@ -53,21 +53,22 @@ int main(int argc, char** argv){
   // generate all values
   int cols = 0;
   while(pivot >= 0){
-    for(size_t i = 0 ; i < sizeof(sgrs) / sizeof(*sgrs) ; ++i){
+    int i;
+    for(i = 0 ; i < 9 ; ++i){
       cols += printf("%c", sgrs[i] ? '1' : '0');
     }
     cols += printf(" (%02d)", pivot);
-    int r = putp(tiparm(sgr, sgrs[0], sgrs[1], sgrs[2], sgrs[3], sgrs[4],
+    i = putp(tiparm(sgr, sgrs[0], sgrs[1], sgrs[2], sgrs[3], sgrs[4],
                          sgrs[5], sgrs[6], sgrs[7], sgrs[8]));
-    if(r != OK){
+    if(i != OK){
       return EXIT_FAILURE;
     }
-    if((r = printf(" %s ", argv[0])) < 0){
+    if((i = printf(" %s ", argv[0])) < 0){
       return EXIT_FAILURE;
     }
-    cols += r;
-    r = putp(tiparm(sgr, 0, 0, 0, 0, 0, 0, 0, 0, 0));
-    if(r != OK){
+    cols += i;
+    i = putp(tiparm(sgr, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+    if(i != OK){
       return EXIT_FAILURE;
     }
     pivot = pivot_on(pivot, sgrs, sgrcount);

--- a/tests/fills.cpp
+++ b/tests/fills.cpp
@@ -425,7 +425,9 @@ TEST_CASE("Fills") {
       for(int x = 0 ; x < DIMX ; ++x){
         CHECK(0 < ncplane_at_yx_cell(p1, y, x, &c1));
         if(y < 1 || y > 5 || x < 1 || x > 5){
-          CHECK(0 == strcmp(extended_gcluster(p1, &c1), "█"));
+          auto cstr = cell_strdup(p1, &c1);
+          CHECK(0 == strcmp(cstr, "█"));
+          free(cstr);
         }else{
           CHECK(0 < ncplane_at_yx_cell(p2, y - 1, x - 1, &c2));
           CHECK(0 == cellcmp(p1, &c1, p2, &c2));
@@ -459,7 +461,9 @@ TEST_CASE("Fills") {
         cell c1 = CELL_TRIVIAL_INITIALIZER;
         CHECK(0 < ncplane_at_yx_cell(p1, y, x, &c1));
         if(y < 1 || y > 5 || x < 1 || x > 5){
-          CHECK(0 == strcmp(extended_gcluster(p1, &c1), "▀"));
+          auto cstr = cell_strdup(p1, &c1);
+          CHECK(0 == strcmp(cstr, "▀"));
+          free(cstr);
         }else{
           cell c2 = CELL_TRIVIAL_INITIALIZER;
           CHECK(0 < ncplane_at_yx_cell(p2, y - 1, x - 1, &c2));

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -539,12 +539,18 @@ TEST_CASE("NCPlane") {
     REQUIRE(0 == ncplane_putstr(n_, STR3));
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_at_cursor_cell(n_, &testcell)); // want first char of STR1
-    CHECK(!strcmp("Σ", cell_extended_gcluster(n_, &testcell)));
+    auto cstr = cell_strdup(n_, &testcell);
+    REQUIRE(nullptr != cstr);
+    CHECK(!strcmp("Σ", cstr));
+    free(cstr);
     CHECK(0 == testcell.attrword);
     CHECK(0 == testcell.channels);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 1, dimx - mbstowcs(nullptr, STR2, 0)));
     REQUIRE(0 < ncplane_at_cursor_cell(n_, &testcell)); // want first char of STR2
-    CHECK(!strcmp("α", cell_extended_gcluster(n_, &testcell)));
+    cstr = cell_strdup(n_, &testcell);
+    REQUIRE(nullptr != cstr);
+    CHECK(!strcmp("α", cstr));
+    free(cstr);
     CHECK(0 == testcell.attrword);
     CHECK(0 == testcell.channels);
     // FIXME maybe check all cells?

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -338,9 +338,9 @@ TEST_CASE("NCPlane") {
     cell cell4 = CELL_TRIVIAL_INITIALIZER;
     cell cell5 = CELL_TRIVIAL_INITIALIZER;
     cell cell6 = CELL_TRIVIAL_INITIALIZER;
-    CHECK(2 == cell_duplicate(n_, &cell4, &cell1));
-    CHECK(3 == cell_duplicate(n_, &cell5, &cell2));
-    CHECK(1 == cell_duplicate(n_, &cell6, &cell3));
+    CHECK(0 == cell_duplicate(n_, &cell4, &cell1));
+    CHECK(0 == cell_duplicate(n_, &cell5, &cell2));
+    CHECK(0 == cell_duplicate(n_, &cell6, &cell3));
     cell_release(n_, &cell1);
     cell_release(n_, &cell2);
     cell_release(n_, &cell3);

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -539,18 +539,12 @@ TEST_CASE("NCPlane") {
     REQUIRE(0 == ncplane_putstr(n_, STR3));
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_at_cursor_cell(n_, &testcell)); // want first char of STR1
-    auto cstr = cell_strdup(n_, &testcell);
-    REQUIRE(nullptr != cstr);
-    CHECK(!strcmp("Σ", cstr));
-    free(cstr);
+    CHECK(!strcmp("Σ", cell_extended_gcluster(n_, &testcell)));
     CHECK(0 == testcell.attrword);
     CHECK(0 == testcell.channels);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 1, dimx - mbstowcs(nullptr, STR2, 0)));
     REQUIRE(0 < ncplane_at_cursor_cell(n_, &testcell)); // want first char of STR2
-    cstr = cell_strdup(n_, &testcell);
-    REQUIRE(nullptr != cstr);
-    CHECK(!strcmp("α", cstr));
-    free(cstr);
+    CHECK(!strcmp("α", cell_extended_gcluster(n_, &testcell)));
     CHECK(0 == testcell.attrword);
     CHECK(0 == testcell.channels);
     // FIXME maybe check all cells?

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -110,15 +110,19 @@ TEST_CASE("Wide") {
     CHECK(0 < ncplane_putegc_yx(n_, 1, 0, w, &sbytes));
     cell c = CELL_TRIVIAL_INITIALIZER;
     ncplane_at_yx_cell(n_, 0, 0, &c);
-    const char* wres = extended_gcluster(n_, &c);
+    char* wres = cell_strdup(n_, &c);
+    REQUIRE(nullptr != wres);
     CHECK(0 == strcmp(wres, FROG));
+    free(wres);
     ncplane_at_yx_cell(n_, 0, 1, &c);
     CHECK(mbswidth(FROG) == 1 + cell_double_wide_p(&c)); // should be wide
     ncplane_at_yx_cell(n_, 0, 2, &c);
     CHECK(0 == c.gcluster); // should be nothing
     ncplane_at_yx_cell(n_, 1, 0, &c);
-    wres = extended_gcluster(n_, &c);
+    wres = cell_strdup(n_, &c);
+    REQUIRE(nullptr != wres);
     CHECK(0 == strcmp(wres, FROG));
+    free(wres);
     ncplane_at_yx_cell(n_, 1, 1, &c);
     CHECK(mbswidth(FROG) == 1 + cell_double_wide_p(&c)); //should be wide
     ncplane_at_yx_cell(n_, 0, 2, &c);
@@ -146,8 +150,10 @@ TEST_CASE("Wide") {
       CHECK(0 == c.gcluster); // should be nothing
     }
     ncplane_at_yx_cell(n_, 0, 1, &c);
-    const char* wres = extended_gcluster(n_, &c);
+    char* wres = cell_strdup(n_, &c);
+    REQUIRE(nullptr != wres);
     CHECK(0 == strcmp(wres, SNAKE));
+    free(wres);
     ncplane_at_yx_cell(n_, 0, 2, &c);
     CHECK(mbswidth(SNAKE) == 1 + cell_double_wide_p(&c)); // should be wide
     CHECK(0 == notcurses_render(nc_));
@@ -200,15 +206,19 @@ TEST_CASE("Wide") {
     CHECK(3 == x);
     cell c = CELL_TRIVIAL_INITIALIZER;
     ncplane_at_yx_cell(n_, 0, 0, &c);
-    const char* wres = extended_gcluster(n_, &c);
+    char* wres = cell_strdup(n_, &c);
+    REQUIRE(nullptr != wres);
     CHECK(0 == strcmp(wres, SNAKE));
+    free(wres);
     ncplane_at_yx_cell(n_, 0, 1, &c);
     CHECK(mbswidth(SNAKE) == 1 + cell_double_wide_p(&c));
     ncplane_at_yx_cell(n_, 0, 2, &c);
     CHECK(cc == c.gcluster); // should be 'X'
     ncplane_at_yx_cell(n_, 0, 3, &c);
-    wres = extended_gcluster(n_, &c);
+    wres = cell_strdup(n_, &c);
+    REQUIRE(nullptr != wres);
     CHECK(0 == strcmp(wres, SCORPION));
+    free(wres);
     ncplane_at_yx_cell(n_, 0, 4, &c);
     CHECK(mbswidth(SCORPION) == 1 + cell_double_wide_p(&c));
     CHECK(0 == notcurses_render(nc_));
@@ -224,14 +234,20 @@ TEST_CASE("Wide") {
     CHECK(0 == notcurses_render(nc_));
     cell c = CELL_TRIVIAL_INITIALIZER;
     REQUIRE(0 < ncplane_at_yx_cell(ncp, 1, 0, &c));
-    CHECK(!strcmp(cell_extended_gcluster(ncp, &c), "│"));
+    auto cstr = cell_strdup(ncp, &c);
+    REQUIRE(nullptr != cstr);
+    CHECK(!strcmp(cstr, "│"));
+    free(cstr);
     cell_release(ncp, &c);
     char* egc = notcurses_at_yx(nc_, 1, 0, &c.attrword, &c.channels);
     REQUIRE(egc);
     CHECK(!strcmp(egc, "│"));
     free(egc);
     REQUIRE(0 < ncplane_at_yx_cell(ncp, 1, 3, &c));
-    CHECK(!strcmp(cell_extended_gcluster(ncp, &c), "│"));
+    cstr = cell_strdup(ncp, &c);
+    REQUIRE(nullptr != cstr);
+    CHECK(!strcmp(cstr, "│"));
+    free(cstr);
     cell_release(ncp, &c);
     egc = notcurses_at_yx(nc_, 1, 3, &c.attrword, &c.channels);
     REQUIRE(egc);

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -418,8 +418,10 @@ TEST_CASE("Wide") {
     free(egc);
     cell cl = CELL_TRIVIAL_INITIALIZER, cr = CELL_TRIVIAL_INITIALIZER;
     CHECK(3 == ncplane_at_yx_cell(n_, 1, 1, &cl));
-    REQUIRE(cell_extended_gcluster(n_, &cl));
-    CHECK(0 == strcmp("六", extended_gcluster(n_, &cl)));
+    egc = cell_strdup(n_, &cl);
+    REQUIRE(nullptr != egc);
+    CHECK(0 == strcmp("六", egc));
+    free(egc);
     CHECK(0 == ncplane_at_yx_cell(n_, 1, 2, &cr));
     REQUIRE(cell_simple_p(&cr));
     CHECK(0 == cr.gcluster);

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -73,16 +73,10 @@ TEST_CASE("Wide") {
       CHECK(0 == ncplane_cursor_move_yx(n_, 0, x));
       cell testcell = CELL_TRIVIAL_INITIALIZER;
       REQUIRE(0 < ncplane_at_cursor_cell(n_, &testcell));
-      auto cstr1 = cell_strdup(n_, &tcell);
-      auto cstr2 = cell_strdup(n_, &testcell);
-      CHECK(!strcmp(cstr1, cstr2));
-      free(cstr1); free(cstr2);
+      CHECK(!strcmp(cell_extended_gcluster(n_, &tcell), cell_extended_gcluster(n_, &testcell)));
       CHECK(0 == testcell.attrword);
       wchar_t w;
-      auto cstr = cell_strdup(n_, &tcell);
-      REQUIRE(cstr);
-      REQUIRE(0 < mbtowc(&w, cstr, MB_CUR_MAX));
-      free(cstr);
+      REQUIRE(0 < mbtowc(&w, cell_extended_gcluster(n_, &tcell), MB_CUR_MAX));
       if(wcwidth(w) == 2){
         CHECK(CELL_WIDEASIAN_MASK == testcell.channels);
         ++x;
@@ -110,19 +104,13 @@ TEST_CASE("Wide") {
     CHECK(0 < ncplane_putegc_yx(n_, 1, 0, w, &sbytes));
     cell c = CELL_TRIVIAL_INITIALIZER;
     ncplane_at_yx_cell(n_, 0, 0, &c);
-    char* wres = cell_strdup(n_, &c);
-    REQUIRE(nullptr != wres);
-    CHECK(0 == strcmp(wres, FROG));
-    free(wres);
+    CHECK(0 == strcmp(cell_extended_gcluster(n_, &c), FROG));
     ncplane_at_yx_cell(n_, 0, 1, &c);
     CHECK(mbswidth(FROG) == 1 + cell_double_wide_p(&c)); // should be wide
     ncplane_at_yx_cell(n_, 0, 2, &c);
     CHECK(0 == c.gcluster); // should be nothing
     ncplane_at_yx_cell(n_, 1, 0, &c);
-    wres = cell_strdup(n_, &c);
-    REQUIRE(nullptr != wres);
-    CHECK(0 == strcmp(wres, FROG));
-    free(wres);
+    CHECK(0 == strcmp(cell_extended_gcluster(n_, &c), FROG));
     ncplane_at_yx_cell(n_, 1, 1, &c);
     CHECK(mbswidth(FROG) == 1 + cell_double_wide_p(&c)); //should be wide
     ncplane_at_yx_cell(n_, 0, 2, &c);
@@ -150,10 +138,7 @@ TEST_CASE("Wide") {
       CHECK(0 == c.gcluster); // should be nothing
     }
     ncplane_at_yx_cell(n_, 0, 1, &c);
-    char* wres = cell_strdup(n_, &c);
-    REQUIRE(nullptr != wres);
-    CHECK(0 == strcmp(wres, SNAKE));
-    free(wres);
+    CHECK(0 == strcmp(cell_extended_gcluster(n_, &c), SNAKE));
     ncplane_at_yx_cell(n_, 0, 2, &c);
     CHECK(mbswidth(SNAKE) == 1 + cell_double_wide_p(&c)); // should be wide
     CHECK(0 == notcurses_render(nc_));
@@ -206,19 +191,13 @@ TEST_CASE("Wide") {
     CHECK(3 == x);
     cell c = CELL_TRIVIAL_INITIALIZER;
     ncplane_at_yx_cell(n_, 0, 0, &c);
-    char* wres = cell_strdup(n_, &c);
-    REQUIRE(nullptr != wres);
-    CHECK(0 == strcmp(wres, SNAKE));
-    free(wres);
+    CHECK(0 == strcmp(cell_extended_gcluster(n_, &c), SNAKE));
     ncplane_at_yx_cell(n_, 0, 1, &c);
     CHECK(mbswidth(SNAKE) == 1 + cell_double_wide_p(&c));
     ncplane_at_yx_cell(n_, 0, 2, &c);
     CHECK(cc == c.gcluster); // should be 'X'
     ncplane_at_yx_cell(n_, 0, 3, &c);
-    wres = cell_strdup(n_, &c);
-    REQUIRE(nullptr != wres);
-    CHECK(0 == strcmp(wres, SCORPION));
-    free(wres);
+    CHECK(0 == strcmp(cell_extended_gcluster(n_, &c), SCORPION));
     ncplane_at_yx_cell(n_, 0, 4, &c);
     CHECK(mbswidth(SCORPION) == 1 + cell_double_wide_p(&c));
     CHECK(0 == notcurses_render(nc_));
@@ -234,20 +213,14 @@ TEST_CASE("Wide") {
     CHECK(0 == notcurses_render(nc_));
     cell c = CELL_TRIVIAL_INITIALIZER;
     REQUIRE(0 < ncplane_at_yx_cell(ncp, 1, 0, &c));
-    auto cstr = cell_strdup(ncp, &c);
-    REQUIRE(nullptr != cstr);
-    CHECK(!strcmp(cstr, "│"));
-    free(cstr);
+    CHECK(!strcmp(cell_extended_gcluster(ncp, &c), "│"));
     cell_release(ncp, &c);
     char* egc = notcurses_at_yx(nc_, 1, 0, &c.attrword, &c.channels);
     REQUIRE(egc);
     CHECK(!strcmp(egc, "│"));
     free(egc);
     REQUIRE(0 < ncplane_at_yx_cell(ncp, 1, 3, &c));
-    cstr = cell_strdup(ncp, &c);
-    REQUIRE(nullptr != cstr);
-    CHECK(!strcmp(cstr, "│"));
-    free(cstr);
+    CHECK(!strcmp(cell_extended_gcluster(ncp, &c), "│"));
     cell_release(ncp, &c);
     egc = notcurses_at_yx(nc_, 1, 3, &c.attrword, &c.channels);
     REQUIRE(egc);
@@ -305,11 +278,8 @@ TEST_CASE("Wide") {
 
     // should be wide char 1
     REQUIRE(3 == ncplane_at_yx_cell(n_, 0, 0, &c));
-    egc = cell_strdup(n_, &c);
-    REQUIRE(egc);
-    CHECK(!strcmp("\xe5\x85\xa8", egc));
+    CHECK(!strcmp("\xe5\x85\xa8", cell_extended_gcluster(n_, &c)));
     CHECK(cell_double_wide_p(&c));
-    free(egc);
     egc = notcurses_at_yx(nc_, 0, 0, &c.attrword, &c.channels);
     REQUIRE(egc);
     CHECK(!strcmp("\xe5\x85\xa8", egc));
@@ -318,11 +288,8 @@ TEST_CASE("Wide") {
     cell_init(&c);
     // should be wide char 1 right side
     REQUIRE(0 == ncplane_at_yx_cell(n_, 0, 1, &c));
-    egc = cell_strdup(n_, &c);
-    REQUIRE(egc);
-    CHECK(!strcmp("", egc));
+    CHECK(!strcmp("", cell_extended_gcluster(n_, &c)));
     CHECK(cell_double_wide_p(&c));
-    free(egc);
     egc = notcurses_at_yx(nc_, 0, 1, &c.attrword, &c.channels);
     REQUIRE(egc);
     CHECK(!strcmp("", egc));
@@ -332,11 +299,8 @@ TEST_CASE("Wide") {
 
     // should be wide char 2
     REQUIRE(3 == ncplane_at_yx_cell(n_, 0, 2, &c));
-    egc = cell_strdup(n_, &c);
-    REQUIRE(egc);
-    CHECK(!strcmp("\xe5\xbd\xa2", egc));
+    CHECK(!strcmp("\xe5\xbd\xa2", cell_extended_gcluster(n_, &c)));
     CHECK(cell_double_wide_p(&c));
-    free(egc);
     egc = notcurses_at_yx(nc_, 0, 2, &c.attrword, &c.channels);
     REQUIRE(egc);
     CHECK(!strcmp("\xe5\xbd\xa2", egc));
@@ -345,11 +309,8 @@ TEST_CASE("Wide") {
     cell_init(&c);
     // should be wide char 2 right side
     CHECK(0 == ncplane_at_yx_cell(n_, 0, 3, &c));
-    egc = cell_strdup(n_, &c);
-    REQUIRE(egc);
-    CHECK(!strcmp("", egc));
+    CHECK(!strcmp("", cell_extended_gcluster(n_, &c)));
     CHECK(cell_double_wide_p(&c));
-    free(egc);
     egc = notcurses_at_yx(nc_, 0, 3, &c.attrword, &c.channels);
     REQUIRE(egc);
     CHECK(!strcmp("", egc));

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -379,10 +379,7 @@ TEST_CASE("Wide") {
     free(egc);
     cell cl = CELL_TRIVIAL_INITIALIZER, cr = CELL_TRIVIAL_INITIALIZER;
     CHECK(3 == ncplane_at_yx_cell(n_, 1, 1, &cl));
-    egc = cell_strdup(n_, &cl);
-    REQUIRE(nullptr != egc);
-    CHECK(0 == strcmp("六", egc));
-    free(egc);
+    CHECK(0 == strcmp("六", cell_extended_gcluster(n_, &cl)));
     CHECK(0 == ncplane_at_yx_cell(n_, 1, 2, &cr));
     REQUIRE(cell_simple_p(&cr));
     CHECK(0 == cr.gcluster);

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -73,11 +73,16 @@ TEST_CASE("Wide") {
       CHECK(0 == ncplane_cursor_move_yx(n_, 0, x));
       cell testcell = CELL_TRIVIAL_INITIALIZER;
       REQUIRE(0 < ncplane_at_cursor_cell(n_, &testcell));
-      CHECK(!strcmp(cell_extended_gcluster(n_, &tcell),
-                    cell_extended_gcluster(n_, &testcell)));
+      auto cstr1 = cell_strdup(n_, &tcell);
+      auto cstr2 = cell_strdup(n_, &testcell);
+      CHECK(!strcmp(cstr1, cstr2));
+      free(cstr1); free(cstr2);
       CHECK(0 == testcell.attrword);
       wchar_t w;
-      REQUIRE(0 < mbtowc(&w, cell_extended_gcluster(n_, &tcell), MB_CUR_MAX));
+      auto cstr = cell_strdup(n_, &tcell);
+      REQUIRE(cstr);
+      REQUIRE(0 < mbtowc(&w, cstr, MB_CUR_MAX));
+      free(cstr);
       if(wcwidth(w) == 2){
         CHECK(CELL_WIDEASIAN_MASK == testcell.channels);
         ++x;


### PR DESCRIPTION
Inline single-Unicode EGCs in the 32 bits of `gcluster` as described in #830. Nice memory savings. ~Should be nice time perf as well, though I did something late that lost a lot of perf -- we're slower with this than without.~ ~5% boost to FPS.

~Don't commit until it's an actual win, lol.~ ~For that matter, don't commit until we figure out why the unit tests are segfaulting on Ubuntu in our Drone CI, ick!~ ~Also need make it endianness-agnostic, ideally using compile-time constructions only.~