### PR TITLE
use libunistring for EGC segmentation #882

### DIFF
--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Cell") {
 
   SUBCASE("Loadchar") {
     cell c = CELL_TRIVIAL_INITIALIZER;
-    REQUIRE(1 == cell_load(n_, &c, " "));
+    CHECK(1 == cell_load(n_, &c, " "));
     CHECK(cell_simple_p(&c));
     cell_release(n_, &c);
   }
@@ -35,7 +35,7 @@ TEST_CASE("Cell") {
     int dimy, dimx;
     notcurses_term_dim_yx(nc_, &dimy, &dimx);
     cell_styles_set(&c, NCSTYLE_ITALIC);
-    REQUIRE(1 == cell_load(n_, &c, "i"));
+    CHECK(1 == cell_load(n_, &c, "i"));
     cell_set_fg_rgb(&c, 255, 255, 255);
     ncplane_set_base_cell(n_, &c);
     cell_release(n_, &c);
@@ -48,7 +48,7 @@ TEST_CASE("Cell") {
     int dimy, dimx;
     notcurses_term_dim_yx(nc_, &dimy, &dimx);
     cell_styles_set(&c, NCSTYLE_BOLD);
-    REQUIRE(1 == cell_load(n_, &c, "b"));
+    CHECK(1 == cell_load(n_, &c, "b"));
     cell_set_fg_rgb(&c, 255, 255, 255);
     ncplane_set_base_cell(n_, &c);
     cell_release(n_, &c);
@@ -61,7 +61,7 @@ TEST_CASE("Cell") {
     int dimy, dimx;
     notcurses_term_dim_yx(nc_, &dimy, &dimx);
     cell_styles_set(&c, NCSTYLE_UNDERLINE);
-    REQUIRE(1 == cell_load(n_, &c, "u"));
+    CHECK(1 == cell_load(n_, &c, "u"));
     cell_set_fg_rgb(&c, 255, 255, 255);
     ncplane_set_base_cell(n_, &c);
     cell_release(n_, &c);
@@ -69,18 +69,18 @@ TEST_CASE("Cell") {
     cell_styles_off(&c, NCSTYLE_UNDERLINE);
   }
 
-/*  SUBCASE("CellLoadTamil") {
-  const char zerodeg[] = "\u0bb8\u0bc0\u0bb0\u0bc7\u0bb3\u0b95\u0bbf\u0b95\u0bbf\u0bb0\u0bbf";
-  cell c = CELL_TRIVIAL_INITIALIZER;
-  size_t ulen = cell_load(n_, &c, zerodeg);
-  // First have U+0BB8 TAMIL LETTER SA U+0BC0 TAMIL VOWEL SIGN II
-  // // e0 ae b8 e0 af 80
-  REQUIRE(6 == ulen);
-  ulen = cell_load(n_, &c, zerodeg + ulen);
-  // U+0BB0 TAMIL LETTER RA U+0BCB TAMIL VOWEL SIGN OO
-  // e0 ae b0 e0 af 8b
-  REQUIRE(6 == ulen);
-  // FIXME
+  /*SUBCASE("CellLoadTamil") {
+    const char zerodeg[] = "\u0bb8\u0bc0\u0bb0\u0bc7\u0bb3\u0b95\u0bbf\u0b95\u0bbf\u0bb0\u0bbf";
+    cell c = CELL_TRIVIAL_INITIALIZER;
+    size_t ulen = cell_load(n_, &c, zerodeg);
+    // First have U+0BB8 TAMIL LETTER SA U+0BC0 TAMIL VOWEL SIGN II
+    // // e0 ae b8 e0 af 80
+    CHECK(6 == ulen);
+    ulen = cell_load(n_, &c, zerodeg + ulen);
+    // U+0BB0 TAMIL LETTER RA U+0BCB TAMIL VOWEL SIGN OO
+    // e0 ae b0 e0 af 8b
+    CHECK(6 == ulen);
+    // FIXME
   }*/
 
   SUBCASE("CellSetFGAlpha"){


### PR DESCRIPTION
It turns out that our `utf8_egc_len()` was really only recognizing "legacy grapheme clusters". Rather than implement Unicode Annex 29 myself, I'm using `uc_is_grapheme_break()` from libunistring, upon which we already depended. Some perf degradation on a few demos, beware.