### PR TITLE
Kill off most plane creation functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,13 @@ rearrangements of Notcurses.
   * Functions ending in `_stainable()` now end in `_stained()`.
   * `ncplane_putwc_stained()` and `ncplane_putwstr_stained()` have been
     added in the interest of orthogonality.
-
+  * `ncplane_new_named()` has been eliminated. `ncplane_new()` now takes a
+    `const char* name` argument. `ncplane_bound()` and `ncplane_bound_named()`
+    have both been eliminated. `ncplane_new()` now accepts an `ncplane*`
+    instead of a `notcurses*`. All functionality exposed by the removed
+    functions is thus now present in `ncplane_new()`.
+  * `ncplane_aligned_named()` has been removed. `ncplane_aligned()` now accepts
+    a `const char* name` argument.
 
 * 1.7.2 (2020-09-09)
   * Exported `ncvisual_default_blitter()`, so that the effective value of

--- a/USAGE.md
+++ b/USAGE.md
@@ -610,42 +610,22 @@ but is the primary drawing surface of notcurses—there is no object
 corresponding to a bare NCURSES `WINDOW`.
 
 In addition to `ncplane_new()`, an `ncplane` can be created aligned relative
-to an existing `ncplane` (including the standard plane) using `ncplane_aligned()`.
-When an `ncplane` is no longer needed, free it with `ncplane_destroy()`. To
-quickly reset the `ncplane`, use `ncplane_erase()`.
+to an existing `ncplane` (including the standard plane) using
+`ncplane_aligned()`. When an `ncplane` is no longer needed, free it with
+`ncplane_destroy()`. To quickly reset the `ncplane`, use `ncplane_erase()`.
 
 ```c
-// Create a new ncplane at the specified offset (relative to the standard plane)
-// and the specified size. The number of rows and columns must both be positive.
-// This plane is initially at the top of the z-buffer, as if ncplane_move_top()
-// had been called on it. The void* 'opaque' can be retrieved (and reset) later.
-struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols,
-                            int yoff, int xoff, void* opaque);
-
-// Create a named plane ala ncplane_new(). Names are only used for debugging.
-struct ncplane* ncplane_new_named(struct notcurses* nc, int rows, int cols,
-                                  int yoff, int xoff, void* opaque,
-                                  const char* name);
-
-// Create a plane bound to plane 'n'. Being bound to 'n' means that 'yoff' and
-// 'xoff' are interpreted relative to that plane's origin, and that if that
-// plane is moved later, this new plane is moved by the same amount.
-struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols,
-                              int yoff, int xoff, void* opaque);
-
-// Create a named plane ala ncplane_bound(). Names are used only for debugging.
-struct ncplane* ncplane_bound_named(struct ncplane* n, int rows, int cols,
-                                    int yoff, int xoff, void* opaque,
-                                    const char* name);
+// Create a new ncplane bound to plane 'n', at the offset 'y'x'x' (relative to
+// the origin of 'n') and the specified size. The number of rows and columns
+// must both be positive. This plane is initially at the top of the z-buffer,
+// as if ncplane_move_top() had been called on it. The void* 'opaque' can be
+// retrieved (and reset) later. A name can be set, used in debugging.
+struct ncplane* ncplane_new(struct ncplane* n, int rows, int cols,
+                            int y, int x, void* opaque, const char* name);
 
 // Create a plane bound to 'n', and aligned relative to it using 'align'.
 struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols,
-                                int yoff, ncalign_e align, void* opaque);
-
-// Create a named plane ala ncplane_aligned(). Names are used only for debugging.
-struct ncplane* ncplane_aligned_named(struct ncplane* n, int rows, int cols,
-                                      int yoff, ncalign_e align,
-                                      void* opaque, const char* name);
+                int y, ncalign_e align, void* opaque, const char* name);
 
 // Plane 'n' will be unbound from its parent plane, if it is currently bound,
 // and will be made a bound child of 'newparent', if 'newparent' is not NULL.

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -14,17 +14,9 @@ notcurses_plane - operations on ncplanes
 
 **struct ncplane* notcurses_bottom(struct notcurses* n);**
 
-**struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque);**
+**struct ncplane* ncplane_new(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);**
 
-**struct ncplane* ncplane_new_named(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);**
-
-**struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque);**
-
-**struct ncplane* ncplane_bound_named(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);**
-
-**struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque);**
-
-**struct ncplane* ncplane_aligned_named(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque, const char* name);**
+**struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque, const char* name);**
 
 **struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparent);**
 
@@ -185,14 +177,14 @@ anywhere. In addition to its framebuffer--a rectilinear matrix of cells
 * the head of the list of its bound planes, and
 * its z-index.
 
-New planes can be created with **ncplane_new**, **ncplane_bound**, and
-**ncplane_aligned**. If a plane is bound to another, x and y coordinates are
-relative to the plane to which it is bound, and if that plane moves, all its
-bound planes move along with it. When a plane is destroyed, all planes bound to
-it (directly or transitively) are destroyed. **ncplane_reparent** detaches the
-plane **n** from any plane to which it is bound, and binds it to **newparent**
-if **newparent** is not **NULL**. All planes bound to **n** move along with it
-during a reparenting operation.
+New planes can be created with **ncplane_new** and **ncplane_aligned**. If a
+plane is bound to another, x and y coordinates are relative to the plane to
+which it is bound, and if this latter plane moves, all its bound planes move
+along with it. When a plane is destroyed, all planes bound to it (directly or
+transitively) are destroyed. **ncplane_reparent** detaches the plane **n** from
+any plane to which it is bound, and binds it to **newparent** if **newparent**
+is not **NULL**. All planes bound to **n** move along with it during a
+reparenting operation.
 
 **ncplane_destroy** destroys a particular ncplane, after which it must not be
 used again. **notcurses_drop_planes** destroys all ncplanes other than the

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -55,12 +55,13 @@ namespace ncpp
 			: Root (ncinst)
 		{
 			plane = ncplane_new (
-				get_notcurses (),
+				notcurses_stdplane(get_notcurses ()),
 				rows,
 				cols,
 				yoff,
 				xoff,
-				opaque
+				opaque,
+        nullptr
 			);
 
 			if (plane == nullptr)
@@ -1090,13 +1091,14 @@ namespace ncpp
 	private:
 		ncplane* create_plane (const Plane &n, int rows, int cols, int yoff, int xoff, void *opaque)
 		{
-			ncplane *ret = ncplane_bound (
+			ncplane *ret = ncplane_new (
 				n.plane,
 				rows,
 				cols,
 				yoff,
 				xoff,
-				opaque
+				opaque,
+        nullptr
 			);
 
 			if (ret == nullptr)
@@ -1115,7 +1117,8 @@ namespace ncpp
 				cols,
 				yoff,
 				static_cast<ncalign_e>(align),
-				opaque
+				opaque,
+        nullptr
 			);
 
 			if (ret == nullptr)

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -993,37 +993,18 @@ notcurses_term_dim_yx(const struct notcurses* n, int* RESTRICT rows, int* RESTRI
 API char* notcurses_at_yx(struct notcurses* nc, int yoff, int xoff,
                           uint16_t* stylemask, uint64_t* channels);
 
-// Create a new ncplane at the specified offset (relative to the standard plane)
-// and the specified size. The number of rows and columns must both be positive.
-// This plane is initially at the top of the z-buffer, as if ncplane_move_top()
-// had been called on it. The void* 'opaque' can be retrieved (and reset) later.
-API struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols,
-                                int yoff, int xoff, void* opaque);
-
-// Create a named plane ala ncplane_new(). Names are only used for debugging.
-API struct ncplane* ncplane_new_named(struct notcurses* nc, int rows, int cols,
-                                      int yoff, int xoff, void* opaque,
-                                      const char* name);
-
-// Create a plane bound to plane 'n'. Being bound to 'n' means that 'yoff' and
-// 'xoff' are interpreted relative to that plane's origin, and that if that
-// plane is moved later, this new plane is moved by the same amount.
-API struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols,
-                                  int yoff, int xoff, void* opaque);
-
-// Create a named plane ala ncplane_bound(). Names are used only for debugging.
-API struct ncplane* ncplane_bound_named(struct ncplane* n, int rows, int cols,
-                                        int yoff, int xoff, void* opaque,
-                                        const char* name);
+// Create a new ncplane bound to plane 'n', at the offset 'y'x'x' (relative to
+// the origin of 'n') and the specified size. The number of rows and columns
+// must both be positive. This plane is initially at the top of the z-buffer,
+// as if ncplane_move_top() had been called on it. The void* 'opaque' can be
+// retrieved (and reset) later. A name can be set, used in debugging.
+API struct ncplane* ncplane_new(struct ncplane* n, int rows, int cols,
+                                int y, int x, void* opaque, const char* name);
 
 // Create a plane bound to 'n', and aligned relative to it using 'align'.
 API struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols,
-                                    int yoff, ncalign_e align, void* opaque);
-
-// Create a named plane ala ncplane_aligned(). Names are used only for debugging.
-API struct ncplane* ncplane_aligned_named(struct ncplane* n, int rows, int cols,
-                                          int yoff, ncalign_e align,
-                                          void* opaque, const char* name);
+                                    int yoff, ncalign_e align, void* opaque,
+                                    const char* name);
 
 // Plane 'n' will be unbound from its parent plane, if it is currently bound,
 // and will be made a bound child of 'newparent', if 'newparent' is not NULL.

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -73,12 +73,8 @@ typedef enum {
   NCALIGN_CENTER,
   NCALIGN_RIGHT,
 } ncalign_e;
-struct ncplane* ncplane_new(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque);
-struct ncplane* ncplane_new_named(struct notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);
-struct ncplane* ncplane_bound(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque);
-struct ncplane* ncplane_bound_named(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);
-struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque);
-struct ncplane* ncplane_aligned_named(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque, const char* name);
+struct ncplane* ncplane_new(struct ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque, const char* name);
+struct ncplane* ncplane_aligned(struct ncplane* n, int rows, int cols, int yoff, ncalign_e align, void* opaque, const char* name);
 unsigned notcurses_supported_styles(const struct notcurses* nc);
 unsigned notcurses_palette_size(const struct notcurses* nc);
 bool notcurses_cantruecolor(const struct notcurses* nc);

--- a/src/demo/all.c
+++ b/src/demo/all.c
@@ -105,7 +105,7 @@ int allglyphs_demo(struct notcurses* nc){
   }
   const int planey = (dimy - height) / 2 + 1;
   struct ncplane* column = ncplane_aligned(n, height, width, planey,
-                                           NCALIGN_CENTER, NULL);
+                                           NCALIGN_CENTER, NULL, NULL);
   if(column == NULL){
     return -1;
   }

--- a/src/demo/eagle.c
+++ b/src/demo/eagle.c
@@ -25,6 +25,7 @@ const char eagle1[] =
 
 static struct ncplane*
 zoom_map(struct notcurses* nc, const char* map, int* ret){
+  struct ncplane* n = notcurses_stdplane(nc);
   *ret = -1;
   // determine size that will be represented on screen at once, and how
   // large that section has been rendered in the outzoomed map. take the map
@@ -80,7 +81,7 @@ zoom_map(struct notcurses* nc, const char* map, int* ret){
   while(vheight > truey || vwidth > truex){
     *ret = -1;
     ncplane_destroy(zncp);
-    if((zncp = ncplane_new(nc, truey, truex, 0, 0, NULL)) == NULL){
+    if((zncp = ncplane_new(n, truey, truex, 0, 0, NULL, NULL)) == NULL){
       ncvisual_destroy(ncv);
       return NULL;
     }
@@ -146,7 +147,7 @@ draw_eagle(struct ncplane* n, const char* sprite){
 }
 
 static int
-eagles(struct notcurses* nc){
+eagles(struct notcurses* nc, struct ncplane* n){
   int ret = 0;
   int truex, truey; // dimensions of true display
   notcurses_term_dim_yx(nc, &truey, &truex);
@@ -161,7 +162,7 @@ eagles(struct notcurses* nc){
   for(size_t i = 0 ; i < sizeof(e) / sizeof(*e) ; ++i){
     e[i].xoff = 0;
     e[i].yoff = random() % ((truey - height) / 2);
-    e[i].n = ncplane_new(nc, height, width, e[i].yoff, e[i].xoff, NULL);
+    e[i].n = ncplane_new(n, height, width, e[i].yoff, e[i].xoff, NULL, NULL);
     if(e[i].n == NULL){
       return -1;
     }
@@ -210,7 +211,8 @@ int eagle_demo(struct notcurses* nc){
     }
     free(map);
   }
-  err = eagles(nc);
+  struct ncplane* n = notcurses_stdplane(nc);
+  err = eagles(nc, n);
   ncplane_destroy(zncp);
   return err;
 }

--- a/src/demo/fallin.c
+++ b/src/demo/fallin.c
@@ -128,7 +128,7 @@ int fallin_demo(struct notcurses* nc){
       if(y + newy >= dimy){
         newy = dimy - y;
       }
-      struct ncplane* n = ncplane_new(nc, newy, newx, y, x, NULL);
+      struct ncplane* n = ncplane_new(stdn, newy, newx, y, x, NULL, NULL);
       if(n == NULL){
         goto err;
       }

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -73,7 +73,7 @@ about_toggle(struct notcurses* nc){
   int dimy;
   notcurses_term_dim_yx(nc, &dimy, NULL);
   struct ncplane* n = ncplane_aligned(notcurses_stdplane(nc), ABOUT_ROWS,
-                                      ABOUT_COLS, 3, NCALIGN_CENTER, NULL);
+                                      ABOUT_COLS, 3, NCALIGN_CENTER, NULL, NULL);
   // let the glyphs below show through, but only dimly
   uint64_t channels = 0;
   channels_set_fg_alpha(&channels, CELL_ALPHA_BLEND);
@@ -324,8 +324,8 @@ struct ncplane* hud_create(struct notcurses* nc){
   int dimx, dimy;
   notcurses_term_dim_yx(nc, &dimy, &dimx);
   int yoffset = dimy - HUD_ROWS;
-  struct ncplane* n = ncplane_new_named(nc, HUD_ROWS, HUD_COLS,
-                                        yoffset, 7, NULL, "hud");
+  struct ncplane* n = ncplane_new(notcurses_stdplane(nc), HUD_ROWS, HUD_COLS,
+                                  yoffset, 7, NULL, "hud");
   if(n == NULL){
     return NULL;
   }
@@ -531,9 +531,9 @@ int demo_render(struct notcurses* nc){
 int fpsgraph_init(struct notcurses* nc){
   const int PLOTHEIGHT = 6;
   int dimy, dimx;
-  notcurses_term_dim_yx(nc, &dimy, &dimx);
-  struct ncplane* newp = ncplane_new_named(nc, PLOTHEIGHT, dimx,
-                                           dimy - PLOTHEIGHT, 0, NULL, "fps");
+  struct ncplane* stdn = notcurses_stddim_yx(nc, &dimy, &dimx);
+  struct ncplane* newp = ncplane_new(stdn, PLOTHEIGHT, dimx,
+                                     dimy - PLOTHEIGHT, 0, NULL, "fps");
   uint32_t style = 0;
   uint64_t channels = 0;
   channels_set_fg_alpha(&channels, CELL_ALPHA_BLEND);

--- a/src/demo/luigi.c
+++ b/src/demo/luigi.c
@@ -168,7 +168,7 @@ int luigi_demo(struct notcurses* nc){
   int i;
   struct ncplane* lastseen = NULL;
   for(i = 0 ; i < 3 ; ++i){
-    lns[i] = ncplane_new(nc, height, 16, yoff, 0, NULL);
+    lns[i] = ncplane_new(notcurses_stdplane(nc), height, 16, yoff, 0, NULL, NULL);
     if(lns[i] == NULL){
       while(i--){
         ncplane_destroy(lns[i]);

--- a/src/demo/mojibake.c
+++ b/src/demo/mojibake.c
@@ -3391,7 +3391,7 @@ const char subdivision_flag[] =
 
 static struct ncplane*
 mojiplane(struct ncplane* title, int y, int rows, const char* summary){
-  struct ncplane* n = ncplane_aligned(title, rows, planewidth, y, NCALIGN_CENTER, NULL);
+  struct ncplane* n = ncplane_aligned(title, rows, planewidth, y, NCALIGN_CENTER, NULL, NULL);
   uint64_t channels = CHANNELS_RGB_INITIALIZER(0xf0, 0xa0, 0xf0, 0x10, 0x10, 0x60);
   if(ncplane_perimeter_rounded(n, 0, channels, NCBOXMASK_RIGHT) < 0){
     ncplane_destroy(n);
@@ -3545,7 +3545,7 @@ makegroup(struct ncplane* title, int y, const char* emoji, const char* name){
 
 struct ncplane*
 maketitle(struct ncplane* std){
-  struct ncplane* title = ncplane_aligned(std, 3, 74, 2, NCALIGN_CENTER, NULL);
+  struct ncplane* title = ncplane_aligned(std, 3, 74, 2, NCALIGN_CENTER, NULL, NULL);
   if(title == NULL){
     return NULL;
   }

--- a/src/demo/outro.c
+++ b/src/demo/outro.c
@@ -81,7 +81,7 @@ videothread(void* vnc){
   }
   ncfadectx_free(samoactx);
   ncplane_destroy(vopts.n);
-  struct ncplane* apiap = ncplane_new(nc, 1, cols, rows - 1, 0, NULL);
+  struct ncplane* apiap = ncplane_new(ncp, 1, cols, 1, 0, NULL, NULL);
   if(apiap == NULL){
     ncfadectx_free(samoactx);
     ncplane_destroy(vopts.n);
@@ -113,7 +113,7 @@ outro_message(struct notcurses* nc, int* rows, int* cols){
   int ystart = *rows - 6;
   struct ncplane* non = ncplane_aligned(notcurses_stdplane(nc), 5,
                                         strlen(str1) + 4, ystart,
-                                        NCALIGN_CENTER, NULL);
+                                        NCALIGN_CENTER, NULL, NULL);
   if(non == NULL){
     return NULL;
   }

--- a/src/demo/reel.c
+++ b/src/demo/reel.c
@@ -195,7 +195,7 @@ ncreel_demo_core(struct notcurses* nc){
   int x = 8, y = 4;
   int dimy, dimx;
   struct ncplane* std = notcurses_stddim_yx(nc, &dimy, &dimx);
-  struct ncplane* w = ncplane_new(nc, dimy - 12, dimx - 16, y, x, NULL);
+  struct ncplane* w = ncplane_new(std, dimy - 12, dimx - 16, y, x, NULL, NULL);
   if(w == NULL){
     return -1;
   }

--- a/src/demo/sliding.c
+++ b/src/demo/sliding.c
@@ -170,8 +170,8 @@ int sliding_puzzle_demo(struct notcurses* nc){
     for(cx = 0 ; cx < CHUNKS_HORZ ; ++cx){
       const int idx = cy * CHUNKS_HORZ + cx;
       chunks[idx] =
-        ncplane_new(nc, chunky, chunkx, cy * chunky + wastey + 1,
-                    cx * chunkx + wastex + 1, NULL);
+        ncplane_new(n, chunky, chunkx, cy * chunky + wastey + 1,
+                    cx * chunkx + wastex + 1, NULL, NULL);
       if(chunks[idx] == NULL){
         goto done;
       }

--- a/src/demo/trans.c
+++ b/src/demo/trans.c
@@ -30,7 +30,7 @@ legend(struct notcurses* nc, const char* msg){
   notcurses_term_dim_yx(nc, &dimy, &dimx);
   struct ncplane* n = ncplane_aligned(notcurses_stdplane(nc), 3,
                                       strlen(msg) + 4, 3,
-                                      NCALIGN_CENTER, NULL);
+                                      NCALIGN_CENTER, NULL, NULL);
   if(n == NULL){
     return NULL;
   }
@@ -93,7 +93,7 @@ slideitslideit(struct notcurses* nc, struct ncplane* n, uint64_t deadline,
 
 // run panels atop the display in an exploration of transparency
 static int
-slidepanel(struct notcurses* nc){
+slidepanel(struct notcurses* nc, struct ncplane* stdn){
   int dimy, dimx;
   notcurses_term_dim_yx(nc, &dimy, &dimx);
   int ny = dimy / 4;
@@ -103,7 +103,7 @@ slidepanel(struct notcurses* nc){
   struct ncplane* l;
 
   // First we just create a plane with no styling and no glyphs.
-  struct ncplane* n = ncplane_new(nc, ny, nx, yoff, xoff, NULL);
+  struct ncplane* n = ncplane_new(stdn, ny, nx, yoff, xoff, NULL, NULL);
 
   // Zero-initialized channels use the default color, opaquely. Since we have
   // no glyph, we should show underlying glyphs in the default colors. The
@@ -274,5 +274,5 @@ int trans_demo(struct notcurses* nc){
     }
     ncplane_destroy(l);
   }
-  return slidepanel(nc);
+  return slidepanel(nc, n);
 }

--- a/src/demo/unicodeblocks.c
+++ b/src/demo/unicodeblocks.c
@@ -188,7 +188,7 @@ int unicodeblocks_demo(struct notcurses* nc){
   ns_to_timespec(nstotal / 5, &subdelay);
   struct ncplane* header = ncplane_aligned(notcurses_stdplane(nc), 2,
                                            (CHUNKSIZE * 2) - 2, 2,
-                                           NCALIGN_CENTER, NULL);
+                                           NCALIGN_CENTER, NULL, NULL);
   if(header == NULL){
     return -1;
   }
@@ -210,7 +210,7 @@ int unicodeblocks_demo(struct notcurses* nc){
     }
     struct ncplane* nn;
     if((nn = ncplane_aligned(notcurses_stdplane(nc), BLOCKSIZE / CHUNKSIZE + 2,
-                             (CHUNKSIZE * 2) + 2, 4, NCALIGN_CENTER, NULL)) == NULL){
+                             (CHUNKSIZE * 2) + 2, 4, NCALIGN_CENTER, NULL, NULL)) == NULL){
       return -1;
     }
     if(draw_block(nn, blockstart)){

--- a/src/demo/view.c
+++ b/src/demo/view.c
@@ -23,8 +23,8 @@ view_video_demo(struct notcurses* nc){
 }
 
 static struct ncplane*
-legend(struct notcurses* nc, int dimy, int dimx){
-  struct ncplane* n = ncplane_new(nc, 4, 25, dimy / 8 - 1, (dimx - 25) / 2, NULL);
+legend(struct ncplane* stdn, int dimy, int dimx){
+  struct ncplane* n = ncplane_new(stdn, 4, 25, dimy / 8 - 1, (dimx - 25) / 2, NULL, NULL);
   ncplane_set_bg_alpha(n, CELL_ALPHA_TRANSPARENT);
   uint64_t channels = 0;
   channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
@@ -63,7 +63,7 @@ view_images(struct notcurses* nc, struct ncplane* nstd, int dimy, int dimx){
   ncplane_erase(nstd);
   // standard plane gets PurpleDrank (which will cover the plane), but first
   // serves as a blocker behind dsplane, which gets the DSSCAW logo.
-  struct ncplane* dsplane = ncplane_new(nc, dimy, dimx, 0, 0, NULL);
+  struct ncplane* dsplane = ncplane_new(nstd, dimy, dimx, 0, 0, NULL, NULL);
   if(dsplane == NULL){
     return -1;
   }
@@ -129,7 +129,7 @@ int view_demo(struct notcurses* nc){
   if(ret){
     return ret;
   }
-  struct ncplane* ncpl = legend(nc, dimy, dimx);
+  struct ncplane* ncpl = legend(nstd, dimy, dimx);
   if(ncpl == NULL){
     return -1;
   }

--- a/src/demo/whiteout.c
+++ b/src/demo/whiteout.c
@@ -13,11 +13,12 @@
 
 static struct ncplane*
 mathplane(struct notcurses* nc){
+  struct ncplane* stdn = notcurses_stdplane(nc);
   int dimx, dimy;
   notcurses_term_dim_yx(nc, &dimy, &dimx);
   const int HEIGHT = 9;
   const int WIDTH = dimx;
-  struct ncplane* n = ncplane_new(nc, HEIGHT, WIDTH, dimy - HEIGHT - 1, dimx - WIDTH, NULL);
+  struct ncplane* n = ncplane_new(stdn, HEIGHT, WIDTH, dimy - HEIGHT - 1, dimx - WIDTH, NULL, NULL);
   uint64_t channels = 0;
   channels_set_fg_rgb(&channels, 0x2b50c8); // metallic gold, inverted
   channels_set_fg_alpha(&channels, CELL_ALPHA_BLEND);
@@ -529,7 +530,7 @@ int witherworm_demo(struct notcurses* nc){
       if(math == NULL){
         return -1;
       }
-      struct ncplane* mess = ncplane_new(nc, 7, 57, 2, 4, NULL);
+      struct ncplane* mess = ncplane_new(n, 7, 57, 2, 4, NULL, NULL);
       if(mess == NULL){
         ncplane_destroy(math);
         return -1;

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -21,7 +21,8 @@ make_slider(struct notcurses* nc, int dimy, int dimx){
   const int len = strlen(leg[0]);
   const int REPS = 600 / len + dimx / len;
   int y = dimy - sizeof(leg) / sizeof(*leg);
-  struct ncplane* n = ncplane_new(nc, sizeof(leg) / sizeof(*leg), len * REPS, y, 0, NULL);
+  struct ncplane* n = ncplane_new(notcurses_stdplane(nc), sizeof(leg) / sizeof(*leg),
+                                  len * REPS, y, 0, NULL, NULL);
   uint64_t channels = 0;
   channels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
   channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
@@ -74,7 +75,7 @@ int xray_demo(struct notcurses* nc){
   }
   int dimx, dimy;
   notcurses_term_dim_yx(nc, &dimy, &dimx);
-  struct ncplane* n = ncplane_new(nc, dimy, dimx, 0, 0, NULL);
+  struct ncplane* n = ncplane_new(notcurses_stdplane(nc), dimy, dimx, 0, 0, NULL, NULL);
   if(n == NULL){
     return -1;
   }

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -378,7 +378,7 @@ reader_demo(struct notcurses* nc){
   const int x = ncplane_align(std, NCALIGN_CENTER, READER_COLS);
   struct ncselector* selector = NULL;
   struct ncmultiselector* mselector = NULL;
-  struct ncplane* rp = ncplane_new(std, READER_ROWS, READER_COLS, dimy, x, NULL, NULL);
+  struct ncplane* rp = ncplane_new(std, READER_ROWS, READER_COLS, dimy, x, NULL, "read");
   ncplane_set_base(rp, " ", 0, echannels);
   struct ncreader* reader = ncreader_create(rp, &nopts);
   if(reader == NULL){

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -77,7 +77,7 @@ multiselector_demo(struct ncplane* n, struct ncplane* under, int y){
   uint64_t bgchannels = CHANNELS_RGB_INITIALIZER(0, 0x40, 0, 0, 0x40, 0);
   channels_set_fg_alpha(&bgchannels, CELL_ALPHA_BLEND);
   channels_set_bg_alpha(&bgchannels, CELL_ALPHA_BLEND);
-  struct ncplane* mseln = ncplane_new(ncplane_notcurses(n), 1, 1, y, 0, NULL);
+  struct ncplane* mseln = ncplane_new(n, 1, 1, y, 0, NULL, NULL);
   if(mseln == NULL){
     return NULL;
   }
@@ -107,7 +107,7 @@ selector_demo(struct ncplane* n, struct ncplane* under, int dimx, int y){
   uint64_t bgchannels = CHANNELS_RGB_INITIALIZER(0, 0, 0x40, 0, 0, 0x40);
   channels_set_fg_alpha(&bgchannels, CELL_ALPHA_BLEND);
   channels_set_bg_alpha(&bgchannels, CELL_ALPHA_BLEND);
-  struct ncplane* seln = ncplane_new(ncplane_notcurses(n), 1, 1, y, dimx, NULL);
+  struct ncplane* seln = ncplane_new(n, 1, 1, y, dimx, NULL, NULL);
   if(seln == NULL){
     return NULL;
   }
@@ -378,7 +378,7 @@ reader_demo(struct notcurses* nc){
   const int x = ncplane_align(std, NCALIGN_CENTER, READER_COLS);
   struct ncselector* selector = NULL;
   struct ncmultiselector* mselector = NULL;
-  struct ncplane* rp = ncplane_new(nc, READER_ROWS, READER_COLS, dimy, x, NULL);
+  struct ncplane* rp = ncplane_new(std, READER_ROWS, READER_COLS, dimy, x, NULL, NULL);
   ncplane_set_base(rp, " ", 0, echannels);
   struct ncreader* reader = ncreader_create(rp, &nopts);
   if(reader == NULL){

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -320,7 +320,7 @@ infoplane(struct ncdirect* ncd, const fetched_info* fi){
   struct ncplane* infop = ncplane_aligned(std,
                                           planeheight, planewidth,
                                           dimy - planeheight,
-                                          NCALIGN_CENTER, NULL);
+                                          NCALIGN_CENTER, NULL, "info");
   if(infop == NULL){
     return -1;
   }

--- a/src/lib/fill.c
+++ b/src/lib/fill.c
@@ -477,7 +477,7 @@ rotate_merge(ncplane* n, ncplane* newp){
 
 // generate a temporary plane that can hold the contents of n, rotated 90°
 static ncplane*
-rotate_plane(const ncplane* n){
+rotate_plane(ncplane* n){
   int absy, absx;
   ncplane_yx(n, &absy, &absx);
   int dimy, dimx;
@@ -487,7 +487,7 @@ rotate_plane(const ncplane* n){
   }
   const int newy = dimx / 2;
   const int newx = dimy * 2;
-  ncplane* newp = ncplane_new(n->nc, newy, newx, absy, absx, n->userptr);
+  ncplane* newp = ncplane_new(n, newy, newx, absy, absx, n->userptr, "copy");
   return newp;
 }
 

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -312,7 +312,7 @@ ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
         totalwidth = dimx;
       }
       int ypos = ret->bottom ? dimy - totalheight : 0;
-      ret->ncp = ncplane_new_named(n->nc, totalheight, totalwidth, ypos, 0, NULL, "menu");
+      ret->ncp = ncplane_new(n, totalheight, totalwidth, ypos, 0, NULL, "menu");
       if(ret->ncp){
         ret->unrolledsection = -1;
         ret->headerchannels = opts->headerchannels;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -325,7 +325,7 @@ ncplane* ncplane_create(notcurses* nc, ncplane* n, int rows, int cols,
     }
     p->bprev = &n->blist;
     *p->bprev = p;
-  }else{
+  }else{ // new standard plane
     p->absx = xoff + (nc ? nc->margin_l : 0);
     p->absy = yoff + (nc ? nc->margin_t : 0);
     p->bnext = NULL;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -372,34 +372,14 @@ const ncplane* notcurses_stdplane_const(const notcurses* nc){
   return nc->stdplane;
 }
 
-ncplane* ncplane_new(notcurses* nc, int rows, int cols, int yoff, int xoff, void* opaque){
-  return ncplane_create(nc, nc->stdplane, rows, cols, yoff, xoff, opaque, NULL);
+ncplane* ncplane_new(ncplane* n, int rows, int cols, int y, int x,
+                     void* opaque, const char* name){
+  return ncplane_create(n->nc, n, rows, cols, y, x, opaque, name);
 }
 
-ncplane* ncplane_new_named(notcurses* nc, int rows, int cols, int yoff,
-                           int xoff, void* opaque, const char* name){
-  return ncplane_create(nc, nc->stdplane, rows, cols, yoff, xoff, opaque, name);
-}
-
-ncplane* ncplane_bound(ncplane* n, int rows, int cols, int yoff, int xoff, void* opaque){
-  return ncplane_create(n->nc, n, rows, cols, yoff, xoff, opaque, NULL);
-}
-
-ncplane* ncplane_bound_named(ncplane* n, int rows, int cols, int yoff, int xoff,
-                             void* opaque, const char* name){
-  return ncplane_create(n->nc, n, rows, cols, yoff, xoff, opaque, name);
-}
-
-ncplane* ncplane_aligned(ncplane* n, int rows, int cols, int yoff,
-                         ncalign_e align, void* opaque){
-  return ncplane_create(n->nc, n, rows, cols, yoff,
-                        ncplane_align(n, align, cols), opaque, NULL);
-}
-
-ncplane* ncplane_aligned_named(ncplane* n, int rows, int cols, int yoff,
-                               ncalign_e align, void* opaque, const char* name){
-  return ncplane_create(n->nc, n, rows, cols, yoff,
-                        ncplane_align(n, align, cols), opaque, name);
+ncplane* ncplane_aligned(ncplane* n, int rows, int cols, int y,
+                         ncalign_e align, void* opaque, const char* name){
+  return ncplane_create(n->nc, n, rows, cols, y, ncplane_align(n, align, cols), opaque, name);
 }
 
 void ncplane_home(ncplane* n){

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -16,12 +16,14 @@ ncreader* ncreader_create(ncplane* n, const ncreader_options* opts){
   nr->ncp = n;
   // do *not* bind it to the visible plane; we always want it offscreen,
   // to the upper left of the true origin
-  if((nr->textarea = ncplane_new(n, ncplane_dim_y(n), ncplane_dim_x(n),
-                      -ncplane_dim_y(n), -ncplane_dim_x(n), NULL, "text")) == NULL){
+  if((nr->textarea = ncplane_new(notcurses_stdplane(ncplane_notcurses(n)),
+                                 ncplane_dim_y(n), ncplane_dim_x(n),
+                                 -ncplane_dim_y(n), -ncplane_dim_x(n), NULL, "text")) == NULL){
     ncplane_destroy(nr->ncp);
     free(nr);
     return NULL;
   }
+
   nr->horscroll = opts->flags & NCREADER_OPTION_HORSCROLL;
   nr->xproject = 0;
   nr->tchannels = opts->tchannels;

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -16,8 +16,8 @@ ncreader* ncreader_create(ncplane* n, const ncreader_options* opts){
   nr->ncp = n;
   // do *not* bind it to the visible plane; we always want it offscreen,
   // to the upper left of the true origin
-  if((nr->textarea = ncplane_new(n->nc, ncplane_dim_y(n), ncplane_dim_x(n),
-                                 -ncplane_dim_y(n), -ncplane_dim_x(n), NULL)) == NULL){
+  if((nr->textarea = ncplane_new(n, ncplane_dim_y(n), ncplane_dim_x(n),
+                      -ncplane_dim_y(n), -ncplane_dim_x(n), NULL, "text")) == NULL){
     ncplane_destroy(nr->ncp);
     free(nr);
     return NULL;

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -257,7 +257,7 @@ ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiertop,
     return -1;
   }
 //fprintf(stderr, "tplacement: %p base %d/%d len %d/%d frontiery %d %d dir %d\n", t, begy, begx, leny, lenx, frontiertop, frontierbottom, direction);
-  ncplane* fp = ncplane_bound_named(nr->p, leny, lenx, begy, begx, NULL, "tab");
+  ncplane* fp = ncplane_new(nr->p, leny, lenx, begy, begx, NULL, "tab");
   if((t->p = fp) == NULL){
 //fprintf(stderr, "failure creating border plane %d %d %d %d\n", leny, lenx, begy, begx);
     return -1;
@@ -276,7 +276,7 @@ ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiertop,
     ++cbx;
   }
   if(cbleny - cby + 1 > 0){
-    t->cbp = ncplane_bound_named(t->p, cbleny - cby + 1, cblenx - cbx + 1, cby, cbx, NULL, "tdat");
+    t->cbp = ncplane_new(t->p, cbleny - cby + 1, cblenx - cbx + 1, cby, cbx, NULL, "tdat");
     if(t->cbp == NULL){
 //fprintf(stderr, "failure creating data plane %d %d %d %d\n", cbleny - cby + 1, cblenx - cbx + 1, cby, cbx);
       ncplane_destroy(t->p);

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -413,8 +413,8 @@ auto ncvisual_render(notcurses* nc, ncvisual* ncv,
       }
     }
 //fprintf(stderr, "PLACING NEW PLANE: %d/%d @ %d/%d\n", disprows, dispcols, placey, placex);
-    n = ncplane_new(nc, disprows / encoding_y_scale(bset),
-                    dispcols / encoding_x_scale(bset), placey, placex, nullptr);
+    n = ncplane_new(notcurses_stdplane(nc), disprows / encoding_y_scale(bset),
+                    dispcols / encoding_x_scale(bset), placey, placex, nullptr, "vis");
     if(n == nullptr){
       return nullptr;
     }

--- a/src/ncreel/main.cpp
+++ b/src/ncreel/main.cpp
@@ -200,7 +200,7 @@ int main(int argc, char** argv){
   if(ncplane_putstr_aligned(nstd, 0, NCALIGN_CENTER, "(a)dd (d)el (+/-) change lines (q)uit") <= 0){
     return -1;
   }
-  n = ncplane_new(nc, dimy - 1, dimx, 1, 0, nullptr);
+  n = ncplane_new(nstd, dimy - 1, dimx, 1, 0, nullptr, "reel");
   if(!n){
     return -1;
   }

--- a/src/poc/menu.c
+++ b/src/poc/menu.c
@@ -6,7 +6,7 @@
 
 static int
 run_menu(struct notcurses* nc, struct ncmenu* ncm){
-  struct ncplane* selplane = ncplane_aligned(notcurses_stdplane(nc), 3, 40, 10, NCALIGN_CENTER, NULL);
+  struct ncplane* selplane = ncplane_aligned(notcurses_stdplane(nc), 3, 40, 10, NCALIGN_CENTER, NULL, NULL);
   if(selplane == NULL){
     return -1;
   }

--- a/src/poc/multiselect.c
+++ b/src/poc/multiselect.c
@@ -106,7 +106,7 @@ int main(void){
 
   ncplane_set_fg_rgb(n, 0x40f040);
   ncplane_putstr_aligned(n, 0, NCALIGN_RIGHT, "multiselect widget demo");
-  struct ncplane* mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  struct ncplane* mseln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   if(mseln == NULL){
     goto err;
   }
@@ -115,14 +115,14 @@ int main(void){
   run_mselect(nc, ns);
 
   sopts.title = "short round title";
-  mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  mseln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   ncplane_set_base(mseln, "", 0, bgchannels);
   ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
 
   sopts.title = "short round title";
   sopts.secondary = "now this secondary is also very, very, very outlandishly long, you see";
-  mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  mseln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   ncplane_set_base(mseln, "", 0, bgchannels);
   ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
@@ -130,7 +130,7 @@ int main(void){
   sopts.title = "the whole world is watching";
   sopts.secondary = NULL;
   sopts.footer = "now this FOOTERFOOTER is also very, very, very outlandishly long, you see";
-  mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  mseln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   ncplane_set_base(mseln, "", 0, bgchannels);
   ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);
@@ -138,7 +138,7 @@ int main(void){
   sopts.title = "chomps";
   sopts.secondary = NULL;
   sopts.footer = NULL;
-  mseln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  mseln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   ncplane_set_base(mseln, "", 0, bgchannels);
   ns = ncmultiselector_create(mseln, &sopts);
   run_mselect(nc, ns);

--- a/src/poc/reader.cpp
+++ b/src/poc/reader.cpp
@@ -36,7 +36,7 @@ auto main(int argc, const char** argv) -> int {
   ncreader_options opts{};
   opts.flags = NCREADER_OPTION_CURSOR | (horscroll ? NCREADER_OPTION_HORSCROLL : 0);
   // can't use Plane until we have move constructor for Reader
-  struct ncplane* rp = ncplane_new(nc, dimy / 8, dimx / 2, 2, 2, nullptr);
+  struct ncplane* rp = ncplane_new(**n, dimy / 8, dimx / 2, 2, 2, nullptr, "read");
   ncplane_set_base(rp, "░", 0, 0);
   auto nr = ncreader_create(rp, &opts);
   if(nr == nullptr){

--- a/src/poc/selector.c
+++ b/src/poc/selector.c
@@ -98,20 +98,20 @@ int main(void){
 
   ncplane_set_fg_rgb(n, 0x40f040);
   ncplane_putstr_aligned(n, 0, NCALIGN_RIGHT, "selector widget demo");
-  struct ncplane* seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  struct ncplane* seln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   ncplane_set_base(seln, "", 0, bgchannels);
   struct ncselector* ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
   sopts.title = "short round title";
-  seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  seln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   ncplane_set_base(seln, "", 0, bgchannels);
   ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
 
   sopts.title = "short round title";
   sopts.secondary = "now this secondary is also very, very, very outlandishly long, you see";
-  seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  seln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   ncplane_set_base(seln, "", 0, bgchannels);
   ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
@@ -119,7 +119,7 @@ int main(void){
   sopts.title = "the whole world is watching";
   sopts.secondary = NULL;
   sopts.footer = "now this FOOTERFOOTER is also very, very, very outlandishly long, you see";
-  seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  seln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   ncplane_set_base(seln, "", 0, bgchannels);
   ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);
@@ -127,7 +127,7 @@ int main(void){
   sopts.title = "chomps";
   sopts.secondary = NULL;
   sopts.footer = NULL;
-  seln = ncplane_new(nc, 1, 1, 3, 0, NULL);
+  seln = ncplane_new(n, 1, 1, 3, 0, NULL, NULL);
   ncplane_set_base(seln, "", 0, bgchannels);
   ns = ncselector_create(seln, &sopts);
   run_selector(nc, ns);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -73,7 +73,8 @@ auto perframe(struct ncvisual* ncv, struct ncvisual_options* vopts,
     if(!subtitle_plane){
       int dimx, dimy;
       ncplane_dim_yx(vopts->n, &dimy, &dimx);
-      subtitle_plane = ncplane_new(nc, 1, dimx, dimy - 1, 0, nullptr);
+      subtitle_plane = ncplane_new(notcurses_stdplane(nc), 1, dimx,
+                                   dimy - 1, 0, nullptr, "subt");
       uint64_t channels = 0;
       channels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
       channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -145,7 +145,7 @@ TEST_CASE("Cell") {
     CHECK(0 == cell_set_fg_rgb8(&c, 0xff, 0xff, 0xff));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
-    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    auto np = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
     cell_load_char(np, &c, '*');
@@ -174,7 +174,7 @@ TEST_CASE("Cell") {
     CHECK(0 == cell_set_fg_rgb8(&c, 0xff, 0xff, 0xff));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
-    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    auto np = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
     cell_load_char(np, &c, '*');
@@ -203,7 +203,7 @@ TEST_CASE("Cell") {
     CHECK(0 == cell_set_fg_rgb8(&c, 0x0, 0x0, 0x0));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
-    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    auto np = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
     cell_load_char(np, &c, '*');
@@ -232,7 +232,7 @@ TEST_CASE("Cell") {
     CHECK(0 == cell_set_fg_rgb8(&c, 0x0, 0x0, 0x0));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_HIGHCONTRAST));
     CHECK(0 == cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT));
-    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    auto np = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
     cell_load_char(np, &c, '*');
@@ -262,7 +262,7 @@ TEST_CASE("Cell") {
     // top has a background of white
     CHECK(0 == cell_set_bg_rgb8(&c, 0xff, 0xff, 0xff));
     CHECK(0 == cell_set_fg_alpha(&c, CELL_ALPHA_TRANSPARENT));
-    auto np = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    auto np = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != np);
     CHECK(1 == ncplane_putc(np, &c));
     cell_load_char(n_, &c, '*');

--- a/tests/fills.cpp
+++ b/tests/fills.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Fills") {
 
   SUBCASE("PolyfillOnGlyph") {
     cell c = CELL_CHAR_INITIALIZER('+');
-    struct ncplane* pfn = ncplane_new(nc_, 4, 4, 0, 0, nullptr);
+    struct ncplane* pfn = ncplane_new(n_, 4, 4, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != pfn);
     CHECK(16 == ncplane_polyfill_yx(pfn, 0, 0, &c));
     CHECK(0 == notcurses_render(nc_));
@@ -56,7 +56,7 @@ TEST_CASE("Fills") {
 
   SUBCASE("PolyfillEmptyPlane") {
     cell c = CELL_CHAR_INITIALIZER('+');
-    struct ncplane* pfn = ncplane_new(nc_, 20, 20, 0, 0, nullptr);
+    struct ncplane* pfn = ncplane_new(n_, 20, 20, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != pfn);
     CHECK(400 == ncplane_polyfill_yx(pfn, 0, 0, &c));
     CHECK(0 == notcurses_render(nc_));
@@ -65,7 +65,7 @@ TEST_CASE("Fills") {
 
   SUBCASE("PolyfillWalledPlane") {
     cell c = CELL_CHAR_INITIALIZER('+');
-    struct ncplane* pfn = ncplane_new(nc_, 4, 4, 0, 0, nullptr);
+    struct ncplane* pfn = ncplane_new(n_, 4, 4, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != pfn);
     CHECK(0 < ncplane_putc_yx(pfn, 0, 1, &c));
     CHECK(0 < ncplane_putc_yx(pfn, 1, 1, &c));
@@ -326,7 +326,7 @@ TEST_CASE("Fills") {
   }
 
   SUBCASE("MergeDownASCII") {
-    auto p1 = ncplane_new(nc_, 1, 10, 0, 0, nullptr);
+    auto p1 = ncplane_new(n_, 1, 10, 0, 0, nullptr, nullptr);
     REQUIRE(p1);
     // make sure glyphs replace nulls
     CHECK(0 < ncplane_putstr(p1, "0123456789"));
@@ -348,7 +348,7 @@ TEST_CASE("Fills") {
       CHECK(0 == cellcmp(n_, &cbase, p1, &cp));
     }
     // make sure nulls do not replace glyphs
-    auto p2 = ncplane_new(nc_, 1, 10, 0, 0, nullptr);
+    auto p2 = ncplane_new(n_, 1, 10, 0, 0, nullptr, nullptr);
     CHECK(0 == ncplane_mergedown_simple(p2, n_));
     ncplane_destroy(p2);
     for(int i = 0 ; i < 10 ; ++i){
@@ -360,7 +360,7 @@ TEST_CASE("Fills") {
   }
 
   SUBCASE("MergeDownUni") {
-    auto p1 = ncplane_new(nc_, 1, 10, 0, 0, nullptr);
+    auto p1 = ncplane_new(n_, 1, 10, 0, 0, nullptr, nullptr);
     REQUIRE(p1);
     // make sure glyphs replace nulls
     CHECK(0 < ncplane_putstr(p1, "█▀▄▌▐🞵🞶🞷🞸🞹"));
@@ -374,7 +374,7 @@ TEST_CASE("Fills") {
     }
     ncplane_destroy(p1);
     CHECK(0 == notcurses_render(nc_));
-    auto p3 = ncplane_new(nc_, 1, 10, 0, 0, nullptr);
+    auto p3 = ncplane_new(n_, 1, 10, 0, 0, nullptr, nullptr);
     CHECK(0 == ncplane_cursor_move_yx(p3, 0, 0));
     // make sure glyphs replace glyps
     CHECK(0 < ncplane_putstr(p3, "🞵🞶🞷🞸🞹█▀▄▌▐"));
@@ -387,7 +387,7 @@ TEST_CASE("Fills") {
     }
     CHECK(0 == notcurses_render(nc_));
     // make sure nulls do not replace glyphs
-    auto p2 = ncplane_new(nc_, 1, 10, 0, 0, nullptr);
+    auto p2 = ncplane_new(n_, 1, 10, 0, 0, nullptr, nullptr);
     CHECK(0 == ncplane_mergedown_simple(p2, nullptr));
     ncplane_destroy(p2);
     for(int i = 0 ; i < 10 ; ++i){
@@ -404,7 +404,7 @@ TEST_CASE("Fills") {
   SUBCASE("MergeDownSmallPlane") {
     constexpr int DIMX = 10;
     constexpr int DIMY = 10;
-    auto p1 = ncplane_new(nc_, DIMY, DIMX, 2, 2, nullptr);        // dst, 10x10
+    auto p1 = ncplane_new(n_, DIMY, DIMX, 2, 2, nullptr, nullptr);        // dst, 10x10
     REQUIRE(p1);
     cell c1 = CELL_TRIVIAL_INITIALIZER;
     CHECK(0 < cell_load(p1, &c1, "█"));
@@ -412,7 +412,7 @@ TEST_CASE("Fills") {
     CHECK(0 == cell_set_fg_rgb(&c1, 0x0000ff));
     CHECK(0 < ncplane_polyfill_yx(p1, 0, 0, &c1));
     CHECK(0 == notcurses_render(nc_));
-    auto p2 = ncplane_new(nc_, DIMY / 2, DIMX / 2, 3, 3, nullptr);  // src, 5x5
+    auto p2 = ncplane_new(n_, DIMY / 2, DIMX / 2, 3, 3, nullptr, nullptr);  // src, 5x5
     REQUIRE(p2);
     cell c2 = CELL_TRIVIAL_INITIALIZER;
     CHECK(0 < cell_load(p2, &c2, "🞶"));
@@ -443,7 +443,7 @@ TEST_CASE("Fills") {
   SUBCASE("MergeDownSmallPlaneUni") {
     constexpr int DIMX = 10;
     constexpr int DIMY = 10;
-    auto p1 = ncplane_new(nc_, DIMY, DIMX, 2, 2, nullptr);
+    auto p1 = ncplane_new(n_, DIMY, DIMX, 2, 2, nullptr, nullptr);
     REQUIRE(p1);
     uint64_t ul = 0, ur = 0, bl = 0, br = 0;
     channels_set_fg_rgb(&ur, 0xff0000);
@@ -451,7 +451,7 @@ TEST_CASE("Fills") {
     channels_set_fg_rgb(&br, 0x0000ff);
     ncplane_highgradient_sized(p1, ul, ur, bl, br, DIMY, DIMX);
     CHECK(0 == notcurses_render(nc_));
-    auto p2 = ncplane_new(nc_, DIMY / 2, DIMX / 2, 3, 3, nullptr);
+    auto p2 = ncplane_new(n_, DIMY / 2, DIMX / 2, 3, 3, nullptr, nullptr);
     REQUIRE(p2);
     ncplane_highgradient_sized(p2, br, bl, ur, ul, DIMY / 2, DIMX / 2);
     CHECK(0 == ncplane_mergedown_simple(p2, p1));

--- a/tests/geom.cpp
+++ b/tests/geom.cpp
@@ -6,8 +6,8 @@ TEST_CASE("Geometry") {
   if(!nc_){
     return;
   }
-  ncplane* ncp_ = notcurses_stdplane(nc_);
-  REQUIRE(ncp_);
+  ncplane* n_ = notcurses_stdplane(nc_);
+  REQUIRE(n_);
 
   SUBCASE("Center") {
     const struct test {
@@ -24,7 +24,7 @@ TEST_CASE("Geometry") {
       { 0, 0, 0, 0, }
     }, *t;
     for(t = tests ; !t->leny ; ++t){
-      auto n = ncplane_new(nc_, t->leny, t->lenx, 0, 0, nullptr);
+      auto n = ncplane_new(n_, t->leny, t->lenx, 0, 0, nullptr, nullptr);
       REQUIRE(n);
       cell tl = CELL_TRIVIAL_INITIALIZER; cell tr = CELL_TRIVIAL_INITIALIZER;
       cell bl = CELL_TRIVIAL_INITIALIZER; cell br = CELL_TRIVIAL_INITIALIZER;
@@ -60,7 +60,7 @@ TEST_CASE("Geometry") {
       { 0, 0, 10, 20, 0, 0, }
     }, *t;
     for(t = tests ; !t->leny ; ++t){
-      auto n = ncplane_new(nc_, t->leny, t->lenx, t->absy, t->absx, nullptr);
+      auto n = ncplane_new(n_, t->leny, t->lenx, t->absy, t->absx, nullptr, nullptr);
       REQUIRE(n);
       cell tl = CELL_TRIVIAL_INITIALIZER; cell tr = CELL_TRIVIAL_INITIALIZER;
       cell bl = CELL_TRIVIAL_INITIALIZER; cell br = CELL_TRIVIAL_INITIALIZER;

--- a/tests/layout.cpp
+++ b/tests/layout.cpp
@@ -6,13 +6,13 @@ TEST_CASE("TextLayout") {
   if(!nc_){
     return;
   }
-  ncplane* ncp_ = notcurses_stdplane(nc_);
-  REQUIRE(ncp_);
+  ncplane* n_ = notcurses_stdplane(nc_);
+  REQUIRE(n_);
 
   const char str[] = "this is going to be broken up";
 
   SUBCASE("LayoutLeft") {
-    auto sp = ncplane_new(nc_, 2, 20, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 2, 20, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, str, &bytes));
@@ -26,7 +26,7 @@ TEST_CASE("TextLayout") {
   }
 
   SUBCASE("LayoutRight") {
-    auto sp = ncplane_new(nc_, 2, 20, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 2, 20, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_RIGHT, str, &bytes));
@@ -40,7 +40,7 @@ TEST_CASE("TextLayout") {
   }
 
   SUBCASE("LayoutCenter") {
-    auto sp = ncplane_new(nc_, 2, 20, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 2, 20, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, str, &bytes));
@@ -55,7 +55,7 @@ TEST_CASE("TextLayout") {
 
   // lay out text where a word ends on the boundary
   SUBCASE("LayoutOnBoundary") {
-    auto sp = ncplane_new(nc_, 3, 10, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 3, 10, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "my nuclear arms";
@@ -71,7 +71,7 @@ TEST_CASE("TextLayout") {
 
   // lay out text where a word crosses the boundary
   SUBCASE("LayoutCrossBoundary") {
-    auto sp = ncplane_new(nc_, 3, 10, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 3, 10, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "my grasping arms";
@@ -87,7 +87,7 @@ TEST_CASE("TextLayout") {
 
   // ensure we're honoring newlines
   SUBCASE("LayoutNewlines") {
-    auto sp = ncplane_new(nc_, 5, 5, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 5, 5, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "a\nb\nc\nd\ne";
@@ -103,7 +103,7 @@ TEST_CASE("TextLayout") {
 
   // ensure we're honoring newlines at the start/end of rows
   SUBCASE("LayoutNewlinesAtBorders") {
-    auto sp = ncplane_new(nc_, 5, 3, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 5, 3, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     const char boundstr[] = "ab\ncde\nfgh";
     size_t bytes;
@@ -120,7 +120,7 @@ TEST_CASE("TextLayout") {
   // lay out text where a wide word crosses the boundary
   SUBCASE("LayoutCrossBoundaryWide") {
     if(enforce_utf8()){
-      auto sp = ncplane_new(nc_, 2, 7, 0, 0, nullptr);
+      auto sp = ncplane_new(n_, 2, 7, 0, 0, nullptr, nullptr);
       REQUIRE(sp);
       size_t bytes;
       const char boundstr[] = "a 血的神";
@@ -138,7 +138,7 @@ TEST_CASE("TextLayout") {
   // a long word (one requiring a split no matter what) ought not force the
   // next line, but instead be printed where it starts
   SUBCASE("LayoutTransPlanar") {
-    auto sp = ncplane_new(nc_, 3, 10, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 3, 10, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "my thermonuclear arms";
@@ -156,7 +156,7 @@ TEST_CASE("TextLayout") {
   // next line, but instead be printed where it starts
   SUBCASE("LayoutTransPlanarWide") {
     if(enforce_utf8()){
-      auto sp = ncplane_new(nc_, 3, 10, 0, 0, nullptr);
+      auto sp = ncplane_new(n_, 3, 10, 0, 0, nullptr, nullptr);
       REQUIRE(sp);
       size_t bytes;
       const char boundstr[] = "1 我能吞下玻璃";
@@ -172,7 +172,7 @@ TEST_CASE("TextLayout") {
   }
 
   SUBCASE("LayoutLeadingSpaces") {
-    auto sp = ncplane_new(nc_, 3, 18, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 3, 18, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "  \t\n my thermonuclear arms";
@@ -188,7 +188,7 @@ TEST_CASE("TextLayout") {
 
   // create a plane of two rows, and fill exactly one with one word
   SUBCASE("LayoutFills1DPlane") {
-    auto sp = ncplane_new(nc_, 2, 15, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 2, 15, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "quarkgluonfart ";
@@ -204,7 +204,7 @@ TEST_CASE("TextLayout") {
 
   // create a plane of two rows, and fill exactly one with words
   SUBCASE("LayoutFills1DPlaneWords") {
-    auto sp = ncplane_new(nc_, 2, 17, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 2, 17, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "quark gluon fart ";
@@ -220,7 +220,7 @@ TEST_CASE("TextLayout") {
 
   // create a plane of two rows, and exactly fill the first line
   SUBCASE("LayoutFillsSingleLine") {
-    auto sp = ncplane_new(nc_, 2, 13, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 2, 13, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "quantum balls";
@@ -236,7 +236,7 @@ TEST_CASE("TextLayout") {
 
   // create a plane of three rows, and exactly fill two with regular ol' words
   SUBCASE("LayoutFillsPlane") {
-    auto sp = ncplane_new(nc_, 3, 14, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 3, 14, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "quantum balls scratchy no?! ";
@@ -252,7 +252,7 @@ TEST_CASE("TextLayout") {
 
   // create a plane of three rows, and exactly fill two, with no spaces
   SUBCASE("LayoutFillsPlaneNoSpaces") {
-    auto sp = ncplane_new(nc_, 3, 6, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 3, 6, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "0123456789AB";
@@ -269,7 +269,7 @@ TEST_CASE("TextLayout") {
   // create a plane of three rows, and exactly fill two with wide chars
   SUBCASE("LayoutFillsPlaneWide") {
     if(enforce_utf8()){
-      auto sp = ncplane_new(nc_, 3, 7, 0, 0, nullptr);
+      auto sp = ncplane_new(n_, 3, 7, 0, 0, nullptr, nullptr);
       REQUIRE(sp);
       size_t bytes;
       const char boundstr[] = "我能吞 下玻璃 ";
@@ -287,7 +287,7 @@ TEST_CASE("TextLayout") {
   // if we don't have scrolling enabled, puttext() with more text than will
   // fit on the plane ought return error, but print what it can.
   SUBCASE("LayoutLongNoScroll") {
-    auto sp = ncplane_new(nc_, 2, 14, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 2, 14, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     const char boundstr[] = "quantum balls scratchy no?! truly! arrrrp";
@@ -303,7 +303,7 @@ TEST_CASE("TextLayout") {
   }
 
   SUBCASE("LayoutLongScroll") {
-    auto sp = ncplane_new(nc_, 2, 13, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, 2, 13, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     ncplane_set_scrolling(sp, true);
     size_t bytes;
@@ -327,7 +327,7 @@ TEST_CASE("TextLayout") {
       "neque ac ipsum viverra, vestibulum hendrerit leo consequat. Integer "
       "velit, pharetra sed nisl quis, porttitor ornare purus. Cras ac "
       "sollicitudin dolor, eget elementum dolor. Quisque lobortis sagittis.";
-    auto sp = ncplane_new(nc_, READER_ROWS, READER_COLS, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, READER_ROWS, READER_COLS, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     ncplane_home(sp);
@@ -351,7 +351,7 @@ TEST_CASE("TextLayout") {
       "NCFdplane streams a file descriptor, while NCSubproc spawns a subprocess and streams its output. "
       "A variety of plots are supported, and menus can be placed along the top and/or bottom of any plane.\n\n"
       "Widgets can be controlled with the keyboard and/or mouse. They are implemented atop ncplanes, and these planes can be manipulated like all others.";
-    auto sp = ncplane_new(nc_, READER_ROWS, READER_COLS, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, READER_ROWS, READER_COLS, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     ncplane_set_scrolling(sp, true);
     size_t bytes;
@@ -378,7 +378,7 @@ TEST_CASE("TextLayout") {
       "NCFdplane streams a file descriptor, while NCSubproc spawns a subprocess and streams its output. "
       "A variety of plots are supported, and menus can be placed along the top and/or bottom of any plane.\n\n"
       "Widgets can be controlled with the keyboard and/or mouse. They are implemented atop ncplanes, and these planes can be manipulated like all others.";
-    auto sp = ncplane_new(nc_, READER_ROWS, READER_COLS, 0, 0, nullptr);
+    auto sp = ncplane_new(n_, READER_ROWS, READER_COLS, 0, 0, nullptr, nullptr);
     REQUIRE(sp);
     size_t bytes;
     ncplane_home(sp);

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -373,7 +373,7 @@ TEST_CASE("NCPlane") {
     int x, y;
     void* sentinel = &x;
     notcurses_term_dim_yx(nc_, &y, &x);
-    struct ncplane* ncp = ncplane_new(nc_, y, x, 0, 0, sentinel);
+    struct ncplane* ncp = ncplane_new(n_, y, x, 0, 0, sentinel, nullptr);
     REQUIRE(ncp);
     CHECK(&x == ncplane_userptr(ncp));
     CHECK(sentinel == ncplane_set_userptr(ncp, nullptr));
@@ -389,7 +389,7 @@ TEST_CASE("NCPlane") {
   SUBCASE("NewPlaneSameSize") {
     int x, y;
     notcurses_term_dim_yx(nc_, &y, &x);
-    struct ncplane* ncp = ncplane_new(nc_, y, x, 0, 0, nullptr);
+    struct ncplane* ncp = ncplane_new(n_, y, x, 0, 0, nullptr, nullptr);
     REQUIRE(ncp);
     int px, py;
     ncplane_dim_yx(ncp, &py, &px);
@@ -406,7 +406,7 @@ TEST_CASE("NCPlane") {
     int maxx, maxy;
     int x = 0, y = 0;
     notcurses_term_dim_yx(nc_, &maxy, &maxx);
-    struct ncplane* newp = ncplane_new(nc_, maxy, maxx, y, x, nullptr);
+    struct ncplane* newp = ncplane_new(n_, maxy, maxx, y, x, nullptr, nullptr);
     REQUIRE(newp);
     CHECK(0 == notcurses_render(nc_));
     while(y > 4 && x > 4){
@@ -445,7 +445,7 @@ TEST_CASE("NCPlane") {
     notcurses_term_dim_yx(nc_, &dimy, &dimx);
     x = dimx / 2 - 1;
     y = dimy / 2 - 1;
-    struct ncplane* newp = ncplane_new(nc_, maxy, maxx, y, x, nullptr);
+    struct ncplane* newp = ncplane_new(n_, maxy, maxx, y, x, nullptr, nullptr);
     REQUIRE(newp);
     while(dimx - maxx > 4 && dimy - maxy > 4){
       maxx += 2;
@@ -680,7 +680,7 @@ TEST_CASE("NCPlane") {
     cell ul{}, ll{}, lr{}, ur{}, hl{}, vl{};
     int y, x;
     ncplane_yx(n_, &y, &x);
-    struct ncplane* ncp = ncplane_new(nc_, 2, 2, y, ncols - 3, nullptr);
+    struct ncplane* ncp = ncplane_new(n_, 2, 2, y, ncols - 3, nullptr, nullptr);
     REQUIRE(ncp);
     REQUIRE(0 == cells_rounded_box(ncp, 0, 0, &ul, &ur, &ll, &lr, &hl, &vl));
     CHECK(0 == ncplane_box(ncp, &ul, &ur, &ll, &lr, &hl, &vl, y + 1, x + 1, 0));
@@ -694,7 +694,7 @@ TEST_CASE("NCPlane") {
     cell ul{}, ll{}, lr{}, ur{}, hl{}, vl{};
     int y, x;
     ncplane_yx(n_, &y, &x);
-    struct ncplane* ncp = ncplane_new(nc_, 2, 2, y, x, nullptr);
+    struct ncplane* ncp = ncplane_new(n_, 2, 2, y, x, nullptr, nullptr);
     REQUIRE(ncp);
     REQUIRE(0 == cells_rounded_box(ncp, 0, 0, &ul, &ur, &ll, &lr, &hl, &vl));
     CHECK(0 == ncplane_box(ncp, &ul, &ur, &ll, &lr, &hl, &vl, y + 1, x + 1, 0));
@@ -741,7 +741,7 @@ TEST_CASE("NCPlane") {
   SUBCASE("MouseEvent") {
     int dimy, dimx;
     notcurses_stddim_yx(nc_, &dimy, &dimx);
-    struct ncplane* n = ncplane_new(nc_, 2, 2, 1, 1, nullptr);
+    struct ncplane* n = ncplane_new(n_, 2, 2, 1, 1, nullptr, nullptr);
     REQUIRE(n);
     ncinput ni{};
     ni.id = NCKEY_RELEASE;
@@ -763,9 +763,9 @@ TEST_CASE("NCPlane") {
   }
 
   SUBCASE("BoundPlaneMoves") {
-    struct ncplane* ndom = ncplane_new(nc_, 2, 2, 1, 1, nullptr);
+    struct ncplane* ndom = ncplane_new(n_, 2, 2, 1, 1, nullptr, nullptr);
     REQUIRE(ndom);
-    struct ncplane* nsub = ncplane_bound(ndom, 2, 2, 1, 1, nullptr);
+    struct ncplane* nsub = ncplane_new(ndom, 2, 2, 1, 1, nullptr, nullptr);
     REQUIRE(nsub);
     int absy, absx;
     ncplane_yx(nsub, &absy, &absx);
@@ -779,9 +779,9 @@ TEST_CASE("NCPlane") {
   }
 
   SUBCASE("BoundToPlaneMoves") { // bound plane ought move along with plane
-    struct ncplane* ndom = ncplane_new(nc_, 2, 2, 1, 1, nullptr);
+    struct ncplane* ndom = ncplane_new(n_, 2, 2, 1, 1, nullptr, nullptr);
     REQUIRE(ndom);
-    struct ncplane* nsub = ncplane_bound(ndom, 2, 2, 1, 1, nullptr);
+    struct ncplane* nsub = ncplane_new(ndom, 2, 2, 1, 1, nullptr, nullptr);
     REQUIRE(nsub);
     int absy, absx;
     ncplane_yx(nsub, &absy, &absx);
@@ -795,9 +795,9 @@ TEST_CASE("NCPlane") {
   }
 
   SUBCASE("UnboundPlaneMoves") { // unbound plane no longer gets pulled along
-    struct ncplane* ndom = ncplane_new(nc_, 2, 2, 1, 1, nullptr);
+    struct ncplane* ndom = ncplane_new(n_, 2, 2, 1, 1, nullptr, nullptr);
     REQUIRE(ndom);
-    struct ncplane* nsub = ncplane_bound(ndom, 2, 2, 1, 1, nullptr);
+    struct ncplane* nsub = ncplane_new(ndom, 2, 2, 1, 1, nullptr, nullptr);
     REQUIRE(nsub);
     int absy, absx;
     CHECK(0 == notcurses_render(nc_));
@@ -815,7 +815,7 @@ TEST_CASE("NCPlane") {
   }
 
   SUBCASE("NoReparentStdPlane") {
-    struct ncplane* ndom = ncplane_new(nc_, 2, 2, 1, 1, nullptr);
+    struct ncplane* ndom = ncplane_new(n_, 2, 2, 1, 1, nullptr, nullptr);
     REQUIRE(ndom);
     CHECK(!ncplane_reparent(n_, ndom)); // can't reparent standard plane
     CHECK(ncplane_reparent(ndom, n_)); // *can* reparent *to* standard plane

--- a/tests/notcurses.cpp
+++ b/tests/notcurses.cpp
@@ -71,7 +71,8 @@ TEST_CASE("NotcursesBase") {
     for(int y = 0 ; y < maxy ; ++y){
       for(int x = 0 ; x < maxx ; ++x){
         const auto idx = y * maxx + x;
-        planes[idx] = ncplane_new(nc_, 1, 1, y, x, &planesecrets[idx]);
+        planes[idx] = ncplane_new(notcurses_stdplane(nc_), 1, 1, y, x,
+                                  &planesecrets[idx], nullptr);
         REQUIRE(planes[idx]);
       }
     }

--- a/tests/reader.cpp
+++ b/tests/reader.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Readers") {
 
   SUBCASE("ReaderRender") {
     ncreader_options opts{};
-    auto ncp = ncplane_new(nc_, dimy / 2, dimx / 2, 0, 0, nullptr);
+    auto ncp = ncplane_new(notcurses_stdplane(nc_), dimy / 2, dimx / 2, 0, 0, nullptr, nullptr);
     uint64_t echannels = CHANNELS_RGB_INITIALIZER(0xff, 0x44, 0xff, 0, 0, 0);
     ncplane_set_base(ncp, enforce_utf8() ? strdup("▒") : strdup("x"), 0, echannels);
     auto nr = ncreader_create(ncp, &opts);

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -238,7 +238,7 @@ TEST_CASE("Reels") {
     notcurses_term_dim_yx(nc_, &dimy, &dimx);
     uint64_t channels = 0;
     channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
-    auto ncp = ncplane_new(nc_, dimy, dimx, 0, 0, nullptr);
+    auto ncp = ncplane_new(n_, dimy, dimx, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != ncp);
     CHECK(0 == ncplane_set_base(ncp, "", 0, channels));
     struct ncreel* nr = ncreel_create(n_, &r);

--- a/tests/resize.cpp
+++ b/tests/resize.cpp
@@ -23,7 +23,7 @@ TEST_CASE("Resize") {
   SUBCASE("ResizeShrink") {
     int y = dimy;
     int x = dimx;
-    struct ncplane* testn = ncplane_new(nc_, y, x, 0, 0, nullptr);
+    struct ncplane* testn = ncplane_new(n_, y, x, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != testn);
     REQUIRE(0 < ncplane_gradient_sized(testn, "V", 0, ul, ur, ll, lr, y, x));
     CHECK(0 == notcurses_render(nc_));
@@ -40,7 +40,7 @@ TEST_CASE("Resize") {
   SUBCASE("ResizeEnlarge") {
     int y = 2;
     int x = 2;
-    struct ncplane* testn = ncplane_new(nc_, y, x, 0, 0, nullptr);
+    struct ncplane* testn = ncplane_new(n_, y, x, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != testn);
     REQUIRE(0 < ncplane_gradient_sized(testn, "V", 0, ul, ur, ll, lr, y, x));
     CHECK(0 == notcurses_render(nc_));

--- a/tests/rotate.cpp
+++ b/tests/rotate.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Rotate") {
   channels_set_bg_rgb(&lr, 0xf040f0);
 
   SUBCASE("RotateTransparentCW") {
-    struct ncplane* testn = ncplane_new(nc_, 8, 16, dimy / 2, dimx / 2, nullptr);
+    struct ncplane* testn = ncplane_new(n_, 8, 16, dimy / 2, dimx / 2, nullptr, nullptr);
     uint64_t channels = 0;
     CHECK(0 == channels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT));
     CHECK(0 == channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT));
@@ -74,7 +74,7 @@ TEST_CASE("Rotate") {
 
   SUBCASE("RotateGradientCW") {
     // should be a square, and should remain a square through rotations
-    struct ncplane* testn = ncplane_new(nc_, 8, 16, dimy / 2, dimx / 2, nullptr);
+    struct ncplane* testn = ncplane_new(n_, 8, 16, dimy / 2, dimx / 2, nullptr, nullptr);
     REQUIRE(0 < ncplane_gradient_sized(testn, " ", 0, ul, ur, ll, lr, 8, 16));
     RotateCW(nc_, testn);
     CHECK(0 == ncplane_destroy(testn));
@@ -82,7 +82,7 @@ TEST_CASE("Rotate") {
 
   SUBCASE("RotateRectangleCW") {
     // should be a square, and should remain a square through rotations
-    struct ncplane* testn = ncplane_new(nc_, 8, 32, dimy / 2, dimx / 2, nullptr);
+    struct ncplane* testn = ncplane_new(n_, 8, 32, dimy / 2, dimx / 2, nullptr, nullptr);
     REQUIRE(0 < ncplane_gradient_sized(testn, " ", 0, ul, ur, ll, lr, 8, 32));
     RotateCW(nc_, testn);
     CHECK(0 == ncplane_destroy(testn));
@@ -90,7 +90,7 @@ TEST_CASE("Rotate") {
 
   SUBCASE("RotateGradientCCW") {
     // should be a square, and should remain a square through rotations
-    struct ncplane* testn = ncplane_new(nc_, 8, 16, dimy / 2, dimx / 2, nullptr);
+    struct ncplane* testn = ncplane_new(n_, 8, 16, dimy / 2, dimx / 2, nullptr, nullptr);
     REQUIRE(0 < ncplane_gradient_sized(testn, " ", 0, ul, ur, ll, lr, 8, 16));
     RotateCCW(nc_, testn);
     CHECK(0 == ncplane_destroy(testn));
@@ -98,7 +98,7 @@ TEST_CASE("Rotate") {
 
   SUBCASE("RotateRectangleCCW") {
     // should be a square, and should remain a square through rotations
-    struct ncplane* testn = ncplane_new(nc_, 8, 32, 0, 0, nullptr);
+    struct ncplane* testn = ncplane_new(n_, 8, 32, 0, 0, nullptr, nullptr);
     REQUIRE(0 < ncplane_gradient_sized(testn, " ", 0, ul, ur, ll, lr, 8, 32));
     RotateCCW(nc_, testn);
     CHECK(0 == ncplane_destroy(testn));

--- a/tests/scrolling.cpp
+++ b/tests/scrolling.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Scrolling") {
   }
 
   SUBCASE("ScrollingStr") {
-    struct ncplane* n = ncplane_new(nc_, 2, 20, 1, 1, nullptr);
+    struct ncplane* n = ncplane_new(n_, 2, 20, 1, 1, nullptr, nullptr);
     REQUIRE(n);
     // verify that the new plane was started without scrolling
     CHECK(!ncplane_set_scrolling(n, false));
@@ -41,7 +41,7 @@ TEST_CASE("Scrolling") {
   // even when scrolling is enabled, you aren't allowed to move the cursor
   // off-plane, or initiate output there
   SUBCASE("NoScrollingManually") {
-    struct ncplane* n = ncplane_new(nc_, 2, 20, 1, 1, nullptr);
+    struct ncplane* n = ncplane_new(n_, 2, 20, 1, 1, nullptr, nullptr);
     REQUIRE(n);
     CHECK(!ncplane_set_scrolling(n, true)); // enable scrolling
     CHECK(0 > ncplane_cursor_move_yx(n, 0, 20));
@@ -55,7 +55,7 @@ TEST_CASE("Scrolling") {
   // verify that two strings, each the length of the plane, can be output when
   // scrolling is enabled (the second ought get an error without scrolling)
   SUBCASE("ScrollingSplitStr") {
-    struct ncplane* n = ncplane_new(nc_, 2, 20, 1, 1, nullptr);
+    struct ncplane* n = ncplane_new(n_, 2, 20, 1, 1, nullptr, nullptr);
     REQUIRE(n);
     CHECK(20 == ncplane_putstr(n, "01234567890123456789"));
     int y, x;
@@ -75,7 +75,7 @@ TEST_CASE("Scrolling") {
   // scrolling is enabled (it ought be an error without scrolling)
   SUBCASE("ScrollingEGC") {
     const char* out = "0123456789012345678901234567890123456789";
-    struct ncplane* n = ncplane_new(nc_, 2, 20, 1, 1, nullptr);
+    struct ncplane* n = ncplane_new(n_, 2, 20, 1, 1, nullptr, nullptr);
     REQUIRE(n);
     // verify that the new plane was started without scrolling
     CHECK(!ncplane_set_scrolling(n, false));
@@ -107,7 +107,7 @@ TEST_CASE("Scrolling") {
   // ensure that if we draw a box on a scrolling plane, it stops at the right
   // side, as opposed to scrolling and making a horrible mess
   SUBCASE("ScrollingBoxen") {
-    struct ncplane* n = ncplane_new(nc_, 4, 20, 1, 1, nullptr);
+    struct ncplane* n = ncplane_new(n_, 4, 20, 1, 1, nullptr, nullptr);
     REQUIRE(n);
     // verify that the new plane was started without scrolling
     CHECK(!ncplane_set_scrolling(n, true));
@@ -124,7 +124,7 @@ TEST_CASE("Scrolling") {
     const char* out = "0123456789012345678901234567890123456789";
     const char* onext = "ABCDEFGHIJKLMNOPQRST";
     const char* next2 = "UVWXYZabcd";
-    struct ncplane* n = ncplane_new(nc_, 2, 20, 1, 1, nullptr);
+    struct ncplane* n = ncplane_new(n_, 2, 20, 1, 1, nullptr, nullptr);
     REQUIRE(n);
     // verify that the new plane was started without scrolling
     CHECK(!ncplane_set_scrolling(n, true));
@@ -177,7 +177,7 @@ TEST_CASE("Scrolling") {
     //const char* next2 = "KLMNOPQRST";
     //const char* next3 = "UVWXYZ";
     CHECK(0 == notcurses_render(nc_));
-    struct ncplane* n = ncplane_new(nc_, 2, 20, 1, 1, nullptr);
+    struct ncplane* n = ncplane_new(n_, 2, 20, 1, 1, nullptr, nullptr);
     REQUIRE(n);
     // verify that the new plane was started without scrolling
     CHECK(!ncplane_set_scrolling(n, true));

--- a/tests/selector.cpp
+++ b/tests/selector.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Selectors") {
 
   SUBCASE("EmptySelector") {
     struct ncselector_options opts{};
-    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
@@ -30,7 +30,7 @@ TEST_CASE("Selectors") {
   SUBCASE("TitledSelector") {
     struct ncselector_options opts{};
     opts.title = strdup("hey hey whaddya say");
-    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
@@ -46,7 +46,7 @@ TEST_CASE("Selectors") {
   SUBCASE("SecondarySelector") {
     struct ncselector_options opts{};
     opts.secondary = strdup("this is not a title, but it's not *not* a title");
-    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
@@ -62,7 +62,7 @@ TEST_CASE("Selectors") {
   SUBCASE("FooterSelector") {
     struct ncselector_options opts{};
     opts.footer = strdup("i am a lone footer, little old footer");
-    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
@@ -84,7 +84,7 @@ TEST_CASE("Selectors") {
     };
     struct ncselector_options opts{};
     opts.items = items;
-    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
@@ -99,7 +99,7 @@ TEST_CASE("Selectors") {
 
   SUBCASE("EmptySelectorMovement") {
     struct ncselector_options opts{};
-    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
@@ -123,7 +123,7 @@ TEST_CASE("Selectors") {
     };
     struct ncselector_options opts{};
     opts.items = items;
-    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     auto sel = ncselector_selected(ncs);
@@ -162,7 +162,7 @@ TEST_CASE("Selectors") {
     struct ncselector_options opts{};
     opts.maxdisplay = 1;
     opts.items = items;
-    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));
@@ -206,7 +206,7 @@ TEST_CASE("Selectors") {
     struct ncselector_options opts{};
     opts.maxdisplay = 2;
     opts.items = items;
-    struct ncplane* n = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     struct ncselector* ncs = ncselector_create(n, &opts);
     REQUIRE(nullptr != ncs);
     CHECK(0 == notcurses_render(nc_));

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -224,7 +224,7 @@ TEST_CASE("Wide") {
   }
 
   SUBCASE("BoxedWideGlyph") {
-    struct ncplane* ncp = ncplane_new(nc_, 3, 4, 0, 0, nullptr);
+    struct ncplane* ncp = ncplane_new(n_, 3, 4, 0, 0, nullptr, nullptr);
     REQUIRE(ncp);
     int dimx, dimy;
     ncplane_dim_yx(n_, &dimy, &dimx);
@@ -338,7 +338,7 @@ TEST_CASE("Wide") {
     free(egc);
     cell_init(&c);
 
-    struct ncplane* n = ncplane_new(nc_, 1, 2, 0, 1, nullptr);
+    struct ncplane* n = ncplane_new(n_, 1, 2, 0, 1, nullptr, nullptr);
     REQUIRE(n);
     CHECK(0 < ncplane_putstr(n, "AB"));
     CHECK(!notcurses_render(nc_));
@@ -375,7 +375,7 @@ TEST_CASE("Wide") {
   // Render a translucent plane atop a wide glyph, and check the colors on both
   // cells. See https://github.com/dankamongmen/notcurses/issues/362.
   SUBCASE("OverWide") {
-    struct ncplane* p = ncplane_new(nc_, 3, 4, 0, 0, nullptr);
+    struct ncplane* p = ncplane_new(n_, 3, 4, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != p);
     cell c = CELL_CHAR_INITIALIZER('X');
     CHECK(0 == ncplane_perimeter(p, &c, &c, &c, &c, &c, &c, 0));
@@ -414,7 +414,7 @@ TEST_CASE("Wide") {
     notcurses_cursor_disable(nc_);
     CHECK(0 == ncplane_set_fg_rgb8(n_, 0xff, 0, 0xff));
     // start the 1x4 top plane at 0, 4
-    struct ncplane* topp = ncplane_new(nc_, 1, 4, 0, 4, nullptr);
+    struct ncplane* topp = ncplane_new(n_, 1, 4, 0, 4, nullptr, nullptr);
     REQUIRE(nullptr != topp);
     CHECK(0 == ncplane_set_bg_rgb8(topp, 0, 0xff, 0));
     CHECK(4 == ncplane_putstr(topp, "abcd"));
@@ -588,7 +588,7 @@ TEST_CASE("Wide") {
   SUBCASE("WidePlaneAtopWide") {
     CHECK(0 == ncplane_set_fg_rgb8(n_, 0xff, 0, 0xff));
     // start the 1x4 top plane at 0, 4
-    struct ncplane* topp = ncplane_new(nc_, 1, 4, 0, 4, nullptr);
+    struct ncplane* topp = ncplane_new(n_, 1, 4, 0, 4, nullptr, nullptr);
     REQUIRE(nullptr != topp);
     CHECK(0 == ncplane_set_bg_rgb8(topp, 0, 0xff, 0));
     CHECK(6 == ncplane_putstr(topp, "次次"));
@@ -733,7 +733,7 @@ TEST_CASE("Wide") {
   SUBCASE("WidePlaneAtopNarrow") {
     CHECK(0 == ncplane_set_fg_rgb8(n_, 0xff, 0, 0xff));
     // start the 1x4 top plane at 0, 4
-    struct ncplane* topp = ncplane_new(nc_, 1, 4, 0, 4, nullptr);
+    struct ncplane* topp = ncplane_new(n_, 1, 4, 0, 4, nullptr, nullptr);
     REQUIRE(nullptr != topp);
     CHECK(0 == ncplane_set_bg_rgb8(topp, 0, 0xff, 0));
     CHECK(6 == ncplane_putstr(topp, "次次"));
@@ -917,7 +917,7 @@ TEST_CASE("Wide") {
 
   // a higher glyph ought not be annihilated by a lower wide glyph
   SUBCASE("HigherGlyphAbides") {
-    auto high = ncplane_new(nc_, 1, 1, 0, 0, nullptr);
+    auto high = ncplane_new(n_, 1, 1, 0, 0, nullptr, nullptr);
     REQUIRE(nullptr != high);
     CHECK(0 < ncplane_putchar_yx(high, 0, 0, 'a'));
     CHECK(0 < ncplane_putegc_yx(n_, 0, 0, "全", nullptr));

--- a/tests/zaxis.cpp
+++ b/tests/zaxis.cpp
@@ -28,7 +28,7 @@ TEST_CASE("ZAxis") {
 
   // you can't place a plane above or below itself, stdplane or otherwise
   SUBCASE("NoMoveSelf") {
-    struct ncplane* np = ncplane_new(nc_, 2, 2, 0, 0, nullptr);
+    struct ncplane* np = ncplane_new(n_, 2, 2, 0, 0, nullptr, nullptr);
     REQUIRE(np);
     CHECK(ncplane_move_below(n_, n_));
     CHECK(ncplane_move_above(n_, n_));
@@ -38,7 +38,7 @@ TEST_CASE("ZAxis") {
 
   // new planes ought be on the top
   SUBCASE("NewPlaneOnTop") {
-    struct ncplane* np = ncplane_new(nc_, 2, 2, 0, 0, nullptr);
+    struct ncplane* np = ncplane_new(n_, 2, 2, 0, 0, nullptr, nullptr);
     REQUIRE(np);
     struct ncplane* top = notcurses_top(nc_);
     CHECK(np == top);
@@ -48,7 +48,7 @@ TEST_CASE("ZAxis") {
 
   // "move" top plane to top. everything ought remain the same.
   SUBCASE("TopToTop") {
-    struct ncplane* np = ncplane_new(nc_, 2, 2, 0, 0, nullptr);
+    struct ncplane* np = ncplane_new(n_, 2, 2, 0, 0, nullptr, nullptr);
     REQUIRE(np);
     struct ncplane* top = notcurses_top(nc_);
     CHECK(np == top);
@@ -64,7 +64,7 @@ TEST_CASE("ZAxis") {
 
   // move top plane to bottom, and verify enumeration
   SUBCASE("TopToBottom") {
-    struct ncplane* np = ncplane_new(nc_, 2, 2, 0, 0, nullptr);
+    struct ncplane* np = ncplane_new(n_, 2, 2, 0, 0, nullptr, nullptr);
     REQUIRE(np);
     struct ncplane* top = notcurses_top(nc_);
     CHECK(np == top);
@@ -89,7 +89,7 @@ TEST_CASE("ZAxis") {
     REQUIRE(1 == ncplane_at_cursor_cell(n_, &cat));
     REQUIRE(cell_simple_p(&cat));
     REQUIRE(0 == strcmp("x", cell_extended_gcluster(n_, &c)));
-    struct ncplane* n2 = ncplane_new(nc_, 2, 2, 0, 0, nullptr);
+    struct ncplane* n2 = ncplane_new(n_, 2, 2, 0, 0, nullptr, nullptr);
     REQUIRE(1 == cell_load(n2, &c, "y"));
     REQUIRE(!cell_set_fg_rgb8(&c, 0, 0xff, 0));
     REQUIRE(1 == ncplane_putc(n2, &c));
@@ -97,7 +97,7 @@ TEST_CASE("ZAxis") {
     REQUIRE(!ncplane_cursor_move_yx(n2, 0, 0));
     REQUIRE(1 == ncplane_at_cursor_cell(n2, &cat));
     REQUIRE(0 == strcmp("y", cell_extended_gcluster(n_, &c)));
-    struct ncplane* n3 = ncplane_new(nc_, 2, 2, 0, 0, nullptr);
+    struct ncplane* n3 = ncplane_new(n_, 2, 2, 0, 0, nullptr, nullptr);
     REQUIRE(1 == cell_load(n3, &c, "z"));
     REQUIRE(!cell_set_fg_rgb8(&c, 0, 0, 0xff));
     REQUIRE(1 == ncplane_putc(n3, &c));
@@ -113,7 +113,7 @@ TEST_CASE("ZAxis") {
   }
 
   SUBCASE("DropPlanes") {
-    auto p = ncplane_new(nc_, 1, 1, 1, 1, nullptr);
+    auto p = ncplane_new(n_, 1, 1, 1, 1, nullptr, nullptr);
     REQUIRE(nullptr != p);
     CHECK(notcurses_top(nc_) == p);
     CHECK(0 == notcurses_render(nc_));


### PR DESCRIPTION
Kill off `ncplane_new_named()`, `ncplane_bound()`, `ncplane_bound_named()`, and `ncplane_aligned_named()`. `ncplane_new()` and `ncplane_aligned()` remain, and both now take a `const char* name` (which may be `NULL`), eliminating the need for the `_named()` variants. All planes are now bound, so there is no need for a different `ncplane_bound()` function.

Update all callers.