### PR TITLE
[C++] API sync

### DIFF
--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -175,6 +175,28 @@ namespace ncpp
 			return error_guard (ncdirect_double_box (direct, ul, ur, ll, lr, ylen, xlen, ctlword), -1);
 		}
 
+		bool flush () const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncdirect_flush (direct), -1);
+		}
+
+		char32_t getc (ncinput *ni, bool blocking) const noexcept
+		{
+			if (blocking)
+				return ncdirect_getc_blocking (direct, ni);
+			return ncdirect_getc_nblock (direct, ni);
+		}
+
+		char32_t getc (const struct timespec *ts, sigset_t *sigmask, ncinput *ni) const noexcept
+		{
+			return ncdirect_getc (direct, ts, sigmask, ni);
+		}
+
+		int get_inputready_fd () const noexcept
+		{
+			return ncdirect_inputready_fd (direct);
+		}
+
 		bool canopen_images () const noexcept
 		{
 			return ncdirect_canopen_images (direct);

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -151,15 +151,15 @@ namespace ncpp
 			return notcurses_cantruecolor (nc);
 		}
 
-    int cursor_enable (int y, int x) const noexcept
-    {
-      return error_guard (notcurses_cursor_enable (nc, y, x), -1);
-    }
+		int cursor_enable (int y, int x) const NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_cursor_enable (nc, y, x), -1);
+		}
 
-    int cursor_disable () const noexcept
-    {
-      return error_guard (notcurses_cursor_disable (nc), -1);
-    }
+		int cursor_disable () const NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_cursor_disable (nc), -1);
+		}
 
 		void get_stats (ncstats *stats) const noexcept
 		{
@@ -273,6 +273,16 @@ namespace ncpp
 			notcurses_debug (nc, debugfp);
 		}
 
+		bool align (int availcols, ncalign_e align, int cols) const NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_align (availcols, align, cols), -INT_MAX);
+		}
+
+		static bool ucs32_to_utf8 (const char32_t *ucs32, unsigned ucs32count, unsigned char *resultbuf, size_t buflen) NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_ucs32_to_utf8 (ucs32, ucs32count, resultbuf, buflen), -1);
+		}
+
 		Plane* get_stdplane () noexcept
 		{
 			return new Plane (notcurses_stdplane (nc), true);
@@ -294,6 +304,7 @@ namespace ncpp
 		}
 
 		Plane* get_top () noexcept;
+		Plane* get_bottom () noexcept;
 
 	private:
 		notcurses *nc;

--- a/include/ncpp/Reader.hh
+++ b/include/ncpp/Reader.hh
@@ -47,6 +47,36 @@ namespace ncpp
 			return error_guard_cond<bool, bool> (ret, ret);
 		}
 
+		//
+		// None of the move* methods should throw since their return value (0 - moved, -1 - not moved) appear to be
+		// purely informational, not errors per se. If we had `can_move*` functions then `move*` could throw exceptions,
+		// potentially.
+		//
+		int move_left () const noexcept
+		{
+			return ncreader_move_left (reader);
+		}
+
+		int move_right () const noexcept
+		{
+			return ncreader_move_right (reader);
+		}
+
+		int move_up () const noexcept
+		{
+			return ncreader_move_up (reader);
+		}
+
+		int move_down () const noexcept
+		{
+			return ncreader_move_down (reader);
+		}
+
+		bool write_egc (const char *egc) const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncreader_write_egc (reader, egc), -1);
+		}
+
 		char* get_contents () const noexcept
 		{
 			return ncreader_contents(reader);

--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -109,6 +109,11 @@ namespace ncpp
 			return error_guard (ncvisual_set_yx (visual, y, x, pixel), -1);
 		}
 
+		static ncblitter_e get_default_blitter (bool utf8, ncscale_e scale) noexcept
+		{
+			return ncvisual_default_blitter (utf8, scale);
+		}
+
 	private:
 		void common_init (ncplane *plane, const char *file)
 		{

--- a/src/libcpp/NotCurses.cc
+++ b/src/libcpp/NotCurses.cc
@@ -50,6 +50,15 @@ Plane* NotCurses::get_top () noexcept
 	return Plane::map_plane (top);
 }
 
+Plane* NotCurses::get_bottom () noexcept
+{
+	ncplane *bottom = notcurses_bottom (nc);
+	if (bottom == nullptr)
+		return nullptr;
+
+	return Plane::map_plane (bottom);
+}
+
 // This is potentially dangerous, but alas necessary. It can cause other calls
 // here to fail in a bad way, but we need a way to report errors to
 // std{out,err} in case of failure and that will work only if notcurses is

--- a/src/libcpp/Reel.cc
+++ b/src/libcpp/Reel.cc
@@ -10,7 +10,7 @@ ncreel_options NcReel::default_options = {
 	/* tabletmask         */ 0,
 	/* tabletchan         */ 0,
 	/* focusedchan        */ 0,
-  /* flags              */ 0,
+	/* flags              */ 0,
 };
 
 Plane* NcReel::get_plane () const noexcept


### PR DESCRIPTION
Fixes: https://github.com/dankamongmen/notcurses/issues/1025

Added:
  * Direct: flush (`ncdirect_flush`)
  * Direct: getc (`ncdirect_getc_blocking` and `ncdirect_getc_nblock`)
  * Direct: getc (`ncdirect_getc`)
  * Direct: get_inputready_fd (`ncdirect_inputready_fd`)
  * NotCurses: align (`notcurses_align`)
  * NotCurses: ucs32_to_utf8 (`notcurses_ucs32_to_utf8`)
  * NotCurses: get_bottom (`notcurses_bottom`)
  * Plane: resize_realign (`ncplane_resize_realign`)
  * Plane: get_x (`ncplane_x`)
  * Plane: get_y (`ncplane_y`)
  * Plane: mergedown (`ncplane_mergedown`)
  * Plane: putwc_stained (`ncplane_putwc_stained`)
  * Plane: putstr_stained (`ncplane_putstr_stained`)
  * Plane: set_fchannel (`ncplane_set_fchannel`)
  * Plane: set_bchannel (`ncplane_set_bchannel`)
  * Plane: get_styles (`ncplane_styles`)
  * Plane: get_above (`ncplane_above`)
  * Reader: move_left (`ncreader_move_left`)
  * Reader: move_right (`ncreader_move_right`)
  * Reader: move_up (`ncreader_move_up`)
  * Reader: move_down (`ncreader_move_down`)
  * Reader: write_egc (`ncreader_write_egc`)
  * Visual: get_default_blitter (`ncvisual_default_blitter`)

Fixed:
  * NotCurses: `cursor_{enable,disable}` must use `NOEXCEPT_MAYBE`
  * Plane: renamed `putcw` to `putwc`