### PR TITLE
tetris: fix up staining #974

### DIFF
--- a/src/lib/fill.c
+++ b/src/lib/fill.c
@@ -188,7 +188,7 @@ int ncplane_highgradient(ncplane* n, uint32_t ul, uint32_t ur,
   return total;
 }
 
-int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur,
+int ncplane_highgradient_sized(ncplane* n, uint32_t ul, uint32_t ur,
                                uint32_t ll, uint32_t lr, int ylen, int xlen){
   if(ylen < 1 || xlen < 1){
     return -1;
@@ -207,6 +207,7 @@ int ncplane_gradient(ncplane* n, const char* egc, uint32_t stylemask,
                      uint64_t ul, uint64_t ur, uint64_t bl, uint64_t br,
                      int ystop, int xstop){
   if(check_gradient_args(ul, ur, bl, br)){
+    logerror(n->nc, "Illegal gradient inputs\n");
     return -1;
   }
   if(egc == NULL){
@@ -216,9 +217,11 @@ int ncplane_gradient(ncplane* n, const char* egc, uint32_t stylemask,
   ncplane_cursor_yx(n, &yoff, &xoff);
   // must be at least 1x1, with its upper-left corner at the current cursor
   if(ystop < yoff){
+    logerror(n->nc, "Ystop %d < yoff %d\n", ystop, yoff);
     return -1;
   }
   if(xstop < xoff){
+    logerror(n->nc, "Xstop %d < xoff %d\n", xstop, xoff);
     return -1;
   }
   ncplane_dim_yx(n, &ymax, &xmax);
@@ -260,19 +263,22 @@ int ncplane_gradient(ncplane* n, const char* egc, uint32_t stylemask,
   return total;
 }
 
-int ncplane_stain(struct ncplane* n, int ystop, int xstop,
+int ncplane_stain(ncplane* n, int ystop, int xstop,
                   uint64_t tl, uint64_t tr, uint64_t bl, uint64_t br){
   // Can't use default or palette-indexed colors in a gradient
   if(check_gradient_args(tl, tr, bl, br)){
+    logerror(n->nc, "Illegal staining inputs\n");
     return -1;
   }
   int yoff, xoff, ymax, xmax;
   ncplane_cursor_yx(n, &yoff, &xoff);
   // must be at least 1x1, with its upper-left corner at the current cursor
   if(ystop < yoff){
+    logerror(n->nc, "Ystop %d < yoff %d\n", ystop, yoff);
     return -1;
   }
   if(xstop < xoff){
+    logerror(n->nc, "Xstop %d < xoff %d\n", xstop, xoff);
     return -1;
   }
   ncplane_dim_yx(n, &ymax, &xmax);
@@ -288,7 +294,7 @@ int ncplane_stain(struct ncplane* n, int ystop, int xstop,
       cell* targc = ncplane_cell_ref_yx(n, y, x);
       if(targc->gcluster){
         calc_gradient_channels(&targc->channels, tl, tr, bl, br,
-                              y - yoff, x - xoff, ylen, xlen);
+                               y - yoff, x - xoff, ylen, xlen);
       }
       ++total;
     }
@@ -296,7 +302,7 @@ int ncplane_stain(struct ncplane* n, int ystop, int xstop,
   return total;
 }
 
-int ncplane_format(struct ncplane* n, int ystop, int xstop, uint32_t stylemask){
+int ncplane_format(ncplane* n, int ystop, int xstop, uint32_t stylemask){
   int yoff, xoff, ymax, xmax;
   ncplane_cursor_yx(n, &yoff, &xoff);
   // must be at least 1x1, with its upper-left corner at the current cursor
@@ -558,8 +564,8 @@ qrcode_cols(int version){
   return QR_BASE_SIZE + (version * PER_QR_VERSION);
 }
 
-int ncplane_qrcode(ncplane* n, ncblitter_e blitter, int* ymax,
-                   int* xmax, const void* data, size_t len){
+int ncplane_qrcode(ncplane* n, ncblitter_e blitter, int* ymax, int* xmax,
+                   const void* data, size_t len){
   const int MAX_QR_VERSION = 40; // QR library only supports up to 40
   if(*ymax <= 0 || *xmax <= 0){
     return -1;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -441,8 +441,7 @@ int ncplane_mergedown_simple(const ncplane* restrict src, ncplane* restrict dst)
   }
   int dimy, dimx;
   ncplane_dim_yx(dst, &dimy, &dimx);
-  return ncplane_mergedown(src, dst, 0, 0, ncplane_dim_y(src),
-                           ncplane_dim_x(src), 0, 0);
+  return ncplane_mergedown(src, dst, 0, 0, ncplane_dim_y(src), ncplane_dim_x(src), 0, 0);
 }
 
 static inline int

--- a/src/tetris/stain.h
+++ b/src/tetris/stain.h
@@ -8,11 +8,11 @@ void StainBoard(int dimy, int dimx){
     low = low % 0x100;
   }
   green = (l / 2) * 0x20;
-  uint64_t tl = 0, tr = 0, bl = 0, br = 0;
-  const int c1 = level_ % 2 ? high : low; const int c2 = level_ % 2 ? low : high;
-  channels_set_fg_rgb(&tl, c1, green, c2); channels_set_bg_alpha(&tl, CELL_ALPHA_TRANSPARENT);
-  channels_set_fg_rgb(&tr, c2, green, c1); channels_set_bg_alpha(&tr, CELL_ALPHA_TRANSPARENT);
-  channels_set_fg_rgb(&bl, c2, green, c1); channels_set_bg_alpha(&bl, CELL_ALPHA_TRANSPARENT);
-  channels_set_fg_rgb(&br, c1, green, c2); channels_set_bg_alpha(&br, CELL_ALPHA_TRANSPARENT);
+  const int c1 = level_ % 2 ? high : low;
+  const int c2 = level_ % 2 ? low : high;
+  uint64_t tl = CHANNELS_RGB_INITIALIZER(c1, green, c2, c1, green, c2);
+  uint64_t tr = CHANNELS_RGB_INITIALIZER(c2, green, c1, c2, green, c1);
+  uint64_t bl = CHANNELS_RGB_INITIALIZER(c2, green, c1, c2, green, c1);
+  uint64_t br = CHANNELS_RGB_INITIALIZER(c1, green, c2, c1, green, c2);
   board_->stain(dimy - 2, dimx - 2, tl, tr, bl, br);
 }


### PR DESCRIPTION
Closes #974. Properly prep tetriminos for staining.