### PR TITLE
Implement NCREADER_OPTION_CURSOR #962

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ rearrangements of Notcurses.
 * 1.7.2 (not yet released)
   * Exported `ncvisual_default_blitter()`, so that the effective value of
     `NCBLIT_DEFAULT` can be determined.
+  * Added `NCREADER_OPTION_CURSOR`, instructing the `ncreader` to make the
+    terminal cursor visible, and manage the cursor's placement.
 
 * 1.7.1 (2020-08-31)
   * Renamed `CELL_SIMPLE_INITIALIZER` to `CELL_CHAR_INITIALIZER`, and

--- a/doc/man/man3/notcurses_reader.3.md
+++ b/doc/man/man3/notcurses_reader.3.md
@@ -16,9 +16,10 @@ struct ncplane;
 struct ncreader;
 struct notcurses;
 
-#define NCREADER_OPTION_HORSCROLL  0x0001
-#define NCREADER_OPTION_VERSCROLL  0x0002
-#define NCREADER_OPTION_NOCMDKEYS  0x0004
+#define NCREADER_OPTION_HORSCROLL 0x0001
+#define NCREADER_OPTION_VERSCROLL 0x0002
+#define NCREADER_OPTION_NOCMDKEYS 0x0004
+#define NCREADER_OPTION_CURSOR    0x0008
 
 typedef struct ncreader_options {
   uint64_t tchannels; // channels used for input
@@ -61,6 +62,17 @@ navigation with the arrow keys and scrolling. While the visible portion of
 the **ncreader** is always the same size (**physrows** by **physcols**), the
 actual text backing this visible region can grow arbitrarily large.
 
+The following option flags are supported:
+
+* **NCREADER_OPTION_HORSCROLL**: The visual area will be backed by a plane
+     that can grow arbitrarily wide.
+* **NCREADER_OPTION_VERSCROLL**: The visual area will be backed by a plane
+     that can grow arbitrarily high.
+* **NCREADER_OPTION_NOCMDKEYS**: The typical keyboard shortcuts (see below)
+     will not be honored.
+* **NCREADER_OPTION_CURSOR**: The terminal's cursor will be made visible across
+     the life of the **ncreader**, and its location will be managed.
+
 The contents of the **ncreader** can be retrieved with **ncreader_contents**.
 
 The **ncreader** consists of at least one **ncplane** (the visible editing
@@ -81,6 +93,10 @@ consumed). Otherwise, most inputs will be reproduced onto the **ncreader**
 
 All the **ncreader**'s content is returned from **ncreader_contents**,
 preserving whitespace.
+
+"Emacs-style" keyboard shortcuts similar to those supported by **readline(3)**
+and most shells are supported unless **NCREADER_OPTION_NOCMDKEYS** is provided
+to **ncreader_create**.
 
 # NOTES
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3020,6 +3020,9 @@ API int ncplane_qrcode(struct ncplane* n, ncblitter_e blitter, int* ymax,
 #define NCREADER_OPTION_VERSCROLL 0x0002ull
 // Disable all editing shortcuts. By default, emacs-style keys are available.
 #define NCREADER_OPTION_NOCMDKEYS 0x0004ull
+// Make the terminal cursor visible across the lifetime of the ncreader, and
+// have the ncreader manage the cursor's placement.
+#define NCREADER_OPTION_CURSOR    0x0008ull
 
 typedef struct ncreader_options {
   uint64_t tchannels; // channels used for input

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -196,6 +196,7 @@ typedef struct ncreader {
   int xproject;               // virtual x location of ncp origin on textarea
   bool horscroll;             // is there horizontal panning?
   bool no_cmd_keys;           // are shortcuts disabled?
+  bool manage_cursor;         // enable and place the terminal cursor
 } ncreader;
 
 typedef struct ncmenu {

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -80,6 +80,9 @@ ncreader_redraw(ncreader* n){
       }
     }
   }
+  if(notcurses_cursor_enable(n->ncp->nc, n->ncp->absy + n->ncp->y, n->ncp->absx + n->ncp->x)){
+    ret = -1;
+  }
   return ret;
 }
 

--- a/src/poc/reader.cpp
+++ b/src/poc/reader.cpp
@@ -37,14 +37,11 @@ auto main(int argc, const char** argv) -> int {
   opts.physrows = dimy / 8;
   opts.physcols = dimx / 2;
   opts.egc = "░";
-  opts.flags = horscroll ? NCREADER_OPTION_HORSCROLL : 0;
+  opts.flags = NCREADER_OPTION_CURSOR | (horscroll ? NCREADER_OPTION_HORSCROLL : 0);
   // FIXME c++ is crashing
   //Reader nr(nc, 0, 0, &opts);
   auto nr = ncreader_create(**n, 2, 2, &opts);
   if(nr == nullptr){
-    return EXIT_FAILURE;
-  }
-  if(!nc.cursor_enable(2, 2)){
     return EXIT_FAILURE;
   }
   ncinput ni;
@@ -55,10 +52,7 @@ auto main(int argc, const char** argv) -> int {
     }else if((ni.ctrl && ni.id == 'D') || ni.id == NCKEY_ENTER){
       break;
     }else if(ncreader_offer_input(nr, &ni)){
-      int y, x;
       struct ncplane* ncp = ncreader_plane(nr);
-      ncplane_cursor_yx(ncp, &y, &x);
-      nc.cursor_enable(y + 2, 2 + (x >= ncplane_dim_x(ncp) ? ncplane_dim_x(ncp) - 1 : x));
       int ncpy, ncpx;
       ncplane_cursor_yx(ncp, &ncpy, &ncpx);
       struct ncplane* tplane = ncplane_above(ncp);


### PR DESCRIPTION
* Add and implement option `NCREADER_OPTION_CURSOR`, causing the `ncreader` takes control of the terminal cursor