### PR TITLE
direct mode: use cbreak mode for terminal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,16 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.6.19 (not yet released)
+  * Direct mode now places the terminal into "cbreak mode". This disables
+    echo and line-buffering of input. If this is undesirable, you can restore
+    the terminal state following `ncdirect_init()`, but this will break the
+    semantics of `ncdirect_getc()` and derivatives (due to line buffering).
+  * The notcurses input layer has been reproduced for direct mode, including
+    `ncdirect_getc()`, `ncdirect_getc_nblock()`, `ncdirect_getc_blocking()`,
+    and `ncdirect_inputready_fd()`. Mouse support is not yet available in
+    direct mode, but becomes possible through these additions.
+
 * 1.6.18 (2020-08-25)
   * `nc_err_e` has been taken behind the shed and shot in the face. All
     functions which once returned `nc_err_e` now return a bimodal `int`. Those

--- a/doc/man/man3/notcurses_directmode.3.md
+++ b/doc/man/man3/notcurses_directmode.3.md
@@ -77,8 +77,11 @@ ncdirect_init - minimal notcurses instances for styling text
 **ncdirect_init** prepares the **FILE** provided as **fp** (which must
 be attached to a terminal) for colorizing and styling. On success, a pointer to
 a valid **struct ncdirect** is returned. **NULL** is returned on failure.
-Before the process exits, **ncdirect_stop(3)** should be called to reset the
-terminal and free up resources.
+Before the process exits, **ncdirect_stop** should be called to reset the
+terminal and free up resources. **ncdirect_init** places the terminal into
+"cbreak" (also known as "rare") mode, disabling line-buffering and echo of
+input. **ncdirect_stop** restores the terminal state as it was when the
+corresponding **ncdirect_init** call was made.
 
 An appropriate **terminfo(5)** entry must exist for the terminal. This entry is
 usually selected using the value of the **TERM** environment variable (see

--- a/python/notcurses-pydemo
+++ b/python/notcurses-pydemo
@@ -16,7 +16,6 @@ def demo():
     b = 0x80
     for y in range(dims[0]):
         for x in range(dims[1]):
-            lib.ncplane_set_fchannel(nc.stdplane(), r, g, b)
             nc.stdplane().setFgRGB(r, g, b)
             nc.stdplane().setBgRGB(b, r, g)
             nc.stdplane().putSimpleYX(y, x, ord('X'))

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -57,6 +57,8 @@ int notcurses_render_to_file(struct notcurses* nc, FILE* fp);
 struct ncplane* notcurses_stdplane(struct notcurses*);
 const struct ncplane* notcurses_stdplane_const(const struct notcurses* nc);
 void ncplane_set_channels(struct ncplane* n, uint64_t channels);
+uint64_t ncplane_set_fchannel(struct ncplane* n, uint32_t channel);
+uint64_t ncplane_set_bchannel(struct ncplane* n, uint32_t channel);
 void ncplane_set_attr(struct ncplane* n, unsigned stylebits);
 int ncplane_set_base_cell(struct ncplane* ncp, const cell* c);
 int ncplane_set_base(struct ncplane* ncp, const char* egc, uint32_t styles, uint64_t channels);

--- a/python/src/notcurses/notcurses.py
+++ b/python/src/notcurses/notcurses.py
@@ -29,6 +29,23 @@ CELL_FG_PALETTE = (CELL_BG_PALETTE << 32)
 CELL_BG_ALPHA_MASK = NCCHANNEL_ALPHA_MASK
 CELL_FG_ALPHA_MASK = (CELL_BG_ALPHA_MASK << 32)
 
+def channel_r(channel):
+    return (channel & 0xff0000) >> 16;
+
+def channel_g(channel):
+    return (channel & 0x00ff00) >> 8;
+
+def channel_b(channel):
+    return (channel & 0x0000ff);
+
+def channel_rgb(channel):
+    return (channel_r(channel), channel_g(channel), channel_b(channel))
+
+def channel_set_rgb(channel, r, g, b):
+    checkRGB(r, g, b)
+    c = (r << 16) | (g << 8) | b
+    return (channel & ~CELL_BG_RGB_MASK) | CELL_BGDEFAULT_MASK | c
+
 def channels_fchannel(channels):
     return channels & 0xffffffff00000000
 

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -425,36 +425,39 @@ ncdirect* ncdirect_init(const char* termtype, FILE* outfp){
   }
   ret->ttyfp = outfp;
   memset(&ret->palette, 0, sizeof(ret->palette));
-  // we don't need a controlling tty for everything we do; allow a failure here
-  if((ret->ctermfd = get_controlling_tty(ret->ttyfp)) >= 0){
-    if(cbreak_mode(ret->ctermfd, &ret->tpreserved)){
-      delete(ret);
-      return nullptr;
-    }
-  }
-  int termerr;
-  if(setupterm(termtype, ret->ctermfd, &termerr) != OK){
-    fprintf(stderr, "Terminfo error %d (see terminfo(3ncurses))\n", termerr);
-    delete(ret);
-    return nullptr;
-  }
-  if(ncvisual_init(ffmpeg_log_level(NCLOGLEVEL_SILENT))){
-    delete(ret);
-    return nullptr;
-  }
-  if(interrogate_terminfo(&ret->tcache)){
-    delete(ret);
-    return nullptr;
-  }
-  ret->fgdefault = ret->bgdefault = true;
-  ret->fgrgb = ret->bgrgb = 0;
-  ncdirect_styles_set(ret, 0);
   init_lang(nullptr);
   const char* encoding = nl_langinfo(CODESET);
   if(encoding && strcmp(encoding, "UTF-8") == 0){
     ret->utf8 = true;
   }
+  // we don't need a controlling tty for everything we do; allow a failure here
+  if((ret->ctermfd = get_controlling_tty(ret->ttyfp)) >= 0){
+    if(cbreak_mode(ret->ctermfd, &ret->tpreserved)){
+      goto err;
+    }
+  }
+  int termerr;
+  if(setupterm(termtype, ret->ctermfd, &termerr) != OK){
+    fprintf(stderr, "Terminfo error %d (see terminfo(3ncurses))\n", termerr);
+    goto err;
+  }
+  if(ncvisual_init(ffmpeg_log_level(NCLOGLEVEL_SILENT))){
+    goto err;
+  }
+  if(interrogate_terminfo(&ret->tcache)){
+    goto err;
+  }
+  ret->fgdefault = ret->bgdefault = true;
+  ret->fgrgb = ret->bgrgb = 0;
+  ncdirect_styles_set(ret, 0);
   return ret;
+
+err:
+  if(ret->ctermfd >= 0){
+    tcsetattr(ret->ctermfd, TCSANOW, &ret->tpreserved);
+  }
+  delete(ret);
+  return nullptr;
 }
 
 int ncdirect_stop(ncdirect* nc){
@@ -473,7 +476,7 @@ int ncdirect_stop(ncdirect* nc){
       if(nc->tcache.cnorm && tty_emit("cnorm", nc->tcache.cnorm, nc->ctermfd)){
         ret = -1;
       }
-      tcsetattr(nc->ctermfd, TCSANOW, &nc->tpreserved);
+      ret |= tcsetattr(nc->ctermfd, TCSANOW, &nc->tpreserved);
       ret |= close(nc->ctermfd);
     }
     delete(nc);

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -436,6 +436,9 @@ ncdirect* ncdirect_init(const char* termtype, FILE* outfp){
       goto err;
     }
   }
+  if(ncinputlayer_init(&ret->input, stdin)){
+    goto err;
+  }
   int termerr;
   if(setupterm(termtype, ret->ctermfd, &termerr) != OK){
     fprintf(stderr, "Terminfo error %d (see terminfo(3ncurses))\n", termerr);
@@ -479,6 +482,7 @@ int ncdirect_stop(ncdirect* nc){
       ret |= tcsetattr(nc->ctermfd, TCSANOW, &nc->tpreserved);
       ret |= close(nc->ctermfd);
     }
+    input_free_esctrie(&nc->input.inputescapes);
     delete(nc);
   }
   return ret;

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -382,6 +382,18 @@ char32_t notcurses_getc(notcurses* nc, const struct timespec *ts,
   return r;
 }
 
+char32_t ncdirect_getc(ncdirect* nc, const struct timespec *ts,
+                       sigset_t* sigmask, ncinput* ni){
+  char32_t r = ncinputlayer_prestamp(&nc->input, ts, sigmask, ni, 0, 0);
+  if(r != (char32_t)-1){
+    uint64_t stamp = nc->input.input_events++; // need increment even if !ni
+    if(ni){
+      ni->seqnum = stamp;
+    }
+  }
+  return r;
+}
+
 int prep_special_keys(ncinputlayer* nc){
   static const struct {
     const char* tinfo;

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include "notcurses/direct.h"
 #include <poll.h>
 #include <ncurses.h> // needed for some definitions, see terminfo(3ncurses)
 #include <term.h>

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -970,6 +970,9 @@ cellcmp_and_dupfar(egcpool* dampool, cell* damcell,
   return 1;
 }
 
+int ncinputlayer_init(ncinputlayer* nilayer, FILE* infp);
+
+// FIXME absorb into ncinputlayer_init()
 int cbreak_mode(int ttyfd, struct termios* tpreserved);
 
 #ifdef __cplusplus

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -261,6 +261,7 @@ typedef struct ncdirect {
   uint16_t stylemask;        // current styles
   bool fgdefault, bgdefault; // are FG/BG currently using default colors?
   bool utf8;                 // are we using utf-8 encoding, as hoped?
+  struct termios tpreserved; // terminal state upon entry
 } ncdirect;
 
 typedef struct notcurses {
@@ -965,6 +966,8 @@ cellcmp_and_dupfar(egcpool* dampool, cell* damcell,
   cell_duplicate_far(dampool, damcell, srcplane, srccell);
   return 1;
 }
+
+int cbreak_mode(int ttyfd, struct termios* tpreserved);
 
 #ifdef __cplusplus
 }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2137,6 +2137,10 @@ int notcurses_inputready_fd(notcurses* n){
   return fileno(n->input.ttyinfp);
 }
 
+int ncdirect_inputready_fd(ncdirect* n){
+  return fileno(n->input.ttyinfp);
+}
+
 uint32_t* ncplane_rgba(const ncplane* nc, ncblitter_e blit,
                        int begy, int begx, int leny, int lenx){
   if(begy < 0 || begx < 0){

--- a/src/poc/direct-input.c
+++ b/src/poc/direct-input.c
@@ -1,0 +1,25 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <notcurses/direct.h>
+
+int main(void){
+  struct ncdirect* n = ncdirect_init(NULL, NULL);
+  if(n == NULL){
+    return EXIT_FAILURE;
+  }
+  ncinput ni;
+  char32_t i;
+  while((i = ncdirect_getc_blocking(n, &ni)) != (char32_t)-1){
+    printf("Read input: [%c%c%c] %lc\n", ni.ctrl ? 'C' : 'c',
+           ni.alt ? 'A' : 'a', ni.shift ? 'S' : 's', i);
+    if(ni.ctrl && i == 'D'){
+      break;
+    }
+  }
+  if(ncdirect_stop(n) || i == (char32_t)-1){
+    fprintf(stderr, "Failure reading input (%s)\n", strerror(errno));
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
* factor out cbreak_mode() #919
* call it from direct mode when we have a terminal fd
* restore the terminal state in ncdirect_stop()