### PR TITLE
Fix up ncdirect_printf_aligned() for wide glyphs, add to docs

### DIFF
--- a/doc/man/man3/notcurses_directmode.3.md
+++ b/doc/man/man3/notcurses_directmode.3.md
@@ -56,6 +56,8 @@ ncdirect_init - minimal notcurses instances for styling text
 
 **int ncdirect_putstr(struct ncdirect* nc, uint64_t channels, const char* utf8);**
 
+**int ncdirect_printf_aligned(struct ncdirect* n, int y, ncalign_e align, const char* fmt, ...);**
+
 **bool ncdirect_canopen_images(const struct ncdirect* n);**
 
 **bool ncdirect_canutf8(const struct ncdirect* n);**
@@ -126,8 +128,8 @@ effect.
 points to a valid **struct ncdirect**, which can be used until it is provided
 to **ncdirect_stop**.
 
-**ncdirect_putstr** returns the number of characters written on success. On
-failure, it returns some negative number.
+**ncdirect_putstr** and **ncdirect_printf_aligned** return the number of bytes
+written on success. On failure, they return some negative number.
 
 All other functions return 0 on success, and non-zero on error.
 

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -51,6 +51,12 @@ API unsigned ncdirect_palette_size(const struct ncdirect* nc);
 // necessarily be immediately visible.
 API int ncdirect_putstr(struct ncdirect* nc, uint64_t channels, const char* utf8);
 
+// Formatted printing (plus alignment relative to the terminal). Returns the
+// number of columns printed on success.
+API int ncdirect_printf_aligned(struct ncdirect* n, int y, ncalign_e align,
+                                const char* fmt, ...)
+  __attribute__ ((format (printf, 4, 5)));
+
 // Force a flush. Returns 0 on success, -1 on failure.
 API int ncdirect_flush(const struct ncdirect* nc);
 
@@ -100,11 +106,6 @@ API int ncdirect_cursor_yx(struct ncdirect* n, int* y, int* x);
 // stack, and indeed its existence, is terminal-dependent.
 API int ncdirect_cursor_push(struct ncdirect* n);
 API int ncdirect_cursor_pop(struct ncdirect* n);
-
-// Formatted printing (plus alignment relative to the terminal).
-API int ncdirect_printf_aligned(struct ncdirect* n, int y, ncalign_e align,
-                                const char* fmt, ...)
-  __attribute__ ((format (printf, 4, 5)));
 
 // Display an image using the specified blitter and scaling. The image may
 // be arbitrarily many rows -- the output will scroll -- but will only occupy

--- a/python/src/notcurses/build_notcurses.py
+++ b/python/src/notcurses/build_notcurses.py
@@ -417,6 +417,7 @@ int ncdirect_bg_rgb8(struct ncdirect* n, unsigned r, unsigned g, unsigned b);
 int ncdirect_fg_rgb8(struct ncdirect* n, unsigned r, unsigned g, unsigned b);
 unsigned ncdirect_palette_size(const struct ncdirect* nc);
 int ncdirect_putstr(struct ncdirect* nc, uint64_t channels, const char* utf8);
+int ncdirect_printf_aligned(struct ncdirect* n, int y, ncalign_e align, const char* fmt, ...);
 int ncdirect_fg_rgb(struct ncdirect* n, unsigned rgb);
 int ncdirect_bg_rgb(struct ncdirect* n, unsigned rgb);
 int ncdirect_styles_set(struct ncdirect* n, unsigned stylebits);

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -491,7 +491,7 @@ int ncdirect_vprintf_aligned(ncdirect* n, int y, ncalign_e align, const char* fm
   if(r == nullptr){
     return -1;
   }
-  const size_t len = strlen(r);
+  const size_t len = ncstrwidth(r);
   const int x = ncdirect_align(n, align, len);
   if(ncdirect_cursor_move_yx(n, y, x)){
     free(r);


### PR DESCRIPTION
* Add `ncdirect_printf_aligned()` to man page and python wrappers
* Use `ncstrwidth()` in plane of `strlen()` when calculating width for `ncdirect_vprintf_aligned()`

Closes #1074 