### PR TITLE
[C++] Deal with widgets grabbing full ownership of Panel

### DIFF
--- a/include/ncpp/FDPlane.hh
+++ b/include/ncpp/FDPlane.hh
@@ -5,51 +5,38 @@
 
 #include "Utilities.hh"
 #include "Plane.hh"
+#include "Widget.hh"
 
 namespace ncpp
 {
-	class NCPP_API_EXPORT FDPlane : public Root
+	class NCPP_API_EXPORT FDPlane : public Widget
 	{
 	public:
 		static ncfdplane_options default_options;
 
 	public:
-		explicit FDPlane (Plane* n, int fd, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: FDPlane (n, fd, nullptr, cbfxn, donecbfxn)
+		explicit FDPlane (Plane *plane, int fd, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: FDPlane (plane, fd, nullptr, cbfxn, donecbfxn)
 		{}
 
-		explicit FDPlane (const Plane* n, int fd, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: FDPlane (n, fd, nullptr, cbfxn, donecbfxn)
-		{}
-
-		explicit FDPlane (Plane* n, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: FDPlane (static_cast<const Plane*>(n), fd, opts, cbfxn, donecbfxn)
-		{}
-
-		explicit FDPlane (const Plane* n, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Root (Utilities::get_notcurses_cpp (n))
+		explicit FDPlane (Plane *plane, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
-			if (n == nullptr)
-				throw invalid_argument ("'n' must be a valid pointer");
-			create_fdplane (const_cast<Plane&>(*n), fd, opts, cbfxn, donecbfxn);
+			ensure_valid_plane (plane);
+			create_fdplane (*plane, fd, opts, cbfxn, donecbfxn);
+			take_plane_ownership (plane);
 		}
 
-		explicit FDPlane (const Plane& n, int fd, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: FDPlane (n, fd, nullptr, cbfxn, donecbfxn)
+		explicit FDPlane (Plane &plane, int fd, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: FDPlane (plane, fd, nullptr, cbfxn, donecbfxn)
 		{}
 
-		explicit FDPlane (Plane& n, int fd, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: FDPlane (n, fd, nullptr, cbfxn, donecbfxn)
-		{}
-
-		explicit FDPlane (Plane& n, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: FDPlane (static_cast<Plane const&>(n), fd, opts, cbfxn, donecbfxn)
-		{}
-
-		explicit FDPlane (const Plane& n, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Root (Utilities::get_notcurses_cpp (n))
+		explicit FDPlane (Plane &plane, int fd, ncfdplane_options *opts = nullptr, ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
-			create_fdplane (const_cast<Plane&>(n), fd, opts, cbfxn, donecbfxn);
+			ensure_valid_plane (plane);
+			create_fdplane (plane, fd, opts, cbfxn, donecbfxn);
+			take_plane_ownership (plane);
 		}
 
 		~FDPlane ()

--- a/include/ncpp/MultiSelector.hh
+++ b/include/ncpp/MultiSelector.hh
@@ -6,33 +6,30 @@
 #include "NCAlign.hh"
 #include "Plane.hh"
 #include "Utilities.hh"
+#include "Widget.hh"
 
 namespace ncpp
 {
-	class NCPP_API_EXPORT MultiSelector : public Root
+	class NCPP_API_EXPORT MultiSelector : public Widget
 	{
 	public:
 		static ncmultiselector_options default_options;
 
 	public:
 		explicit MultiSelector (Plane *plane, const ncmultiselector_options *opts = nullptr)
-			: MultiSelector (static_cast<const Plane*>(plane), opts)
-		{}
-
-		explicit MultiSelector (Plane const* plane, const ncmultiselector_options *opts = nullptr)
-			: Root (Utilities::get_notcurses_cpp (plane))
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
+			ensure_valid_plane (plane);
 			common_init (Utilities::to_ncplane (plane), opts);
+			take_plane_ownership (plane);
 		}
 
 		explicit MultiSelector (Plane &plane, const ncmultiselector_options *opts = nullptr)
-			: MultiSelector (static_cast<Plane const&>(plane), opts)
-		{}
-
-		explicit MultiSelector (Plane const& plane, const ncmultiselector_options *opts = nullptr)
-			: Root (Utilities::get_notcurses_cpp (plane))
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
+			ensure_valid_plane (plane);
 			common_init (Utilities::to_ncplane (plane), opts);
+			take_plane_ownership (plane);
 		}
 
 		~MultiSelector ()

--- a/include/ncpp/Reader.hh
+++ b/include/ncpp/Reader.hh
@@ -6,33 +6,27 @@
 #include "NCAlign.hh"
 #include "Plane.hh"
 #include "Utilities.hh"
+#include "Widget.hh"
 
 namespace ncpp
 {
-	class NCPP_API_EXPORT Reader : public Root
+	class NCPP_API_EXPORT Reader : public Widget
 	{
 	public:
-		explicit Reader (Plane *p, const ncreader_options *opts)
-			: Reader (static_cast<const Plane*>(p), opts)
-		{}
-
-		explicit Reader (Plane const* p, const ncreader_options *opts)
-			: Root (Utilities::get_notcurses_cpp (p))
+		explicit Reader (Plane *plane, const ncreader_options *opts)
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
-			if (p == nullptr)
-				throw invalid_argument ("'plane' must be a valid pointer");
-
-			common_init (Utilities::to_ncplane (p), opts);
+			ensure_valid_plane (plane);
+			common_init (Utilities::to_ncplane (plane), opts);
+			take_plane_ownership (plane);
 		}
 
-		explicit Reader (Plane &p, const ncreader_options *opts)
-			: Reader (static_cast<Plane const&>(p), opts)
-		{}
-
-		explicit Reader (Plane const& p, const ncreader_options *opts)
-			: Root (Utilities::get_notcurses_cpp (p))
+		explicit Reader (Plane &plane, const ncreader_options *opts)
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
-			common_init (Utilities::to_ncplane (p), opts);
+			ensure_valid_plane (plane);
+			common_init (Utilities::to_ncplane (plane), opts);
+			take_plane_ownership (plane);
 		}
 
 		~Reader ()

--- a/include/ncpp/Reel.hh
+++ b/include/ncpp/Reel.hh
@@ -7,35 +7,32 @@
 #include "Tablet.hh"
 #include "Plane.hh"
 #include "Utilities.hh"
+#include "Widget.hh"
 
 namespace ncpp
 {
-	class NCPP_API_EXPORT NcReel : public Root
+	class NCPP_API_EXPORT NcReel : public Widget
 	{
 	public:
 		static ncreel_options default_options;
 
 		explicit NcReel (Plane &plane, const ncreel_options *popts = nullptr)
-			: NcReel (static_cast<Plane const&>(plane), popts)
-		{}
-
-		explicit NcReel (Plane const&plane, const ncreel_options *popts = nullptr)
-			: Root (Utilities::get_notcurses_cpp (plane))
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
+			ensure_valid_plane (plane);
 			common_init (Utilities::to_ncplane (plane), popts);
+			take_plane_ownership (plane);
 		}
 
 		explicit NcReel (Plane *plane, const ncreel_options *popts = nullptr)
-			: NcReel (static_cast<const Plane*>(plane), popts)
-		{}
-
-		explicit NcReel (const Plane *plane, const ncreel_options *popts = nullptr)
-			: Root (Utilities::get_notcurses_cpp (plane))
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
 			if (plane == nullptr)
 				throw invalid_argument ("'plane' must be a valid pointer");
 
+			ensure_valid_plane (plane);
 			common_init (Utilities::to_ncplane (plane), popts);
+			take_plane_ownership (plane);
 		}
 
 		~NcReel ()

--- a/include/ncpp/Selector.hh
+++ b/include/ncpp/Selector.hh
@@ -6,35 +6,33 @@
 #include "NCAlign.hh"
 #include "Plane.hh"
 #include "Utilities.hh"
+#include "Widget.hh"
 
 namespace ncpp
 {
-	class NCPP_API_EXPORT Selector : public Root
+	class NCPP_API_EXPORT Selector : public Widget
 	{
 	public:
 		static ncselector_options default_options;
 
 	public:
 		explicit Selector (Plane *plane, const ncselector_options *opts = nullptr)
-			: Selector (static_cast<const Plane*>(plane), opts)
-		{}
-
-		explicit Selector (Plane const* plane, const ncselector_options *opts = nullptr)
-			: Root (Utilities::get_notcurses_cpp (plane))
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
 			if (plane == nullptr)
 				throw invalid_argument ("'plane' must be a valid pointer");
+
+			ensure_valid_plane (plane);
 			common_init (Utilities::to_ncplane (plane), opts);
+			take_plane_ownership (plane);
 		}
 
 		explicit Selector (Plane &plane, const ncselector_options *opts = nullptr)
-			: Selector (static_cast<Plane const&>(plane), opts)
-		{}
-
-		explicit Selector (Plane const& plane, const ncselector_options *opts = nullptr)
-			: Root (Utilities::get_notcurses_cpp (plane))
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
+			ensure_valid_plane (plane);
 			common_init (Utilities::to_ncplane (plane), opts);
+			take_plane_ownership (plane);
 		}
 
 		~Selector ()

--- a/include/ncpp/Subproc.hh
+++ b/include/ncpp/Subproc.hh
@@ -5,67 +5,47 @@
 
 #include "Root.hh"
 #include "Plane.hh"
+#include "Widget.hh"
+#include "Utilities.hh"
 
 namespace ncpp
 {
-	class NCPP_API_EXPORT Subproc : public Root
+	class NCPP_API_EXPORT Subproc : public Widget
 	{
 	public:
 		static ncsubproc_options default_options;
 
 	public:
-		explicit Subproc (Plane* n, const char* bin, bool use_path = true,
+		explicit Subproc (Plane* plane, const char* bin, bool use_path = true,
 		                  char* const arg[] = nullptr, char* const env[] = nullptr,
 		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Subproc (n, bin, nullptr, use_path, arg, env, cbfxn, donecbfxn)
+			: Subproc (plane, bin, nullptr, use_path, arg, env, cbfxn, donecbfxn)
 		{}
 
-		explicit Subproc (const Plane* n, const char* bin, bool use_path = true,
+		explicit Subproc (Plane* plane, const char* bin, const ncsubproc_options* opts, bool use_path = true,
 		                  char* const arg[] = nullptr, char* const env[] = nullptr,
 		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Subproc (n, bin, nullptr, use_path, arg, env, cbfxn, donecbfxn)
-		{}
-
-		explicit Subproc (Plane* n, const char* bin, const ncsubproc_options* opts, bool use_path = true,
-		                  char* const arg[] = nullptr, char* const env[] = nullptr,
-		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Subproc (static_cast<const Plane*>(n), bin, opts, use_path, arg, env, cbfxn, donecbfxn)
-		{}
-
-		explicit Subproc (const Plane* n, const char* bin, const ncsubproc_options* opts, bool use_path = true,
-		                  char* const arg[] = nullptr, char* const env[] = nullptr,
-		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Root (Utilities::get_notcurses_cpp (n))
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
-			if (n == nullptr)
-				throw invalid_argument ("'n' must be a valid pointer");
-			create_subproc (const_cast<Plane&>(*n), bin, opts, use_path, arg, env, cbfxn, donecbfxn);
+			ensure_valid_plane (plane);
+			create_subproc (*plane, bin, opts, use_path, arg, env, cbfxn, donecbfxn);
+			take_plane_ownership (plane);
 		}
 
-		explicit Subproc (Plane const& n, const char* bin, bool use_path = true,
+		explicit Subproc (Plane& plane, const char* bin, bool use_path = true,
 		                  char* const arg[] = nullptr, char* const env[] = nullptr,
 		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Subproc (n, bin, nullptr, use_path, arg, env, cbfxn, donecbfxn)
+			: Subproc (plane, bin, nullptr, use_path, arg, env, cbfxn, donecbfxn)
 		{}
 
-		explicit Subproc (Plane& n, const char* bin, bool use_path = true,
+		explicit Subproc (Plane& plane, const char* bin, const ncsubproc_options* opts, bool use_path = true,
 		                  char* const arg[] = nullptr, char* const env[] = nullptr,
 		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Subproc (n, bin, nullptr, use_path, arg, env, cbfxn, donecbfxn)
-		{}
-
-		explicit Subproc (Plane& n, const char* bin, const ncsubproc_options* opts, bool use_path = true,
-		                  char* const arg[] = nullptr, char* const env[] = nullptr,
-		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Subproc (static_cast<Plane const&>(n), bin, opts, use_path, arg, env, cbfxn, donecbfxn)
-		{}
-
-		explicit Subproc (const Plane& n, const char* bin, const ncsubproc_options* opts, bool use_path = true,
-		                  char* const arg[] = nullptr, char* const env[] = nullptr,
-		                  ncfdplane_callback cbfxn = nullptr, ncfdplane_done_cb donecbfxn = nullptr)
-			: Root (Utilities::get_notcurses_cpp (n))
+			: Widget (Utilities::get_notcurses_cpp (plane))
 		{
-			create_subproc (const_cast<Plane&>(n), bin, opts, use_path, arg, env, cbfxn, donecbfxn);
+			ensure_valid_plane (plane);
+			create_subproc (plane, bin, opts, use_path, arg, env, cbfxn, donecbfxn);
+			take_plane_ownership (plane);
 		}
 
 		~Subproc ()

--- a/include/ncpp/Widget.hh
+++ b/include/ncpp/Widget.hh
@@ -1,0 +1,43 @@
+#ifndef __NCPP_WIDGET_HH
+#define __NCPP_WIDGET_HH
+
+#include "Root.hh"
+#include "Plane.hh"
+
+namespace ncpp
+{
+	class NCPP_API_EXPORT Widget : public Root
+	{
+	protected:
+		explicit Widget (NotCurses *ncinst)
+			: Root (ncinst)
+		{}
+
+		void ensure_valid_plane (Plane *plane) const
+		{
+			if (plane == nullptr)
+				throw invalid_argument ("'plane' must be a valid pointer");
+			ensure_valid_plane (*plane);
+		}
+
+		void ensure_valid_plane (Plane &plane) const
+		{
+			if (!plane.is_valid ())
+				throw invalid_argument ("Invalid Plane object passed in 'plane'. Widgets must not reuse the same plane.");
+		}
+
+		void take_plane_ownership (Plane *plane) const
+		{
+			if (plane == nullptr)
+				return;
+
+			take_plane_ownership (*plane);
+		}
+
+		void take_plane_ownership (Plane &plane) const
+		{
+			plane.release_native_plane ();
+		}
+	};
+}
+#endif // __NCPP_WIDGET_HH

--- a/src/libcpp/Plane.cc
+++ b/src/libcpp/Plane.cc
@@ -1,4 +1,5 @@
 #include <ncpp/Plane.hh>
+#include <ncpp/Reel.hh>
 #include <ncpp/internal/Helpers.hh>
 
 using namespace ncpp;
@@ -27,4 +28,9 @@ void Plane::unmap_plane (Plane *p) noexcept
 		return;
 
 	internal::Helpers::remove_map_entry (plane_map, plane_map_mutex, p->plane);
+}
+
+NcReel* Plane::ncreel_create (const ncreel_options *popts)
+{
+	return new NcReel (this, popts);
 }

--- a/src/poc/ncpp_build.cpp
+++ b/src/poc/ncpp_build.cpp
@@ -27,14 +27,12 @@ int run ()
 
 	const char *ncver = nc.version ();
 	{
-    /*
 		Plane p1 (1, 1, 0, 0);
 		Plot plot1 (p1);
 		Plane p2 (1, 1, 0, 0);
 		PlotU plot2 (p2);
 		Plane p3 (1, 1, 0, 0);
 		PlotD plot3 (p3);
-    */
 	}
 
 	nc.stop ();

--- a/src/poc/ncpp_build_exceptions.cpp
+++ b/src/poc/ncpp_build_exceptions.cpp
@@ -27,14 +27,14 @@ int run ()
 	NotCurses nc;
 
 	const char *ncver = nc.version ();
-  {
-    /*
-    Plane plane (1, 1, 0, 0);
-    Plot plot1 (plane);
-    PlotU plot2 (plane);
-    PlotD plot3 (plane);
-    */
-  }
+	{
+		Plane p1 (1, 1, 0, 0);
+		Plot plot1 (p1);
+		Plane p2 (1, 1, 0, 0);
+		PlotU plot2 (p2);
+		Plane p3 (1, 1, 0, 0);
+		PlotD plot3 (p3);
+	}
 
 	nc.stop ();
 


### PR DESCRIPTION
Fixes: https://github.com/dankamongmen/notcurses/issues/1009

Whenever a widget is created with its `*_create` function it currently
claims full ownership of the passed panel, including its destruction.
However, the C++ wrapper around the panel is not aware of this and will
attempt to destroy the native panel in the destructor, leading to
segfaults.

Fix this by introduction of a `Widget` class which contains the logic to
properly modify the `Panel` instance to not double-destroy the native
panel.  The solution is a bit fragile since the `Panel` instance is left
intact (we can't free it for the user) in a state that's safe for the
C++ wrapper, but calling any C function via the wrapper **will** pass a
`NULL` pointer in the panel argument - therefore the C functions MUST be
proofed against this.  The proofing belongs in the C backend code since
this protects also C and other language binding users from such abuse.

The Widget class will first verify that the passed `Plane` instance
hasn't already been "disowned" and will throw an exception to the effect
if it was.  Next, it will proceed to take over ownership of the native
panel instance and mark the passed `Panel` as "invalid" (i.e. not owning
any native panel instance anymore)

The above changes require modification of `Panel` instances and so all
the widget constructors taking `const*` or `const&` have been removed
from widget classes.