### PR TITLE
Recursively cascading resizing #869

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@ rearrangements of Notcurses.
     `ncplane_new()`. The latter ought be considered deprecated, and will be
     removed in the future. To align a place as previously done with
     `ncplane_aligned()`, use the `NCPLANE_OPTION_HORALIGNED` flag.
+  * The `ncplane_options` struct includes a function pointer member,
+    `resizecb`. If not `NULL`, this function will be called after the parent
+    plane is resized. See `notcurses_plane.3` for more information.
 
 * 1.7.3 (2020-09-19)
   * API changes pursuant to 2.0 API finalization:

--- a/USAGE.md
+++ b/USAGE.md
@@ -629,6 +629,7 @@ typedef struct ncplane_options {
   int cols;         // number of columns, must be positive
   void* userptr;    // user curry, may be NULL
   const char* name; // name (used only for debugging), may be NULL
+  int (*resizecb)(struct ncplane*); // callback when parent is resized
   uint64_t flags;   // closure over NCPLANE_OPTION_*
 } ncplane_options;
 

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -23,6 +23,7 @@ typedef struct ncplane_options {
   int cols;         // number of columns, must be positive
   void* userptr;    // user curry, may be NULL
   const char* name; // name (used only for debugging), may be NULL
+  int (*resizecb)(struct ncplane*); // callback when parent is resized
   uint64_t flags;   // closure over NCPLANE_OPTION_*
 } ncplane_options;
 ```
@@ -229,6 +230,13 @@ might see changes. It is an error to merge a plane onto itself.
 
 **ncplane_erase** zeroes out every cell of the plane, dumps the egcpool, and
 homes the cursor. The base cell is preserved.
+
+When a plane is resized (whether by **ncplane_resize**, **SIGWINCH**, or any
+other mechanism), a breadth-first recursion is performed on its children.
+Each child plane having a non-**NULL** **resizecb** will see that callback
+invoked following resizing of its parent's plane. If it returns non-zero, the
+resizing cascade terminates, returning non-zero. Otherwise, resizing proceeds
+recursively.
 
 ## Scrolling
 

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -232,7 +232,7 @@ might see changes. It is an error to merge a plane onto itself.
 homes the cursor. The base cell is preserved.
 
 When a plane is resized (whether by **ncplane_resize**, **SIGWINCH**, or any
-other mechanism), a breadth-first recursion is performed on its children.
+other mechanism), a depth-first recursion is performed on its children.
 Each child plane having a non-**NULL** **resizecb** will see that callback
 invoked following resizing of its parent's plane. If it returns non-zero, the
 resizing cascade terminates, returning non-zero. Otherwise, resizing proceeds

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -1118,6 +1118,7 @@ namespace ncpp
 				cols,
 				opaque,
 				nullptr,
+        nullptr,
 				0
 			};
 			ncplane *ret = ncplane_create (

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1006,6 +1006,7 @@ typedef struct ncplane_options {
   int cols;         // number of columns, must be positive
   void* userptr;    // user curry, may be NULL
   const char* name; // name (used only for debugging), may be NULL
+  int (*resizecb)(struct ncplane*); // callback when parent is resized
   uint64_t flags;   // closure over NCPLANE_OPTION_*
 } ncplane_options;
 
@@ -1029,6 +1030,7 @@ ncplane_new(struct ncplane* n, int rows, int cols, int y, int x, void* opaque, c
     .cols = cols,
     .userptr = opaque,
     .name = name,
+    .resizecb = NULL,
     .flags = 0,
   };
   return ncplane_create(n, &nopts);

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -83,6 +83,7 @@ typedef struct ncplane_options {
   int cols;         // number of columns, must be positive
   void* userptr;    // user curry, may be NULL
   const char* name; // name (used only for debugging), may be NULL
+  int (*resizecb)(struct ncplane*); // callback when parent is resized
   uint64_t flags;   // closure over NCPLANE_OPTION_*
 } ncplane_options;
 struct ncplane* ncplane_create(struct ncplane* n, const ncplane_options* nopts);

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -511,6 +511,7 @@ int main(int argc, char** argv){
     return EXIT_FAILURE;
   }
   sigset_t sigmask;
+  // ensure SIGWINCH is delivered only to a thread doing input
   sigemptyset(&sigmask);
   sigaddset(&sigmask, SIGWINCH);
   pthread_sigmask(SIG_SETMASK, &sigmask, NULL);

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -443,13 +443,16 @@ int ncdirect_render_image(ncdirect* n, const char* file, ncalign_e align,
   lenx = (lenx / (double)ncv->cols) * ((double)dispcols);
 //fprintf(stderr, "render: %d+%d of %d/%d stride %u %p\n", leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
   ncplane_options nopts = {
+    .y = 0,
+    .horiz = {
+      .x = 0,
+    },
     .rows = disprows / encoding_y_scale(bset),
     .cols = dispcols / encoding_x_scale(bset),
-    .horiz.x = 0,
-    .y = 0,
     .userptr = nullptr,
-    .resizecb = nullptr,
     .name = "direct",
+    .resizecb = nullptr,
+    .flags = 0,
   };
   struct ncplane* faken = ncplane_new_internal(nullptr, nullptr, &nopts);
   if(faken == nullptr){

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -442,10 +442,16 @@ int ncdirect_render_image(ncdirect* n, const char* file, ncalign_e align,
   leny = (leny / (double)ncv->rows) * ((double)disprows);
   lenx = (lenx / (double)ncv->cols) * ((double)dispcols);
 //fprintf(stderr, "render: %d+%d of %d/%d stride %u %p\n", leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
-  struct ncplane* faken = ncplane_new_internal(nullptr, nullptr,
-                                               disprows / encoding_y_scale(bset),
-                                               dispcols / encoding_x_scale(bset),
-                                               0, 0, nullptr, nullptr, nullptr);
+  ncplane_options nopts = {
+    .rows = disprows / encoding_y_scale(bset),
+    .cols = dispcols / encoding_x_scale(bset),
+    .horiz.x = 0,
+    .y = 0,
+    .userptr = nullptr,
+    .resizecb = nullptr,
+    .name = "direct",
+  };
+  struct ncplane* faken = ncplane_new_internal(nullptr, nullptr, &nopts);
   if(faken == nullptr){
     return -1;
   }

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -445,7 +445,7 @@ int ncdirect_render_image(ncdirect* n, const char* file, ncalign_e align,
   struct ncplane* faken = ncplane_new_internal(nullptr, nullptr,
                                                disprows / encoding_y_scale(bset),
                                                dispcols / encoding_x_scale(bset),
-                                               0, 0, nullptr, nullptr);
+                                               0, 0, nullptr, nullptr, nullptr);
   if(faken == nullptr){
     return -1;
   }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -776,10 +776,7 @@ calc_gradient_channels(uint64_t* channels, uint64_t ul, uint64_t ur,
 // ncdirect needs to "fake" an isolated ncplane as a drawing surface for
 // ncvisual_render(), and thus calls these low-level internal functions.
 // they are not for general use -- check ncplane_new() and ncplane_destroy().
-// FIXME rewrite using ncplane_options
-ncplane* ncplane_new_internal(notcurses* nc, ncplane* n, int rows, int cols,
-                              int yoff, int xoff, void* opaque,
-                              const char* name, int (*resizecb)(ncplane*));
+ncplane* ncplane_new_internal(notcurses* nc, ncplane* n, const ncplane_options* nopts);
 
 void free_plane(ncplane* p);
 

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -81,6 +81,7 @@ typedef struct ncplane {
   egcpool pool;          // attached storage pool for UTF-8 EGCs
   uint64_t channels;     // works the same way as cells
   void* userptr;         // slot for the user to stick some opaque pointer
+  int (*resizecb)(struct ncplane*); // callback after parent is resized
   cell basecell;         // cell written anywhere that fb[i].gcluster == 0
   struct notcurses* nc;  // notcurses object of which we are a part
   char* name;            // used only for debugging
@@ -775,8 +776,10 @@ calc_gradient_channels(uint64_t* channels, uint64_t ul, uint64_t ur,
 // ncdirect needs to "fake" an isolated ncplane as a drawing surface for
 // ncvisual_render(), and thus calls these low-level internal functions.
 // they are not for general use -- check ncplane_new() and ncplane_destroy().
+// FIXME rewrite using ncplane_options
 ncplane* ncplane_new_internal(notcurses* nc, ncplane* n, int rows, int cols,
-                              int yoff, int xoff, void* opaque, const char* name);
+                              int yoff, int xoff, void* opaque,
+                              const char* name, int (*resizecb)(ncplane*));
 
 void free_plane(ncplane* p);
 


### PR DESCRIPTION
* Define `resizecb` as part of `ncplane` and `ncplane_options`
* Add `resize_children()`, called whenever an `ncplane` is resized (two paths in `ncplane_resize_internal()`
* `resize_children()` is corecursive against `ncplane_resize_internal()`, resulting in a DFS that terminates whenever an `ncplane` is **not** resized, just like we want

Closes #869 