### PR TITLE
zoo demo: show cursor in reader box #835

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,6 @@ rearrangements of Notcurses.
     functions which once returned `nc_err_e` now return a bimodal `int`. Those
     functions which accepted a value-result `nc_err_e*` no longer take this
     argument.
-  * `notcurses_cursor_move_yx()` has been added for placement of the terminal
-    cursor. Remember, you must call `notcurses_cursor_enable()` before it will
-    be made visible.
   * `notcurses_cursor_enable()` now takes two `int` parameters specifying the
     desired location of the cursor. Both `notcurses_cursor_enable()` and
     `notcurses_cursor_disable()` now return `int` rather than `void`.

--- a/USAGE.md
+++ b/USAGE.md
@@ -228,14 +228,9 @@ notcurses_term_dim_yx(const struct notcurses* n, int* restrict rows,
 int notcurses_refresh(struct notcurses* n, int* restrict y, int* restrict x);
 
 // Enable or disable the terminal's cursor, if supported. Immediate effect.
+// It is an error to supply coordinates outside of the standard plane.
 void notcurses_cursor_enable(struct notcurses* nc, int y, int x);
 void notcurses_cursor_disable(struct notcurses* nc);
-
-// Move the terminal cursor to the specified location. If 'y' or 'x' is
-// negative, there is no movement along that axis. Returns error if the
-// coordinates are outside the viewing area. The cursor must be explicitly
-// enabled with notcurses_cursor_enable() to be seen.
-int notcurses_cursor_move_yx(struct notcurses* nc, int y, int x);
 
 // Returns a 16-bit bitmask in the LSBs of supported curses-style attributes
 // (NCSTYLE_UNDERLINE, NCSTYLE_BOLD, etc.) The attribute is only

--- a/doc/man/man3/notcurses_init.3.md
+++ b/doc/man/man3/notcurses_init.3.md
@@ -48,8 +48,6 @@ typedef struct notcurses_options {
 
 **int notcurses_cursor_enable(struct notcurses* nc, int y, int x);**
 
-**int notcurses_cursor_move_yx(struct notcurses* nc, int y, int x);**
-
 **int notcurses_cursor_disable(struct notcurses* nc);**
 
 # DESCRIPTION
@@ -79,9 +77,9 @@ by setting **NCOPTION_NO_ALTERNATE_SCREEN** in **flags**. Users tend to have
 strong opinions regarding the alternate screen, so it's often useful to expose
 this via a command-line option.
 
-notcurses hides the cursor by default. It can be dynamically enabled or
+notcurses hides the cursor by default. It can be dynamically enabled, moved, or
 disabled during execution via **notcurses_cursor_enable(3)** and
-**notcurses_cursor_disable(3)**, and moved with **notcurses_cursor_move_yx()**.
+**notcurses_cursor_disable(3)**.
 
 **notcurses_init** typically emits some diagnostics at startup, including version
 information and some details of the configured terminal. This can be inhibited

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -161,11 +161,6 @@ namespace ncpp
       return error_guard (notcurses_cursor_disable (nc), -1);
     }
 
-    int cursor_move_yx (int y, int x) const noexcept
-    {
-      return error_guard (notcurses_cursor_move_yx (nc, y, x), -1);
-    }
-
 		void get_stats (ncstats *stats) const noexcept
 		{
 			if (stats == nullptr)

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2574,12 +2574,6 @@ bprefix(uintmax_t val, uintmax_t decimal, char* buf, int omitdec){
 API int notcurses_cursor_enable(struct notcurses* nc, int y, int x);
 API int notcurses_cursor_disable(struct notcurses* nc);
 
-// Move the terminal cursor to the specified location. If 'y' or 'x' is
-// negative, there is no movement along that axis. Returns error if the
-// coordinates are outside the viewing area. The cursor must be explicitly
-// enabled with notcurses_cursor_enable() to be seen.
-API int notcurses_cursor_move_yx(struct notcurses* nc, int y, int x);
-
 // Palette API. Some terminals only support 256 colors, but allow the full
 // palette to be specified with arbitrary RGB colors. In all cases, it's more
 // performant to use indexed colors, since it's much less data to write to the

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -432,7 +432,6 @@ int ncdirect_render_image(struct ncdirect* n, const char* filename, ncalign_e al
 struct ncplane* ncplane_parent(struct ncplane* n);
 const struct ncplane* ncplane_parent_const(const struct ncplane* n);
 int notcurses_cursor_enable(struct notcurses* nc, int y, int x);
-int notcurses_cursor_move_yx(struct notcurses* nc, int y, int x);
 int notcurses_cursor_disable(struct notcurses* nc);
 int ncreader_move_left(struct ncreader* n);
 int ncreader_move_right(struct ncreader* n);

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -55,7 +55,7 @@ static int
 ncreader_redraw(ncreader* n){
   int ret = 0;
 //fprintf(stderr, "redraw: xproj %d\n", n->xproject);
-notcurses_debug(n->ncp->nc, stderr);
+//notcurses_debug(n->ncp->nc, stderr);
   assert(n->xproject >= 0);
   assert(n->textarea->lenx >= n->ncp->lenx);
   assert(n->textarea->leny >= n->ncp->leny);

--- a/src/poc/reader.cpp
+++ b/src/poc/reader.cpp
@@ -39,7 +39,7 @@ auto main() -> int {
     }
     int y, x;
     ncplane_cursor_yx(ncreader_plane(nr), &y, &x);
-    nc.cursor_move_yx(y + 2, x + 2);
+    nc.cursor_enable(y + 2, x + 2);
     nc.render();
   }
   nc.render();


### PR DESCRIPTION
* Add cursor to `ncreader` widget used for exposition in `zoo` demo
* Remove `notcurses_cursor_move_yx()`
* `notcurses_cursor_enable()` can now be called with the cursor already enabled