### PR TITLE
notcurses-demo: add debug window, toggled with Alt+d

### DIFF
--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -4,7 +4,7 @@ void notcurses_debug(notcurses* nc, FILE* debugfp){
   const ncplane* n = nc->top;
   const ncplane* prev = NULL;
   int planeidx = 0;
-  fprintf(debugfp, "*************************** notcurses debug state *****************************\n");
+  fprintf(debugfp, " ************************** notcurses debug state *****************************\n");
   while(n){
     fprintf(debugfp, "%04d off y: %3d x: %3d geom y: %3d x: %3d curs y: %3d x: %3d %p %.8s\n",
             planeidx, n->absy, n->absx, n->leny, n->lenx, n->y, n->x, n, n->name);
@@ -28,5 +28,5 @@ void notcurses_debug(notcurses* nc, FILE* debugfp){
   if(nc->bottom != prev){
     fprintf(stderr, " WARNING: expected ->bottom %p, got %p\n", prev, nc->bottom);
   }
-  fprintf(debugfp, "*******************************************************************************\n");
+  fprintf(debugfp, " ******************************************************************************\n");
 }


### PR DESCRIPTION
* Add new menu option to `notcurses-demo`'s Help menu: "Debug info", shortcut Alt+d
* If present, Alt+d eliminates window
* If absent, Alt+d collects debug info from `notcurses_debug()` and puts it up in a window
* Keep debug window atop display in `demo_render()`

Closes #1013.