### PR TITLE
NCBLIT_BRAILLE: invert around vertical axis, fixing plots

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,7 +24,7 @@ name: ubuntu-focal
 
 steps:
 - name: ubuntu-build
-  image: dankamongmen/focal:2020-08-31a
+  image: dankamongmen/focal:2020-09-22a
   commands:
     - export LANG=en_US.UTF-8
     - mkdir build

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -583,7 +583,7 @@ const struct blitset notcurses_blitters[] = {
      .blit = quadrant_blit,  .name = "quadblitter",   .fill = false, },
    { .geom = NCBLIT_4x1,     .width = 1, .height = 4, .egcs = L" ▂▄▆█",
      .blit = tria_blit,      .name = "fourstep",      .fill = false, },
-   { .geom = NCBLIT_BRAILLE, .width = 2, .height = 4, .egcs = L"⠀⡀⡄⡆⡇⢀⣀⣄⣆⣇⢠⣠⣤⣦⣧⢰⣰⣴⣶⣷⢸⣸⣼⣾⣿",
+   { .geom = NCBLIT_BRAILLE, .width = 2, .height = 4, .egcs = L"⠀⢀⢠⢰⢸⡀⣀⣠⣰⣸⡄⣄⣤⣴⣼⡆⣆⣦⣶⣾⡇⣇⣧⣷⣿",
      .blit = braille_blit,   .name = "braille",       .fill = true,  },
    { .geom = NCBLIT_SIXEL,   .width = 1, .height = 6, .egcs = L"",
      .blit = NULL,           .name = "sixel",         .fill = true,  }, // FIXME


### PR DESCRIPTION
Closes #1026. Running a plot with `NCBLIT_BRAILLE` swapped each pair of columns. I've flipped the blitset around the vertical axis, correcting the visual.