### PR TITLE
Handle section shortcuts within ncmenu_offer_input()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,12 @@ rearrangements of Notcurses.
 
 * 2.1.0 (not yet released)
   * Add `ncmenu_item_set_status()` for disabling or enabling menu items.
+    * Disabled menu items cannot be selected.
+    * Menu sections consisting only of disabled items are themselves disabled,
+      and cannot be unrolled.
   * Add `ncinput_equal_p()` for comparison of `ncinput` structure data.
+  * `ncmenu_offer_input()` now recognizes the shortcuts for registered
+    sections, and will unroll the appropriate section when given input.
 
 * 2.0.0 (2020-10-12) "Stankonia"
   * **API STABILITY!** The API expressed in 2.0.0 will be maintained throughout

--- a/include/notcurses/nckeys.h
+++ b/include/notcurses/nckeys.h
@@ -119,6 +119,9 @@ extern "C" {
 #define NCKEY_SCROLL_DOWN NCKEY_BUTTON5
 #define NCKEY_RETURN      NCKEY_ENTER
 
+// Just aliases, ma'am, from the 128 characters common to ASCII+UTF8
+#define NCKEY_ESC      0x1b
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -204,12 +204,6 @@ bool menu_or_hud_key(struct notcurses *nc, const struct ncinput *ni){
   }
   if(ncmenu_offer_input(menu, ni)){
     return true;
-  }else if(ni->id == 'o' && ni->alt && !ni->ctrl){
-    ncmenu_unroll(menu, 0);
-    return true;
-  }else if(ni->id == 'h' && ni->alt && !ni->ctrl){
-    ncmenu_unroll(menu, 2);
-    return true;
   }
   return false;
 }

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -142,7 +142,7 @@ const char* nckeystr(char32_t spkey){
 
 // Print the utf8 Control Pictures for otherwise unprintable ASCII
 char32_t printutf8(char32_t kp){
-  if(kp <= 27){
+  if(kp <= NCKEY_ESC){
     return 0x2400 + kp;
   }
   return kp;

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -153,7 +153,7 @@ cursor_yx_get(int ttyfd, int* y, int* x){
   while(read(ttyfd, &in, 1) == 1){
     bool valid = false;
     switch(state){
-      case CURSOR_ESC: valid = (in == '\x1b'); state = CURSOR_LSQUARE; break;
+      case CURSOR_ESC: valid = (in == NCKEY_ESC); state = CURSOR_LSQUARE; break;
       case CURSOR_LSQUARE: valid = (in == '['); state = CURSOR_ROW; break;
       case CURSOR_ROW:
         if(isdigit(in)){

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -12,8 +12,6 @@
 #define CSIPREFIX "\x1b[<"
 static const char32_t NCKEY_CSI = 1;
 
-static const unsigned char ESC = 0x1b; // 27
-
 static sig_atomic_t resize_seen;
 
 void sigwinch_handler(int signo){
@@ -75,7 +73,7 @@ void input_free_esctrie(esctrie** eptr){
 
 static int
 ncinputlayer_add_input_escape(ncinputlayer* nc, const char* esc, char32_t special){
-  if(esc[0] != ESC || strlen(esc) < 2){ // assume ESC prefix + content
+  if(esc[0] != NCKEY_ESC || strlen(esc) < 2){ // assume ESC prefix + content
     fprintf(stderr, "Not an escape: %s (0x%x)\n", esc, special);
     return -1;
   }
@@ -205,7 +203,7 @@ handle_getc(ncinputlayer* nc, int kpress, ncinput* ni, int leftmargin, int topma
   if(kpress < 0){
     return -1;
   }
-  if(kpress == ESC){
+  if(kpress == NCKEY_ESC){
     const esctrie* esc = nc->inputescapes;
     int candidate = 0;
     while(esc && esc->special == NCKEY_INVALID && nc->inputbuf_occupied){
@@ -524,7 +522,7 @@ int prep_special_keys(ncinputlayer* nc){
 //fprintf(stderr, "no support for terminfo's %s\n", k->tinfo);
       continue;
     }
-    if(seq[0] != ESC){
+    if(seq[0] != NCKEY_ESC){
 //fprintf(stderr, "Terminfo's %s is not an escape sequence (%zub)\n", k->tinfo, strlen(seq));
       continue;
     }

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -609,7 +609,7 @@ bool ncmenu_offer_input(ncmenu* n, const ncinput* nc){
       return false;
     }
     return true;
-  }else if(nc->id == 0x1b){
+  }else if(nc->id == NCKEY_ESC){
     ncmenu_rollup(n);
     return true;
   }

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -586,7 +586,19 @@ bool ncmenu_offer_input(ncmenu* n, const ncinput* nc){
       ncmenu_unroll(n, i);
     }
     return true;
-  }else if(n->unrolledsection < 0){ // all following need an unrolled section
+  }
+  for(int si = 0 ; si < n->sectioncount ; ++si){
+    const ncmenu_int_section* sec = &n->sections[si];
+    if(sec->enabled_item_count == 0){
+      continue;
+    }
+    if(!ncinput_equal_p(&sec->shortcut, nc)){
+      continue;
+    }
+    ncmenu_unroll(n, si);
+    return true;
+  }
+  if(n->unrolledsection < 0){ // all following need an unrolled section
     return false;
   }
   if(nc->id == NCKEY_LEFT){

--- a/src/poc/menu.c
+++ b/src/poc/menu.c
@@ -32,29 +32,7 @@ run_menu(struct notcurses* nc, struct ncmenu* ncm){
   notcurses_render(nc);
   while((keypress = notcurses_getc_blocking(nc, &ni)) != (char32_t)-1){
     if(!ncmenu_offer_input(ncm, &ni)){
-      if(keypress == '\x1b'){
-        if(ncmenu_rollup(ncm)){
-          goto err;
-        }
-      }else if(ni.alt){
-        switch(keypress){
-          case 'a': case 'A': case 0x00e4:
-            if(ncmenu_unroll(ncm, 0)){
-              goto err;
-            }
-            break;
-          case 'f': case 'F':
-            if(ncmenu_unroll(ncm, 1)){
-              goto err;
-            }
-            break;
-          case 'h': case 'H':
-            if(ncmenu_unroll(ncm, 3)){
-              goto err;
-            }
-            break;
-        }
-      }else if(keypress == 'q'){
+      if(keypress == 'q'){
         ncmenu_destroy(ncm);
         ncplane_destroy(selplane);
         return 0;


### PR DESCRIPTION
It's ridiculous that every user of `ncmenu` had to handle the shortcuts for opening and rolling up menu sections themselves. With the addition of `ncinput_equal_p()` in #1059, there's no reason for this. Handle them in `ncmenu_offer_input()` directly, and remove the special handling in `menu` and `notcurses-demo`. Closes #1058.