### PR TITLE
Normalize style setters for ncplane and cell

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,13 @@ rearrangements of Notcurses.
   * `ncreel_destroy()` now returns `void` rather than `int`.
   * `nctablet_ncplane()` has been renamed `nctablet_plane()`.
   * The standard plane now has the name `std`.
+  * Removed long-deprecated `ncplane_set_attrs()` and `ncplane_attrs()`.
+  * Renamed `ncplane_styles_*()` to `ncplane_*_styles()`, to conform with
+    every other `ncplane_set_*()` function, but retained the old versions as
+    (deprecated) aliases.
+  * Renamed `cell_styles_*()` to `cell_*_styles()`, to conform with every other
+    `cell_set_*()` function. Since these were inline functions, I've not
+    bothered to retain the old versions.
 
 * 1.7.4 (2020-09-20)
   * All `_rgb_clipped()` functions have been renamed `_rgb8_clipped()`, to

--- a/USAGE.md
+++ b/USAGE.md
@@ -778,15 +778,17 @@ not rendered. Note that the base cell, like every other cell, has its own
 foreground and background channels.
 
 ```c
+uint16_t ncplane_styles(const struct ncplane* n);**
+
 // Set the specified style bits for the ncplane 'n', whether they're actively
 // supported or not.
-void ncplane_styles_set(struct ncplane* n, unsigned stylebits);
+void ncplane_set_styles(struct ncplane* n, unsigned stylebits);
 
 // Add the specified styles to the ncplane's existing spec.
-void ncplane_styles_on(struct ncplane* n, unsigned stylebits);
+void ncplane_on_styles(struct ncplane* n, unsigned stylebits);
 
 // Remove the specified styles from the ncplane's existing spec.
-void ncplane_styles_off(struct ncplane* n, unsigned stylebits);
+void ncplane_off_styles(struct ncplane* n, unsigned stylebits);
 
 // Set the ncplane's base cell to this cell. It will be used for purposes of
 // rendering anywhere that the ncplane's gcluster is 0. Erasing the ncplane

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -100,11 +100,7 @@ typedef struct ncplane_options {
 
 **uint64_t ncplane_channels(const struct ncplane* n);**
 
-**uint16_t ncplane_attr(const struct ncplane* n);**
-
 **void ncplane_set_channels(struct ncplane* nc, uint64_t channels);**
-
-**void ncplane_set_attr(struct ncplane* nc, uint32_t styles);**
 
 **static inline unsigned ncplane_bchannel(struct ncplane* nc);**
 
@@ -146,11 +142,13 @@ typedef struct ncplane_options {
 
 **int ncplane_set_bg_palindex(struct ncplane* n, int idx);**
 
-**void ncplane_styles_set(struct ncplane* n, unsigned stylebits);**
+**uint16_t ncplane_styles(const struct ncplane* n);**
 
-**void ncplane_styles_on(struct ncplane* n, unsigned stylebits);**
+**void ncplane_set_styles(struct ncplane* n, unsigned stylebits);**
 
-**void ncplane_styles_off(struct ncplane* n, unsigned stylebits);**
+**void ncplane_on_styles(struct ncplane* n, unsigned stylebits);**
+
+**void ncplane_off_styles(struct ncplane* n, unsigned stylebits);**
 
 **void ncplane_greyscale(struct ncplane* n);**
 

--- a/include/ncpp/Cell.hh
+++ b/include/ncpp/Cell.hh
@@ -88,7 +88,7 @@ namespace ncpp
 
 		void set_styles (CellStyle styles) noexcept
 		{
-			cell_styles_set (&_cell, static_cast<unsigned>(styles));
+			cell_set_styles (&_cell, static_cast<unsigned>(styles));
 		}
 
 		CellStyle get_styles () noexcept
@@ -98,12 +98,12 @@ namespace ncpp
 
 		void styles_on (CellStyle styles) noexcept
 		{
-			cell_styles_on (&_cell, static_cast<unsigned>(styles));
+			cell_on_styles (&_cell, static_cast<unsigned>(styles));
 		}
 
 		void styles_off (CellStyle styles) noexcept
 		{
-			cell_styles_off (&_cell, static_cast<unsigned>(styles));
+			cell_off_styles (&_cell, static_cast<unsigned>(styles));
 		}
 
 		bool is_double_wide () const noexcept

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -713,11 +713,6 @@ namespace ncpp
 			return ncplane_channels (plane);
 		}
 
-		uint32_t get_attr () const noexcept
-		{
-			return ncplane_attr (plane);
-		}
-
 		unsigned get_bchannel () const noexcept
 		{
 			return ncplane_bchannel (plane);
@@ -756,11 +751,6 @@ namespace ncpp
 		void set_channels (uint64_t channels) const noexcept
 		{
 			ncplane_set_channels (plane, channels);
-		}
-
-		void set_attr (uint32_t attr) const noexcept
-		{
-			ncplane_set_attr (plane, attr);
 		}
 
 		bool set_fg_alpha (unsigned alpha) const NOEXCEPT_MAYBE
@@ -850,17 +840,17 @@ namespace ncpp
 
 		void styles_set (CellStyle styles) const noexcept
 		{
-			ncplane_styles_set (plane, static_cast<unsigned>(styles));
+			ncplane_set_styles (plane, static_cast<unsigned>(styles));
 		}
 
 		void styles_on (CellStyle styles) const noexcept
 		{
-			ncplane_styles_on (plane, static_cast<unsigned>(styles));
+			ncplane_on_styles (plane, static_cast<unsigned>(styles));
 		}
 
 		void styles_off (CellStyle styles) const noexcept
 		{
-			ncplane_styles_off (plane, static_cast<unsigned>(styles));
+			ncplane_off_styles (plane, static_cast<unsigned>(styles));
 		}
 
 		int format (int ystop, int xstop, uint16_t stylemask) const NOEXCEPT_MAYBE

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -621,7 +621,7 @@ API void cell_release(struct ncplane* n, cell* c);
 // Set the specified style bits for the cell 'c', whether they're actively
 // supported or not. Only the lower 16 bits are meaningful.
 static inline void
-cell_styles_set(cell* c, unsigned stylebits){
+cell_set_styles(cell* c, unsigned stylebits){
   c->stylemask = stylebits & NCSTYLE_MASK;
 }
 
@@ -634,13 +634,13 @@ cell_styles(const cell* c){
 // Add the specified styles (in the LSBs) to the cell's existing spec, whether
 // they're actively supported or not.
 static inline void
-cell_styles_on(cell* c, unsigned stylebits){
+cell_on_styles(cell* c, unsigned stylebits){
   c->stylemask |= (stylebits & NCSTYLE_MASK);
 }
 
 // Remove the specified styles (in the LSBs) from the cell's existing spec.
 static inline void
-cell_styles_off(cell* c, unsigned stylebits){
+cell_off_styles(cell* c, unsigned stylebits){
   c->stylemask &= ~(stylebits & NCSTYLE_MASK);
 }
 
@@ -1020,8 +1020,7 @@ API struct ncplane* ncplane_create(struct ncplane* n, const ncplane_options* nop
 
 // This function will be marked deprecated in 2.0 in favor of ncplane_create().
 // It persists only for backwards compatibility.
-API struct ncplane* ncplane_new(struct ncplane* n, int rows, int cols, int y, int x, void* opaque, const char* name)
-  __attribute__ ((deprecated));
+API struct ncplane* ncplane_new(struct ncplane* n, int rows, int cols, int y, int x, void* opaque, const char* name);
 
 // Suitable for use as a `resizecb`. This will realign the plane 'n' against its
 // parent, using the alignment specified at ncplane_create()-time.
@@ -1309,8 +1308,7 @@ API void ncplane_cursor_yx(const struct ncplane* n, int* RESTRICT y, int* RESTRI
 API uint64_t ncplane_channels(const struct ncplane* n);
 
 // Return the current styling for this ncplane.
-API uint16_t ncplane_attr(const struct ncplane* n);
-API unsigned ncplane_styles(const struct ncplane* n);
+API uint16_t ncplane_styles(const struct ncplane* n);
 
 // Replace the cell at the specified coordinates with the provided cell 'c',
 // and advance the cursor by the width of the cell (but not past the end of the
@@ -1332,7 +1330,7 @@ ncplane_putc(struct ncplane* n, const cell* c){
 // This works whether the underlying char is signed or unsigned.
 static inline int
 ncplane_putchar_yx(struct ncplane* n, int y, int x, char c){
-  cell ce = CELL_INITIALIZER((uint32_t)c, ncplane_attr(n), ncplane_channels(n));
+  cell ce = CELL_INITIALIZER((uint32_t)c, ncplane_styles(n), ncplane_channels(n));
   return ncplane_putc_yx(n, y, x, &ce);
 }
 
@@ -1914,17 +1912,23 @@ ncplane_fchannel(const struct ncplane* n){
 
 API void ncplane_set_channels(struct ncplane* n, uint64_t channels);
 
-API void ncplane_set_attr(struct ncplane* n, unsigned stylebits);
-
 // Set the specified style bits for the ncplane 'n', whether they're actively
 // supported or not.
-API void ncplane_styles_set(struct ncplane* n, unsigned stylebits);
+API void ncplane_set_styles(struct ncplane* n, unsigned stylebits);
 
 // Add the specified styles to the ncplane's existing spec.
-API void ncplane_styles_on(struct ncplane* n, unsigned stylebits);
+API void ncplane_on_styles(struct ncplane* n, unsigned stylebits);
 
 // Remove the specified styles from the ncplane's existing spec.
-API void ncplane_styles_off(struct ncplane* n, unsigned stylebits);
+API void ncplane_off_styles(struct ncplane* n, unsigned stylebits);
+
+// Deprecated forms of above.
+API void ncplane_styles_set(struct ncplane* n, unsigned stylebits)
+  __attribute__ ((deprecated));
+API void ncplane_styles_on(struct ncplane* n, unsigned stylebits)
+  __attribute__ ((deprecated));
+API void ncplane_styles_off(struct ncplane* n, unsigned stylebits)
+  __attribute__ ((deprecated));
 
 // Extract 24 bits of working foreground RGB from an ncplane, shifted to LSBs.
 static inline unsigned

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -59,7 +59,6 @@ const struct ncplane* notcurses_stdplane_const(const struct notcurses* nc);
 void ncplane_set_channels(struct ncplane* n, uint64_t channels);
 uint64_t ncplane_set_fchannel(struct ncplane* n, uint32_t channel);
 uint64_t ncplane_set_bchannel(struct ncplane* n, uint32_t channel);
-void ncplane_set_attr(struct ncplane* n, unsigned stylebits);
 int ncplane_set_base_cell(struct ncplane* ncp, const cell* c);
 int ncplane_set_base(struct ncplane* ncp, const char* egc, uint32_t styles, uint64_t channels);
 int ncplane_base(struct ncplane* ncp, cell* c);
@@ -138,8 +137,6 @@ void* ncplane_userptr(struct ncplane* n);
 int ncplane_resize(struct ncplane* n, int keepy, int keepx, int keepleny,
                        int keeplenx, int yoff, int xoff, int ylen, int xlen);
 uint64_t ncplane_channels(const struct ncplane* n);
-uint16_t ncplane_attr(const struct ncplane* n);
-unsigned ncplane_styles(const struct ncplane* n);
 int ncplane_set_fg_rgb8(struct ncplane* n, int r, int g, int b);
 int ncplane_set_bg_rgb8(struct ncplane* n, int r, int g, int b);
 void ncplane_set_fg_rgb8_clipped(struct ncplane* n, int r, int g, int b);
@@ -152,9 +149,10 @@ int ncplane_set_fg_alpha(struct ncplane* n, unsigned alpha);
 int ncplane_set_bg_alpha(struct ncplane* n, unsigned alpha);
 int ncplane_set_fg_palindex(struct ncplane* n, int idx);
 int ncplane_set_bg_palindex(struct ncplane* n, int idx);
-void ncplane_styles_set(struct ncplane* n, unsigned stylebits);
-void ncplane_styles_on(struct ncplane* n, unsigned stylebits);
-void ncplane_styles_off(struct ncplane* n, unsigned stylebits);
+unsigned ncplane_styles(const struct ncplane* n);
+void ncplane_set_styles(struct ncplane* n, unsigned stylebits);
+void ncplane_on_styles(struct ncplane* n, unsigned stylebits);
+void ncplane_off_styles(struct ncplane* n, unsigned stylebits);
 typedef struct ncstats {
   uint64_t renders;          // number of successful notcurses_render() runs
   uint64_t failed_renders;   // number of aborted renders, should be 0

--- a/src/demo/all.c
+++ b/src/demo/all.c
@@ -54,11 +54,11 @@ allglyphs(struct notcurses* nc, struct ncplane* column, int legendy){
         }
         ncplane_cursor_yx(column, NULL, &x);
         if(x >= dimx){
-          ncplane_set_attr(std, NCSTYLE_BOLD | NCSTYLE_UNDERLINE | NCSTYLE_ITALIC);
+          ncplane_set_styles(std, NCSTYLE_BOLD | NCSTYLE_UNDERLINE | NCSTYLE_ITALIC);
           if(ncplane_printf_aligned(std, legendy, NCALIGN_CENTER, "0x%06x", wc) < 0){
             return -1;
           }
-          ncplane_set_attr(std, NCSTYLE_NONE);
+          ncplane_set_styles(std, NCSTYLE_NONE);
           DEMO_RENDER(nc);
           ncplane_set_fg_rgb8(column,
                              random() % 192 + 64,

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -510,7 +510,7 @@ int demo_render(struct notcurses* nc){
     ncplane_set_fg_rgb(hud, 0x80d0ff);
     ncplane_set_fg_alpha(hud, CELL_ALPHA_OPAQUE);
     cell_release(hud, &c);
-    ncplane_styles_on(hud, NCSTYLE_BOLD);
+    ncplane_on_styles(hud, NCSTYLE_BOLD);
     if(ncplane_printf_yx(hud, 1, 1, "%d", elems->frames) < 0){
       return -1;
     }
@@ -521,7 +521,7 @@ int demo_render(struct notcurses* nc){
     if(ncplane_putstr_yx(hud, 1, 16, elems->name) < 0){
       return -1;
     }
-    ncplane_styles_off(hud, NCSTYLE_BOLD);
+    ncplane_off_styles(hud, NCSTYLE_BOLD);
   }
   ncinput ni;
   char32_t id;

--- a/src/demo/intro.c
+++ b/src/demo/intro.c
@@ -95,11 +95,11 @@ int intro(struct notcurses* nc){
   if(ncplane_putstr_aligned(ncp, rows / 2 - 4, NCALIGN_CENTER, s1) != (int)strlen(s1)){
     return -1;
   }
-  ncplane_styles_on(ncp, NCSTYLE_ITALIC | NCSTYLE_BOLD);
+  ncplane_on_styles(ncp, NCSTYLE_ITALIC | NCSTYLE_BOLD);
   if(ncplane_putstr_aligned(ncp, rows / 2 - 3, NCALIGN_CENTER, str) != (int)strlen(str)){
     return -1;
   }
-  ncplane_styles_off(ncp, NCSTYLE_ITALIC);
+  ncplane_off_styles(ncp, NCSTYLE_ITALIC);
   ncplane_set_fg_rgb8(ncp, 0xff, 0xff, 0xff);
   int major, minor, patch, tweak;
   notcurses_version_components(&major, &minor, &patch, &tweak);
@@ -114,7 +114,7 @@ int intro(struct notcurses* nc){
       return -1;
     }
   }
-  ncplane_styles_off(ncp, NCSTYLE_BOLD);
+  ncplane_off_styles(ncp, NCSTYLE_BOLD);
   const wchar_t wstr[] = L"▏▁ ▂ ▃ ▄ ▅ ▆ ▇ █ █ ▇ ▆ ▅ ▄ ▃ ▂ ▁▕";
   if(ncplane_putwstr_aligned(ncp, rows / 2 - 6, NCALIGN_CENTER, wstr) < 0){
     return -1;
@@ -126,11 +126,11 @@ int intro(struct notcurses* nc){
   if(rows < 45){
     ncplane_set_fg_rgb8(ncp, 0xc0, 0x80, 0x80);
     ncplane_set_bg_rgb8(ncp, 0x20, 0x20, 0x20);
-    ncplane_styles_on(ncp, NCSTYLE_BLINK); // heh FIXME replace with pulse
+    ncplane_on_styles(ncp, NCSTYLE_BLINK); // heh FIXME replace with pulse
     if(ncplane_putstr_aligned(ncp, 2, NCALIGN_CENTER, "demo runs best with at least 45 lines") < 0){
       return -1;
     }
-    ncplane_styles_off(ncp, NCSTYLE_BLINK); // heh FIXME replace with pulse
+    ncplane_off_styles(ncp, NCSTYLE_BLINK); // heh FIXME replace with pulse
   }
   struct timespec now;
   clock_gettime(CLOCK_MONOTONIC_RAW, &now);

--- a/src/demo/outro.c
+++ b/src/demo/outro.c
@@ -159,19 +159,19 @@ outro_message(struct notcurses* nc, int* rows, int* cols){
   if(ncplane_set_bg_alpha(non, CELL_ALPHA_BLEND)){
     return NULL;
   }
-  ncplane_styles_on(non, NCSTYLE_BOLD);
+  ncplane_on_styles(non, NCSTYLE_BOLD);
   if(ncplane_putstr_aligned(non, ++ybase, NCALIGN_CENTER, str0) < 0){
     return NULL;
   }
-  ncplane_styles_off(non, NCSTYLE_BOLD);
+  ncplane_off_styles(non, NCSTYLE_BOLD);
   if(ncplane_putstr_aligned(non, ++ybase, NCALIGN_CENTER, str1) < 0){
     return NULL;
   }
-  ncplane_styles_on(non, NCSTYLE_ITALIC);
+  ncplane_on_styles(non, NCSTYLE_ITALIC);
   if(ncplane_putstr_aligned(non, ++ybase, NCALIGN_CENTER, str2) < 0){
     return NULL;
   }
-  ncplane_styles_off(non, NCSTYLE_ITALIC);
+  ncplane_off_styles(non, NCSTYLE_ITALIC);
   *rows = ystart;
   *cols = xs;
   return non;

--- a/src/demo/reel.c
+++ b/src/demo/reel.c
@@ -101,13 +101,13 @@ drawcb(struct nctablet* t, bool drawfromtop){
   ncplane_set_fg_rgb8(p, 242, 242, 242);
   if(ll){
     const int summaryy = drawfromtop ? 0 : ll - 1;
-    ncplane_styles_on(p, NCSTYLE_BOLD);
+    ncplane_on_styles(p, NCSTYLE_BOLD);
     if(ncplane_printf_yx(p, summaryy, 0, "[#%u %d lines %u available] ",
                          tctx->id, tctx->lines, maxy) < 0){
       pthread_mutex_unlock(&tctx->lock);
       return -1;
     }
-    ncplane_styles_off(p, NCSTYLE_BOLD);
+    ncplane_off_styles(p, NCSTYLE_BOLD);
   }
 //fprintf(stderr, "  \\--> callback for %d, %d lines (%d/%d -> %d/%d) dir: %s wrote: %d\n", tctx->id, tctx->lines, begy, begx, maxy, maxx, cliptop ? "up" : "down", ll);
   pthread_mutex_unlock(&tctx->lock);
@@ -229,11 +229,11 @@ ncreel_demo_core(struct notcurses* nc){
   }
   // Press a for a new nc above the current, c for a new one below the
   // current, and b for a new block at arbitrary placement.
-  ncplane_styles_on(std, NCSTYLE_BOLD | NCSTYLE_ITALIC);
+  ncplane_on_styles(std, NCSTYLE_BOLD | NCSTYLE_ITALIC);
   ncplane_set_fg_rgb8(std, 58, 150, 221);
   ncplane_set_bg_default(std);
   ncplane_printf_yx(std, 1, 2, "a, b, c create tablets, DEL deletes.");
-  ncplane_styles_off(std, NCSTYLE_BOLD | NCSTYLE_ITALIC);
+  ncplane_off_styles(std, NCSTYLE_BOLD | NCSTYLE_ITALIC);
   // FIXME clrtoeol();
   struct timespec deadline;
   clock_gettime(CLOCK_MONOTONIC, &deadline);
@@ -252,12 +252,12 @@ ncreel_demo_core(struct notcurses* nc){
     tctxs = newtablet;
   }
   do{
-    ncplane_styles_set(std, NCSTYLE_NONE);
+    ncplane_set_styles(std, NCSTYLE_NONE);
     ncplane_set_fg_rgb8(std, 197, 15, 31);
     int count = ncreel_tabletcount(nr);
-    ncplane_styles_on(std, NCSTYLE_BOLD);
+    ncplane_on_styles(std, NCSTYLE_BOLD);
     ncplane_printf_yx(std, 2, 2, "%d tablet%s", count, count == 1 ? "" : "s");
-    ncplane_styles_off(std, NCSTYLE_BOLD);
+    ncplane_off_styles(std, NCSTYLE_BOLD);
     // FIXME wclrtoeol(w);
     ncplane_set_fg_rgb8(std, 0, 55, 218);
     wchar_t rw;

--- a/src/demo/trans.c
+++ b/src/demo/trans.c
@@ -53,7 +53,7 @@ legend(struct notcurses* nc, const char* msg){
     ncplane_destroy(n);
     return NULL;
   }
-  ncplane_styles_on(n, NCSTYLE_BOLD | NCSTYLE_ITALIC);
+  ncplane_on_styles(n, NCSTYLE_BOLD | NCSTYLE_ITALIC);
   if(ncplane_printf_aligned(n, 1, NCALIGN_CENTER, " %s ", msg) < 0){
     ncplane_destroy(n);
     return NULL;

--- a/src/demo/view.c
+++ b/src/demo/view.c
@@ -29,7 +29,7 @@ legend(struct ncplane* stdn, int dimy, int dimx){
   uint64_t channels = 0;
   channels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
   ncplane_set_base(n, " ", 0, channels);
-  ncplane_styles_set(n, NCSTYLE_BOLD);
+  ncplane_set_styles(n, NCSTYLE_BOLD);
   ncplane_set_fg_rgb8(n, 0xff, 0xff, 0xff);
   ncplane_set_fg_alpha(n, CELL_ALPHA_HIGHCONTRAST);
   if(ncplane_putstr_aligned(n, 0, NCALIGN_CENTER, "target launch") <= 0){
@@ -50,7 +50,7 @@ legend(struct ncplane* stdn, int dimy, int dimx){
     ncplane_destroy(n);
     return NULL;
   }
-  ncplane_styles_off(n, NCSTYLE_BOLD);
+  ncplane_off_styles(n, NCSTYLE_BOLD);
   return n;
 }
 

--- a/src/demo/whiteout.c
+++ b/src/demo/whiteout.c
@@ -199,10 +199,10 @@ message(struct ncplane* n, int maxy, int maxx, int num, int total,
   ncplane_putegc_yx(n, 2, 19, "╨", NULL);
   ncplane_set_fg_rgb8(n, 64, 128, 240);
   ncplane_set_bg_rgb8(n, 32, 64, 32);
-  ncplane_styles_on(n, NCSTYLE_ITALIC);
+  ncplane_on_styles(n, NCSTYLE_ITALIC);
   ncplane_printf_yx(n, 5, 18, " bytes: %05d EGCs: %05d cols: %05d ", bytes_out, egs_out, cols_out);
   ncplane_printf_yx(n, 1, 4, " %03dx%03d (%d/%d) ", maxx, maxy, num + 1, total);
-  ncplane_styles_off(n, NCSTYLE_ITALIC);
+  ncplane_off_styles(n, NCSTYLE_ITALIC);
   ncplane_set_fg_rgb8(n, 224, 128, 224);
   ncplane_putstr_yx(n, 3, 1, "   🔥 unicode 13, resize awareness, 24b truecolor…🔥   ");
   ncplane_set_fg_rgb8(n, 255, 255, 255);

--- a/src/demo/yield.c
+++ b/src/demo/yield.c
@@ -73,12 +73,12 @@ int yield_demo(struct notcurses* nc){
     }
     ncplane_set_bg_rgb8(std, 0x10, 0x10, 0x10);
     ncplane_set_fg_rgb8(std, 0xf0, 0x20, 0x20);
-    ncplane_set_attr(std, NCSTYLE_BOLD);
+    ncplane_set_styles(std, NCSTYLE_BOLD);
     if(tfilled > threshold_painted){
       tfilled = threshold_painted; // don't allow printing of 100.1% etc
     }
     ncplane_printf_aligned(std, 3, NCALIGN_CENTER, "Yield: %3.1f%%", ((double)tfilled * 100) / threshold_painted);
-    ncplane_set_attr(std, NCSTYLE_NONE);
+    ncplane_set_styles(std, NCSTYLE_NONE);
     DEMO_RENDER(nc);
     demo_nanosleep(nc, &scaled);
     ++iters;

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -331,12 +331,12 @@ infoplane(struct ncdirect* ncd, const fetched_info* fi){
     return -1;
   }
   ncplane_set_fg_rgb8(infop, 0xd0, 0xd0, 0xd0);
-  ncplane_set_attr(infop, NCSTYLE_UNDERLINE);
+  ncplane_set_styles(infop, NCSTYLE_UNDERLINE);
   ncplane_printf_aligned(infop, 1, NCALIGN_LEFT, " %s %s", fi->kernel, fi->kernver);
   if(fi->distro_pretty){
     ncplane_printf_aligned(infop, 1, NCALIGN_RIGHT, "%s ", fi->distro_pretty);
   }
-  ncplane_set_attr(infop, NCSTYLE_NONE);
+  ncplane_set_styles(infop, NCSTYLE_NONE);
 #ifdef __linux__
   struct sysinfo sinfo;
   sysinfo(&sinfo);
@@ -351,7 +351,7 @@ infoplane(struct ncdirect* ncd, const fetched_info* fi){
   if(notcurses_cantruecolor(nc)){
     ncplane_printf_aligned(infop, 4, NCALIGN_LEFT, " RGB TERM: %s", fi->term);
     cell c = CELL_CHAR_INITIALIZER('R');
-    cell_styles_set(&c, NCSTYLE_BOLD);
+    cell_set_styles(&c, NCSTYLE_BOLD);
     cell_set_fg_rgb8(&c, 0xd0, 0, 0);
     ncplane_putc_yx(infop, 4, 1, &c);
     cell_load_char(infop, &c, 'G');
@@ -360,14 +360,14 @@ infoplane(struct ncdirect* ncd, const fetched_info* fi){
     cell_load_char(infop, &c, 'B');
     cell_set_fg_rgb8(&c, 0, 0, 0xd);
     ncplane_putc_yx(infop, 4, 3, &c);
-    cell_styles_set(&c, NCSTYLE_NONE);
+    cell_set_styles(&c, NCSTYLE_NONE);
   }else{
     ncplane_printf_aligned(infop, 4, NCALIGN_LEFT, " TERM: %s", fi->term);
   }
   ncplane_printf_aligned(infop, 4, NCALIGN_RIGHT, "Screen0: %dx%d ", fi->dimx, fi->dimy);
   ncplane_printf_aligned(infop, 5, NCALIGN_LEFT, " LANG: %s", fi->lang);
   ncplane_printf_aligned(infop, 5, NCALIGN_RIGHT, "UID: %ju ", (uintmax_t)getuid());
-  ncplane_set_attr(infop, NCSTYLE_ITALIC);
+  ncplane_set_styles(infop, NCSTYLE_ITALIC);
   ncplane_printf_aligned(infop, 6, NCALIGN_CENTER, "%s (%d cores)", fi->cpu_model, fi->core_count);
   cell ul = CELL_TRIVIAL_INITIALIZER; cell ur = CELL_TRIVIAL_INITIALIZER;
   cell ll = CELL_TRIVIAL_INITIALIZER; cell lr = CELL_TRIVIAL_INITIALIZER;
@@ -392,7 +392,7 @@ infoplane(struct ncdirect* ncd, const fetched_info* fi){
   cell_release(infop, &ll); cell_release(infop, &lr);
   cell_release(infop, &hl); cell_release(infop, &vl);
   ncplane_set_fg_rgb8(infop, 0xff, 0xff, 0xff);
-  ncplane_set_attr(infop, NCSTYLE_BOLD);
+  ncplane_set_styles(infop, NCSTYLE_BOLD);
   if(ncplane_printf_aligned(infop, 0, NCALIGN_CENTER, "[ %s@%s ]",
                             fi->username, fi->hostname) < 0){
     return -1;

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -237,7 +237,7 @@ write_header(ncmenu* ncm){ ncm->ncp->channels = ncm->headerchannels;
     return -1;
   }
   cell c = CELL_INITIALIZER(' ', 0, ncm->headerchannels);
-  ncplane_set_attr(ncm->ncp, 0);
+  ncplane_set_styles(ncm->ncp, 0);
   if(ncplane_putc(ncm->ncp, &c) < 0){
     return -1;
   }
@@ -268,7 +268,7 @@ write_header(ncmenu* ncm){ ncm->ncp->channels = ncm->headerchannels;
         if(ncplane_at_yx_cell(ncm->ncp, ypos, xoff + ncm->sections[i].shortcut_offset, &cl) < 0){
           return -1;
         }
-        cell_styles_on(&cl, NCSTYLE_UNDERLINE|NCSTYLE_BOLD);
+        cell_on_styles(&cl, NCSTYLE_UNDERLINE|NCSTYLE_BOLD);
         if(ncplane_putc_yx(ncm->ncp, ypos, xoff + ncm->sections[i].shortcut_offset, &cl) < 0){
           return -1;
         }
@@ -377,9 +377,9 @@ int ncmenu_unroll(ncmenu* n, int sectionidx){
     if(sec->items[i].desc){
       n->ncp->channels = n->sectionchannels;
       if(i == sec->itemselected){
-        ncplane_set_attr(n->ncp, NCSTYLE_REVERSE);
+        ncplane_set_styles(n->ncp, NCSTYLE_REVERSE);
       }else{
-        ncplane_set_attr(n->ncp, 0);
+        ncplane_set_styles(n->ncp, 0);
       }
       int cols = ncplane_putstr_yx(n->ncp, ypos, xpos + 1, sec->items[i].desc);
       if(cols < 0){
@@ -408,7 +408,7 @@ int ncmenu_unroll(ncmenu* n, int sectionidx){
         if(ncplane_at_yx_cell(n->ncp, ypos, xpos + 1 + sec->items[i].shortcut_offset, &cl) < 0){
           return -1;
         }
-        cell_styles_on(&cl, NCSTYLE_UNDERLINE|NCSTYLE_BOLD);
+        cell_on_styles(&cl, NCSTYLE_UNDERLINE|NCSTYLE_BOLD);
         if(ncplane_putc_yx(n->ncp, ypos, xpos + 1 + sec->items[i].shortcut_offset, &cl) < 0){
           return -1;
         }
@@ -416,7 +416,7 @@ int ncmenu_unroll(ncmenu* n, int sectionidx){
       }
     }else{
       n->ncp->channels = n->headerchannels;
-      ncplane_set_attr(n->ncp, 0);
+      ncplane_set_styles(n->ncp, 0);
       if(ncplane_putegc_yx(n->ncp, ypos, xpos, "├", NULL) < 0){
         return -1;
       }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -451,7 +451,7 @@ inline int ncplane_cursor_move_yx(ncplane* n, int y, int x){
 ncplane* ncplane_dup(const ncplane* n, void* opaque){
   int dimy = n->leny;
   int dimx = n->lenx;
-  uint16_t attr = ncplane_attr(n);
+  uint16_t attr = ncplane_styles(n);
   uint64_t chan = ncplane_channels(n);
   // if we're duping the standard plane, we need adjust for marginalia
   const struct notcurses* nc = ncplane_notcurses_const(n);
@@ -1132,11 +1132,7 @@ uint64_t ncplane_channels(const ncplane* n){
   return n->channels;
 }
 
-uint16_t ncplane_attr(const ncplane* n){
-  return n->stylemask;
-}
-
-unsigned ncplane_styles(const ncplane* n){
+uint16_t ncplane_styles(const ncplane* n){
   return n->stylemask;
 }
 
@@ -1517,23 +1513,30 @@ bool notcurses_cantruecolor(const notcurses* nc){
 }
 
 // conform to the specified stylebits
-void ncplane_styles_set(ncplane* n, unsigned stylebits){
+void ncplane_set_styles(ncplane* n, unsigned stylebits){
   n->stylemask = (stylebits & NCSTYLE_MASK);
 }
 
+void ncplane_styles_set(ncplane* n, unsigned stylebits){ // deprecated
+  ncplane_set_styles(n, stylebits);
+}
+
 // turn on any specified stylebits
-void ncplane_styles_on(ncplane* n, unsigned stylebits){
+void ncplane_on_styles(ncplane* n, unsigned stylebits){
   n->stylemask |= (stylebits & NCSTYLE_MASK);
 }
 
+void ncplane_styles_on(ncplane* n, unsigned stylebits){ // deprecated
+  ncplane_on_styles(n, stylebits);
+}
+
 // turn off any specified stylebits
-void ncplane_styles_off(ncplane* n, unsigned stylebits){
+void ncplane_off_styles(ncplane* n, unsigned stylebits){
   n->stylemask &= ~(stylebits & NCSTYLE_MASK);
 }
 
-// set the current stylebits to exactly those provided
-void ncplane_set_attr(ncplane* n, unsigned stylebits){
-  n->stylemask = stylebits & NCSTYLE_MASK;
+void ncplane_styles_off(ncplane* n, unsigned stylebits){ // deprecated
+  ncplane_off_styles(n, stylebits);
 }
 
 // i hate the big allocation and two copies here, but eh what you gonna do?

--- a/src/lib/plot.h
+++ b/src/lib/plot.h
@@ -146,7 +146,7 @@ class ncppplot {
    // if we want fewer slots than there are available columns, our final column
    // will be other than the plane's final column. most recent x goes here.
    const int finalx = (slotcount < scaleddim - 1 - (startx * scale) ? startx + (slotcount / scale) - 1 : dimx - 1);
-   ncplane_set_attr(ncp, legendstyle);
+   ncplane_set_styles(ncp, legendstyle);
    if(labelaxisd){
      // show the *top* of each interval range
      for(int y = 0 ; y < dimy ; ++y){
@@ -177,7 +177,7 @@ class ncppplot {
       ncplane_set_channels(ncp, channels);
       ncplane_printf_yx(ncp, 0, PREFIXCOLUMNS - title.length(), "%s", title.c_str());
    }
-   ncplane_set_attr(ncp, NCSTYLE_NONE);
+   ncplane_set_styles(ncp, NCSTYLE_NONE);
    if(finalx < startx){ // exit on pathologically narrow planes
      return 0;
    }

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -31,7 +31,7 @@ ncreader* ncreader_create(ncplane* n, const ncreader_options* opts){
   nr->no_cmd_keys = opts->flags & NCREADER_OPTION_NOCMDKEYS;
   nr->manage_cursor = opts->flags & NCREADER_OPTION_CURSOR;
   ncplane_set_channels(nr->ncp, opts->tchannels);
-  ncplane_set_attr(nr->ncp, opts->tattrword);
+  ncplane_set_styles(nr->ncp, opts->tattrword);
   return nr;
 }
 

--- a/src/poc/sgr-full.c
+++ b/src/poc/sgr-full.c
@@ -9,15 +9,15 @@ int main(void){
   }
   int dimy, dimx;
   struct ncplane* n = notcurses_stddim_yx(nc, &dimy, &dimx);
-  ncplane_set_attr(n, NCSTYLE_NONE);
+  ncplane_set_styles(n, NCSTYLE_NONE);
   ncplane_putstr_yx(n, 0, 0, "a ═ none");
-  ncplane_set_attr(n, NCSTYLE_ITALIC);
+  ncplane_set_styles(n, NCSTYLE_ITALIC);
   ncplane_putstr_yx(n, 1, 0, "a ═ italic");
-  ncplane_set_attr(n, NCSTYLE_BOLD);
+  ncplane_set_styles(n, NCSTYLE_BOLD);
   ncplane_putstr_yx(n, 2, 0, "a ═ bold");
-  ncplane_set_attr(n, NCSTYLE_REVERSE);
+  ncplane_set_styles(n, NCSTYLE_REVERSE);
   ncplane_putstr_yx(n, 3, 0, "a ═ reverse");
-  ncplane_set_attr(n, NCSTYLE_UNDERLINE);
+  ncplane_set_styles(n, NCSTYLE_UNDERLINE);
   ncplane_putstr_yx(n, 4, 0, "a ═ underline");
   ncplane_putstr_yx(n, 5, 0, "sleeping for 5s...");
   if(notcurses_render(nc)){

--- a/tests/cell.cpp
+++ b/tests/cell.cpp
@@ -63,39 +63,39 @@ TEST_CASE("Cell") {
     cell c = CELL_TRIVIAL_INITIALIZER;
     int dimy, dimx;
     notcurses_term_dim_yx(nc_, &dimy, &dimx);
-    cell_styles_set(&c, NCSTYLE_ITALIC);
+    cell_set_styles(&c, NCSTYLE_ITALIC);
     CHECK(1 == cell_load(n_, &c, "i"));
     cell_set_fg_rgb8(&c, 255, 255, 255);
     ncplane_set_base_cell(n_, &c);
     cell_release(n_, &c);
     CHECK(0 == notcurses_render(nc_));
-    cell_styles_off(&c, NCSTYLE_ITALIC);
+    cell_off_styles(&c, NCSTYLE_ITALIC);
   }
 
   SUBCASE("SetBold") {
     cell c = CELL_TRIVIAL_INITIALIZER;
     int dimy, dimx;
     notcurses_term_dim_yx(nc_, &dimy, &dimx);
-    cell_styles_set(&c, NCSTYLE_BOLD);
+    cell_set_styles(&c, NCSTYLE_BOLD);
     CHECK(1 == cell_load(n_, &c, "b"));
     cell_set_fg_rgb8(&c, 255, 255, 255);
     ncplane_set_base_cell(n_, &c);
     cell_release(n_, &c);
     CHECK(0 == notcurses_render(nc_));
-    cell_styles_off(&c, NCSTYLE_BOLD);
+    cell_off_styles(&c, NCSTYLE_BOLD);
   }
 
   SUBCASE("SetUnderline") {
     cell c = CELL_TRIVIAL_INITIALIZER;
     int dimy, dimx;
     notcurses_term_dim_yx(nc_, &dimy, &dimx);
-    cell_styles_set(&c, NCSTYLE_UNDERLINE);
+    cell_set_styles(&c, NCSTYLE_UNDERLINE);
     CHECK(1 == cell_load(n_, &c, "u"));
     cell_set_fg_rgb8(&c, 255, 255, 255);
     ncplane_set_base_cell(n_, &c);
     cell_release(n_, &c);
     CHECK(0 == notcurses_render(nc_));
-    cell_styles_off(&c, NCSTYLE_UNDERLINE);
+    cell_off_styles(&c, NCSTYLE_UNDERLINE);
   }
 
   /*SUBCASE("CellLoadTamil") {

--- a/tests/fills.cpp
+++ b/tests/fills.cpp
@@ -216,7 +216,7 @@ TEST_CASE("Fills") {
     // attr should change, but not the EGC/color
     CHECK(0 == ncplane_cursor_move_yx(n_, 0, 0));
     cell c = CELL_TRIVIAL_INITIALIZER;
-    cell_styles_on(&c, NCSTYLE_BOLD);
+    cell_on_styles(&c, NCSTYLE_BOLD);
     CHECK(0 < ncplane_format(n_, 0, 0, c.stylemask));
     cell d = CELL_TRIVIAL_INITIALIZER;
     CHECK(1 == ncplane_at_yx_cell(n_, 0, 0, &d));

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -482,7 +482,7 @@ TEST_CASE("NCPlane") {
     const char STR1[] = "Jackdaws love my big sphinx of quartz";
     const char STR2[] = "Cwm fjord bank glyphs vext quiz";
     const char STR3[] = "Pack my box with five dozen liquor jugs";
-    ncplane_styles_set(n_, NCSCALE_NONE);
+    ncplane_set_styles(n_, NCSCALE_NONE);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_putstr(n_, STR1));
     cell testcell = CELL_TRIVIAL_INITIALIZER;
@@ -519,7 +519,7 @@ TEST_CASE("NCPlane") {
     const char STR1[] = "Σιβυλλα τι θελεις; respondebat illa:";
     const char STR2[] = "αποθανειν θελω";
     const char STR3[] = "Война и мир"; // just thrown in to complicate things
-    ncplane_styles_set(n_, NCSTYLE_NONE);
+    ncplane_set_styles(n_, NCSTYLE_NONE);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
     REQUIRE(0 < ncplane_putstr(n_, STR1));
     cell testcell = CELL_TRIVIAL_INITIALIZER;
@@ -556,17 +556,17 @@ TEST_CASE("NCPlane") {
     const char STR1[] = "this has been a world destroyer production";
     const char STR2[] = "not to mention dank";
     const char STR3[] = "da chronic lives";
-    ncplane_styles_set(n_, NCSTYLE_BOLD);
+    ncplane_set_styles(n_, NCSTYLE_BOLD);
     REQUIRE(0 < ncplane_putstr(n_, STR1));
     int y, x;
     ncplane_cursor_yx(n_, &y, &x);
     CHECK(0 == ncplane_cursor_move_yx(n_, y + 1, x - strlen(STR2)));
-    ncplane_styles_on(n_, NCSTYLE_ITALIC);
+    ncplane_on_styles(n_, NCSTYLE_ITALIC);
     REQUIRE(0 < ncplane_putstr(n_, STR2));
     CHECK(0 == ncplane_cursor_move_yx(n_, y + 2, x - strlen(STR3)));
-    ncplane_styles_off(n_, NCSTYLE_BOLD);
+    ncplane_off_styles(n_, NCSTYLE_BOLD);
     REQUIRE(0 < ncplane_putstr(n_, STR3));
-    ncplane_styles_off(n_, NCSTYLE_ITALIC);
+    ncplane_off_styles(n_, NCSTYLE_ITALIC);
     CHECK(0 == notcurses_render(nc_));
     int newx;
     ncplane_cursor_yx(n_, &y, &newx);

--- a/tests/wide.cpp
+++ b/tests/wide.cpp
@@ -881,7 +881,7 @@ TEST_CASE("Wide") {
     cell c = CELL_TRIVIAL_INITIALIZER;
     cell_load(n_, &c, "\U0001F90C");
     CHECK(0x8ca49ff0lu == c.gcluster);
-    cell_styles_on(&c, NCSTYLE_ITALIC);
+    cell_on_styles(&c, NCSTYLE_ITALIC);
     CHECK(4 == strlen(cell_extended_gcluster(n_, &c)));
     CHECK(0 == strcmp("\U0001F90C", cell_extended_gcluster(n_, &c)));
     CHECK(0 < ncplane_putc_yx(n_, 0, 0, &c));
@@ -900,7 +900,7 @@ TEST_CASE("Wide") {
     cell c = CELL_TRIVIAL_INITIALIZER;
     cell_load(n_, &c, "\U0001F90C");
     CHECK(0x8ca49ff0lu == c.gcluster);
-    cell_styles_on(&c, NCSTYLE_MASK);
+    cell_on_styles(&c, NCSTYLE_MASK);
     CHECK(4 == strlen(cell_extended_gcluster(n_, &c)));
     CHECK(0 == strcmp("\U0001F90C", cell_extended_gcluster(n_, &c)));
     CHECK(0 < ncplane_putc_yx(n_, 0, 0, &c));


### PR DESCRIPTION
Every other `*_set*` function in `notcurses.h` takes the form `object_set_property()`, but these troublemakers took the form `object_property_set()`. Renamed. Retained the older versions as deprecated aliases for `ncplane`, so that older binaries continue to link. Didn't bother with `cell`, since those were inline.

I *think* this is the last API change needing making.

Updated all demos, tests, and PoCs.