### PR TITLE
utf8_egc_len: work around treacherous wcwidth #903

### DIFF
--- a/src/demo/mojibake.c
+++ b/src/demo/mojibake.c
@@ -3528,8 +3528,8 @@ makegroup(struct ncplane* title, int y, const char* emoji, const char* name){
     if(bytes < 0){
       break;
     }
-fprintf(stderr, "PLACING %d/%d: %zu [%s]\n", y, x, strlen(cell_extended_gcluster(n, &c)), cell_extended_gcluster(n, &c));
     int w = ncplane_putc_yx(n, y, x, &c);
+//fprintf(stderr, "PLACED %d/%d (%d): %zu [%s]\n", y, x, w, strlen(cell_extended_gcluster(n, &c)), cell_extended_gcluster(n, &c));
     cell_release(n, &c);
     if(w < 0){
       ncplane_destroy(n);

--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -88,7 +88,8 @@ utf8_egc_len(const char* gcluster, int* colcount){
           if(iswspace(wc)){ // newline or tab
             return ret + 1;
           }
-          cols = 0;
+          ret += r;
+          break;
         }
         *colcount += cols;
       }


### PR DESCRIPTION
If we get a `wcwidth()` result of -1, don't just swallow it. Consider it zero columns, and immediately exit. Otherwise, glyphs that libc doesn't know about yet get combined with others, messing up the display due to incorrect cursor calculations. Closes #903.