### PR TITLE
hoist out init_lang(), call from ncdirect #888

### DIFF
--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -445,7 +445,7 @@ ncdirect* ncdirect_init(const char* termtype, FILE* outfp){
   ret->fgdefault = ret->bgdefault = true;
   ret->fgrgb = ret->bgrgb = 0;
   ncdirect_styles_set(ret, 0);
-  init_lang(false);
+  init_lang(nullptr);
   const char* encoding = nl_langinfo(CODESET);
   if(encoding && strcmp(encoding, "UTF-8") == 0){
     ret->utf8 = true;

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -445,11 +445,10 @@ ncdirect* ncdirect_init(const char* termtype, FILE* outfp){
   ret->fgdefault = ret->bgdefault = true;
   ret->fgrgb = ret->bgrgb = 0;
   ncdirect_styles_set(ret, 0);
+  init_lang(false);
   const char* encoding = nl_langinfo(CODESET);
   if(encoding && strcmp(encoding, "UTF-8") == 0){
     ret->utf8 = true;
-  }else if(encoding && strcmp(encoding, "ANSI_X3.4-1968") == 0){
-    ret->utf8 = false;
   }
   return ret;
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -314,6 +314,7 @@ typedef struct notcurses {
 
 void sigwinch_handler(int signo);
 
+void init_lang(int verbose);
 int terminfostr(char** gseq, const char* name);
 int interrogate_terminfo(tinfo* ti);
 

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -314,7 +314,7 @@ typedef struct notcurses {
 
 void sigwinch_handler(int signo);
 
-void init_lang(int verbose);
+void init_lang(struct notcurses* nc); // nc may be NULL, only used for logging
 int terminfostr(char** gseq, const char* name);
 int interrogate_terminfo(tinfo* ti);
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -774,24 +774,22 @@ init_banner(const notcurses* nc){
 // practice is for the client code to have called setlocale() themselves, and
 // set the NCOPTION_INHIBIT_SETLOCALE flag. if that flag is set, we take the
 // locale as we get it.
-void init_lang(int verbose){
+void init_lang(struct notcurses* nc){
   const char* locale = setlocale(LC_ALL, "");
   if(locale && (!strcmp(locale, "C") || !strcmp(locale, "POSIX"))){
     const char* lang = getenv("LANG");
     if(lang){
       // if LANG was explicitly set to C/POSIX, roll with it
       if(strcmp(locale, "C") && strcmp(locale, "POSIX")){
-        if(verbose){
-          if(!locale){ // otherwise, generate diagnostic
-            fprintf(stderr, "Couldn't set locale based off LANG %s\n", lang);
-          }else{
-            fprintf(stderr, "Set %s locale from LANG; client should call setlocale(2)!\n",
-                    lang ? lang : "???");
-          }
+        if(!locale){ // otherwise, generate diagnostic
+          logerror(nc, "Couldn't set locale based off LANG %s\n", lang);
+        }else{
+          loginfo(nc, "Set %s locale from LANG; client should call setlocale(2)!\n",
+                  lang ? lang : "???");
         }
       }
-    }else if(verbose){
-      fprintf(stderr, "No LANG environment variable was set, ick :/\n");
+    }else{
+      logwarn(nc, "No LANG environment variable was set, ick :/\n");
     }
   }
 }
@@ -842,7 +840,7 @@ notcurses* notcurses_init(const notcurses_options* opts, FILE* outfp){
   }
   ret->loglevel = opts->loglevel;
   if(!(opts->flags & NCOPTION_INHIBIT_SETLOCALE)){
-    init_lang(true);
+    init_lang(ret);
   }
   const char* encoding = nl_langinfo(CODESET);
   if(encoding && strcmp(encoding, "UTF-8") == 0){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -774,15 +774,14 @@ init_banner(const notcurses* nc){
 // practice is for the client code to have called setlocale() themselves, and
 // set the NCOPTION_INHIBIT_SETLOCALE flag. if that flag is set, we take the
 // locale as we get it.
-static void
-init_lang(const notcurses_options* opts){
-  if(!(opts->flags & NCOPTION_INHIBIT_SETLOCALE)){
-    const char* locale = setlocale(LC_ALL, "");
-    if(locale && (!strcmp(locale, "C") || !strcmp(locale, "POSIX"))){
-      const char* lang = getenv("LANG");
-      if(lang){
-        // if LANG was explicitly set to C/POSIX, roll with it
-        if(strcmp(locale, "C") && strcmp(locale, "POSIX")){
+void init_lang(int verbose){
+  const char* locale = setlocale(LC_ALL, "");
+  if(locale && (!strcmp(locale, "C") || !strcmp(locale, "POSIX"))){
+    const char* lang = getenv("LANG");
+    if(lang){
+      // if LANG was explicitly set to C/POSIX, roll with it
+      if(strcmp(locale, "C") && strcmp(locale, "POSIX")){
+        if(verbose){
           if(!locale){ // otherwise, generate diagnostic
             fprintf(stderr, "Couldn't set locale based off LANG %s\n", lang);
           }else{
@@ -790,9 +789,9 @@ init_lang(const notcurses_options* opts){
                     lang ? lang : "???");
           }
         }
-      }else{
-        fprintf(stderr, "No LANG environment variable was set, ick :/\n");
       }
+    }else if(verbose){
+      fprintf(stderr, "No LANG environment variable was set, ick :/\n");
     }
   }
 }
@@ -842,7 +841,9 @@ notcurses* notcurses_init(const notcurses_options* opts, FILE* outfp){
     return ret;
   }
   ret->loglevel = opts->loglevel;
-  init_lang(opts);
+  if(!(opts->flags & NCOPTION_INHIBIT_SETLOCALE)){
+    init_lang(true);
+  }
   const char* encoding = nl_langinfo(CODESET);
   if(encoding && strcmp(encoding, "UTF-8") == 0){
     ret->utf8 = true;


### PR DESCRIPTION
Much like `notcurses_init()`, `ncdirect_init()` will now check the active encoding, and if it is not `UTF-8`, attempt to `setlocale()` using `LANG`. If the client code has simply failed to initialize the locale, this ought catch it as a backstop.

Unlike `notcurses_init()`, there is no flag to disable this behavior for `ncdirect_init()`.