### PR TITLE
Remove cell_simple_p() from public API, fix tetris

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.6.16 (not yet released)
+  * `cell_simple_p()` has been removed. It is no longer a useful concept for
+    user code, and its presence is indicative of a likely error.
+
 * 1.6.15 (2020-08-16)
   * Styles now work properly with `ncdirect`, which apparently has never
     been the case until now :/.

--- a/USAGE.md
+++ b/USAGE.md
@@ -902,9 +902,6 @@ ncplane_putc(struct ncplane* n, const cell* c){
 static inline int
 ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c){
   cell ce = CELL_INITIALIZER(c, ncplane_attr(n), ncplane_channels(n));
-  if(!cell_simple_p(&ce)){
-    return -1;
-  }
   return ncplane_putc_yx(n, y, x, &ce);
 }
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1645,16 +1645,7 @@ void cell_release(struct ncplane* n, cell* c);
 // result is not tied to the ncplane, and persists across erases / destruction.
 static inline char*
 cell_strdup(const struct ncplane* n, const cell* c){
-  char* ret;
-  if(cell_simple_p(c)){
-    if( (ret = (char*)malloc(2)) ){ // cast is here for C++ clients
-      ret[0] = c->gcluster;
-      ret[1] = '\0';
-    }
-  }else{
-    ret = strdup(cell_extended_gcluster(n, c));
-  }
-  return ret;
+  return strdup(cell_extended_gcluster(n, c));
 }
 
 // Set the specified style bits for the cell 'c', whether they're actively
@@ -1689,21 +1680,12 @@ cell_double_wide_p(const cell* c){
   return (c->channels & CELL_WIDEASIAN_MASK);
 }
 
-// is the cell simple (a lone ASCII character, encoded as such)?
-static inline bool
-cell_simple_p(const cell* c){
-  return c->gcluster < 0x80;
-}
-
 static inline int
 cell_load_simple(struct ncplane* n, cell* c, char ch){
   cell_release(n, c);
-  c->channels &= ~CELL_WIDEASIAN_MASK;
+  c->channels &= ~(CELL_WIDEASIAN_MASK | CELL_NOBACKGROUND_MASK);
   c->gcluster = ch;
-  if(cell_simple_p(c)){
-    return 1;
-  }
-  return -1;
+  return 1;
 }
 
 // return a pointer to the NUL-terminated EGC referenced by 'c'. this pointer

--- a/doc/man/man3/notcurses_cell.3.md
+++ b/doc/man/man3/notcurses_cell.3.md
@@ -70,8 +70,6 @@ typedef struct cell {
 
 **bool cell_double_wide_p(const cell* c);**
 
-**bool cell_simple_p(const cell* c);**
-
 **const char* cell_extended_gcluster(const struct ncplane* n, const cell* c);**
 
 **int cell_load_simple(struct ncplane* n, cell* c, char ch);**

--- a/include/ncpp/Cell.hh
+++ b/include/ncpp/Cell.hh
@@ -121,11 +121,6 @@ namespace ncpp
 			return cell_double_wide_p (&_cell);
 		}
 
-		bool is_simple () const noexcept
-		{
-			return cell_simple_p (&_cell);
-		}
-
 		unsigned get_bchannel () const noexcept
 		{
 			return cell_bchannel (&_cell);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -200,7 +200,6 @@ void cell_set_bg_default(cell* c);
 int cell_set_fg_alpha(cell* c, unsigned alpha);
 int cell_set_bg_alpha(cell* c, unsigned alpha);
 bool cell_double_wide_p(const cell* c);
-bool cell_simple_p(const cell* c);
 const char* cell_extended_gcluster(const struct ncplane* n, const cell* c);
 int cell_load_simple(struct ncplane* n, cell* c, char ch);
 unsigned cell_bchannel(const cell* cl);

--- a/src/demo/fallin.c
+++ b/src/demo/fallin.c
@@ -141,14 +141,15 @@ int fallin_demo(struct notcurses* nc){
             continue;
           }
           cell c = CELL_TRIVIAL_INITIALIZER;
-          if(ncplane_at_yx_cell(stdn, usey, usex, &c) < 0){
+          cell stdc = CELL_TRIVIAL_INITIALIZER;
+          if(ncplane_at_yx_cell(stdn, usey, usex, &stdc) < 0){
             goto err;
           }
-          if(!cell_simple_p(&c)){
-            const char* cons = cell_extended_gcluster(stdn, &c);
-            c.gcluster = 0;
-            cell_load(n, &c, cons);
+          if(cell_load(n, &c, cell_extended_gcluster(stdn, &stdc)) < 0){
+            cell_release(stdn, &stdc);
+            goto err;
           }
+          cell_release(stdn, &stdc);
           if(c.gcluster){
             if(ncplane_putc_yx(n, usey - y, usex - x, &c) < 0){
               // allow a fail if we were printing a wide char to the

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -317,6 +317,12 @@ void sigwinch_handler(int signo);
 int terminfostr(char** gseq, const char* name);
 int interrogate_terminfo(tinfo* ti);
 
+// Is the cell simple (a UTF8-encoded EGC of four bytes or fewer)?
+static inline bool
+cell_simple_p(const cell* c){
+  return (c->gcluster >> 24u) != 0x01;
+}
+
 // Search the provided multibyte (UTF8) string 's' for the provided unicode
 // codepoint 'cp'. If found, return the column offset of the EGC in which the
 // codepoint appears in 'col', and the byte offset as the return value. If not

--- a/src/tetris/clear.h
+++ b/src/tetris/clear.h
@@ -4,7 +4,7 @@ bool LineClear(int y){
   for(int x = 1 ; x < dimx - 1 ; ++x){
     ncpp::Cell c;
     board_->get_at(y, x, &c);
-    if(c.is_simple()){
+    if(strcmp(board_->get_extended_gcluster(c), "") == 0){
       return false;
     }
   }

--- a/src/tetris/stuck.h
+++ b/src/tetris/stuck.h
@@ -1,4 +1,4 @@
-bool InvalidMove() { // a bit wasteful, but piece are tiny
+bool InvalidMove() { // a bit wasteful, but pieces are tiny
   int dy, dx;
   curpiece_->get_dim(&dy, &dx);
   while(dy--){
@@ -6,7 +6,7 @@ bool InvalidMove() { // a bit wasteful, but piece are tiny
     while(x--){
       ncpp::Cell c, b;
       curpiece_->get_at(dy, x, &c);
-      if(c.is_simple()){
+      if(strcmp(curpiece_->get_extended_gcluster(c), "") == 0){
         continue;
       }
       curpiece_->release(c);
@@ -16,7 +16,7 @@ bool InvalidMove() { // a bit wasteful, but piece are tiny
         return true;
       }
       board_->get_at(transy, transx, &b);
-      if(!b.is_simple()){
+      if(strcmp(board_->get_extended_gcluster(b), "")){
         return true;
       }
       board_->release(b);


### PR DESCRIPTION
Get notcurses-tetris working again, since its collision
detection relied on simple vs non-simple EGCs, which are
no longer an operative concept. Closes #899.