### PR TITLE
Split render+raster process/stats from writing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 1.7.6 (not yet released)
+  * `ncstats` added the new stats `writeout_ns`, `writeout_min_ns`, and
+    `writeout_max_ns`. The `render_*ns` stats now only cover the rendering
+    and rasterizing process. The `writeout*ns` stats cover the time spent
+    writing data out to the terminal. `notcurses_render()` involves both of
+    these processes.
+
 * 1.7.5 (2020-09-29)
   * `ncreel_destroy()` now returns `void` rather than `int`.
   * `nctablet_ncplane()` has been renamed `nctablet_plane()`.

--- a/USAGE.md
+++ b/USAGE.md
@@ -12,6 +12,7 @@ version 2, notcurses will honor Semantic Versioning.
 * [Widgets](#widgets) ([Readers](#readers))
 * [Channels](#channels)
 * [Visuals](#visuals) ([QR codes](#qrcodes)) ([Multimedia](#multimedia)) ([Pixels](#pixels))
+* [Stats](#stats)
 * [C++](#c++)
 
 A full API reference [is available](https://nick-black.com/notcurses/). Manual
@@ -2808,6 +2809,47 @@ ncpixel_set_rgb8(uint32_t* pixel, int r, int g, int b){
   return 0;
 }
 ```
+
+## Stats
+
+Notcurses supplies a number of stats related to performance and state.
+Cumulative stats can be reset at any time.
+
+```c
+typedef struct ncstats {
+  // purely increasing stats
+  uint64_t renders;          // number of successful notcurses_render() runs
+  uint64_t failed_renders;   // number of aborted renders, should be 0
+  uint64_t render_bytes;     // bytes emitted to ttyfp
+  int64_t render_max_bytes;  // max bytes emitted for a frame
+  int64_t render_min_bytes;  // min bytes emitted for a frame
+  uint64_t render_ns;        // nanoseconds spent in render+raster
+  int64_t render_max_ns;     // max ns spent in render+raster for a frame
+  int64_t render_min_ns;     // min ns spent in render+raster for a frame
+  uint64_t writeout_ns;      // nanoseconds spent writing frames to terminal
+  int64_t writeout_max_ns;   // max ns spent writing out a frame
+  int64_t writeout_min_ns;   // min ns spent writing out a frame
+  uint64_t cellelisions;     // cells we elided entirely thanks to damage maps
+  uint64_t cellemissions;    // total number of cells emitted to terminal
+  uint64_t fgelisions;       // RGB fg elision count
+  uint64_t fgemissions;      // RGB fg emissions
+  uint64_t bgelisions;       // RGB bg elision count
+  uint64_t bgemissions;      // RGB bg emissions
+  uint64_t defaultelisions;  // default color was emitted
+  uint64_t defaultemissions; // default color was elided
+
+  // current state -- these can decrease
+  uint64_t fbbytes;          // total bytes devoted to all active framebuffers
+  unsigned planes;           // number of planes currently in existence
+} ncstats;
+
+// Acquire an atomic snapshot of the notcurses object's stats.
+void notcurses_stats(const struct notcurses* nc, ncstats* stats);
+
+// Reset all cumulative stats (immediate ones, such as fbbytes, are not reset).
+void notcurses_reset_stats(struct notcurses* nc, ncstats* stats);
+```
+
 
 ## C++
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1093,11 +1093,14 @@ typedef struct ncstats {
   uint64_t render_bytes;     // bytes emitted to ttyfp
   int64_t render_max_bytes;  // max bytes emitted for a frame
   int64_t render_min_bytes;  // min bytes emitted for a frame
-  uint64_t render_ns;        // nanoseconds spent in notcurses_render()
-  int64_t render_max_ns;     // max ns spent in notcurses_render()
-  int64_t render_min_ns;     // min ns spent in successful notcurses_render()
+  uint64_t render_ns;        // nanoseconds spent in render+raster
+  int64_t render_max_ns;     // max ns spent in render+raster for a frame
+  int64_t render_min_ns;     // min ns spent in render+raster for a frame
+  uint64_t writeout_ns;      // nanoseconds spent writing frames to terminal
+  int64_t writeout_max_ns;   // max ns spent writing out a frame
+  int64_t writeout_min_ns;   // min ns spent writing out a frame
   uint64_t cellelisions;     // cells we elided entirely thanks to damage maps
-  uint64_t cellemissions;    // cells we emitted due to inferred damage
+  uint64_t cellemissions;    // total number of cells emitted to terminal
   uint64_t fgelisions;       // RGB fg elision count
   uint64_t fgemissions;      // RGB fg emissions
   uint64_t bgelisions;       // RGB bg elision count

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -403,14 +403,16 @@ summary_table(struct ncdirect* nc, const char* spec){
   uint64_t totalbytes = 0;
   long unsigned totalframes = 0;
   uint64_t totalrenderns = 0;
+  uint64_t totalwriteoutns = 0;
   printf("\n");
   table_segment(nc, "             runtime", "│");
   table_segment(nc, " frames", "│");
   table_segment(nc, "output(B)", "│");
   table_segment(nc, "rendering", "│");
   table_segment(nc, " %r", "│");
+  table_segment(nc, " %w", "│");
   table_segment(nc, "    FPS", "│");
-  table_segment(nc, "TheoFPS", "║\n══╤════════╤════════╪═══════╪═════════╪═════════╪═══╪═══════╪═══════╣\n");
+  table_segment(nc, "TheoFPS", "║\n══╤════════╤════════╪═══════╪═════════╪═════════╪═══╪═══╪═══════╪═══════╣\n");
   char timebuf[PREFIXSTRLEN + 1];
   char tfpsbuf[PREFIXSTRLEN + 1];
   char totalbuf[BPREFIXSTRLEN + 1];
@@ -444,11 +446,13 @@ summary_table(struct ncdirect* nc, const char* spec){
     ncdirect_fg_rgb(nc, rescolor);
     printf("%8s", demos[results[i].selector - 'a'].name);
     ncdirect_fg_rgb8(nc, 178, 102, 255);
-    printf("│%*ss│%7ju│%*s│ %*ss│%3jd│%7.1f│%*s║",
+    printf("│%*ss│%7ju│%*s│ %*ss│%3jd│%3jd│%7.1f│%*s║",
            PREFIXFMT(timebuf), (uintmax_t)(results[i].stats.renders),
            BPREFIXFMT(totalbuf), PREFIXFMT(rtimebuf),
            (uintmax_t)(results[i].timens ?
             results[i].stats.render_ns * 100 / results[i].timens : 0),
+           (uintmax_t)(results[i].timens ?
+            results[i].stats.writeout_ns * 100 / results[i].timens : 0),
            results[i].timens ?
             results[i].stats.renders / ((double)results[i].timens / GIG) : 0.0,
            PREFIXFMT(tfpsbuf));
@@ -462,17 +466,19 @@ summary_table(struct ncdirect* nc, const char* spec){
     totalframes += results[i].stats.renders;
     totalbytes += results[i].stats.render_bytes;
     totalrenderns += results[i].stats.render_ns;
+    totalwriteoutns += results[i].stats.writeout_ns;
   }
   qprefix(nsdelta, GIG, timebuf, 0);
   bprefix(totalbytes, 1, totalbuf, 0);
   qprefix(totalrenderns, GIG, rtimebuf, 0);
-  table_segment(nc, "", "══╧════════╧════════╪═══════╪═════════╪═════════╪═══╪═══════╪═══════╝\n");
+  table_segment(nc, "", "══╧════════╧════════╪═══════╪═════════╪═════════╪═══╪═══╪═══════╪═══════╝\n");
   printf("            ");
   table_printf(nc, "│", "%*ss", PREFIXFMT(timebuf));
   table_printf(nc, "│", "%7lu", totalframes);
   table_printf(nc, "│", "%*s", BPREFIXFMT(totalbuf));
   table_printf(nc, "│", " %*ss", PREFIXFMT(rtimebuf));
   table_printf(nc, "│", "%3ld", nsdelta ? totalrenderns * 100 / nsdelta : 0);
+  table_printf(nc, "│", "%3ld", nsdelta ? totalwriteoutns * 100 / nsdelta : 0);
   table_printf(nc, "│", "%7.1f", nsdelta ? totalframes / ((double)nsdelta / GIG) : 0);
   printf("\n");
   ncdirect_fg_rgb8(nc, 0xff, 0xb0, 0xb0);

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -409,10 +409,10 @@ summary_table(struct ncdirect* nc, const char* spec){
   table_segment(nc, " frames", "│");
   table_segment(nc, "output(B)", "│");
   table_segment(nc, "rendering", "│");
-  table_segment(nc, " %r", "│");
-  table_segment(nc, " %w", "│");
+  table_segment(nc, "%r", "│");
+  table_segment(nc, "%w", "│");
   table_segment(nc, "    FPS", "│");
-  table_segment(nc, "TheoFPS", "║\n══╤════════╤════════╪═══════╪═════════╪═════════╪═══╪═══╪═══════╪═══════╣\n");
+  table_segment(nc, "TheoFPS", "║\n══╤════════╤════════╪═══════╪═════════╪═════════╪══╪══╪═══════╪═══════╣\n");
   char timebuf[PREFIXSTRLEN + 1];
   char tfpsbuf[PREFIXSTRLEN + 1];
   char totalbuf[BPREFIXSTRLEN + 1];
@@ -446,7 +446,7 @@ summary_table(struct ncdirect* nc, const char* spec){
     ncdirect_fg_rgb(nc, rescolor);
     printf("%8s", demos[results[i].selector - 'a'].name);
     ncdirect_fg_rgb8(nc, 178, 102, 255);
-    printf("│%*ss│%7ju│%*s│ %*ss│%3jd│%3jd│%7.1f│%*s║",
+    printf("│%*ss│%7ju│%*s│ %*ss│%2jd│%2jd│%7.1f│%*s║",
            PREFIXFMT(timebuf), (uintmax_t)(results[i].stats.renders),
            BPREFIXFMT(totalbuf), PREFIXFMT(rtimebuf),
            (uintmax_t)(results[i].timens ?
@@ -471,14 +471,14 @@ summary_table(struct ncdirect* nc, const char* spec){
   qprefix(nsdelta, GIG, timebuf, 0);
   bprefix(totalbytes, 1, totalbuf, 0);
   qprefix(totalrenderns, GIG, rtimebuf, 0);
-  table_segment(nc, "", "══╧════════╧════════╪═══════╪═════════╪═════════╪═══╪═══╪═══════╪═══════╝\n");
+  table_segment(nc, "", "══╧════════╧════════╪═══════╪═════════╪═════════╪══╪══╪═══════╪═══════╝\n");
   printf("            ");
   table_printf(nc, "│", "%*ss", PREFIXFMT(timebuf));
   table_printf(nc, "│", "%7lu", totalframes);
   table_printf(nc, "│", "%*s", BPREFIXFMT(totalbuf));
   table_printf(nc, "│", " %*ss", PREFIXFMT(rtimebuf));
-  table_printf(nc, "│", "%3ld", nsdelta ? totalrenderns * 100 / nsdelta : 0);
-  table_printf(nc, "│", "%3ld", nsdelta ? totalwriteoutns * 100 / nsdelta : 0);
+  table_printf(nc, "│", "%2ld", nsdelta ? totalrenderns * 100 / nsdelta : 0);
+  table_printf(nc, "│", "%2ld", nsdelta ? totalwriteoutns * 100 / nsdelta : 0);
   table_printf(nc, "│", "%7.1f", nsdelta ? totalframes / ((double)nsdelta / GIG) : 0);
   printf("\n");
   ncdirect_fg_rgb8(nc, 0xff, 0xb0, 0xb0);


### PR DESCRIPTION
This breaks up the render+raster operation (generating as its final result a buffer) and the writing of that buffer to the terminal. Necessary for user-managed I/O. Adapts statistics, updates statistics documentation. Closes #1039.