### PR TITLE
internalize highgradient_sized implementation #920

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1298,7 +1298,7 @@ ncplane_gradient_sized(struct ncplane* n, const char* egc, uint32_t attrword,
 int ncplane_highgradient(struct ncplane* n, uint32_t ul, uint32_t ur,
                          uint32_t ll, uint32_t lr, int ystop, int xstop);
 
-// ncplane_gradent_sized() meet ncplane_highgradient().
+// ncplane_gradent_sized() meets ncplane_highgradient().
 int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur,
                                uint32_t ll, uint32_t lr, int ylen, int xlen);
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1298,16 +1298,9 @@ ncplane_gradient_sized(struct ncplane* n, const char* egc, uint32_t attrword,
 int ncplane_highgradient(struct ncplane* n, uint32_t ul, uint32_t ur,
                          uint32_t ll, uint32_t lr, int ystop, int xstop);
 
-static inline int
-ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur,
-                           uint32_t ll, uint32_t lr, int ylen, int xlen){
-  if(ylen < 1 || xlen < 1){
-    return -1;
-  }
-  int y, x;
-  ncplane_cursor_yx(n, &y, &x);
-  return ncplane_highgradient(n, ul, ur, ll, lr, y + ylen - 1, x + xlen - 1);
-}
+// ncplane_gradent_sized() meet ncplane_highgradient().
+int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur,
+                               uint32_t ll, uint32_t lr, int ylen, int xlen);
 
 // Set the given style throughout the specified region, keeping content and
 // channels unchanged. Returns the number of cells set, or -1 on failure.

--- a/doc/man/man3/notcurses_lines.3.md
+++ b/doc/man/man3/notcurses_lines.3.md
@@ -65,7 +65,7 @@ ncplane_box_sized(struct ncplane* n, const cell* ul, const cell* ur,
 
 **int ncplane_highgradient(struct ncplane* n, uint32_t ul, uint32_t ur, uint32_t ll, uint32_t lr, int ystop, int xstop);**
 
-**static inline int ncplane_highgradient_sized(struct ncplane* n, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ylen, int xlen);**
+**int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur, uint32_t ll, uint32_t lr, int ylen, int xlen);**
 
 **int ncplane_format(struct ncplane* n, int ystop, int xstop, uint32_t attrword);**
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1660,7 +1660,7 @@ ncplane_gradient_sized(struct ncplane* n, const char* egc, uint32_t stylemask,
                           y + ylen - 1, x + xlen - 1);
 }
 
-// ncplane_gradent_sized() meet ncplane_highgradient().
+// ncplane_gradent_sized() meets ncplane_highgradient().
 API int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur,
                                    uint32_t ll, uint32_t lr, int ylen, int xlen);
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1660,21 +1660,9 @@ ncplane_gradient_sized(struct ncplane* n, const char* egc, uint32_t stylemask,
                           y + ylen - 1, x + xlen - 1);
 }
 
-static inline int
-ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur,
-                           uint32_t ll, uint32_t lr, int ylen, int xlen){
-  if(ylen < 1 || xlen < 1){
-    return -1;
-  }
-  int y, x;
-  if(!notcurses_canutf8(ncplane_notcurses_const(n))){
-    // this works because the uin32_ts we pass in will be promoted to uint64_ts
-    // via extension, and the space will employ the background. mwahh!
-    return ncplane_gradient_sized(n, " ", 0, ul, ur, ll, lr, ylen, xlen);
-  }
-  ncplane_cursor_yx(n, &y, &x);
-  return ncplane_highgradient(n, ul, ur, ll, lr, y + ylen - 1, x + xlen - 1);
-}
+// ncplane_gradent_sized() meet ncplane_highgradient().
+API int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur,
+                                   uint32_t ll, uint32_t lr, int ylen, int xlen);
 
 // Set the given style throughout the specified region, keeping content and
 // channels unchanged. Returns the number of cells set, or -1 on failure.

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -383,7 +383,7 @@ int ncplane_polyfill_yx(struct ncplane* n, int y, int x, const cell* c);
 int ncplane_gradient(struct ncplane* n, const char* egc, uint32_t attrword, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ystop, int xstop);
 int ncplane_gradient_sized(struct ncplane* n, const char* egc, uint32_t attrword, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ylen, int xlen);
 int ncplane_highgradient(struct ncplane* n, uint32_t ul, uint32_t ur, uint32_t ll, uint32_t lr, int ystop, int xstop);
-int ncplane_highgradient_sized(struct ncplane* n, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ylen, int xlen);
+int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur, uint32_t ll, uint32_t lr, int ylen, int xlen);
 int ncplane_putsimple_stainable(struct ncplane* n, char c);
 int ncplane_putegc_stainable(struct ncplane* n, const char* gclust, int* sbytes);
 int ncplane_putwegc_stainable(struct ncplane* n, const wchar_t* gclust, int* sbytes);

--- a/src/lib/fill.c
+++ b/src/lib/fill.c
@@ -188,6 +188,21 @@ int ncplane_highgradient(ncplane* n, uint32_t ul, uint32_t ur,
   return total;
 }
 
+int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur,
+                               uint32_t ll, uint32_t lr, int ylen, int xlen){
+  if(ylen < 1 || xlen < 1){
+    return -1;
+  }
+  int y, x;
+  if(!notcurses_canutf8(ncplane_notcurses_const(n))){
+    // this works because the uin32_ts we pass in will be promoted to uint64_ts
+    // via extension, and the space will employ the background. mwahh!
+    return ncplane_gradient_sized(n, " ", 0, ul, ur, ll, lr, ylen, xlen);
+  }
+  ncplane_cursor_yx(n, &y, &x);
+  return ncplane_highgradient(n, ul, ur, ll, lr, y + ylen - 1, x + xlen - 1);
+}
+
 int ncplane_gradient(ncplane* n, const char* egc, uint32_t stylemask,
                      uint64_t ul, uint64_t ur, uint64_t bl, uint64_t br,
                      int ystop, int xstop){


### PR DESCRIPTION
Due to socially dubious use of 64-bit values within `ncplane_highgradient_sized()`, and the presumed infrequency with which it is called (and the negligible cost of function call overhead compared to this rather expensive function), it has been deemed best to internalize its implementation. Closes #920.