### PR TITLE
ncselector/ncmultiselector: conform to the New Way #627

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,12 +6,14 @@ rearrangements of Notcurses.
     all widgets, has been effected. Sorry, there was no getting around this
     one. Pretty much all widgets have slightly changed, because pretty much all
     widgets previously behaved slightly differently:
-     * `ncselector` no longer accepts `y, x` placement parameters.
-     * `ncselector` now takes ownership of the provided `ncplane`. It is
-       destroyed by `ncselector_destroy`/`ncselector_create`.
-     * `ncmultiselector` no longer accepts `y, x` placement parameters.
-     * `ncmultiselector` now takes ownership of the provided `ncplane`. It is
-       destroyed by `ncmultiselector_destroy`/`ncmultiselector_create`.
+     * `ncselector_create()` and `ncmultiselector_create()` now take ownership
+       of the provided `ncplane`. On an error in these functions, the `ncplane`
+       will be destroyed. Otherwise, the `ncplane` is destroyed by
+       `ncselector_destroy()` or `ncmultiselector_destroy()`.
+     * `ncselector_create()` and `ncmultiselector_create()` no longer accept
+       `int y, int x` placement parameters. Just place the `ncplane`.
+     * `ncselector_options` and `ncmultiselector_options` have lost their
+       `bgchannels` members. Just set the base character for the `ncplane`.
      * ...
 
 * 1.7.2 (2020-09-09)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,19 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.7.3 (not yet released)
+  * The long-promised/dreaded Great Widget Review, normalizing behavior across
+    all widgets, has been effected. Sorry, there was no getting around this
+    one. Pretty much all widgets have slightly changed, because pretty much all
+    widgets previously behaved slightly differently:
+     * `ncselector` no longer accepts `y, x` placement parameters.
+     * `ncselector` now takes ownership of the provided `ncplane`. It is
+       destroyed by `ncselector_destroy`/`ncselector_create`.
+     * `ncmultiselector` no longer accepts `y, x` placement parameters.
+     * `ncmultiselector` now takes ownership of the provided `ncplane`. It is
+       destroyed by `ncmultiselector_destroy`/`ncmultiselector_create`.
+     * ...
+
 * 1.7.2 (2020-09-09)
   * Exported `ncvisual_default_blitter()`, so that the effective value of
     `NCBLIT_DEFAULT` can be determined.

--- a/USAGE.md
+++ b/USAGE.md
@@ -2221,36 +2221,36 @@ Selectors:
                               ╭──────────────────────────╮
                               │This is the primary header│
 ╭──────────────────────this is the secondary header──────╮
-│         ↑                                              │
-│ option1   Long text #1                                 │
-│ option2   Long text #2                                 │
-│ option3   Long text #3                                 │
-│ option4   Long text #4                                 │
-│ option5   Long text #5                                 │
-│ option6   Long text #6                                 │
-│         ↓                                              │
+│        ↑                                               │
+│ option1 Long text #1                                   │
+│ option2 Long text #2                                   │
+│ option3 Long text #3                                   │
+│ option4 Long text #4                                   │
+│ option5 Long text #5                                   │
+│ option6 Long text #6                                   │
+│        ↓                                               │
 ╰────────────────────────────────────here's the footer───╯
 ```
 
 Multiselectors:
 
 ```
-      ╭────────────────────────────────────────────────────────────────╮
-      │ this is truly an awfully long example of a MULTISELECTOR title │
-╭─────┴─────────────────────────────pick one or more options───────────┤
+                                                   ╭───────────────────╮
+                                                   │ short round title │
+╭now this secondary is also very, very, very outlandishly long, you see┤
 │  ↑                                                                   │
-│ ☐ 1 Across the Atlantic Ocean, there was a place called North America│
-│ ☐ 2 Discovered by an Italian in the employ of the queen of Spain     │
-│ ☒ 3 Colonized extensively by the Spanish and the French              │
-│ ☐ 4 Developed into a rich nation by Dutch-supplied African slaves    │
-│ ☐ 5 And thus became the largest English-speaking nation on earth     │
-│ ☐ 6 Namely, the United States of America                             │
-│ ☐ 7 The inhabitants of the United States called themselves Yankees   │
-│ ☒ 8 For some reason                                                  │
-│ ☐ 9 And, eventually noticing the rest of the world was there,        │
-│ ☐ 10 Decided to rule it.                                             │
+│ ☐ Pa231 Protactinium-231 (162kg)                                     │
+│ ☐ U233 Uranium-233 (15kg)                                            │
+│ ☐ U235 Uranium-235 (50kg)                                            │
+│ ☐ Np236 Neptunium-236 (7kg)                                          │
+│ ☐ Np237 Neptunium-237 (60kg)                                         │
+│ ☐ Pu238 Plutonium-238 (10kg)                                         │
+│ ☐ Pu239 Plutonium-239 (10kg)                                         │
+│ ☐ Pu240 Plutonium-240 (40kg)                                         │
+│ ☐ Pu241 Plutonium-241 (13kg)                                         │
+│ ☐ Am241 Americium-241 (100kg)                                        │
 │  ↓                                                                   │
-╰─────────────────────────press q to exit (there is sartrev("no exit")─╯
+╰────────────────────────press q to exit (there is sartrev("no exit"))─╯
 ```
 
 Menus:

--- a/USAGE.md
+++ b/USAGE.md
@@ -2221,14 +2221,14 @@ Selectors:
                               ╭──────────────────────────╮
                               │This is the primary header│
 ╭──────────────────────this is the secondary header──────╮
-│                                                        │
+│         ↑                                              │
 │ option1   Long text #1                                 │
 │ option2   Long text #2                                 │
 │ option3   Long text #3                                 │
 │ option4   Long text #4                                 │
 │ option5   Long text #5                                 │
 │ option6   Long text #6                                 │
-│                                                        │
+│         ↓                                              │
 ╰────────────────────────────────────here's the footer───╯
 ```
 
@@ -2237,7 +2237,7 @@ Multiselectors:
 ```
       ╭────────────────────────────────────────────────────────────────╮
       │ this is truly an awfully long example of a MULTISELECTOR title │
-╭─────┴─────────────────────────────pick one (you will die regardless)─┤
+╭─────┴─────────────────────────────pick one or more options───────────┤
 │  ↑                                                                   │
 │ ☐ 1 Across the Atlantic Ocean, there was a place called North America│
 │ ☐ 2 Discovered by an Italian in the employ of the queen of Spain     │

--- a/USAGE.md
+++ b/USAGE.md
@@ -2242,11 +2242,11 @@ Multiselectors:
 │ ☐ Pa231 Protactinium-231 (162kg)                                     │
 │ ☐ U233 Uranium-233 (15kg)                                            │
 │ ☐ U235 Uranium-235 (50kg)                                            │
-│ ☐ Np236 Neptunium-236 (7kg)                                          │
+│ ☒ Np236 Neptunium-236 (7kg)                                          │
 │ ☐ Np237 Neptunium-237 (60kg)                                         │
 │ ☐ Pu238 Plutonium-238 (10kg)                                         │
 │ ☐ Pu239 Plutonium-239 (10kg)                                         │
-│ ☐ Pu240 Plutonium-240 (40kg)                                         │
+│ ☒ Pu240 Plutonium-240 (40kg)                                         │
 │ ☐ Pu241 Plutonium-241 (13kg)                                         │
 │ ☐ Am241 Americium-241 (100kg)                                        │
 │  ↓                                                                   │

--- a/doc/man/man3/notcurses_multiselector.3.md
+++ b/doc/man/man3/notcurses_multiselector.3.md
@@ -42,7 +42,7 @@ typedef struct ncmultiselector_options {
 } ncmultiselector_options;
 ```
 
-**struct ncmultiselector* ncmultiselector_create(struct ncplane* n, int y, int x, const ncmultiselector_options* opts);**
+**struct ncmultiselector* ncmultiselector_create(struct ncplane* n, const ncmultiselector_options* opts);**
 
 **int ncmultiselector_selected(bool* selected, unsigned n);**
 
@@ -56,23 +56,33 @@ typedef struct ncmultiselector_options {
 
 # NOTES
 
-Currently, the **ncplane** **n** provided to **ncmultiselector_create**
-must not be **NULL**, though the **ncmultiselector** will always get its
-own plane, and this plane will not (currently) be bound to **n**.
-**ncmultiselector_selected** returns a bitmap corresponding to the
-currently-selected options.
+The **ncplane** **n** provided to **ncmultiselector_create** must not be
+**NULL**. It will be freely resized by the new **ncmultiselector**.
+
+**ncmultiselector_selected** returns the index of the option currently
+highlighted. It stores to the **n**-ary bitmap pointed to by **selected**
+based on the currently-selected options.
 
 **ncmultiselector_plane** will return the **ncplane** on which the widget is
 drawn.
 
-While the **ncmultiselector** can be driven entirely by client code,
-input can be run through **ncmultiselector_offer_input** to take
-advantage of common controls. It will handle the up and down arrows,
-along with PageUp and PageDown, and space to select/deselect options.
-If the mouse is enabled, the mouse scrollwheel and mouse clicks on the scroll
-arrows will be handled.
+Input should be run through **ncmultiselector_offer_input** to take advantage
+of common controls. It will handle the up and down arrows, along with PageUp
+and PageDown. If the mouse is enabled, the mouse scrollwheel and mouse clicks
+on the scroll arrows will be handled.
+
+**ncmultiselector_destroy** destroys the backing **ncplane**, as does
+**ncmultiselector_create** in the event of any error.
 
 # RETURN VALUES
+
+**ncmultiselector_create** returns **NULL** on an error, in which case the
+passed **ncplane** is destroyed.
+
+**ncmultiselector_selected** returns -1 if there are no items, or if **n** is
+not equal to the number of items. It otherwise returns the index of the
+currently highlighted option, and writes a bitmap to **selected** based off
+the selected items.
 
 # SEE ALSO
 

--- a/doc/man/man3/notcurses_multiselector.3.md
+++ b/doc/man/man3/notcurses_multiselector.3.md
@@ -37,7 +37,6 @@ typedef struct ncmultiselector_options {
   uint64_t titlechannels;// title channels
   uint64_t footchannels; // secondary and footer channels
   uint64_t boxchannels;  // border channels
-  uint64_t bgchannels;   // background channels for body
   unsigned flags;        // bitfield over NCMULTISELECTOR_OPTION_*
 } ncmultiselector_options;
 ```

--- a/doc/man/man3/notcurses_selector.3.md
+++ b/doc/man/man3/notcurses_selector.3.md
@@ -41,7 +41,7 @@ typedef struct ncselector_options {
 } ncselector_options;
 ```
 
-**struct ncselector* ncselector_create(struct ncplane* n, int y, int x, const ncselector_options* opts);**
+**struct ncselector* ncselector_create(struct ncplane* n, const ncselector_options* opts);**
 
 **int ncselector_additem(struct ncselector* n, const struct ncselector_item* item);**
 
@@ -63,13 +63,16 @@ typedef struct ncselector_options {
 
 # NOTES
 
-Currently, the **ncplane** **n** provided to **ncselector_create** must not be
-**NULL**, though the **ncselector** will always get its own plane, and this
-plane will not (currently) be bound to **n**. **ncselector_selected**
+The **ncplane** **n** provided to **ncselector_create** must not be **NULL**.
+It will be freely resized by the new **ncselector**. **ncselector_selected**
 returns the currently-selected option. **ncselector_additem** and
 **ncselector_delitem** allow items to be added and deleted on the fly
 (a static set of items can all be provided in the **ncselector_create**
-call).
+call). The backing plane will be resized as necessary for item changes.
+
+**ncselector_nextitem** and **ncselector_previtem** select the next (down) or
+previous (up) option, scrolling if necessary. It is safe to call these
+functions even if no options are present.
 
 **ncselector_plane** will return the **ncplane** on which the widget is
 drawn.
@@ -80,7 +83,20 @@ controls. It will handle the up and down arrows, along with PageUp and
 PageDown. If the mouse is enabled, the mouse scrollwheel and mouse clicks
 on the scroll arrows will be handled.
 
+**ncselector_destroy** destroys the backing **ncplane**, as does
+**ncselector_create** in the event of any error.
+
 # RETURN VALUES
+
+**ncselector_create** returns **NULL** on an error, in which case the passed
+**ncplane** is destroyed.
+
+**ncselector_selected** returns a reference to the **option** part of the
+selected **ncselector_item**. If there are no items, it returns **NULL**.
+
+**ncselector_previtem** and **ncselector_nextitem** return references to the
+**option** part of the newly-selected **ncselector_item**. If there are no
+items, they return **NULL**.
 
 # SEE ALSO
 

--- a/doc/man/man3/notcurses_selector.3.md
+++ b/doc/man/man3/notcurses_selector.3.md
@@ -36,7 +36,6 @@ typedef struct ncselector_options {
   uint64_t titlechannels;// title channels
   uint64_t footchannels; // secondary and footer channels
   uint64_t boxchannels;  // border channels
-  uint64_t bgchannels;   // background channels for body
   unsigned flags;        // bitfield over NCSELECTOR_OPTION_*
 } ncselector_options;
 ```

--- a/include/ncpp/MultiSelector.hh
+++ b/include/ncpp/MultiSelector.hh
@@ -15,24 +15,24 @@ namespace ncpp
 		static ncmultiselector_options default_options;
 
 	public:
-		explicit MultiSelector (Plane *plane, int y, int x, const ncmultiselector_options *opts = nullptr)
-			: MultiSelector (static_cast<const Plane*>(plane), y, x, opts)
+		explicit MultiSelector (Plane *plane, const ncmultiselector_options *opts = nullptr)
+			: MultiSelector (static_cast<const Plane*>(plane), opts)
 		{}
 
-		explicit MultiSelector (Plane const* plane, int y, int x, const ncmultiselector_options *opts = nullptr)
+		explicit MultiSelector (Plane const* plane, const ncmultiselector_options *opts = nullptr)
 			: Root (Utilities::get_notcurses_cpp (plane))
 		{
-			common_init (Utilities::to_ncplane (plane), y, x, opts);
+			common_init (Utilities::to_ncplane (plane), opts);
 		}
 
-		explicit MultiSelector (Plane &plane, int y, int x, const ncmultiselector_options *opts = nullptr)
-			: MultiSelector (static_cast<Plane const&>(plane), y, x, opts)
+		explicit MultiSelector (Plane &plane, const ncmultiselector_options *opts = nullptr)
+			: MultiSelector (static_cast<Plane const&>(plane), opts)
 		{}
 
-		explicit MultiSelector (Plane const& plane, int y, int x, const ncmultiselector_options *opts = nullptr)
+		explicit MultiSelector (Plane const& plane, const ncmultiselector_options *opts = nullptr)
 			: Root (Utilities::get_notcurses_cpp (plane))
 		{
-			common_init (Utilities::to_ncplane (plane), y, x, opts);
+			common_init (Utilities::to_ncplane (plane), opts);
 		}
 
 		~MultiSelector ()
@@ -54,12 +54,12 @@ namespace ncpp
 		Plane* get_plane () const noexcept;
 
 	private:
-		void common_init (ncplane *plane, int y, int x, const ncmultiselector_options *opts)
+		void common_init (ncplane *plane, const ncmultiselector_options *opts)
 		{
 			if (plane == nullptr)
 				throw invalid_argument ("'plane' must be a valid pointer");
 
-			multiselector = ncmultiselector_create (plane, y, x, opts == nullptr ? &default_options : opts);
+			multiselector = ncmultiselector_create (plane, opts == nullptr ? &default_options : opts);
 			if (multiselector == nullptr)
 				throw init_error ("Notcurses failed to create a new multiselector");
 		}

--- a/include/ncpp/Selector.hh
+++ b/include/ncpp/Selector.hh
@@ -15,26 +15,26 @@ namespace ncpp
 		static ncselector_options default_options;
 
 	public:
-		explicit Selector (Plane *plane, int y, int x, const ncselector_options *opts = nullptr)
-			: Selector (static_cast<const Plane*>(plane), y, x, opts)
+		explicit Selector (Plane *plane, const ncselector_options *opts = nullptr)
+			: Selector (static_cast<const Plane*>(plane), opts)
 		{}
 
-		explicit Selector (Plane const* plane, int y, int x, const ncselector_options *opts = nullptr)
+		explicit Selector (Plane const* plane, const ncselector_options *opts = nullptr)
 			: Root (Utilities::get_notcurses_cpp (plane))
 		{
 			if (plane == nullptr)
 				throw invalid_argument ("'plane' must be a valid pointer");
-			common_init (Utilities::to_ncplane (plane), y, x, opts);
+			common_init (Utilities::to_ncplane (plane), opts);
 		}
 
-		explicit Selector (Plane &plane, int y, int x, const ncselector_options *opts = nullptr)
-			: Selector (static_cast<Plane const&>(plane), y, x, opts)
+		explicit Selector (Plane &plane, const ncselector_options *opts = nullptr)
+			: Selector (static_cast<Plane const&>(plane), opts)
 		{}
 
-		explicit Selector (Plane const& plane, int y, int x, const ncselector_options *opts = nullptr)
+		explicit Selector (Plane const& plane, const ncselector_options *opts = nullptr)
 			: Root (Utilities::get_notcurses_cpp (plane))
 		{
-			common_init (Utilities::to_ncplane (plane), y, x, opts);
+			common_init (Utilities::to_ncplane (plane), opts);
 		}
 
 		~Selector ()
@@ -76,12 +76,12 @@ namespace ncpp
 		Plane* get_plane () const noexcept;
 
 	private:
-		void common_init (ncplane *plane, int y, int x, const ncselector_options *opts = nullptr)
+		void common_init (ncplane *plane, const ncselector_options *opts = nullptr)
 		{
 			if (plane == nullptr)
 				throw invalid_argument ("'plane' must be a valid pointer");
 
-			selector = ncselector_create (plane, y, x, opts == nullptr ? &default_options : opts);
+			selector = ncselector_create (plane, opts == nullptr ? &default_options : opts);
 			if (selector == nullptr)
 				throw init_error ("Notcurses failed to create a new selector");
 		}

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2657,14 +2657,14 @@ API void ncplane_greyscale(struct ncplane* n);
 //                                 ╭──────────────────────────╮
 //                                 │This is the primary header│
 //   ╭──────────────────────this is the secondary header──────╮
-//   │                                                        │
-//   │ option1   Long text #1                                 │
-//   │ option2   Long text #2                                 │
-//   │ option3   Long text #3                                 │
-//   │ option4   Long text #4                                 │
-//   │ option5   Long text #5                                 │
-//   │ option6   Long text #6                                 │
-//   │                                                        │
+//   │        ↑                                               │
+//   │ option1 Long text #1                                   │
+//   │ option2 Long text #2                                   │
+//   │ option3 Long text #3                                   │
+//   │ option4 Long text #4                                   │
+//   │ option5 Long text #5                                   │
+//   │ option6 Long text #6                                   │
+//   │        ↓                                               │
 //   ╰────────────────────────────────────here's the footer───╯
 //
 // At all times, exactly one item is selected.
@@ -2736,22 +2736,22 @@ struct ncmselector_item {
 
 // multiselection widget -- a selector supporting multiple selections.
 //
-//      ╭────────────────────────────────────────────────────────────────╮
-//      │ this is truly an awfully long example of a MULTISELECTOR title │
-//╭─────┴─────────────────────────────pick one (you will die regardless)─┤
+//                                                   ╭───────────────────╮
+//                                                   │ short round title │
+//╭now this secondary is also very, very, very outlandishly long, you see┤
 //│  ↑                                                                   │
-//│ ☐ 1 Across the Atlantic Ocean, there was a place called North America│
-//│ ☐ 2 Discovered by an Italian in the employ of the queen of Spain     │
-//│ ☐ 3 Colonized extensively by the Spanish and the French              │
-//│ ☐ 4 Developed into a rich nation by Dutch-supplied African slaves    │
-//│ ☐ 5 And thus became the largest English-speaking nation on earth     │
-//│ ☐ 6 Namely, the United States of America                             │
-//│ ☐ 7 The inhabitants of the United States called themselves Yankees   │
-//│ ☐ 8 For some reason                                                  │
-//│ ☐ 9 And, eventually noticing the rest of the world was there,        │
-//│ ☐ 10 Decided to rule it.                                             │
+//│ ☐ Pa231 Protactinium-231 (162kg)                                     │
+//│ ☐ U233 Uranium-233 (15kg)                                            │
+//│ ☐ U235 Uranium-235 (50kg)                                            │
+//│ ☐ Np236 Neptunium-236 (7kg)                                          │
+//│ ☐ Np237 Neptunium-237 (60kg)                                         │
+//│ ☐ Pu238 Plutonium-238 (10kg)                                         │
+//│ ☐ Pu239 Plutonium-239 (10kg)                                         │
+//│ ☐ Pu240 Plutonium-240 (40kg)                                         │
+//│ ☐ Pu241 Plutonium-241 (13kg)                                         │
+//│ ☐ Am241 Americium-241 (100kg)                                        │
 //│  ↓                                                                   │
-//╰─────────────────────────press q to exit (there is sartrev("no exit")─╯
+//╰────────────────────────press q to exit (there is sartrev("no exit"))─╯
 //
 // Unlike the selector widget, zero to all of the items can be selected, but
 // also the widget does not support adding or removing items at runtime.
@@ -2772,8 +2772,7 @@ typedef struct ncmultiselector_options {
   uint64_t flags;        // bitfield of NCMULTISELECTOR_OPTION_*
 } ncmultiselector_options;
 
-API struct ncmultiselector* ncmultiselector_create(struct ncplane* n, int y, int x,
-                                                   const ncmultiselector_options* opts)
+API struct ncmultiselector* ncmultiselector_create(struct ncplane* n, const ncmultiselector_options* opts)
   __attribute__ ((nonnull (1)));
 
 // Return selected vector. An array of bools must be provided, along with its

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2692,7 +2692,6 @@ typedef struct ncselector_options {
   uint64_t titlechannels;// title channels
   uint64_t footchannels; // secondary and footer channels
   uint64_t boxchannels;  // border channels
-  uint64_t bgchannels;   // background channels, used only in body
   uint64_t flags;        // bitfield of NCSELECTOR_OPTION_*
 } ncselector_options;
 
@@ -2768,7 +2767,6 @@ typedef struct ncmultiselector_options {
   uint64_t titlechannels;// title channels
   uint64_t footchannels; // secondary and footer channels
   uint64_t boxchannels;  // border channels
-  uint64_t bgchannels;   // background channels, used only in body
   uint64_t flags;        // bitfield of NCMULTISELECTOR_OPTION_*
 } ncmultiselector_options;
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2696,8 +2696,7 @@ typedef struct ncselector_options {
   uint64_t flags;        // bitfield of NCSELECTOR_OPTION_*
 } ncselector_options;
 
-API struct ncselector* ncselector_create(struct ncplane* n, int y, int x,
-                                         const ncselector_options* opts)
+API struct ncselector* ncselector_create(struct ncplane* n, const ncselector_options* opts)
   __attribute__ ((nonnull (1)));
 
 // Dynamically add or delete items. It is usually sufficient to supply a static

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -246,7 +246,7 @@ typedef struct ncselector_options {
   uint64_t titlechannels;// title channels
   uint64_t footchannels; // secondary and footer channels
   uint64_t boxchannels;  // border channels
-  uint64_t bgchannels;   // background channels, used only in body
+  uint64_t flags;        // bitmap over NCSELECTOR_OPTIONS_*
 } ncselector_options;
 struct ncselector* ncselector_create(struct ncplane* n, const ncselector_options* opts);
 int ncselector_additem(struct ncselector* n, const struct ncselector_item* item);
@@ -275,7 +275,7 @@ typedef struct ncmultiselector_options {
   uint64_t titlechannels;// title channels
   uint64_t footchannels; // secondary and footer channels
   uint64_t boxchannels;  // border channels
-  uint64_t bgchannels;   // background channels, used only in body
+  uint64_t flags;        // bitmap over NCSELECTOR_OPTIONS_*
 } ncmultiselector_options;
 struct ncmultiselector* ncmultiselector_create(struct ncplane* n, const ncmultiselector_options* opts);
 int ncmultiselector_selected(struct ncmultiselector* n, bool* selected, unsigned count);
@@ -316,7 +316,6 @@ typedef struct ncreel_options {
   unsigned tabletmask;
   uint64_t tabletchan;
   uint64_t focusedchan;
-  uint64_t bgchannel;
   unsigned flags;      // bitfield over NCREEL_OPTION_*
 } ncreel_options;
 struct ncreel* ncreel_create(struct ncplane* nc, const ncreel_options* popts);
@@ -353,6 +352,7 @@ typedef struct ncplot_options {
   uint64_t rangex;
   unsigned flags;
   const char* title;
+  uint64_t flags;        // bitmap over NCPLOT_OPTIONS_*
 } ncplot_options;
 struct ncuplot* ncuplot_create(struct ncplane* n, const ncplot_options* opts, uint64_t miny, uint64_t maxy);
 struct ncdplot* ncdplot_create(struct ncplane* n, const ncplot_options* opts, double miny, double maxy);
@@ -370,6 +370,7 @@ bool ncplane_set_scrolling(struct ncplane* n, bool scrollp);
 typedef struct ncfdplane_options {
   void* curry; // parameter provided to callbacks
   bool follow; // keep reading after hitting end? (think tail -f)
+  uint64_t flags;        // bitmap over NCPLOT_OPTIONS_*
 } ncfdplane_options;
 typedef int(ncfdplane_callback)(struct ncfdplane* n, const void* buf, size_t s, void* curry);
 typedef int(ncfdplane_done_cb)(struct ncfdplane* n, int fderrno, void* curry);
@@ -379,6 +380,7 @@ int ncfdplane_destroy(struct ncfdplane* n);
 typedef struct ncsubproc_options {
   void* curry;
   uint64_t restart_period;  // restart this many seconds after an exit (watch)
+  uint64_t flags;        // bitmap over NCPLOT_OPTIONS_*
 } ncsubproc_options;
 struct ncsubproc* ncsubproc_createv(struct ncplane* n, const ncsubproc_options* opts, const char* bin, char* const arg[], ncfdplane_callback cbfxn, ncfdplane_done_cb donecbfxn);
 struct ncsubproc* ncsubproc_createvp(struct ncplane* n, const ncsubproc_options* opts, const char* bin, char* const arg[], ncfdplane_callback cbfxn, ncfdplane_done_cb donecbfxn);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -248,7 +248,7 @@ typedef struct ncselector_options {
   uint64_t boxchannels;  // border channels
   uint64_t bgchannels;   // background channels, used only in body
 } ncselector_options;
-struct ncselector* ncselector_create(struct ncplane* n, int y, int x, const ncselector_options* opts);
+struct ncselector* ncselector_create(struct ncplane* n, const ncselector_options* opts);
 int ncselector_additem(struct ncselector* n, const struct ncselector_item* item);
 int ncselector_delitem(struct ncselector* n, const char* item);
 const char* ncselector_selected(const struct ncselector* n);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -277,7 +277,7 @@ typedef struct ncmultiselector_options {
   uint64_t boxchannels;  // border channels
   uint64_t bgchannels;   // background channels, used only in body
 } ncmultiselector_options;
-struct ncmultiselector* ncmultiselector_create(struct ncplane* n, int y, int x, const ncmultiselector_options* opts);
+struct ncmultiselector* ncmultiselector_create(struct ncplane* n, const ncmultiselector_options* opts);
 int ncmultiselector_selected(struct ncmultiselector* n, bool* selected, unsigned count);
 struct ncplane* ncmultiselector_plane(struct ncmultiselector* n);
 bool ncmultiselector_offer_input(struct ncmultiselector* n, const struct ncinput* nc);

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -77,7 +77,11 @@ multiselector_demo(struct ncplane* n, struct ncplane* under, int y){
   };
   channels_set_fg_alpha(&mopts.bgchannels, CELL_ALPHA_BLEND);
   channels_set_bg_alpha(&mopts.bgchannels, CELL_ALPHA_BLEND);
-  struct ncmultiselector* mselect = ncmultiselector_create(n, y, 0, &mopts);
+  struct ncplane* mseln = ncplane_new(ncplane_notcurses(n), 1, 1, y, 0, NULL);
+  if(mseln == NULL){
+    return NULL;
+  }
+  struct ncmultiselector* mselect = ncmultiselector_create(mseln, &mopts);
   if(mselect == NULL){
     return NULL;
   }

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -73,14 +73,15 @@ multiselector_demo(struct ncplane* n, struct ncplane* under, int y){
     .descchannels = CHANNELS_RGB_INITIALIZER(0x80, 0xe0, 0x40, 0, 0, 0),
     .footchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0, 0x40, 0x20, 0x20, 0),
     .titlechannels = CHANNELS_RGB_INITIALIZER(0x80, 0x80, 0xff, 0, 0, 0x20),
-    .bgchannels = CHANNELS_RGB_INITIALIZER(0, 0x40, 0, 0, 0x40, 0),
   };
-  channels_set_fg_alpha(&mopts.bgchannels, CELL_ALPHA_BLEND);
-  channels_set_bg_alpha(&mopts.bgchannels, CELL_ALPHA_BLEND);
+  uint64_t bgchannels = CHANNELS_RGB_INITIALIZER(0, 0x40, 0, 0, 0x40, 0);
+  channels_set_fg_alpha(&bgchannels, CELL_ALPHA_BLEND);
+  channels_set_bg_alpha(&bgchannels, CELL_ALPHA_BLEND);
   struct ncplane* mseln = ncplane_new(ncplane_notcurses(n), 1, 1, y, 0, NULL);
   if(mseln == NULL){
     return NULL;
   }
+  ncplane_set_base(mseln, "", 0, bgchannels);
   struct ncmultiselector* mselect = ncmultiselector_create(mseln, &mopts);
   if(mselect == NULL){
     return NULL;
@@ -102,19 +103,20 @@ selector_demo(struct ncplane* n, struct ncplane* under, int dimx, int y){
     .descchannels = CHANNELS_RGB_INITIALIZER(0x80, 0xe0, 0x40, 0, 0, 0),
     .footchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0, 0x40, 0x20, 0, 0),
     .titlechannels = CHANNELS_RGB_INITIALIZER(0xff, 0xff, 0x80, 0, 0, 0x20),
-    .bgchannels = CHANNELS_RGB_INITIALIZER(0, 0, 0x40, 0, 0, 0x40),
   };
-  channels_set_fg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
-  channels_set_bg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
-  struct ncplane* mplane = ncplane_new(ncplane_notcurses(n), 1, 1, y, dimx, NULL);
-  if(mplane == NULL){
+  uint64_t bgchannels = CHANNELS_RGB_INITIALIZER(0, 0, 0x40, 0, 0, 0x40);
+  channels_set_fg_alpha(&bgchannels, CELL_ALPHA_BLEND);
+  channels_set_bg_alpha(&bgchannels, CELL_ALPHA_BLEND);
+  struct ncplane* seln = ncplane_new(ncplane_notcurses(n), 1, 1, y, dimx, NULL);
+  if(seln == NULL){
     return NULL;
   }
-  struct ncselector* selector = ncselector_create(mplane, &sopts);
+  ncplane_set_base(seln, "", 0, bgchannels);
+  struct ncselector* selector = ncselector_create(seln, &sopts);
   if(selector == NULL){
     return NULL;
   }
-  ncplane_move_below(mplane, under);
+  ncplane_move_below(seln, under);
   return selector;
 }
 

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -102,11 +102,14 @@ selector_demo(struct ncplane* n, struct ncplane* under, int dimx, int y){
   };
   channels_set_fg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
   channels_set_bg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
-  struct ncselector* selector = ncselector_create(n, y, dimx, &sopts);
+  struct ncplane* mplane = ncplane_new(ncplane_notcurses(n), 1, 1, y, dimx, NULL);
+  if(mplane == NULL){
+    return NULL;
+  }
+  struct ncselector* selector = ncselector_create(mplane, &sopts);
   if(selector == NULL){
     return NULL;
   }
-  struct ncplane* mplane = ncselector_plane(selector);
   ncplane_move_below(mplane, under);
   return selector;
 }

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -100,7 +100,7 @@ pipe_getline(const char* cmdline){
   }
   char* buf = malloc(BUFSIZ); // gatesv("BUFSIZ bytes is enough for anyone")
   if(fgets(buf, BUFSIZ, p) == NULL){
-    fprintf(stderr, "Error reading from %s (%s)\n", cmdline, strerror(errno));
+//fprintf(stderr, "Error reading from %s (%s)\n", cmdline, strerror(errno));
     fclose(p);
     free(buf);
     return NULL;
@@ -116,7 +116,7 @@ pipe_getline(const char* cmdline){
 
 static int
 fetch_x_props(fetched_info* fi){
-  char* xrandr = pipe_getline("xrandr --current");
+  char* xrandr = pipe_getline("xrandr --current 2>/dev/null");
   if(xrandr == NULL){
     return -1;
   }

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -79,17 +79,27 @@ ncselector_draw(ncselector* n){
   if(n->title){
     size_t riserwidth = n->titlecols + 4;
     int offx = ncplane_align(n->ncp, NCALIGN_RIGHT, riserwidth);
+    ncplane_cursor_move_yx(n->ncp, 0, 0);
+    ncplane_hline(n->ncp, &transchar, offx);
     ncplane_cursor_move_yx(n->ncp, 0, offx);
     ncplane_rounded_box_sized(n->ncp, 0, n->boxchannels, 3, riserwidth, 0);
     n->ncp->channels = n->titlechannels;
     ncplane_printf_yx(n->ncp, 1, offx + 1, " %s ", n->title);
     yoff += 2;
+    ncplane_cursor_move_yx(n->ncp, 1, 0);
+    ncplane_hline(n->ncp, &transchar, offx);
   }
   int bodywidth = ncselector_body_width(n);
-  int xoff = ncplane_align(n->ncp, NCALIGN_RIGHT, bodywidth);
-  ncplane_cursor_move_yx(n->ncp, yoff, xoff);
   int dimy, dimx;
   ncplane_dim_yx(n->ncp, &dimy, &dimx);
+  int xoff = ncplane_align(n->ncp, NCALIGN_RIGHT, bodywidth);
+  if(xoff){
+    for(int y = yoff + 1 ; y < dimy ; ++y){
+      ncplane_cursor_move_yx(n->ncp, y, 0);
+      ncplane_hline(n->ncp, &transchar, xoff);
+    }
+  }
+  ncplane_cursor_move_yx(n->ncp, yoff, xoff);
   ncplane_rounded_box_sized(n->ncp, 0, n->boxchannels, dimy - yoff, bodywidth, 0);
   if(n->title){
     n->ncp->channels = n->boxchannels;
@@ -135,7 +145,8 @@ ncselector_draw(ncselector* n){
   ++yoff;
   ncplane_cursor_move_yx(n->ncp, yoff, xoff + 1);
   for(int i = xoff + 1 ; i < dimx - 1 ; ++i){
-    ncplane_putc(n->ncp, &transchar);
+    cell transc = CELL_TRIVIAL_INITIALIZER; // fall back to base cell
+    ncplane_putc(n->ncp, &transc);
   }
   const int bodyoffset = dimx - bodywidth + 2;
   if(n->maxdisplay && n->maxdisplay < n->itemcount){
@@ -158,7 +169,8 @@ ncselector_draw(ncselector* n){
     }
     ncplane_cursor_move_yx(n->ncp, yoff, xoff + 1);
     for(int i = xoff + 1 ; i < dimx - 1 ; ++i){
-      ncplane_putc(n->ncp, &transchar);
+      cell transc = CELL_TRIVIAL_INITIALIZER; // fall back to base cell
+      ncplane_putc(n->ncp, &transc);
     }
     n->ncp->channels = n->opchannels;
     if(printidx == n->selected){
@@ -178,7 +190,8 @@ ncselector_draw(ncselector* n){
   // Bottom line of body (background and possibly down arrow)
   ncplane_cursor_move_yx(n->ncp, yoff, xoff + 1);
   for(int i = xoff + 1 ; i < dimx - 1 ; ++i){
-    ncplane_putc(n->ncp, &transchar);
+    cell transc = CELL_TRIVIAL_INITIALIZER; // fall back to base cell
+    ncplane_putc(n->ncp, &transc);
   }
   if(n->maxdisplay && n->maxdisplay < n->itemcount){
     n->ncp->channels = n->descchannels;
@@ -279,7 +292,8 @@ ncselector* ncselector_create(ncplane* n, const ncselector_options* opts){
       ns->longop = cols;
     }
     cols = mbswidth(src->desc);
-    ns->items[ns->itemcount].desccolumns = cols; if(cols > ns->longdesc){
+    ns->items[ns->itemcount].desccolumns = cols;
+    if(cols > ns->longdesc){
       ns->longdesc = cols;
     }
     ns->items[ns->itemcount].option = strdup(src->option);

--- a/src/libcpp/MultiSelector.cc
+++ b/src/libcpp/MultiSelector.cc
@@ -14,7 +14,6 @@ ncmultiselector_options MultiSelector::default_options = {
 	/* titlechannels */ 0,
 	/* footchannels */ 0,
 	/* boxchannels */ 0,
-	/* bgchannels */ 0,
 	/* flags */ 0,
 };
 

--- a/src/libcpp/Selector.cc
+++ b/src/libcpp/Selector.cc
@@ -15,7 +15,6 @@ ncselector_options Selector::default_options = {
 	/* titlechannels */ 0,
 	/* footchannels */ 0,
 	/* boxchannels */ 0,
-	/* bgchannels */ 0,
 	/* flags */ 0,
 };
 

--- a/src/poc/multiselect.c
+++ b/src/poc/multiselect.c
@@ -7,17 +7,27 @@
 
 // http://theboomerbible.com/tbb112.html
 static struct ncmselector_item items[] = {
-  { "1", "Across the Atlantic Ocean, there was a place called North America", .selected = false, },
-  { "2", "Discovered by an Italian in the employ of the queen of Spain", .selected = false, },
-  { "3", "Colonized extensively by the Spanish and the French", .selected = false, },
-  { "4", "Developed into a rich nation by Dutch-supplied African slaves", .selected = false, },
-  { "5", "And thus became the largest English-speaking nation on earth", .selected = false, },
-  { "6", "Namely, the United States of America", .selected = false, },
-  { "7", "The inhabitants of the United States called themselves Yankees", .selected = false, },
-  { "8", "For some reason", .selected = false, },
-  { "9", "And, eventually noticing the rest of the world was there,", .selected = false, },
-  { "10", "Decided to rule it.", .selected = false, },
-  { "11", "This is their story.", .selected = false, },
+  { "Pa231", "Protactinium-231 (162kg)", .selected = false, },
+  { "U233", "Uranium-233 (15kg)", .selected = false, },
+  { "U235", "Uranium-235 (50kg)", .selected = false, },
+  { "Np236", "Neptunium-236 (7kg)", .selected = false, },
+  { "Np237", "Neptunium-237 (60kg)", .selected = false, },
+  { "Pu238", "Plutonium-238 (10kg)", .selected = false, },
+  { "Pu239", "Plutonium-239 (10kg)", .selected = false, },
+  { "Pu240", "Plutonium-240 (40kg)", .selected = false, },
+  { "Pu241", "Plutonium-241 (13kg)", .selected = false, },
+  { "Am241", "Americium-241 (100kg)", .selected = false, },
+  { "Pu242", "Plutonium-242 (100kg)", .selected = false, },
+  { "Am242", "Americium-242 (18kg)", .selected = false, },
+  { "Am243", "Americium-243 (155kg)", .selected = false, },
+  { "Cm243", "Curium-243 (10kg)", .selected = false, },
+  { "Cm244", "Curium-244 (30kg)", .selected = false, },
+  { "Cm245", "Curium-245 (13kg)", .selected = false, },
+  { "Cm246", "Curium-246 (84kg)", .selected = false, },
+  { "Cm247", "Curium-247 (7kg)", .selected = false, },
+  { "Bk247", "Berkelium-247 (10kg)", .selected = false, },
+  { "Cf249", "Californium-249 (6kg)", .selected = false, },
+  { "Cf251", "Californium-251 (9kg)", .selected = false, },
   { NULL, NULL, .selected = false, },
 };
 
@@ -96,28 +106,36 @@ int main(void){
 
   ncplane_set_fg(n, 0x40f040);
   ncplane_putstr_aligned(n, 0, NCALIGN_RIGHT, "multiselect widget demo");
-  struct ncmultiselector* ns = ncmultiselector_create(n, 3, 0, &sopts);
+  struct ncplane* mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  if(mseln == NULL){
+    goto err;
+  }
+  struct ncmultiselector* ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
   sopts.title = "short round title";
-  ns = ncmultiselector_create(n, 3, 0, &sopts);
+  mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
   sopts.title = "short round title";
   sopts.secondary = "now this secondary is also very, very, very outlandishly long, you see";
-  ns = ncmultiselector_create(n, 3, 0, &sopts);
+  mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
   sopts.title = "the whole world is watching";
   sopts.secondary = NULL;
   sopts.footer = "now this FOOTERFOOTER is also very, very, very outlandishly long, you see";
-  ns = ncmultiselector_create(n, 3, 0, &sopts);
+  mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
   sopts.title = "chomps";
   sopts.secondary = NULL;
   sopts.footer = NULL;
-  ns = ncmultiselector_create(n, 3, 0, &sopts);
+  mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
   if(notcurses_stop(nc)){

--- a/src/poc/multiselect.c
+++ b/src/poc/multiselect.c
@@ -80,14 +80,14 @@ int main(void){
   sopts.title = "this is truly an awfully long example of a MULTISELECTOR title";
   sopts.secondary = "pick one (you will die regardless)";
   sopts.footer = "press q to exit (there is sartrev(\"no exit\"))";
-  sopts.boxchannels = CHANNELS_RGB_INITIALIZER(0x20, 0xe0, 0xe0, 0x20, 0, 0),
-  sopts.opchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0x80, 0x40, 0, 0, 0),
-  sopts.descchannels = CHANNELS_RGB_INITIALIZER(0x80, 0xe0, 0x40, 0, 0, 0),
-  sopts.footchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0, 0x40, 0x20, 0x20, 0),
-  sopts.titlechannels = CHANNELS_RGB_INITIALIZER(0x20, 0xff, 0xff, 0, 0, 0x20),
-  sopts.bgchannels = CHANNELS_RGB_INITIALIZER(0, 0x20, 0, 0, 0x20, 0),
-  channels_set_fg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
-  channels_set_bg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
+  sopts.boxchannels = CHANNELS_RGB_INITIALIZER(0x20, 0xe0, 0xe0, 0x20, 0, 0);
+  sopts.opchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0x80, 0x40, 0, 0, 0);
+  sopts.descchannels = CHANNELS_RGB_INITIALIZER(0x80, 0xe0, 0x40, 0, 0, 0);
+  sopts.footchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0, 0x40, 0x20, 0x20, 0);
+  sopts.titlechannels = CHANNELS_RGB_INITIALIZER(0x20, 0xff, 0xff, 0, 0, 0x20);
+  uint64_t bgchannels = CHANNELS_RGB_INITIALIZER(0, 0x20, 0, 0, 0x20, 0);
+  channels_set_fg_alpha(&bgchannels, CELL_ALPHA_BLEND);
+  channels_set_bg_alpha(&bgchannels, CELL_ALPHA_BLEND);
   struct ncplane* n = notcurses_stdplane(nc);
 
   if(notcurses_canopen_images(nc)){
@@ -110,17 +110,20 @@ int main(void){
   if(mseln == NULL){
     goto err;
   }
+  ncplane_set_base(mseln, "", 0, bgchannels);
   struct ncmultiselector* ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
   sopts.title = "short round title";
   mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ncplane_set_base(mseln, "", 0, bgchannels);
   ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
   sopts.title = "short round title";
   sopts.secondary = "now this secondary is also very, very, very outlandishly long, you see";
   mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ncplane_set_base(mseln, "", 0, bgchannels);
   ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
@@ -128,6 +131,7 @@ int main(void){
   sopts.secondary = NULL;
   sopts.footer = "now this FOOTERFOOTER is also very, very, very outlandishly long, you see";
   mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ncplane_set_base(mseln, "", 0, bgchannels);
   ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
@@ -135,6 +139,7 @@ int main(void){
   sopts.secondary = NULL;
   sopts.footer = NULL;
   mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ncplane_set_base(mseln, "", 0, bgchannels);
   ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 

--- a/src/poc/selector.c
+++ b/src/poc/selector.c
@@ -7,16 +7,16 @@
 
 static struct ncselector_item items[] = {
 #define SITEM(short, long) { short, long, 0, 0, }
-  SITEM("first", "this is the first option"),
-  SITEM("2nd", "this is the second option"),
-  SITEM("3", "third, third, third option am i"),
-  SITEM("fourth", "i have another option here"),
-  SITEM("five", "golden rings"),
-  SITEM("666", "now it is time for me to REIGN IN BLOOD"),
-  SITEM("7seven7", "this monkey's gone to heaven"),
-  SITEM("8 8 8", "the chinese 平仮名平平仮名仮名love me, i'm told"),
-  SITEM("nine", "nine, nine, nine 'cause you left me"),
-  SITEM("ten", "stunning and brave"),
+  SITEM("Afrikaans", "Ek kan glas eet, dit maak my nie seer nie."),
+  SITEM("Kabuverdianu", "M’tá podê kumê vidru, ká stá máguame."),
+  SITEM("Lao", "ຂອ້ຍກິນແກ້ວໄດ້ໂດຍທີ່ມັນບໍ່ໄດ້ເຮັດໃຫ້ຂອ້ຍເຈັບ."),
+  SITEM("Japanese", "私はガラスを食べられます。それは私を傷つけません。"),
+  SITEM("Khmer", "ខ្ញុំអាចញុំកញ្ចក់បាន ដោយគ្មានបញ្ហារ"),
+  SITEM("Hindi", "मैं काँच खा सकता हूँ और मुझे उससे कोई चोट नहीं पहुंचती. "),
+  SITEM("Tamil", "நான் கண்ணாடி சாப்பிடுவேன், அதனால் எனக்கு ஒரு கேடும் வராது. "),
+  SITEM("Telugu", "నేను గాజు తినగలను మరియు అలా చేసినా నాకు ఏమి ఇబ్బంది లేదు "),
+  SITEM("Tibetan", "ཤེལ་སྒོ་ཟ་ནས་ང་ན་གི་མ་རེད།"),
+  SITEM("Russian", "Я могу есть стекло, оно мне не вредит."),
   SITEM(NULL, NULL),
 #undef SITEM
 };
@@ -98,28 +98,33 @@ int main(void){
 
   ncplane_set_fg(n, 0x40f040);
   ncplane_putstr_aligned(n, 0, NCALIGN_RIGHT, "selector widget demo");
-  struct ncselector* ns = ncselector_create(n, 3, 0, &sopts);
+  struct ncplane* seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  struct ncselector* ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
   sopts.title = "short round title";
-  ns = ncselector_create(n, 3, 0, &sopts);
+  seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
   sopts.title = "short round title";
   sopts.secondary = "now this secondary is also very, very, very outlandishly long, you see";
-  ns = ncselector_create(n, 3, 0, &sopts);
+  seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
   sopts.title = "the whole world is watching";
   sopts.secondary = NULL;
   sopts.footer = "now this FOOTERFOOTER is also very, very, very outlandishly long, you see";
-  ns = ncselector_create(n, 3, 0, &sopts);
+  seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
   sopts.title = "chomps";
   sopts.secondary = NULL;
   sopts.footer = NULL;
-  ns = ncselector_create(n, 3, 0, &sopts);
+  seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
   if(notcurses_stop(nc)){

--- a/src/poc/selector.c
+++ b/src/poc/selector.c
@@ -71,14 +71,14 @@ int main(void){
   sopts.secondary = "pick one (you will die regardless)";
   sopts.footer = "press q to exit (there is no exit)";
   sopts.defidx = 1;
-  sopts.boxchannels = CHANNELS_RGB_INITIALIZER(0x20, 0xe0, 0x40, 0x20, 0x20, 0x20),
-  sopts.opchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0x80, 0x40, 0, 0, 0),
-  sopts.descchannels = CHANNELS_RGB_INITIALIZER(0x80, 0xe0, 0x40, 0, 0, 0),
-  sopts.footchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0, 0x40, 0x20, 0, 0),
-  sopts.titlechannels = CHANNELS_RGB_INITIALIZER(0xff, 0xff, 0x80, 0, 0, 0x20),
-  sopts.bgchannels = CHANNELS_RGB_INITIALIZER(0, 0x20, 0, 0, 0x20, 0),
-  channels_set_fg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
-  channels_set_bg_alpha(&sopts.bgchannels, CELL_ALPHA_BLEND);
+  sopts.boxchannels = CHANNELS_RGB_INITIALIZER(0x20, 0xe0, 0x40, 0x20, 0x20, 0x20);
+  sopts.opchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0x80, 0x40, 0, 0, 0);
+  sopts.descchannels = CHANNELS_RGB_INITIALIZER(0x80, 0xe0, 0x40, 0, 0, 0);
+  sopts.footchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0, 0x40, 0x20, 0, 0);
+  sopts.titlechannels = CHANNELS_RGB_INITIALIZER(0xff, 0xff, 0x80, 0, 0, 0x20);
+  uint64_t bgchannels = CHANNELS_RGB_INITIALIZER(0, 0x20, 0, 0, 0x20, 0);
+  channels_set_fg_alpha(&bgchannels, CELL_ALPHA_BLEND);
+  channels_set_bg_alpha(&bgchannels, CELL_ALPHA_BLEND);
   struct ncplane* n = notcurses_stdplane(nc);
 
   if(notcurses_canopen_images(nc)){
@@ -99,17 +99,20 @@ int main(void){
   ncplane_set_fg(n, 0x40f040);
   ncplane_putstr_aligned(n, 0, NCALIGN_RIGHT, "selector widget demo");
   struct ncplane* seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ncplane_set_base(seln, "", 0, bgchannels);
   struct ncselector* ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
   sopts.title = "short round title";
   seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ncplane_set_base(seln, "", 0, bgchannels);
   ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
   sopts.title = "short round title";
   sopts.secondary = "now this secondary is also very, very, very outlandishly long, you see";
   seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ncplane_set_base(seln, "", 0, bgchannels);
   ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
@@ -117,6 +120,7 @@ int main(void){
   sopts.secondary = NULL;
   sopts.footer = "now this FOOTERFOOTER is also very, very, very outlandishly long, you see";
   seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ncplane_set_base(seln, "", 0, bgchannels);
   ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
@@ -124,6 +128,7 @@ int main(void){
   sopts.secondary = NULL;
   sopts.footer = NULL;
   seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  ncplane_set_base(seln, "", 0, bgchannels);
   ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 

--- a/tests/selector.cpp
+++ b/tests/selector.cpp
@@ -13,7 +13,8 @@ TEST_CASE("Selectors") {
 
   SUBCASE("EmptySelector") {
     struct ncselector_options opts{};
-    struct ncselector* ncs = ncselector_create(n_, 0, 0, &opts);
+    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
     CHECK(nullptr == ncselector_selected(ncs));
@@ -29,7 +30,8 @@ TEST_CASE("Selectors") {
   SUBCASE("TitledSelector") {
     struct ncselector_options opts{};
     opts.title = strdup("hey hey whaddya say");
-    struct ncselector* ncs = ncselector_create(n_, 0, 0, &opts);
+    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
     struct ncplane* ncsp = ncselector_plane(ncs);
@@ -44,7 +46,8 @@ TEST_CASE("Selectors") {
   SUBCASE("SecondarySelector") {
     struct ncselector_options opts{};
     opts.secondary = strdup("this is not a title, but it's not *not* a title");
-    struct ncselector* ncs = ncselector_create(n_, 0, 0, &opts);
+    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
     struct ncplane* ncsp = ncselector_plane(ncs);
@@ -59,7 +62,8 @@ TEST_CASE("Selectors") {
   SUBCASE("FooterSelector") {
     struct ncselector_options opts{};
     opts.footer = strdup("i am a lone footer, little old footer");
-    struct ncselector* ncs = ncselector_create(n_, 0, 0, &opts);
+    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
     struct ncplane* ncsp = ncselector_plane(ncs);
@@ -80,7 +84,8 @@ TEST_CASE("Selectors") {
     };
     struct ncselector_options opts{};
     opts.items = items;
-    struct ncselector* ncs = ncselector_create(n_, 0, 0, &opts);
+    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
     struct ncplane* ncsp = ncselector_plane(ncs);
@@ -94,7 +99,8 @@ TEST_CASE("Selectors") {
 
   SUBCASE("EmptySelectorMovement") {
     struct ncselector_options opts{};
-    struct ncselector* ncs = ncselector_create(n_, 0, 0, &opts);
+    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
     auto sel = ncselector_selected(ncs);
@@ -117,7 +123,8 @@ TEST_CASE("Selectors") {
     };
     struct ncselector_options opts{};
     opts.items = items;
-    struct ncselector* ncs = ncselector_create(n_, 0, 0, &opts);
+    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     auto sel = ncselector_selected(ncs);
     REQUIRE(nullptr != sel);
@@ -155,7 +162,8 @@ TEST_CASE("Selectors") {
     struct ncselector_options opts{};
     opts.maxdisplay = 1;
     opts.items = items;
-    struct ncselector* ncs = ncselector_create(n_, 0, 0, &opts);
+    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
     auto sel = ncselector_selected(ncs);
@@ -198,7 +206,8 @@ TEST_CASE("Selectors") {
     struct ncselector_options opts{};
     opts.maxdisplay = 2;
     opts.items = items;
-    struct ncselector* ncs = ncselector_create(n_, 0, 0, &opts);
+    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
     const char* sel = ncselector_selected(ncs);


### PR DESCRIPTION
* Remove all parameters save `ncplane` and options struct
* Remove all fields from options struct having to do with plane-level characteristics
* Take ownership of the `ncplane` we're handed, including destroying it on all error paths in `_create()`
* Update man pages, python, demo, PoCs, and `NEWS.md`
* Replace selector/multiselector PoC and example text

This completes `ncselector` and `ncmultiselector` for #627.