### PR TITLE
ncplane_put (#961, #967)

### DIFF
--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1323,7 +1323,7 @@ API unsigned ncplane_styles(const struct ncplane* n);
 // Replace the cell at the specified coordinates with the provided cell 'c',
 // and advance the cursor by the width of the cell (but not past the end of the
 // plane). On success, returns the number of columns the cursor was advanced.
-// On failure, -1 is returned.
+// 'c' must already be associated with 'n'. On failure, -1 is returned.
 API int ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c);
 
 // Call ncplane_putc_yx() for the current cursor location.

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1340,8 +1340,15 @@ static inline int
 ncplane_put(ncplane* n, int y, int x, const char* egc, int cols,
             uint16_t stylemask, uint64_t channels, int bytes){
   // if scrolling is enabled, check *before ncplane_cursor_move_yx()* whether
-  // we're past the end of the line, and move to the next line if so.
-  if(x == -1 && y == -1 && n->x + cols > n->lenx){
+  // we're past the end of the line, and move to the next line if so. if x or y
+  // are specified, however, we must always try to print there.
+  if(x != -1){
+    if(x + cols > n->lenx){
+      logerror(n->nc, "Target x %d + %d cols >= length %d\n", x, cols, n->lenx);
+      ncplane_cursor_move_yx(n, y, x); // update cursor, though
+      return -1;
+    }
+  }else if(y == -1 && n->x + cols > n->lenx){
     if(!n->scrolling){
       logerror(n->nc, "No room to output [%.*s] %d/%d\n", bytes, egc, n->y, n->x);
       return -1;

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -77,24 +77,24 @@ TEST_CASE("Wide") {
     for(auto & tcell : tcells){
       cell_init(&tcell);
     }
-    REQUIRE(1 < cell_load(n_, &tcells[0], EGC0));
-    REQUIRE(1 < cell_load(n_, &tcells[1], EGC1));
-    REQUIRE(1 < cell_load(n_, &tcells[2], EGC2));
-    REQUIRE(1 < cell_load(n_, &tcells[3], EGC3));
-    REQUIRE(1 < cell_load(n_, &tcells[4], EGC4));
+    CHECK(1 < cell_load(n_, &tcells[0], EGC0));
+    CHECK(1 < cell_load(n_, &tcells[1], EGC1));
+    CHECK(1 < cell_load(n_, &tcells[2], EGC2));
+    CHECK(1 < cell_load(n_, &tcells[3], EGC3));
+    CHECK(1 < cell_load(n_, &tcells[4], EGC4));
     for(auto & tcell : tcells){
-      REQUIRE(0 < ncplane_putc(n_, &tcell));
+      CHECK(0 < ncplane_putc(n_, &tcell));
     }
     CHECK(0 == notcurses_render(nc_));
     int x = 0;
     for(auto & tcell : tcells){
       CHECK(0 == ncplane_cursor_move_yx(n_, 0, x));
       cell testcell = CELL_TRIVIAL_INITIALIZER;
-      REQUIRE(0 < ncplane_at_cursor_cell(n_, &testcell));
+      CHECK(0 < ncplane_at_cursor_cell(n_, &testcell));
       CHECK(!strcmp(cell_extended_gcluster(n_, &tcell), cell_extended_gcluster(n_, &testcell)));
       CHECK(0 == testcell.stylemask);
       wchar_t w;
-      REQUIRE(0 < mbtowc(&w, cell_extended_gcluster(n_, &tcell), MB_CUR_MAX));
+      CHECK(0 < mbtowc(&w, cell_extended_gcluster(n_, &tcell), MB_CUR_MAX));
       if(wcwidth(w) == 2){
         CHECK(CELL_WIDEASIAN_MASK == testcell.channels);
         ++x;
@@ -230,14 +230,14 @@ TEST_CASE("Wide") {
     CHECK(mbswidth(SCORPION) == ncplane_putegc_yx(ncp, 1, 1, SCORPION, nullptr));
     CHECK(0 == notcurses_render(nc_));
     cell c = CELL_TRIVIAL_INITIALIZER;
-    REQUIRE(0 < ncplane_at_yx_cell(ncp, 1, 0, &c));
+    CHECK(0 < ncplane_at_yx_cell(ncp, 1, 0, &c));
     CHECK(!strcmp(cell_extended_gcluster(ncp, &c), "│"));
     cell_release(ncp, &c);
     char* egc = notcurses_at_yx(nc_, 1, 0, &c.stylemask, &c.channels);
     REQUIRE(egc);
     CHECK(!strcmp(egc, "│"));
     free(egc);
-    REQUIRE(0 < ncplane_at_yx_cell(ncp, 1, 3, &c));
+    CHECK(0 < ncplane_at_yx_cell(ncp, 1, 3, &c));
     CHECK(!strcmp(cell_extended_gcluster(ncp, &c), "│"));
     cell_release(ncp, &c);
     egc = notcurses_at_yx(nc_, 1, 3, &c.stylemask, &c.channels);
@@ -260,7 +260,7 @@ TEST_CASE("Wide") {
     CHECK(cell_double_wide_p(&c));
     ncplane_at_yx_cell(n_, 0, 4, &c);
     CHECK(!cell_double_wide_p(&c));
-    REQUIRE(0 == notcurses_render(nc_));
+    CHECK(0 == notcurses_render(nc_));
     notcurses_at_yx(nc_, 0, 0, &c.stylemask, &c.channels);
     CHECK(0 != (c.channels & 0x8000000080000000ull));
     notcurses_at_yx(nc_, 0, 1, &c.stylemask, &c.channels);
@@ -295,7 +295,7 @@ TEST_CASE("Wide") {
     CHECK(!notcurses_render(nc_));
 
     // should be wide char 1
-    REQUIRE(3 == ncplane_at_yx_cell(n_, 0, 0, &c));
+    CHECK(3 == ncplane_at_yx_cell(n_, 0, 0, &c));
     CHECK(!strcmp("\xe5\x85\xa8", cell_extended_gcluster(n_, &c)));
     CHECK(cell_double_wide_p(&c));
     egc = notcurses_at_yx(nc_, 0, 0, &c.stylemask, &c.channels);
@@ -399,7 +399,7 @@ TEST_CASE("Wide") {
     CHECK(3 == ncplane_at_yx_cell(n_, 1, 1, &cl));
     CHECK(0 == strcmp("六", cell_extended_gcluster(n_, &cl)));
     CHECK(0 == ncplane_at_yx_cell(n_, 1, 2, &cr));
-    REQUIRE(cell_simple_p(&cr));
+    CHECK(cell_simple_p(&cr));
     CHECK(0 == cr.gcluster);
     cell_release(n_, &cl);
     cell_release(n_, &cr);

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -119,8 +119,10 @@ TEST_CASE("Wide") {
     CHECK(1 == y);
     CHECK(2 == x);
     CHECK(0 < ncplane_putegc_yx(n_, 0, 0, w, &sbytes));
-    CHECK(0 < ncplane_putegc_yx(n_, 1, 0, w, &sbytes));
     cell c = CELL_TRIVIAL_INITIALIZER;
+    CHECK(0 < cell_load(n_, &c, w));
+    CHECK(0 < ncplane_putc_yx(n_, 1, 0, &c));
+    cell_release(n_, &c);
     ncplane_at_yx_cell(n_, 0, 0, &c);
     CHECK(0 == strcmp(cell_extended_gcluster(n_, &c), FROG));
     ncplane_at_yx_cell(n_, 0, 1, &c);


### PR DESCRIPTION
Changes deep in the heart of output.

* Unite `ncplane_putegc_yx()` and `ncplane_putc_yx()`, which were essentially the same function, into thin wrappers around new function `ncplane_put()`.  Closes #961.
* Reject placing a wide character on the last column of a plane. Closes #967.