### PR TITLE
Fix ncdirect input #972

### DIFF
--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -202,7 +202,6 @@ handle_csi(ncinputlayer* nc, ncinput* ni, int leftmargin, int topmargin){
 // return it, and pop it from the queue.
 static char32_t
 handle_getc(ncinputlayer* nc, int kpress, ncinput* ni, int leftmargin, int topmargin){
-//fprintf(stderr, "KEYPRESS: %d\n", kpress);
   if(kpress < 0){
     return -1;
   }
@@ -303,7 +302,11 @@ handle_queued_input(ncinputlayer* nc, ncinput* ni, int leftmargin, int topmargin
     return -1;
   }
   int r = pop_input_keypress(nc);
-  return handle_getc(nc, r, ni, leftmargin, topmargin);
+  char32_t ret = handle_getc(nc, r, ni, leftmargin, topmargin);
+  if(ret != (char32_t)-1 && ni){
+    ni->id = ret;
+  }
+  return ret;
 }
 
 static char32_t

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -844,6 +844,7 @@ int cbreak_mode(int ttyfd, struct termios* tpreserved){
 }
 
 int ncinputlayer_init(ncinputlayer* nilayer, FILE* infp){
+  setbuffer(infp, NULL, 0);
   nilayer->inputescapes = NULL;
   nilayer->ttyinfp = infp;
   if(prep_special_keys(nilayer)){

--- a/src/poc/reader.cpp
+++ b/src/poc/reader.cpp
@@ -50,6 +50,7 @@ auto main(int argc, const char** argv) -> int {
   ncinput ni;
   nc.render();
   while(nc.getc(true, &ni) != (char32_t)-1){
+fprintf(stderr, "READ ME %lc\n", ni.id);
     if(ni.ctrl && ni.id == 'L'){
       notcurses_refresh(nc, NULL, NULL);
     }else if((ni.ctrl && ni.id == 'D') || ni.id == NCKEY_ENTER){

--- a/src/poc/reader.cpp
+++ b/src/poc/reader.cpp
@@ -50,7 +50,6 @@ auto main(int argc, const char** argv) -> int {
   ncinput ni;
   nc.render();
   while(nc.getc(true, &ni) != (char32_t)-1){
-fprintf(stderr, "READ ME %lc\n", ni.id);
     if(ni.ctrl && ni.id == 'L'){
       notcurses_refresh(nc, NULL, NULL);
     }else if((ni.ctrl && ni.id == 'D') || ni.id == NCKEY_ENTER){


### PR DESCRIPTION
`ncdirect` can't place `stdin` into non-blocking mode, as it will also affect `stdout` when they share the same fd (as they often will). This is fine in full mode, because we control the output, and can retry/flush as necessary. Since we're not nonblocking, the `getc()` will hang until output is available. Instead, use `poll()` to verify that data is available, and disable stdio buffering on stdin in `ncdirect` mode. Closes #972.