### PR TITLE
rename ncplane_putsimple() -> ncplane_putchar() #912

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.7.1 (not yet released)
+  * Renamed `CELL_SIMPLE_INITIALIZER` to `CELL_CHAR_INITIALIZER`, and
+    `cell_load_simple()` to `cell_load_char()`.
+  * Renamed `ncplane_putsimple()` to `ncplane_putchar()`,
+    `ncplane_putsimple_stainable()` to `ncplane_putchar_stainable()`,
+    and `ncplane_putsimple_yx()` to `ncplane_putchar_yx()`.
+
 * 1.7.0 (2020-08-30)
   * Added `notcurses_ucs32_to_utf8()` conversion helper.
   * `ncdirect_init()` now takes a third `uint64_t flags` parameter. No flags

--- a/USAGE.md
+++ b/USAGE.md
@@ -910,20 +910,20 @@ ncplane_putc(struct ncplane* n, const cell* c){
 // 'c'. Advance the cursor by 1. On success, returns 1. On failure, returns -1.
 // This works whether the underlying char is signed or unsigned.
 static inline int
-ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c){
+ncplane_putchar_yx(struct ncplane* n, int y, int x, char c){
   cell ce = CELL_INITIALIZER(c, ncplane_attr(n), ncplane_channels(n));
   return ncplane_putc_yx(n, y, x, &ce);
 }
 
-// Call ncplane_putsimple_yx() at the current cursor location.
+// Call ncplane_putchar_yx() at the current cursor location.
 static inline int
-ncplane_putsimple(struct ncplane* n, char c){
-  return ncplane_putsimple_yx(n, -1, -1, c);
+ncplane_putchar(struct ncplane* n, char c){
+  return ncplane_putchar_yx(n, -1, -1, c);
 }
 
 // Replace the EGC underneath us, but retain the styling. The current styling
 // of the plane will not be changed.
-int ncplane_putsimple_stainable(struct ncplane* n, char c);
+int ncplane_putchar_stainable(struct ncplane* n, char c);
 
 // Replace the cell at the specified coordinates with the provided wide char
 // 'w'. Advance the cursor by the character's width as reported by wcwidth().
@@ -1597,7 +1597,7 @@ simply zero out the `cell`.
 
 ```c
 #define CELL_TRIVIAL_INITIALIZER { }
-#define CELL_SIMPLE_INITIALIZER(c) { .gcluster = (c), .gcluster_backstop = 0, .reserved = 0, .stylemask = 0, .channels = 0, }
+#define CELL_CHAR_INITIALIZER(c) { .gcluster = (c), .gcluster_backstop = 0, .reserved = 0, .stylemask = 0, .channels = 0, }
 #define CELL_INITIALIZER(c, s, chan) { .gcluster = (c), .gcluster_backstop = 0, .reserved = 0, .stylemask = (s), .channels = (chan), }
 
 static inline void
@@ -1698,7 +1698,7 @@ cell_double_wide_p(const cell* c){
 }
 
 static inline int
-cell_load_simple(struct ncplane* n, cell* c, char ch){
+cell_load_char(struct ncplane* n, cell* c, char ch){
   cell_release(n, c);
   c->channels &= ~(CELL_WIDEASIAN_MASK | CELL_NOBACKGROUND_MASK);
   c->gcluster = ch;

--- a/doc/man/man3/notcurses_output.3.md
+++ b/doc/man/man3/notcurses_output.3.md
@@ -14,11 +14,11 @@ notcurses_output - output to ncplanes
 
 **int ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c);**
 
-**static inline int ncplane_putsimple(struct ncplane* n, char c);**
+**static inline int ncplane_putchar(struct ncplane* n, char c);**
 
-**static inline int ncplane_putsimple_yx(struct ncplane* n, int y, int x, char c);**
+**static inline int ncplane_putchar_yx(struct ncplane* n, int y, int x, char c);**
 
-**int ncplane_putsimple_stainable(struct ncplane* n, char c);**
+**int ncplane_putchar_stainable(struct ncplane* n, char c);**
 
 **static inline int ncplane_putwc(struct ncplane* n, wchar_t w);**
 
@@ -78,7 +78,7 @@ These functions write EGCs (Extended Grapheme Clusters) to the specified
 **struct ncplane**s. The following inputs are supported:
 
 * **ncplane_putc()**: writes a single cell (see **notcurses_cell(3)**)
-* **ncplane_put_simple()**: writes a single 7-bit ASCII character
+* **ncplane_putchar()**: writes a single 7-bit ASCII character
 * **ncplane_putwc()**: writes a single **wchar_t** (following UTF-8 conversion)
 * **ncplane_putwegc()**: writes a single EGC from an array of **wchar_t**
 * **ncplane_putegc()**: writes a single EGC from an array of UTF-8

--- a/include/ncpp/Cell.hh
+++ b/include/ncpp/Cell.hh
@@ -37,7 +37,7 @@ namespace ncpp
 		explicit Cell (uint32_t c, NotCurses *ncinst = nullptr) noexcept
 			: Root (ncinst)
 		{
-			_cell = CELL_SIMPLE_INITIALIZER (c);
+			_cell = CELL_CHAR_INITIALIZER (c);
 		}
 
 		explicit Cell (uint32_t c, uint16_t a, uint64_t chan, NotCurses *ncinst = nullptr) noexcept

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -389,9 +389,9 @@ namespace ncpp
 		{
 			int ret;
 			if (retain_styling) {
-				ret = ncplane_putsimple_stainable (plane, c);
+				ret = ncplane_putchar_stainable (plane, c);
 			} else {
-				ret = ncplane_putsimple (plane, c);
+				ret = ncplane_putchar (plane, c);
 			}
 
 			return error_guard<int> (ret, -1);
@@ -399,7 +399,7 @@ namespace ncpp
 
 		int putc (int y, int x, char c) const NOEXCEPT_MAYBE
 		{
-			return error_guard<int> (ncplane_putsimple_yx (plane, y, x, c), -1);
+			return error_guard<int> (ncplane_putchar_yx (plane, y, x, c), -1);
 		}
 
 		int putc (const char *gclust, int *sbytes = nullptr, bool retain_styling = false) const NOEXCEPT_MAYBE
@@ -922,7 +922,7 @@ namespace ncpp
 
 		bool load (Cell &cell, char ch) const NOEXCEPT_MAYBE
 		{
-			return error_guard (cell_load_simple (plane, cell, ch), -1);
+			return error_guard (cell_load_char (plane, cell, ch), -1);
 		}
 
 		int prime (Cell &cell, const char *gcluster, uint16_t styles, uint64_t channels) const NOEXCEPT_MAYBE

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -336,7 +336,7 @@ int ncplane_polyfill_yx(struct ncplane* n, int y, int x, const cell* c);
 int ncplane_gradient(struct ncplane* n, const char* egc, uint32_t styles, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ystop, int xstop);
 int ncplane_highgradient(struct ncplane* n, uint32_t ul, uint32_t ur, uint32_t ll, uint32_t lr, int ystop, int xstop);
 int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur, uint32_t ll, uint32_t lr, int ylen, int xlen);
-int ncplane_putsimple_stainable(struct ncplane* n, char c);
+int ncplane_putchar_stainable(struct ncplane* n, char c);
 int ncplane_putegc_stainable(struct ncplane* n, const char* gclust, int* sbytes);
 int ncplane_putwegc_stainable(struct ncplane* n, const wchar_t* gclust, int* sbytes);
 int ncplane_format(struct ncplane* n, int ystop, int xstop, uint32_t styles);

--- a/src/demo/boxdemo.c
+++ b/src/demo/boxdemo.c
@@ -92,7 +92,7 @@ int box_demo(struct notcurses* nc){
   const int targx = 7;
   const int targy = 7;
   int ytargbase = (ylen - targy) / 2;
-  cell c = CELL_SIMPLE_INITIALIZER(' ');
+  cell c = CELL_CHAR_INITIALIZER(' ');
   cell_set_bg_default(&c);
   ncplane_set_base_cell(n, &c);
   cell_release(n, &c);

--- a/src/demo/highcon.c
+++ b/src/demo/highcon.c
@@ -82,7 +82,7 @@ int highcontrast_demo(struct notcurses* nc){
     if(total > 768){
       total = r = g = b = 0;
     }
-    cell_load_simple(n, &c, motto[out % strlen(motto)]);
+    cell_load_char(n, &c, motto[out % strlen(motto)]);
     cell_set_bg(&c, scrcolors[out % totcells]);
     if(ncplane_putc_yx(n, (out + dimx) / dimx, out % dimx, &c) < 0){
       free(scrcolors);

--- a/src/demo/outro.c
+++ b/src/demo/outro.c
@@ -130,17 +130,17 @@ outro_message(struct notcurses* nc, int* rows, int* cols){
   if(ncplane_set_bg_alpha(non, CELL_ALPHA_TRANSPARENT)){
     return NULL;
   }
-  if(ncplane_putsimple_yx(non, ybase, 0, ' ') < 0 || ncplane_putsimple(non, ' ') < 0){
+  if(ncplane_putchar_yx(non, ybase, 0, ' ') < 0 || ncplane_putchar(non, ' ') < 0){
     return NULL;
   }
-  if(ncplane_putsimple_yx(non, ybase, *cols - 2, ' ') < 0 || ncplane_putsimple(non, ' ') < 0){
+  if(ncplane_putchar_yx(non, ybase, *cols - 2, ' ') < 0 || ncplane_putchar(non, ' ') < 0){
     return NULL;
   }
   // ...and now the lower corners
-  if(ncplane_putsimple_yx(non, *rows - 1, 0, ' ') < 0 || ncplane_putsimple(non, ' ') < 0){
+  if(ncplane_putchar_yx(non, *rows - 1, 0, ' ') < 0 || ncplane_putchar(non, ' ') < 0){
     return NULL;
   }
-  if(ncplane_putsimple_yx(non, *rows - 1, *cols - 2, ' ') < 0 || ncplane_putsimple(non, ' ') < 0){
+  if(ncplane_putchar_yx(non, *rows - 1, *cols - 2, ' ') < 0 || ncplane_putchar(non, ' ') < 0){
     return NULL;
   }
   if(ncplane_set_fg_rgb(non, 0, 0, 0)){

--- a/src/demo/trans.c
+++ b/src/demo/trans.c
@@ -109,7 +109,7 @@ slidepanel(struct notcurses* nc){
   // no glyph, we should show underlying glyphs in the default colors. The
   // background default might be transparent, at the window level (i.e. a copy
   // of the underlying desktop).
-  cell c = CELL_SIMPLE_INITIALIZER(' ');
+  cell c = CELL_CHAR_INITIALIZER(' ');
   struct timespec cur;
   ncplane_set_base_cell(n, &c);
   clock_gettime(CLOCK_MONOTONIC, &cur);
@@ -125,7 +125,7 @@ slidepanel(struct notcurses* nc){
   }
   ncplane_destroy(l);
 
-  cell_load_simple(n, &c, '\0');
+  cell_load_char(n, &c, '\0');
   ncplane_set_base_cell(n, &c);
   clock_gettime(CLOCK_MONOTONIC, &cur);
   deadlinens = timespec_to_ns(&cur) + timespec_to_ns(&demodelay);
@@ -183,7 +183,7 @@ slidepanel(struct notcurses* nc){
 
   // Now we replace the characters with X's, colored as underneath us.
   // Our background color remains opaque default.
-  cell_load_simple(n, &c, 'X');
+  cell_load_char(n, &c, 'X');
   cell_set_fg_default(&c);
   cell_set_fg_alpha(&c, CELL_ALPHA_TRANSPARENT);
   cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE);
@@ -258,7 +258,7 @@ int trans_demo(struct notcurses* nc){
     while(x < maxx - 1){
       ncplane_set_fg_rgb(n, (rgb & 0xff0000) >> 16u, (rgb & 0xff00) >> 8u, rgb & 0xff);
       ncplane_set_bg_rgb(n, 0, 10, 0);
-      ncplane_putsimple(n, x % 10 + '0');
+      ncplane_putchar(n, x % 10 + '0');
       grow_rgb(&rgb);
       ++x;
     }

--- a/src/demo/whiteout.c
+++ b/src/demo/whiteout.c
@@ -513,7 +513,7 @@ int witherworm_demo(struct notcurses* nc){
               }
             }
           }else{
-            if((r = ncplane_putsimple(n, '#')) < 1){
+            if((r = ncplane_putchar(n, '#')) < 1){
               return -1;
             }
           }

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -344,14 +344,14 @@ infoplane(struct ncdirect* ncd, const fetched_info* fi){
   ncplane_printf_aligned(infop, 3, NCALIGN_RIGHT, "Shell: %s ", fi->shell);
   if(notcurses_cantruecolor(nc)){
     ncplane_printf_aligned(infop, 4, NCALIGN_LEFT, " RGB TERM: %s", fi->term);
-    cell c = CELL_SIMPLE_INITIALIZER('R');
+    cell c = CELL_CHAR_INITIALIZER('R');
     cell_styles_set(&c, NCSTYLE_BOLD);
     cell_set_fg_rgb(&c, 0xd0, 0, 0);
     ncplane_putc_yx(infop, 4, 1, &c);
-    cell_load_simple(infop, &c, 'G');
+    cell_load_char(infop, &c, 'G');
     cell_set_fg_rgb(&c, 0, 0xd0, 0);
     ncplane_putc_yx(infop, 4, 2, &c);
-    cell_load_simple(infop, &c, 'B');
+    cell_load_char(infop, &c, 'B');
     cell_set_fg_rgb(&c, 0, 0, 0xd);
     ncplane_putc_yx(infop, 4, 3, &c);
     cell_styles_set(&c, NCSTYLE_NONE);

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -313,7 +313,7 @@ ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
         ret->unrolledsection = -1;
         ret->headerchannels = opts->headerchannels;
         ret->sectionchannels = opts->sectionchannels;
-        cell c = CELL_SIMPLE_INITIALIZER('\0');
+        cell c = CELL_TRIVIAL_INITIALIZER;
         cell_set_fg_alpha(&c, CELL_ALPHA_TRANSPARENT);
         cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT);
         ncplane_set_base_cell(ret->ncp, &c);
@@ -390,7 +390,7 @@ int ncmenu_unroll(ncmenu* n, int sectionidx){
       }
       // print any necessary padding spaces
       for(int j = cols + 1 ; j < thiswidth - 1 ; ++j){
-        if(ncplane_putsimple(n->ncp, ' ') < 0){
+        if(ncplane_putchar(n->ncp, ' ') < 0){
           return -1;
         }
       }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1421,13 +1421,13 @@ int ncplane_putegc_yx(ncplane* n, int y, int x, const char* gclust, int* sbytes)
   return ncplane_put(n, y, x, gclust, cols, n->stylemask, n->channels, bytes);
 }
 
-int ncplane_putsimple_stainable(ncplane* n, char c){
+int ncplane_putchar_stainable(ncplane* n, char c){
   uint64_t channels = n->channels;
   uint32_t stylemask = n->stylemask;
   const cell* targ = &n->fb[nfbcellidx(n, n->y, n->x)];
   n->channels = targ->channels;
   n->stylemask = targ->stylemask;
-  int ret = ncplane_putsimple(n, c);
+  int ret = ncplane_putchar(n, c);
   n->channels = channels;
   n->stylemask = stylemask;
   return ret;

--- a/src/lib/plot.h
+++ b/src/lib/plot.h
@@ -241,7 +241,7 @@ class ncppplot {
            channels_set_bchannel(&channels, swapfg);
            channels_set_fchannel(&channels, swapbg);
            ncplane_set_channels(ncp, channels);
-           if(ncplane_putsimple_yx(ncp, dimy - y - 1, x, ' ') <= 0){
+           if(ncplane_putchar_yx(ncp, dimy - y - 1, x, ' ') <= 0){
              return -1;
            }
            channels_set_bchannel(&channels, swapbg);

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -95,20 +95,20 @@ ncselector_draw(ncselector* n){
     if(notcurses_canutf8(n->ncp->nc)){
       ncplane_putegc_yx(n->ncp, 2, dimx - 1, "┤", NULL);
     }else{
-      ncplane_putsimple_yx(n->ncp, 2, dimx - 1, '|');
+      ncplane_putchar_yx(n->ncp, 2, dimx - 1, '|');
     }
     if(bodywidth < dimx){
       if(notcurses_canutf8(n->ncp->nc)){
         ncplane_putegc_yx(n->ncp, 2, dimx - bodywidth, "┬", NULL);
       }else{
-        ncplane_putsimple_yx(n->ncp, 2, dimx - bodywidth, '-');
+        ncplane_putchar_yx(n->ncp, 2, dimx - bodywidth, '-');
       }
     }
     if((n->titlecols + 4 != dimx) && n->titlecols > n->secondarycols){
       if(notcurses_canutf8(n->ncp->nc)){
         ncplane_putegc_yx(n->ncp, 2, dimx - (n->titlecols + 4), "┴", NULL);
       }else{
-        ncplane_putsimple_yx(n->ncp, 2, dimx - (n->titlecols + 4), '-');
+        ncplane_putchar_yx(n->ncp, 2, dimx - (n->titlecols + 4), '-');
       }
     }
   }
@@ -143,7 +143,7 @@ ncselector_draw(ncselector* n){
     if(notcurses_canutf8(n->ncp->nc)){
       ncplane_putegc_yx(n->ncp, yoff, n->arrowx, "↑", NULL);
     }else{
-      ncplane_putsimple_yx(n->ncp, yoff, n->arrowx, '<');
+      ncplane_putchar_yx(n->ncp, yoff, n->arrowx, '<');
     }
   }else{
     n->arrowx = -1;
@@ -184,7 +184,7 @@ ncselector_draw(ncselector* n){
     if(notcurses_canutf8(n->ncp->nc)){
       ncplane_putegc_yx(n->ncp, yoff, n->arrowx, "↓", NULL);
     }else{
-      ncplane_putsimple_yx(n->ncp, yoff, n->arrowx, '>');
+      ncplane_putchar_yx(n->ncp, yoff, n->arrowx, '>');
     }
   }
   n->darrowy = yoff;
@@ -624,7 +624,7 @@ ncmultiselector_draw(ncmultiselector* n){
     if(notcurses_canutf8(n->ncp->nc)){
       ncplane_putegc_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? "☒" : "☐", NULL);
     }else{
-      ncplane_putsimple_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? 'X' : '-');
+      ncplane_putchar_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? 'X' : '-');
     }
     n->ncp->channels = n->opchannels;
     if(printidx == n->current){

--- a/src/poc/rgb.c
+++ b/src/poc/rgb.c
@@ -31,7 +31,7 @@ int main(void){
       if(ncplane_cursor_move_yx(n, y, x)){
         goto err;
       }
-      if(ncplane_putsimple(n, 'x') <= 0){
+      if(ncplane_putchar(n, 'x') <= 0){
         goto err;
       }
       if(g % 2){

--- a/src/poc/rgbbg.cpp
+++ b/src/poc/rgbbg.cpp
@@ -30,7 +30,7 @@ auto main() -> int {
       if(ncplane_cursor_move_yx(n, y, x)){
         goto err;
       }
-      if(ncplane_putsimple(n, 'x') <= 0){
+      if(ncplane_putchar(n, 'x') <= 0){
         goto err;
       }
       if(g % 2){

--- a/src/poc/scroll.c
+++ b/src/poc/scroll.c
@@ -18,7 +18,7 @@ int main(void){
   while(true){
     struct timespec req = { .tv_sec = 0, .tv_nsec = 1000000, };
     nanosleep(&req, NULL);
-    if(ncplane_putsimple(n, c) != 1){
+    if(ncplane_putchar(n, c) != 1){
       break;
     }
     if(++c == '{'){

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Cell") {
   struct ncplane* n_ = notcurses_stdplane(nc_);
   REQUIRE(nullptr != n_);
 
-  SUBCASE("LoadSimple") {
+  SUBCASE("Loadchar") {
     cell c = CELL_TRIVIAL_INITIALIZER;
     REQUIRE(1 == cell_load(n_, &c, " "));
     CHECK(cell_simple_p(&c));
@@ -112,14 +112,14 @@ TEST_CASE("Cell") {
 
   // white on a black background ought be unmolested for highcontrast
   SUBCASE("HighContrastWhiteOnBlackBackground"){
-    cell c = CELL_SIMPLE_INITIALIZER('+');
+    cell c = CELL_CHAR_INITIALIZER('+');
     CHECK(0 == cell_set_fg_rgb(&c, 0xff, 0xff, 0xff));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
     auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
-    cell_load_simple(np, &c, '*');
+    cell_load_char(np, &c, '*');
     CHECK(0 == cell_set_bg_rgb(&c, 0x0, 0x0, 0x0));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
     CHECK(1 == ncplane_putc(n_, &c));
@@ -141,14 +141,14 @@ TEST_CASE("Cell") {
 
   // white on a white background ought be changed for highcontrast
   SUBCASE("HighContrastWhiteOnWhiteBackground"){
-    cell c = CELL_SIMPLE_INITIALIZER('+');
+    cell c = CELL_CHAR_INITIALIZER('+');
     CHECK(0 == cell_set_fg_rgb(&c, 0xff, 0xff, 0xff));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
     auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
-    cell_load_simple(np, &c, '*');
+    cell_load_char(np, &c, '*');
     CHECK(0 == cell_set_bg_rgb(&c, 0xff, 0xff, 0xff));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
     CHECK(1 == ncplane_putc(n_, &c));
@@ -170,14 +170,14 @@ TEST_CASE("Cell") {
 
   // black on a black background must be changed for highcontrast
   SUBCASE("HighContrastBlackOnBlackBackground"){
-    cell c = CELL_SIMPLE_INITIALIZER('+');
+    cell c = CELL_CHAR_INITIALIZER('+');
     CHECK(0 == cell_set_fg_rgb(&c, 0x0, 0x0, 0x0));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
     auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
-    cell_load_simple(np, &c, '*');
+    cell_load_char(np, &c, '*');
     CHECK(0 == cell_set_bg_rgb(&c, 0x0, 0x0, 0x0));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
     CHECK(1 == ncplane_putc(n_, &c));
@@ -199,14 +199,14 @@ TEST_CASE("Cell") {
 
   // black on a white background ought be unmolested for highcontrast
   SUBCASE("HighContrastBlackOnWhiteBackground"){
-    cell c = CELL_SIMPLE_INITIALIZER('+');
+    cell c = CELL_CHAR_INITIALIZER('+');
     CHECK(0 == cell_set_fg_rgb(&c, 0x0, 0x0, 0x0));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
     auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
-    cell_load_simple(np, &c, '*');
+    cell_load_char(np, &c, '*');
     CHECK(0 == cell_set_bg_rgb(&c, 0xff, 0xff, 0xff));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_OPAQUE));
     CHECK(1 == ncplane_putc(n_, &c));
@@ -236,7 +236,7 @@ TEST_CASE("Cell") {
     auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
-    cell_load_simple(n_, &c, '*');
+    cell_load_char(n_, &c, '*');
     // bottom has white foreground + HIGHCONTRAST, should remain white
     CHECK(0 == cell_set_fg_rgb(&c, 0xff, 0x0, 0xff));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));

--- a/tests/fills.cpp
+++ b/tests/fills.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Fills") {
   SUBCASE("PolyfillOffplane") {
     int dimx, dimy;
     ncplane_dim_yx(n_, &dimy, &dimx);
-    cell c = CELL_SIMPLE_INITIALIZER('+');
+    cell c = CELL_CHAR_INITIALIZER('+');
     CHECK(0 > ncplane_polyfill_yx(n_, dimy, 0, &c));
     CHECK(0 > ncplane_polyfill_yx(n_, 0, dimx, &c));
     CHECK(0 > ncplane_polyfill_yx(n_, 0, -1, &c));
@@ -33,7 +33,7 @@ TEST_CASE("Fills") {
   }
 
   SUBCASE("PolyfillOnGlyph") {
-    cell c = CELL_SIMPLE_INITIALIZER('+');
+    cell c = CELL_CHAR_INITIALIZER('+');
     struct ncplane* pfn = ncplane_new(nc_, 4, 4, 0, 0, nullptr);
     REQUIRE(nullptr != pfn);
     CHECK(16 == ncplane_polyfill_yx(pfn, 0, 0, &c));
@@ -49,13 +49,13 @@ TEST_CASE("Fills") {
   }
 
   SUBCASE("PolyfillStandardPlane") {
-    cell c = CELL_SIMPLE_INITIALIZER('-');
+    cell c = CELL_CHAR_INITIALIZER('-');
     CHECK(0 < ncplane_polyfill_yx(n_, 0, 0, &c));
     CHECK(0 == notcurses_render(nc_));
   }
 
   SUBCASE("PolyfillEmptyPlane") {
-    cell c = CELL_SIMPLE_INITIALIZER('+');
+    cell c = CELL_CHAR_INITIALIZER('+');
     struct ncplane* pfn = ncplane_new(nc_, 20, 20, 0, 0, nullptr);
     REQUIRE(nullptr != pfn);
     CHECK(400 == ncplane_polyfill_yx(pfn, 0, 0, &c));
@@ -64,7 +64,7 @@ TEST_CASE("Fills") {
   }
 
   SUBCASE("PolyfillWalledPlane") {
-    cell c = CELL_SIMPLE_INITIALIZER('+');
+    cell c = CELL_CHAR_INITIALIZER('+');
     struct ncplane* pfn = ncplane_new(nc_, 4, 4, 0, 0, nullptr);
     REQUIRE(nullptr != pfn);
     CHECK(0 < ncplane_putc_yx(pfn, 0, 1, &c));

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -706,7 +706,7 @@ TEST_CASE("NCPlane") {
   }
 
   SUBCASE("Perimeter") {
-    cell c = CELL_SIMPLE_INITIALIZER('X');
+    cell c = CELL_CHAR_INITIALIZER('X');
     CHECK(0 == ncplane_perimeter(n_, &c, &c, &c, &c, &c, &c, 0));
     CHECK(0 == notcurses_render(nc_));
   }

--- a/tests/palette.cpp
+++ b/tests/palette.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Palette256") {
   // write it to an ncplane, and verify attributes via reflection
   SUBCASE("PutCAttrs") {
     cell c = CELL_TRIVIAL_INITIALIZER;
-    CHECK(1 == cell_load_simple(n_, &c, 'X'));
+    CHECK(1 == cell_load_char(n_, &c, 'X'));
     CHECK(0 == cell_set_fg_palindex(&c, 0x20));
     CHECK(0 == cell_set_bg_palindex(&c, 0x40));
     CHECK(1 == ncplane_putc_yx(n_, 0, 0, &c));
@@ -82,7 +82,7 @@ TEST_CASE("Palette256") {
 
   SUBCASE("RenderCAttrs") {
     cell c = CELL_TRIVIAL_INITIALIZER;
-    cell_load_simple(n_, &c, 'X');
+    cell_load_char(n_, &c, 'X');
     CHECK(0 == cell_set_fg_palindex(&c, 0x20));
     CHECK(0 == cell_set_bg_palindex(&c, 0x40));
     CHECK(0 == ncplane_set_fg_palindex(n_, 0x20));

--- a/tests/scrolling.cpp
+++ b/tests/scrolling.cpp
@@ -47,9 +47,9 @@ TEST_CASE("Scrolling") {
     CHECK(0 > ncplane_cursor_move_yx(n, 0, 20));
     CHECK(0 > ncplane_cursor_move_yx(n, 1, 20));
     CHECK(0 > ncplane_cursor_move_yx(n, 2, 2));
-    CHECK(0 > ncplane_putsimple_yx(n, 0, 20, 'c'));
-    CHECK(0 > ncplane_putsimple_yx(n, 1, 20, 'c'));
-    CHECK(0 > ncplane_putsimple_yx(n, 2, 0, 'c'));
+    CHECK(0 > ncplane_putchar_yx(n, 0, 20, 'c'));
+    CHECK(0 > ncplane_putchar_yx(n, 1, 20, 'c'));
+    CHECK(0 > ncplane_putchar_yx(n, 2, 0, 'c'));
   }
 
   // verify that two strings, each the length of the plane, can be output when
@@ -81,7 +81,7 @@ TEST_CASE("Scrolling") {
     CHECK(!ncplane_set_scrolling(n, false));
     // try to write 40 EGCs; the last 20 ought fail
     for(const char* c = out ; *c ; ++c){
-      int ret = ncplane_putsimple(n, *c);
+      int ret = ncplane_putchar(n, *c);
       if(c - out < 20){
         CHECK(1 == ret);
       }else{
@@ -96,7 +96,7 @@ TEST_CASE("Scrolling") {
     CHECK(!ncplane_set_scrolling(n, true)); // enable scrolling
     // try to write 40 EGCs; all ought succeed
     for(const char* c = out ; *c ; ++c){
-      CHECK(1 == ncplane_putsimple(n, *c));
+      CHECK(1 == ncplane_putchar(n, *c));
     }
     ncplane_cursor_yx(n, &y, &x);
     CHECK(1 == y);

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Wide") {
     const char bashed = 'X';
     int sbytes = 0;
     CHECK(0 < ncplane_putegc_yx(n_, 0, 1, wbashed, &sbytes));
-    CHECK(0 < ncplane_putsimple_yx(n_, 1, 1, bashed));
+    CHECK(0 < ncplane_putchar_yx(n_, 1, 1, bashed));
     int x, y;
     ncplane_cursor_yx(n_, &y, &x);
     CHECK(1 == y);
@@ -173,8 +173,8 @@ TEST_CASE("Wide") {
     int sbytes = 0;
     CHECK(0 < ncplane_putegc_yx(n_, 0, 0, wbashedl, &sbytes));
     CHECK(0 < ncplane_putegc_yx(n_, 0, 2, wbashedr, &sbytes));
-    CHECK(1 == ncplane_putsimple_yx(n_, 0, 1, *cc));
-    CHECK(1 == ncplane_putsimple_yx(n_, 0, 2, *cc));
+    CHECK(1 == ncplane_putchar_yx(n_, 0, 1, *cc));
+    CHECK(1 == ncplane_putchar_yx(n_, 0, 2, *cc));
     int x, y;
     ncplane_cursor_yx(n_, &y, &x);
     CHECK(0 == y);
@@ -204,7 +204,7 @@ TEST_CASE("Wide") {
     int sbytes = 0;
     CHECK(0 < ncplane_putegc_yx(n_, 0, 0, wsafel, &sbytes));
     CHECK(0 < ncplane_putegc_yx(n_, 0, 3, wsafer, &sbytes));
-    CHECK(1 == ncplane_putsimple_yx(n_, 0, 2, *cc));
+    CHECK(1 == ncplane_putchar_yx(n_, 0, 2, *cc));
     int x, y;
     ncplane_cursor_yx(n_, &y, &x);
     CHECK(0 == y);
@@ -377,7 +377,7 @@ TEST_CASE("Wide") {
   SUBCASE("OverWide") {
     struct ncplane* p = ncplane_new(nc_, 3, 4, 0, 0, nullptr);
     REQUIRE(nullptr != p);
-    cell c = CELL_SIMPLE_INITIALIZER('X');
+    cell c = CELL_CHAR_INITIALIZER('X');
     CHECK(0 == ncplane_perimeter(p, &c, &c, &c, &c, &c, &c, 0));
     ncplane_set_bg_rgb(n_, 0x20, 0x20, 0x20);
     int sbytes;
@@ -919,7 +919,7 @@ TEST_CASE("Wide") {
   SUBCASE("HigherGlyphAbides") {
     auto high = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
     REQUIRE(nullptr != high);
-    CHECK(0 < ncplane_putsimple_yx(high, 0, 0, 'a'));
+    CHECK(0 < ncplane_putchar_yx(high, 0, 0, 'a'));
     CHECK(0 < ncplane_putegc_yx(n_, 0, 0, "全", nullptr));
     CHECK(0 == notcurses_render(nc_));
     auto egc = notcurses_at_yx(nc_, 0, 0, nullptr, nullptr);

--- a/tests/zaxis.cpp
+++ b/tests/zaxis.cpp
@@ -81,7 +81,7 @@ TEST_CASE("ZAxis") {
   // render time (requires explicit damage maintenance from move functionality).
   SUBCASE("ZAxisDamage") {
     cell cat = CELL_TRIVIAL_INITIALIZER;
-    cell c = CELL_SIMPLE_INITIALIZER('x');
+    cell c = CELL_CHAR_INITIALIZER('x');
     REQUIRE(!cell_set_fg_rgb(&c, 0xff, 0, 0));
     REQUIRE(1 == ncplane_putc(n_, &c));
     CHECK(!notcurses_render(nc_));


### PR DESCRIPTION
Rename all instances of `simple` where `simple` meant `char` with `char`. Closes #912.