### PR TITLE
Detect inverted cursor position reply from terminal

### DIFF
--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -136,6 +136,11 @@ int ncdirect_cursor_move_yx(ncdirect* n, int y, int x){
 }
 
 static int
+detect_cursor_inversion(ncdirect* n, int* y, int* x){
+  return 0; // FIXME
+}
+
+static int
 cursor_yx_get(int ttyfd, int* y, int* x){
   if(write(ttyfd, "\033[6n", 4) != 4){
     return -1;
@@ -199,12 +204,12 @@ cursor_yx_get(int ttyfd, int* y, int* x){
   return 0;
 }
 
-// no terminfo capability for this. dangerous! kmscon and possibly other
-// terminals report y and x inverted from the normal form; we ought detect this
-// using the algorithm in https://github.com/dankamongmen/notcurses/issues/784.
+// no terminfo capability for this. dangerous--it involves writing controls to
+// the terminal, and then reading a response. many things can distupt this
+// non-atomic procedure.
 int ncdirect_cursor_yx(ncdirect* n, int* y, int* x){
   struct termios termio, oldtermios;
-  // this only works for real terminals
+  // this is only meaningful for real terminals
   if(n->ctermfd < 0){
     return -1;
   }
@@ -213,22 +218,39 @@ int ncdirect_cursor_yx(ncdirect* n, int* y, int* x){
     return -1;
   }
   memcpy(&oldtermios, &termio, sizeof(termio));
+  // we should already be in cbreak mode from ncdirect_init(), but just in case
+  // it got changed by the client code since then, duck into cbreak mode anew.
   termio.c_lflag &= ~(ICANON | ECHO);
   if(tcsetattr(n->ctermfd, TCSAFLUSH, &termio)){
     fprintf(stderr, "Couldn't put terminal into cbreak mode via %d (%s)\n",
             n->ctermfd, strerror(errno));
     return -1;
   }
-  int ret = cursor_yx_get(n->ctermfd, y, x);
+  int ret;
+  if(!n->detected_cursor_inversion){
+    ret = detect_cursor_inversion(n, y, x);
+  }else{
+    int yval, xval;
+    if(!y){
+      y = &yval;
+    }
+    if(!x){
+      x = &xval;
+    }
+    // we use 0-based coordinates, but known terminals use 1-based coordinates
+    if((ret = cursor_yx_get(n->ctermfd, y, x)) == 0){
+      if(n->inverted_cursor){
+        int tmp = *y;
+        *y = *x;
+        *x = tmp;
+      }
+      --*y;
+      --*x;
+    }
+  }
   if(tcsetattr(n->ctermfd, TCSANOW, &oldtermios)){
     fprintf(stderr, "Couldn't restore terminal mode on %d (%s)\n",
             n->ctermfd, strerror(errno)); // don't return error for this
-  }
-  if(y){
-    --*y;
-  }
-  if(x){
-    --*x;
   }
   return ret;
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -282,6 +282,10 @@ typedef struct ncdirect {
   bool fgdefault, bgdefault; // are FG/BG currently using default colors?
   bool utf8;                 // are we using utf-8 encoding, as hoped?
   struct termios tpreserved; // terminal state upon entry
+  // some terminals (e.g. kmscon) return cursor coordinates inverted from the
+  // typical order. we detect it the first time ncdirect_cursor_yx() is called.
+  bool detected_cursor_inversion; // have we performed inversion testing?
+  bool inverted_cursor;      // does the terminal return inverted coordinates?
 } ncdirect;
 
 typedef struct notcurses {

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -102,6 +102,8 @@ int interrogate_terminfo(tinfo* ti){
   terminfostr(&ti->cub, "cub"); // n non-destructive backspaces
   terminfostr(&ti->cuf1, "cuf1"); // non-destructive space
   terminfostr(&ti->cub1, "cub1"); // non-destructive backspace
+  terminfostr(&ti->sc, "sc"); // push ("save") cursor
+  terminfostr(&ti->rc, "rc"); // pop ("restore") cursor
   // Some terminals cannot combine certain styles with colors. Don't advertise
   // support for the style in that case.
   int nocolor_stylemask = tigetnum("ncv");

--- a/src/poc/direct.c
+++ b/src/poc/direct.c
@@ -44,22 +44,24 @@ int main(void){
     printf("\n\tRead cursor position: y: %d x: %d\n", y, x);
     y += 2; // we just went down two lines
     while(y > 3){
+      ret = -1;
       const int up = y >= 3 ? 3 : y;
       if(ncdirect_cursor_up(n, up)){
-        return EXIT_FAILURE;
+        break;
       }
       fflush(stdout);
       y -= up;
       int newy;
       if(ncdirect_cursor_yx(n, &newy, NULL)){
-        return EXIT_FAILURE;
+        break;
       }
       if(newy != y){
         fprintf(stderr, "Expected %d, got %d\n", y, newy);
-        return EXIT_FAILURE;
+        break;
       }
       printf("\n\tRead cursor position: y: %d x: %d\n", newy, x);
       y += 2;
+      ret = 0;
     }
   }else{
     ret = -1;


### PR DESCRIPTION
* Fixes `ncdirect_cursor_push()` and `ncdirect_cursor_pop()` by properly loading `sc` and `rc` terminfo capabilities #998 
* Runs my algorithm for detecting inverted cursor coordinate reporting the first time `ncdirect_cursor_yx()` is called. #784 
* `direct` PoC: always call `ncdirect_stop()` on exit to restore terminal state

Closes #784. Closes #998.