### PR TITLE
Nonblocking render #214

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,10 @@ rearrangements of Notcurses.
      * `ncreader_options` has lost its `echannels`, `eattrword`, `egc`,
        `physrows`, and `physcols` fields. Just set the base character and size
        for the `ncplane`.
-     * ...
+  * Added `notcurses_render_nblock()`. This function enlists a helper thread to
+    write rendered frames to the terminal. It returns immediately following
+    rendering of the current frame to a buffer. If frames are rendered more
+    quickly than the terminal can ingest them, frames can be dropped.
 
 * 1.7.2 (2020-09-09)
   * Exported `ncvisual_default_blitter()`, so that the effective value of

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,8 @@ rearrangements of Notcurses.
   * Added `notcurses_render_nblock()`. This function enlists a helper thread to
     write rendered frames to the terminal. It returns immediately following
     rendering of the current frame to a buffer. If frames are rendered more
-    quickly than the terminal can ingest them, frames can be dropped.
+    quickly than the terminal can ingest them, frames can be dropped. Added
+    `notcurses_render_flush()` to block on all outstanding rasterizations.
 
 * 1.7.2 (2020-09-09)
   * Exported `ncvisual_default_blitter()`, so that the effective value of

--- a/USAGE.md
+++ b/USAGE.md
@@ -177,6 +177,9 @@ int notcurses_render(struct notcurses* nc);
 // rapidly than the terminal is updated.
 int notcurses_render_nblock(struct notcurses* nc);
 
+// Block on all outstanding rasterizations.
+void notcurses_render_flush(struct notcurses* nc);
+
 // Write the last rendered frame, in its entirety, to 'fp'. If
 // notcurses_render() has not yet been called, nothing will be written.
 int notcurses_render_to_file(struct notcurses* nc, FILE* fp);

--- a/USAGE.md
+++ b/USAGE.md
@@ -170,6 +170,13 @@ updated to reflect the changes:
 // successful call to notcurses_render().
 int notcurses_render(struct notcurses* nc);
 
+// Render the virtual screen to a buffer, and alert a helper thread so that it
+// is written to the screen. Returns independently of writing to the terminal.
+// Successive calls to notcurses_render_nblock() can be made immediately. Use
+// of notcurses_render_nblock() can see frames dropped if they're produced more
+// rapidly than the terminal is updated.
+int notcurses_render_nblock(struct notcurses* nc);
+
 // Write the last rendered frame, in its entirety, to 'fp'. If
 // notcurses_render() has not yet been called, nothing will be written.
 int notcurses_render_to_file(struct notcurses* nc, FILE* fp);

--- a/doc/man/index.html
+++ b/doc/man/index.html
@@ -16,8 +16,9 @@
 <body>
   <center>
     <h2>
-    <a href="https://github.com/dankamongmen/notcurses">github</a><span>	</span>
-    <a href="https://nick-black.com/htp-notcurses.pdf">book</a><span>	</span>
+    <a href="https://github.com/dankamongmen/notcurses">github</a>
+    <a href="https://github.com/dankamongmen/notcurses/issues">issues</a>
+    <a href="https://nick-black.com/htp-notcurses.pdf">book</a>
     <a href="https://nick-black.com/dankwiki/index.php/Notcurses">dankwiki</a>
     <a href="html/index.html">doxygen</a>
     <a href="https://drone.dsscaw.com:4443/dankamongmen/notcurses/">drone</a>

--- a/doc/man/man1/notcurses-demo.1.md
+++ b/doc/man/man1/notcurses-demo.1.md
@@ -10,7 +10,7 @@ notcurses-demo - Show off some notcurses features
 
 **notcurses-demo** [**-h|--help**] [**-p path**] [**-d delaymult**]
  [**-l loglevel**] [**-f renderfile**] [**-J jsonfile**] [**-m margins**]
- [**-ikVc**] demospec
+ [**-inkVc**] demospec
 
 # DESCRIPTION
 
@@ -69,6 +69,8 @@ At any time, press 'q' to quit. The demo is best run in at least an 80x45 termin
 
 **-i**: Continue after a failing demo.
 
+**-n**: Use nonblocking rendering.
+
 **-h**: Print a usage message, and exit with success.
 
 **-V**: Print the program name and version, and exit with success.
@@ -80,6 +82,9 @@ Default margins are all 0, and thus the full screen will be rendered. Using
 **-m**, margins can be supplied. Provide a single number to set all four margins
 to the same value, or four comma-delimited values for the top, right, bottom,
 and left margins respectively. Negative margins are illegal.
+
+Nonblocking rendering will drop frames when rasterization isn't keeping up with
+frame production. It's thus unsuitable for benchmarking.
 
 # NOTES
 
@@ -112,6 +117,9 @@ The following keypresses are recognized (and are also available from the menu):
 * **Ctrl-R**: Restart the demo.
 * **q**: Quit.
 
+Benchmarking should be performed using **-c** to get a well-defined PRNG seed,
+and should not use **-n**. JSON output via **-J** will probably be useful.
+
 # BUGS
 
 # COPYRIGHT
@@ -121,7 +129,7 @@ The following keypresses are recognized (and are also available from the menu):
 * Images from Super Mario Bros. copyright Nintendo of America.
 * Images from Ninja Gaiden copyright Koei Tecmo America.
 * Images from Final Fantasy copyright Square Enix Co Ltd.
-* "Jungle with Rain" and "Ruins with Rain" copyright Mark Ferrari/Living Worlds.
+* "Jungle with Rain" copyright Mark Ferrari/Living Worlds.
 
 # SEE ALSO
 

--- a/doc/man/man3/notcurses_render.3.md
+++ b/doc/man/man3/notcurses_render.3.md
@@ -12,6 +12,8 @@ notcurses_render - sync the physical display to the virtual ncplanes
 
 **int notcurses_render(struct notcurses* nc);**
 
+**int notcurses_render_nblock(struct notcurses* nc);**
+
 **char* notcurses_at_yx(struct notcurses* nc, int yoff, int xoff, uint16_t* styles, uint64_t* channels);**
 
 **int notcurses_render_to_file(struct notcurses* nc, FILE* fp);**
@@ -67,6 +69,15 @@ the color as computed thus far is used.
 
 **notcurses_at_yx** retrieves a call *as rendered*. The EGC in that cell is
 copied and returned; it must be **free(3)**d by the caller.
+
+## Nonblocking use
+
+**notcurses_render_nblock** renders the virtual screen to a buffer, and alerts a
+helper thread to actually rasterize the frame to the terminal. It returns
+independently of writing to the terminal, returning immediately following
+the render. Successive calls to **notcurses_render_nblock** can be made
+immediately. Use of **notcurses_render_nblock** can see frames dropped if
+they're produced more rapidly than the terminal is updated.
 
 # RETURN VALUES
 

--- a/doc/man/man3/notcurses_render.3.md
+++ b/doc/man/man3/notcurses_render.3.md
@@ -14,6 +14,8 @@ notcurses_render - sync the physical display to the virtual ncplanes
 
 **int notcurses_render_nblock(struct notcurses* nc);**
 
+**void notcurses_render_flush(struct notcurses* nc);**
+
 **char* notcurses_at_yx(struct notcurses* nc, int yoff, int xoff, uint16_t* styles, uint64_t* channels);**
 
 **int notcurses_render_to_file(struct notcurses* nc, FILE* fp);**
@@ -77,7 +79,14 @@ helper thread to actually rasterize the frame to the terminal. It returns
 independently of writing to the terminal, returning immediately following
 the render. Successive calls to **notcurses_render_nblock** can be made
 immediately. Use of **notcurses_render_nblock** can see frames dropped if
-they're produced more rapidly than the terminal is updated.
+they're produced more rapidly than the terminal is updated. Nonblocking use
+is not intended to cut down on the total time between when rendering begins,
+and when the frame is displayed.
+
+It is important that functions which directly write to the terminal
+(**notcurses_refresh()**, **notcurses_cursor_enable()**, and
+**notcurses_cursor_disable**) are not called while rasterization is occurring.
+**notcurses_render_flush** is provided to block on rasterization.
 
 # RETURN VALUES
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -846,6 +846,13 @@ API int notcurses_stop(struct notcurses* nc);
 // successful call to notcurses_render().
 API int notcurses_render(struct notcurses* nc);
 
+// Render the virtual screen to a buffer, and alert a helper thread so that it
+// is written to the screen. Returns independently of writing to the terminal.
+// Successive calls to notcurses_render_nblock() can be made immediately. Use
+// of notcurses_render_nblock() can see frames dropped if they're produced more
+// rapidly than the terminal is updated.
+API int notcurses_render_nblock(struct notcurses* nc);
+
 // Write the last rendered frame, in its entirety, to 'fp'. If
 // notcurses_render() has not yet been called, nothing will be written.
 API int notcurses_render_to_file(struct notcurses* nc, FILE* fp);

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -853,6 +853,10 @@ API int notcurses_render(struct notcurses* nc);
 // rapidly than the terminal is updated.
 API int notcurses_render_nblock(struct notcurses* nc);
 
+// Block until all rendered frames have been rasterized. Only meaningful
+// following the use of notcurses_render_nblock().
+API void notcurses_render_flush(struct notcurses* nc);
+
 // Write the last rendered frame, in its entirety, to 'fp'. If
 // notcurses_render() has not yet been called, nothing will be written.
 API int notcurses_render_to_file(struct notcurses* nc, FILE* fp);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -53,6 +53,7 @@ void notcurses_version_components(int* major, int* minor, int* patch, int* tweak
 int notcurses_lex_margins(const char* op, notcurses_options* opts);
 int notcurses_stop(struct notcurses*);
 int notcurses_render(struct notcurses*);
+int notcurses_render_nblock(struct notcurses* nc);
 int notcurses_render_to_file(struct notcurses* nc, FILE* fp);
 struct ncplane* notcurses_stdplane(struct notcurses*);
 const struct ncplane* notcurses_stdplane_const(const struct notcurses* nc);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -54,6 +54,7 @@ int notcurses_lex_margins(const char* op, notcurses_options* opts);
 int notcurses_stop(struct notcurses*);
 int notcurses_render(struct notcurses*);
 int notcurses_render_nblock(struct notcurses* nc);
+void notcurses_render_flush(struct notcurses* nc);
 int notcurses_render_to_file(struct notcurses* nc, FILE* fp);
 struct ncplane* notcurses_stdplane(struct notcurses*);
 const struct ncplane* notcurses_stdplane_const(const struct notcurses* nc);

--- a/src/demo/all.c
+++ b/src/demo/all.c
@@ -59,7 +59,10 @@ allglyphs(struct notcurses* nc, struct ncplane* column, int legendy){
             return -1;
           }
           ncplane_set_attr(std, NCSTYLE_NONE);
-          DEMO_RENDER(nc);
+          int r = demo_render_blocking(nc);
+          if(r){
+            return r;
+          }
           ncplane_set_fg_rgb(column,
                              random() % 192 + 64,
                              random() % 192 + 64,
@@ -68,8 +71,7 @@ allglyphs(struct notcurses* nc, struct ncplane* column, int legendy){
       }
     }
   }
-  DEMO_RENDER(nc);
-  return 0;
+  return demo_render_blocking(nc);
 }
 
 // render all the glyphs worth rendering

--- a/src/demo/all.c
+++ b/src/demo/all.c
@@ -59,10 +59,7 @@ allglyphs(struct notcurses* nc, struct ncplane* column, int legendy){
             return -1;
           }
           ncplane_set_attr(std, NCSTYLE_NONE);
-          int r = demo_render_blocking(nc);
-          if(r){
-            return r;
-          }
+          DEMO_RENDER_BLOCK(nc);
           ncplane_set_fg_rgb(column,
                              random() % 192 + 64,
                              random() % 192 + 64,

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -22,6 +22,7 @@ static char *datadir = NOTCURSES_SHARE;
 
 static const char DEFAULT_DEMO[] = "ixezcydthnbgmarwuvlsfjqo";
 
+bool nonblocking_rendering = false;
 atomic_bool interrupted = ATOMIC_VAR_INIT(false);
 // checked following demos, whether aborted, failed, or otherwise
 static atomic_bool restart_demos = ATOMIC_VAR_INIT(false);
@@ -523,9 +524,9 @@ int main(int argc, char** argv){
   const char* spec;
   FILE* json = NULL; // emit JSON summary to this file? (-J)
   bool ignore_failures; // continue after a failure? (-k)
-  bool nonblocking; // use nonblocking rendering? (-n)
   notcurses_options nopts;
-  if((spec = handle_opts(argc, argv, &nopts, &ignore_failures, &nonblocking, &json)) == NULL){
+  if((spec = handle_opts(argc, argv, &nopts, &ignore_failures,
+                         &nonblocking_rendering, &json)) == NULL){
     if(argv[optind] != NULL){
       usage(*argv, EXIT_FAILURE);
     }

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -231,7 +231,6 @@ ext_demos(struct notcurses* nc, const char* spec, bool ignore_failures){
     if(ret && !ignore_failures){
       break;
     }
-    notcurses_refresh(nc, NULL, NULL);
   }
   return 0;
 }

--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -165,8 +165,8 @@ int hud_schedule(const char* demoname);
 // returns -1 on error, 1 if the demo has been aborted, and 0 on success.
 // this result ought be propagated out so that the demo is reported as having
 // been aborted, rather than having failed.
+int demo_render_blocking(struct notcurses* nc);
 int demo_render(struct notcurses* nc);
-int demo_render_nblock(struct notcurses* nc);
 
 #define DEMO_RENDER(nc) { int demo_render_err = demo_render(nc); if(demo_render_err){ return demo_render_err; }}
 

--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -166,6 +166,7 @@ int hud_schedule(const char* demoname);
 // this result ought be propagated out so that the demo is reported as having
 // been aborted, rather than having failed.
 int demo_render(struct notcurses* nc);
+int demo_render_nblock(struct notcurses* nc);
 
 #define DEMO_RENDER(nc) { int demo_render_err = demo_render(nc); if(demo_render_err){ return demo_render_err; }}
 

--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -169,6 +169,7 @@ int demo_render_blocking(struct notcurses* nc);
 int demo_render(struct notcurses* nc);
 
 #define DEMO_RENDER(nc) { int demo_render_err = demo_render(nc); if(demo_render_err){ return demo_render_err; }}
+#define DEMO_RENDER_BLOCK(nc) { int demo_render_err = demo_render_blocking(nc); if(demo_render_err){ return demo_render_err; }}
 
 // if you won't be doing things, and it's a long sleep, consider using
 // demo_nanosleep(). it updates the HUD, which looks better to the user, and

--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -25,6 +25,7 @@ extern "C" {
 // configured via command line option -- the base number of ns between demos
 extern struct timespec demodelay;
 extern float delaymultiplier; // scales demodelay (applied internally)
+extern bool nonblocking_rendering; // use nonblocking rendering by default
 
 // checked in demo_render() and between demos
 extern atomic_bool interrupted;

--- a/src/demo/grid.c
+++ b/src/demo/grid.c
@@ -165,7 +165,7 @@ gridinv_demo(struct notcurses* nc, struct ncplane *n){
     ccell_set_bg_rgb(&lr, 255 - rs * x, 255 - gs * (x + y), 255 - bs * y);
     ncplane_putc(n, &lr);
 
-    DEMO_RENDER(nc);
+    DEMO_RENDER_BLOCK(nc);
   }
   release_cells(n, &ul, &uc, &ur, &cl, &cc, &cr, &ll, &lc, &lr);
   return 0;
@@ -238,7 +238,7 @@ gridswitch_demo(struct notcurses* nc, struct ncplane *n){
     ncplane_putc(n, &lr);
 
     // render!
-    DEMO_RENDER(nc);
+    DEMO_RENDER_BLOCK(nc);
   }
   release_cells(n, &ul, &uc, &ur, &cl, &cc, &cr, &ll, &lc, &lr);
   return gridinv_demo(nc, n);
@@ -326,7 +326,7 @@ int grid_demo(struct notcurses* nc){
     if(ret){
       return -1;
     }
-    DEMO_RENDER(nc);
+    DEMO_RENDER_BLOCK(nc);
   }
   release_cells(n, &ul, &uc, &ur, &cl, &cc, &cr, &ll, &lc, &lr);
   return gridswitch_demo(nc, n);

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -520,9 +520,9 @@ demo_render_internal(struct notcurses* nc){
   return demo_getc_nblock(nc, &ni);
 }
 
-int demo_render_nblock(struct notcurses* nc){
+int demo_render_blocking(struct notcurses* nc){
   char32_t id = demo_render_internal(nc);
-  int ret = notcurses_render_nblock(nc);
+  int ret = notcurses_render(nc);
   if(ret){
     return ret;
   }
@@ -534,7 +534,7 @@ int demo_render_nblock(struct notcurses* nc){
 
 int demo_render(struct notcurses* nc){
   char32_t id = demo_render_internal(nc);
-  int ret = notcurses_render(nc);
+  int ret = notcurses_render_nblock(nc);
   if(ret){
     return ret;
   }

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -533,6 +533,9 @@ int demo_render_blocking(struct notcurses* nc){
 }
 
 int demo_render(struct notcurses* nc){
+  if(!nonblocking_rendering){
+    return demo_render_blocking(nc);
+  }
   char32_t id = demo_render_internal(nc);
   int ret = notcurses_render_nblock(nc);
   if(ret){

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -470,7 +470,8 @@ int demo_nanosleep_abstime(struct notcurses* nc, const struct timespec* abstime)
 }
 
 // FIXME needs to pass back any ncinput read, if requested...hrmmm
-int demo_render(struct notcurses* nc){
+static char32_t
+demo_render_internal(struct notcurses* nc){
   if(interrupted){
     return 1;
   }
@@ -516,8 +517,23 @@ int demo_render(struct notcurses* nc){
     ncplane_styles_off(hud, NCSTYLE_BOLD);
   }
   ncinput ni;
-  char32_t id;
-  id = demo_getc_nblock(nc, &ni);
+  return demo_getc_nblock(nc, &ni);
+}
+
+int demo_render_nblock(struct notcurses* nc){
+  char32_t id = demo_render_internal(nc);
+  int ret = notcurses_render_nblock(nc);
+  if(ret){
+    return ret;
+  }
+  if(id == 'q'){
+    return 1;
+  }
+  return 0;
+}
+
+int demo_render(struct notcurses* nc){
+  char32_t id = demo_render_internal(nc);
   int ret = notcurses_render(nc);
   if(ret){
     return ret;

--- a/src/demo/whiteout.c
+++ b/src/demo/whiteout.c
@@ -146,7 +146,7 @@ worm_move(struct notcurses* nc, struct worm_ctx* wctx, int dimy, int dimx){
     }
   }
   int err;
-  if( (err = demo_render(nc)) ){
+  if( (err = demo_render_blocking(nc)) ){
     return err;
   }
   for(int s = 0 ; s < wctx->wormcount ; ++s){
@@ -540,7 +540,7 @@ int witherworm_demo(struct notcurses* nc){
         return -1;
       }
       int err;
-      if( (err = demo_render(nc)) ){
+      if( (err = demo_render_blocking(nc)) ){
         ncplane_destroy(math); ncplane_destroy(mess);
         return err;
       }
@@ -579,7 +579,9 @@ int witherworm_demo(struct notcurses* nc){
         return err;
       }
       if(key == NCKEY_RESIZE){
-        DEMO_RENDER(nc);
+        if( (i = demo_render_blocking(nc)) ){
+          return i;
+        }
       }
     }while(key == NCKEY_RESIZE);
   }

--- a/src/demo/yield.c
+++ b/src/demo/yield.c
@@ -74,6 +74,9 @@ int yield_demo(struct notcurses* nc){
     ncplane_set_bg_rgb(std, 0x10, 0x10, 0x10);
     ncplane_set_fg_rgb(std, 0xf0, 0x20, 0x20);
     ncplane_set_attr(std, NCSTYLE_BOLD);
+    if(tfilled > threshold_painted){
+      tfilled = threshold_painted; // don't allow printing of 100.1% etc
+    }
     ncplane_printf_aligned(std, 3, NCALIGN_CENTER, "Yield: %3.1f%%", ((double)tfilled * 100) / threshold_painted);
     ncplane_set_attr(std, NCSTYLE_NONE);
     DEMO_RENDER(nc);

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -412,6 +412,7 @@ done:
   ncselector_destroy(selector, NULL);
   ncmultiselector_destroy(mselector);
   ncreader_destroy(reader, NULL);
+  notcurses_render_flush(nc);
   if(notcurses_cursor_disable(nc)){
     return -1;
   }

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -141,7 +141,7 @@ reader_post(struct notcurses* nc, struct ncselector* selector, struct ncmultisel
     }
     clock_gettime(CLOCK_MONOTONIC, &ts);
     cur = timespec_to_ns(&ts);
-    if( (ret = demo_render(nc)) ){
+    if( (ret = demo_render_blocking(nc)) ){
       return ret;
     }
   }while(cur < targ);
@@ -269,7 +269,7 @@ selector_run(struct notcurses* nc, struct ncreader* reader, struct ncselector* s
     const uint64_t deadline_ns = timespec_to_ns(&start) + timespec_to_ns(&targettime);
     clock_gettime(CLOCK_MONOTONIC, &now);
     while(timespec_to_ns(&now) < deadline_ns){
-      if( (ret = demo_render(nc)) ){
+      if( (ret = demo_render_blocking(nc)) ){
         return ret;
       }
       struct ncinput ni;
@@ -343,7 +343,7 @@ mselector_run(struct notcurses* nc, struct ncreader* reader, struct ncmultiselec
     const uint64_t deadline_ns = timespec_to_ns(&start) + timespec_to_ns(&targettime);
     clock_gettime(CLOCK_MONOTONIC, &now);
     while(timespec_to_ns(&now) < deadline_ns){
-      if( (ret = demo_render(nc)) ){
+      if( (ret = demo_render_blocking(nc)) ){
         return ret;
       }
       struct ncinput ni;

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -141,7 +141,7 @@ reader_post(struct notcurses* nc, struct ncselector* selector, struct ncmultisel
     }
     clock_gettime(CLOCK_MONOTONIC, &ts);
     cur = timespec_to_ns(&ts);
-    if( (ret = demo_render_blocking(nc)) ){
+    if( (ret = demo_render(nc)) ){
       return ret;
     }
   }while(cur < targ);
@@ -269,7 +269,7 @@ selector_run(struct notcurses* nc, struct ncreader* reader, struct ncselector* s
     const uint64_t deadline_ns = timespec_to_ns(&start) + timespec_to_ns(&targettime);
     clock_gettime(CLOCK_MONOTONIC, &now);
     while(timespec_to_ns(&now) < deadline_ns){
-      if( (ret = demo_render_blocking(nc)) ){
+      if( (ret = demo_render(nc)) ){
         return ret;
       }
       struct ncinput ni;
@@ -343,7 +343,7 @@ mselector_run(struct notcurses* nc, struct ncreader* reader, struct ncmultiselec
     const uint64_t deadline_ns = timespec_to_ns(&start) + timespec_to_ns(&targettime);
     clock_gettime(CLOCK_MONOTONIC, &now);
     while(timespec_to_ns(&now) < deadline_ns){
-      if( (ret = demo_render_blocking(nc)) ){
+      if( (ret = demo_render(nc)) ){
         return ret;
       }
       struct ncinput ni;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -304,7 +304,9 @@ typedef struct notcurses {
   int lfdimy;     // lfdimx/lfdimy are 0 until first render
   egcpool pool;   // duplicate EGCs into this pool
 
-  pthread_t writer_tid; // tid of rasterizer thread, for nonblocking rendering
+  pthread_mutex_t raster_lock; // lock for rasterizer thread
+  pthread_cond_t raster_cond;  // condvar for rasterization
+  pthread_t raster_tid; // tid of rasterizer thread, for nonblocking rendering
 
   int cursory;    // desired cursor placement according to user. -1 is a don't-
   int cursorx;    //  care, otherwise moved here after each render.

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -306,6 +306,7 @@ typedef struct notcurses {
 
   pthread_mutex_t raster_lock; // lock for rasterizer thread
   pthread_cond_t raster_cond;  // condvar for rasterization
+  int next_to_render;          // next rendered_frame into which we'll render
   pthread_t raster_tid; // tid of rasterizer thread, for nonblocking rendering
 
   int cursory;    // desired cursor placement according to user. -1 is a don't-

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -989,6 +989,8 @@ int ncinputlayer_init(ncinputlayer* nilayer, FILE* infp);
 // FIXME absorb into ncinputlayer_init()
 int cbreak_mode(int ttyfd, struct termios* tpreserved);
 
+int render_init(notcurses* nc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -304,6 +304,8 @@ typedef struct notcurses {
   int lfdimy;     // lfdimx/lfdimy are 0 until first render
   egcpool pool;   // duplicate EGCs into this pool
 
+  pthread_t writer_tid; // tid of rasterizer thread, for nonblocking rendering
+
   int cursory;    // desired cursor placement according to user. -1 is a don't-
   int cursorx;    //  care, otherwise moved here after each render.
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -964,6 +964,9 @@ notcurses* notcurses_init(const notcurses_options* opts, FILE* outfp){
   if(make_nonblocking(ret->input.ttyinfp)){
     goto err;
   }
+  if(render_init(ret)){
+    goto err;
+  }
   // Neither of these is supported on e.g. the "linux" virtual console.
   if(!(opts->flags & NCOPTION_NO_ALTERNATE_SCREEN)){
     terminfostr(&ret->tcache.smcup, "smcup");


### PR DESCRIPTION
* Add `notcurses_render_nblock()`, which renders into a stateful frame and returns immediately. A rasterizing thread picks this up, and writes it to the terminal. Add `notcurses_render_flush()`, which blocks on completed rasterization of all outstanding renders.
* If regular `notcurses_render()` is used, nothing changes. and `notcurses_render_flush()` is effectively a no-op.

Closes #214.