### PR TITLE
Add ncmenu_item_set_status() #1057

### DIFF
--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2859,6 +2859,10 @@ API int ncmenu_prevsection(struct ncmenu* n);
 API int ncmenu_nextitem(struct ncmenu* n);
 API int ncmenu_previtem(struct ncmenu* n);
 
+// Disable or enable a menu item. Returns 0 if the item was found.
+API int ncmenu_item_set_status(struct ncmenu* n, const char* section,
+                               const char* item, bool enabled);
+
 // Return the selected item description, or NULL if no section is unrolled. If
 // 'ni' is not NULL, and the selected item has a shortcut, 'ni' will be filled
 // in with that shortcut--this can allow faster matching.

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -158,6 +158,7 @@ typedef struct ncmenu_int_item {
   int shortcut_offset;  // column offset with desc of shortcut EGC
   char* shortdesc;      // description of shortcut, can be NULL
   int shortdesccols;    // columns occupied by shortcut description
+  bool disabled;        // disabled?
 } ncmenu_int_item;
 
 typedef struct ncmenu_int_section {
@@ -251,10 +252,10 @@ typedef struct tinfo {
   char* smkx;     // enter keypad transmit mode (keypad_xmit)
   char* rmkx;     // leave keypad transmit mode (keypad_local)
   char* getm;     // get mouse events
-  bool RGBflag;   // ti-reported "RGB" flag for 24bpc truecolor
-  bool CCCflag;   // ti-reported "CCC" flag for palette set capability
-  bool BCEflag;   // ti-reported "BCE" flag for erases with background color
-  bool AMflag;    // ti-reported "AM" flag for automatic movement to next line
+  bool RGBflag;   // "RGB" flag for 24bpc truecolor
+  bool CCCflag;   // "CCC" flag for palette set capability
+  bool BCEflag;   // "BCE" flag for erases with background color
+  bool AMflag;    // "AM" flag for automatic movement to next line
   char* smcup;    // enter alternate mode
   char* rmcup;    // restore primary mode
 } tinfo;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -211,6 +211,7 @@ typedef struct ncmenu {
   int headerwidth;          // minimum space necessary to display all sections
   uint64_t headerchannels;  // styling for header
   uint64_t sectionchannels; // styling for sections
+  uint64_t disablechannels; // styling for disabled entries
   bool bottom;              // are we on the bottom (vs top)?
 } ncmenu;
 

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -170,6 +170,7 @@ typedef struct ncmenu_int_section {
   int bodycols;           // column width of longest item
   int itemselected;       // current item selected, -1 for no selection
   int shortcut_offset;    // column offset within name of shortcut EGC
+  int enabled_item_count; // number of enabled items: section is disabled iff 0
 } ncmenu_int_section;
 
 typedef struct ncfdplane {

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -211,6 +211,7 @@ typedef struct ncmenu {
   int unrolledsection;      // currently unrolled section, -1 if none
   int headerwidth;          // minimum space necessary to display all sections
   uint64_t headerchannels;  // styling for header
+  uint64_t dissectchannels; // styling for disabled section headers
   uint64_t sectionchannels; // styling for sections
   uint64_t disablechannels; // styling for disabled entries
   bool bottom;              // are we on the bottom (vs top)?

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -490,11 +490,12 @@ int ncmenu_nextitem(ncmenu* n){
       return -1;
     }
   }
+  ncmenu_int_section* sec = &n->sections[n->unrolledsection];
   do{
-    if(++n->sections[n->unrolledsection].itemselected == n->sections[n->unrolledsection].itemcount){
-      n->sections[n->unrolledsection].itemselected = 0;
+    if(++sec->itemselected == sec->itemcount){
+      sec->itemselected = 0;
     }
-  }while(!n->sections[n->unrolledsection].items[n->sections[n->unrolledsection].itemselected].desc);
+  }while(!sec->items[sec->itemselected].desc || sec->items[sec->itemselected].disabled);
   return ncmenu_unroll(n, n->unrolledsection);
 }
 
@@ -504,11 +505,12 @@ int ncmenu_previtem(ncmenu* n){
       return -1;
     }
   }
+  ncmenu_int_section* sec = &n->sections[n->unrolledsection];
   do{
-    if(n->sections[n->unrolledsection].itemselected-- == 0){
-      n->sections[n->unrolledsection].itemselected = n->sections[n->unrolledsection].itemcount - 1;
+    if(sec->itemselected-- == 0){
+      sec->itemselected = sec->itemcount - 1;
     }
-  }while(!n->sections[n->unrolledsection].items[n->sections[n->unrolledsection].itemselected].desc);
+  }while(!sec->items[sec->itemselected].desc || sec->items[sec->itemselected].disabled);
   return ncmenu_unroll(n, n->unrolledsection);
 }
 

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -318,6 +318,8 @@ ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
         ret->unrolledsection = -1;
         ret->headerchannels = opts->headerchannels;
         ret->sectionchannels = opts->sectionchannels;
+        ret->disablechannels = ret->sectionchannels;
+        channels_set_fg_rgb(&ret->disablechannels, 0xdddddd);
         cell c = CELL_TRIVIAL_INITIALIZER;
         cell_set_fg_alpha(&c, CELL_ALPHA_TRANSPARENT);
         cell_set_bg_alpha(&c, CELL_ALPHA_TRANSPARENT);
@@ -376,10 +378,11 @@ int ncmenu_unroll(ncmenu* n, int sectionidx){
   for(int i = 0 ; i < sec->itemcount ; ++i){
     ++ypos;
     if(sec->items[i].desc){
-      n->ncp->channels = n->sectionchannels;
       // FIXME the user ought be able to configure the disabled channel
-      if(sec->items[i].disabled){
-        ncplane_set_fg_rgb(n->ncp, 0xdddddd);
+      if(!sec->items[i].disabled){
+        ncplane_set_channels(n->ncp, n->sectionchannels);
+      }else{
+        ncplane_set_channels(n->ncp, n->disablechannels);
       }
       if(i == sec->itemselected){
         ncplane_set_styles(n->ncp, NCSTYLE_REVERSE);

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -293,6 +293,7 @@ ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
     opts = &zeroed;
   }
   if(opts->sectioncount <= 0 || !opts->sections){
+    logerror(n->nc, "Invalid %d-ary section information\n", opts->sectioncount);
     return NULL;
   }
   if(opts->flags > NCMENU_OPTION_HIDING){

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -604,6 +604,29 @@ bool ncmenu_offer_input(ncmenu* n, const ncinput* nc){
   return false;
 }
 
+// FIXME we probably ought implement this with a trie or something
+int ncmenu_item_set_status(ncmenu* n, const char* section, const char* item,
+                           bool enabled){
+  for(int si = 0 ; si < n->sectioncount ; ++si){
+    const struct ncmenu_int_section* sec = &n->sections[si];
+    if(strcmp(sec->name, section) == 0){
+      for(int ii = 0 ; ii < sec->itemcount ; ++ii){
+        struct ncmenu_int_item* i = &sec->items[ii];
+        if(strcmp(i->desc, item) == 0){
+          const bool changed = i->disabled != enabled;
+          i->disabled = !enabled;
+          if(changed && n->unrolledsection == si){
+            ncmenu_unroll(n, n->unrolledsection);
+          }
+          return 0;
+        }
+      }
+      break;
+    }
+  }
+  return -1;
+}
+
 ncplane* ncmenu_plane(ncmenu* menu){
   return menu->ncp;
 }

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -608,15 +608,23 @@ bool ncmenu_offer_input(ncmenu* n, const ncinput* nc){
 int ncmenu_item_set_status(ncmenu* n, const char* section, const char* item,
                            bool enabled){
   for(int si = 0 ; si < n->sectioncount ; ++si){
-    const struct ncmenu_int_section* sec = &n->sections[si];
+    struct ncmenu_int_section* sec = &n->sections[si];
     if(strcmp(sec->name, section) == 0){
       for(int ii = 0 ; ii < sec->itemcount ; ++ii){
         struct ncmenu_int_item* i = &sec->items[ii];
         if(strcmp(i->desc, item) == 0){
-          const bool changed = i->disabled != enabled;
+          const bool changed = i->disabled == enabled;
           i->disabled = !enabled;
-          if(changed && n->unrolledsection == si){
-            ncmenu_unroll(n, n->unrolledsection);
+          if(changed){
+            if(i->disabled){
+              --sec->enabled_item_count;
+            }else{
+              ++sec->enabled_item_count;
+            }
+            if(n->unrolledsection == si){
+              // FIXME if sec->enabled_item_count == 0, need choose new section
+              ncmenu_unroll(n, n->unrolledsection);
+            }
           }
           return 0;
         }

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -351,11 +351,15 @@ section_width(const ncmenu* n, int sectionidx){
 }
 
 int ncmenu_unroll(ncmenu* n, int sectionidx){
-  if(sectionidx < 0 || sectionidx >= n->sectioncount){
-    return -1;
-  }
   if(ncmenu_rollup(n)){ // roll up any unrolled section
     return -1;
+  }
+  if(sectionidx < 0 || sectionidx >= n->sectioncount){
+    logerror(n->ncp->nc, "Unrolled invalid sectionidx %d\n", sectionidx);
+    return -1;
+  }
+  if(n->sections[sectionidx].enabled_item_count <= 0){
+    return 0;
   }
   if(n->sections[sectionidx].name == NULL){
     return -1;

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -22,6 +22,7 @@ static int
 dup_menu_item(ncmenu_int_item* dst, const struct ncmenu_item* src){
 #define ALTMOD "Alt+"
 #define CTLMOD "Ctrl+"
+  dst->disabled = false;
   if((dst->desc = strdup(src->desc)) == NULL){
     return -1;
   }
@@ -376,6 +377,10 @@ int ncmenu_unroll(ncmenu* n, int sectionidx){
     ++ypos;
     if(sec->items[i].desc){
       n->ncp->channels = n->sectionchannels;
+      // FIXME the user ought be able to configure the disabled channel
+      if(sec->items[i].disabled){
+        ncplane_set_fg_rgb(n->ncp, 0xdddddd);
+      }
       if(i == sec->itemselected){
         ncplane_set_styles(n->ncp, NCSTYLE_REVERSE);
       }else{

--- a/src/poc/menu.c
+++ b/src/poc/menu.c
@@ -88,6 +88,7 @@ int main(void){
   notcurses_mouse_enable(nc);
   struct ncmenu_item demo_items[] = {
     { .desc = "Restart", .shortcut = { .id = 'r', .ctrl = true, }, },
+    { .desc = "Disabled", .shortcut = { .id = 'd', .ctrl = false, }, },
   };
   struct ncmenu_item file_items[] = {
     { .desc = "New", .shortcut = { .id = 'n', .ctrl = true, }, },
@@ -123,6 +124,9 @@ int main(void){
   struct ncplane* n = notcurses_stddim_yx(nc, &dimy, &dimx);
   struct ncmenu* top = ncmenu_create(n, &mopts);
   if(top == NULL){
+    goto err;
+  }
+  if(ncmenu_item_set_status(top, "Schwarzgerät", "Disabled", false)){
     goto err;
   }
   uint64_t channels = 0;

--- a/src/poc/menu.c
+++ b/src/poc/menu.c
@@ -129,6 +129,9 @@ int main(void){
   if(ncmenu_item_set_status(top, "Schwarzgerät", "Disabled", false)){
     goto err;
   }
+  if(ncmenu_item_set_status(top, "Schwarzgerät", "Restart", false)){
+    goto err;
+  }
   uint64_t channels = 0;
   channels_set_fg_rgb(&channels, 0x88aa00);
   channels_set_bg_rgb(&channels, 0x000088);


### PR DESCRIPTION
* Add `ncmenu_item_set_status()` allowing menu items to be enabled or disabled on the fly
* Don't allow disabled items to be selected
* A menu section containing only disabled items cannot be unrolled
* Roll up a menu section if it is unrolled and all items are disabled

Closes #1057 