### PR TITLE
cmake: remove 4 c++ build options that aren't widely supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,14 +305,10 @@ target_link_libraries(notcurses++
 set(NCPP_COMPILE_OPTIONS
   -Werror=format-security
   -Wnull-dereference
-  -Wmisleading-indentation
   -Wunused
-  -Wsuggest-override
   -Wno-c99-extensions
   -fno-strict-aliasing
   -ffunction-sections
-  -funswitch-loops
-  -finline-limit=300
   -fstack-protector
   -fno-rtti
   -fpic


### PR DESCRIPTION
These four options generate a storm of warnings on certain compilers:

```
c++: warning: optimization flag '-funswitch-loops' is not supported [-Wignored-optimization-argument]
c++: warning: optimization flag '-finline-limit=300' is not supported [-Wignored-optimization-argument]
warning: unknown warning option '-Wmisleading-indentation'; did you mean
      '-Wbinding-in-condition'? [-Wunknown-warning-option]
warning: unknown warning option '-Wsuggest-override'; did you mean
      '-Wshift-overflow'? [-Wunknown-warning-option]
2 warnings generated.
```

how wedded to them are we? can we just drop them? if they're of great value, can we tie them to some horrible compiler detection (ugh, sorry :/)? this has caused me to miss real warnings twice now.