### PR TITLE
Properly size tablets in all border situations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,8 @@ rearrangements of Notcurses.
 
 * 1.7.5 (not yet released)
   * `ncreel_destroy()` now returns `void` rather than `int`.
-  * `nctablet_ncplane()` has been renamed `nctablet_plane()`. The former name
-    has been retained as a (deprecated) alias, to be removed in the near future.
+  * `nctablet_ncplane()` has been renamed `nctablet_plane()`.
+  * The standard plane now has the name `std`.
 
 * 1.7.4 (2020-09-20)
   * All `_rgb_clipped()` functions have been renamed `_rgb8_clipped()`, to

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@ rearrangements of Notcurses.
 
 * 1.7.5 (not yet released)
   * `ncreel_destroy()` now returns `void` rather than `int`.
-  * `nctablet_ncplane()` has been renamed `nctablet_plane()`.
+  * `nctablet_ncplane()` has been renamed `nctablet_plane()`. The former name
+    has been retained as a (deprecated) alias, to be removed in the near future.
 
 * 1.7.4 (2020-09-20)
   * All `_rgb_clipped()` functions have been renamed `_rgb8_clipped()`, to

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2543,6 +2543,15 @@ API void* nctablet_userptr(struct nctablet* t);
 // Access the ncplane associated with nctablet 't', if one exists.
 API struct ncplane* nctablet_plane(struct nctablet* t);
 
+// deprecated predecessor of nctablet_plane()
+static inline struct ncplane*
+nctablet_ncplane(struct nctablet* t) __attribute__ ((deprecated));
+
+static inline struct ncplane*
+nctablet_ncplane(struct nctablet* t){
+  return nctablet_plane(t);
+}
+
 // The number of columns is one fewer, as the STRLEN expressions must leave
 // an extra byte open in case 'µ' (U+00B5, 0xC2 0xB5) shows up. PREFIXCOLUMNS
 // is the maximum number of columns used by a mult == 1000 (standard)

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2543,15 +2543,6 @@ API void* nctablet_userptr(struct nctablet* t);
 // Access the ncplane associated with nctablet 't', if one exists.
 API struct ncplane* nctablet_plane(struct nctablet* t);
 
-// deprecated predecessor of nctablet_plane()
-static inline struct ncplane*
-nctablet_ncplane(struct nctablet* t) __attribute__ ((deprecated));
-
-static inline struct ncplane*
-nctablet_ncplane(struct nctablet* t){
-  return nctablet_plane(t);
-}
-
 // The number of columns is one fewer, as the STRLEN expressions must leave
 // an extra byte open in case 'µ' (U+00B5, 0xC2 0xB5) shows up. PREFIXCOLUMNS
 // is the maximum number of columns used by a mult == 1000 (standard)

--- a/src/demo/reel.c
+++ b/src/demo/reel.c
@@ -83,7 +83,7 @@ tabletdraw(struct ncplane* w, int maxy, tabletctx* tctx, unsigned rgb){
     }
     cell_release(w, &c);
   }
-  return y - 1;
+  return y;
 }
 
 static int

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -380,6 +380,7 @@ create_initial_ncplane(notcurses* nc, int dimy, int dimx){
     },
     .rows = dimy - (nc->margin_t + nc->margin_b),
     .cols = dimx - (nc->margin_l + nc->margin_r),
+    .name = "std",
   };
   return nc->stdplane = ncplane_new_internal(nc, NULL, &nopts);
 }

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -276,9 +276,10 @@ ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiertop,
     ++cbx;
   }
   if(cbleny - cby + 1 > 0){
-    t->cbp = ncplane_new(t->p, cbleny - cby + 1, cblenx - cbx + 1, cby, cbx, NULL, "tdat");
+//fprintf(stderr, "CREATING %dx%d\n", cbleny, cblenx);
+    t->cbp = ncplane_new(t->p, cbleny, cblenx, cby, cbx, NULL, "tdat");
     if(t->cbp == NULL){
-//fprintf(stderr, "failure creating data plane %d %d %d %d\n", cbleny - cby + 1, cblenx - cbx + 1, cby, cbx);
+//fprintf(stderr, "failure creating data plane %d %d %d %d\n", cbleny, cblenx, cby, cbx);
       ncplane_destroy(t->p);
       t->p = NULL;
       return -1;

--- a/tests/reel.cpp
+++ b/tests/reel.cpp
@@ -73,7 +73,7 @@ int check_allborders(nctablet* t, bool drawfromtop) {
   ncplane_dim_yx(ncp, &rows, &cols);
   int srows, scols;
   ncplane_dim_yx(notcurses_stdplane(ncplane_notcurses(ncp)), &srows, &scols);
-  CHECK(srows == rows + 4);
+  CHECK(srows == rows + 2);
   CHECK(scols == cols + 4);
   return 1;
 }
@@ -99,7 +99,7 @@ int check_notborders(nctablet* t, bool drawfromtop) {
   ncplane_dim_yx(ncp, &rows, &cols);
   int srows, scols;
   ncplane_dim_yx(notcurses_stdplane(ncplane_notcurses(ncp)), &srows, &scols);
-  CHECK(srows == rows + 2);
+  CHECK(srows == rows); // we get maximum possible size to try out
   CHECK(scols == cols + 2);
   return 1;
 }


### PR DESCRIPTION
* Add four unit tests to `Reels` testcase, checking geometry of generated tablets.
* Fix up tablet size calculation in `ncreel_draw_tablet()` (closes #1031)
* Name the standard plane `std`
* Correct the `lines` output for all cases in the `reel` demo.