### PR TITLE
rename Plane::putwc -> Plane::putwch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ rearrangements of Notcurses.
     `NCDIRECT_OPTION_INHIBIT_SETLOCALE` and `NCDIRECT_OPTION_INHIBIT_CBREAK`.
     The former is similar to `NCOPTION_INHIBIT_SETLOCALE`. The latter keeps
     `ncdirect_init()` from touching the termios and entering cbreak mode.
+  * The C++ wrapper `Ncplane::putwc()` has been renamed `Ncplane::putwch()`, so
+    as not to clash with standard libraries implementing `putwc()` as a macro.
 
 * 1.7.5 (2020-09-29)
   * `ncreel_destroy()` now returns `void` rather than `int`.

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -482,13 +482,13 @@ namespace ncpp
 
 		// OK, this is ugly, but we need to rename this overload or calls similar to n->putc (0, 0, '0') will be
 		// considered ambiguous with the above `putc (int, int, char)` overload.
-		int putwc (int y, int x, wchar_t w) const NOEXCEPT_MAYBE
+		int putwch (int y, int x, wchar_t w) const NOEXCEPT_MAYBE
 		{
 			return error_guard<int> (ncplane_putwc_yx (plane, y, x, w), -1);
 		}
 
 		// Ditto
-		int putwc (wchar_t w) const NOEXCEPT_MAYBE
+		int putwch (wchar_t w) const NOEXCEPT_MAYBE
 		{
 			return error_guard<int> (ncplane_putwc (plane, w), -1);
 		}


### PR DESCRIPTION
See #1046. `putwc` is a standard library identifier which may be implemented as a macro. It is implemented as such on FreeBSD, causing `Plane.hh` to fail compilation. I've renamed `putwc` to `putwch`, for lack of a better solution.