### PR TITLE
migrate all direct uses to ncplane_notcurses()

### DIFF
--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -863,12 +863,13 @@ int ncblit_rgba(const void* data, int linesize, const struct ncvisual_options* v
   }
   ncblitter_e blitter;
   if(!vopts || vopts->blitter == NCBLIT_DEFAULT){
-    blitter = ncvisual_default_blitter(notcurses_canutf8(nc->nc), NCSCALE_NONE);
+    blitter = ncvisual_default_blitter(notcurses_canutf8(ncplane_notcurses(nc)),
+                                       NCSCALE_NONE);
   }else{
     blitter = vopts->blitter;
   }
   const bool degrade = !(vopts->flags & NCVISUAL_OPTION_NODEGRADE);
-  const struct blitset* bset = lookup_blitset(notcurses_canutf8(nc->nc),
+  const struct blitset* bset = lookup_blitset(notcurses_canutf8(ncplane_notcurses(nc)),
                                               blitter, degrade);
   if(bset == NULL){
     return -1;

--- a/src/lib/fade.c
+++ b/src/lib/fade.c
@@ -140,9 +140,9 @@ int ncplane_fadein_iteration(ncplane* n, ncfadectx* nctx, int iter,
   sleepspec.tv_nsec = nextwake % NANOSECS_IN_SEC;
   int ret = 0;
   if(fader){
-    ret |= fader(n->nc, n, &sleepspec, curry);
+    ret |= fader(ncplane_notcurses(n), n, &sleepspec, curry);
   }else{
-    ret |= notcurses_render(n->nc);
+    ret |= notcurses_render(ncplane_notcurses(n));
     // clock_nanosleep() has no love for CLOCK_MONOTONIC_RAW, at least as
     // of Glibc 2.29 + Linux 5.3 (or FreeBSD 12) :/.
     clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &sleepspec, NULL);
@@ -220,9 +220,9 @@ int ncplane_fadeout_iteration(ncplane* n, ncfadectx* nctx, int iter,
   sleepspec.tv_nsec = nextwake % NANOSECS_IN_SEC;
   int ret;
   if(fader){
-    ret = fader(n->nc, n, &sleepspec, curry);
+    ret = fader(ncplane_notcurses(n), n, &sleepspec, curry);
   }else{
-    ret = notcurses_render(n->nc);
+    ret = notcurses_render(ncplane_notcurses(n));
     // clock_nanosleep() has no love for CLOCK_MONOTONIC_RAW, at least as
     // of Glibc 2.29 + Linux 5.3 (or FreeBSD 12) :/.
     clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &sleepspec, NULL);
@@ -232,7 +232,8 @@ int ncplane_fadeout_iteration(ncplane* n, ncfadectx* nctx, int iter,
 
 static ncfadectx* 
 ncfadectx_setup_internal(ncplane* n, const struct timespec* ts){
-  if(!n->nc->tcache.RGBflag && !n->nc->tcache.CCCflag){ // terminal can't fade
+  if(!ncplane_notcurses(n)->tcache.RGBflag &&
+     !ncplane_notcurses(n)->tcache.CCCflag){ // terminal can't fade
     return NULL;
   }
   ncfadectx* nctx = malloc(sizeof(*nctx));
@@ -286,9 +287,9 @@ int ncplane_fadein(ncplane* n, const struct timespec* ts, fadecb fader, void* cu
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     if(fader){
-      fader(n->nc, n, &now, curry);
+      fader(ncplane_notcurses(n), n, &now, curry);
     }else{
-      notcurses_render(n->nc);
+      notcurses_render(ncplane_notcurses(n));
     }
     return -1;
   }
@@ -300,7 +301,8 @@ int ncplane_fadein(ncplane* n, const struct timespec* ts, fadecb fader, void* cu
 int ncplane_pulse(ncplane* n, const struct timespec* ts, fadecb fader, void* curry){
   ncfadectx pp;
   int ret;
-  if(!n->nc->tcache.RGBflag && !n->nc->tcache.CCCflag){ // terminal can't fade
+  if(!ncplane_notcurses(n)->tcache.RGBflag &&
+     !ncplane_notcurses(n)->tcache.CCCflag){ // terminal can't fade
     return -1;
   }
   if(alloc_ncplane_palette(n, &pp, ts)){

--- a/src/lib/fd.c
+++ b/src/lib/fd.c
@@ -101,7 +101,7 @@ ncfdplane_create_internal(ncplane* n, const ncfdplane_options* opts, int fd,
                           ncfdplane_callback cbfxn, ncfdplane_done_cb donecbfxn,
                           bool thread){
   if(opts->flags > 0){
-    logwarn(n->nc, "Provided unsupported flags %016lx\n", opts->flags);
+    logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", opts->flags);
   }
   ncfdplane* ret = malloc(sizeof(*ret));
   if(ret == NULL){
@@ -302,7 +302,7 @@ ncsubproc* ncsubproc_createv(ncplane* n, const ncsubproc_options* opts,
     return NULL;
   }
   if(opts->flags > 0){
-    logwarn(n->nc, "Provided unsupported flags %016lx\n", opts->flags);
+    logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", opts->flags);
   }
   int fd = -1;
   ncsubproc* ret = malloc(sizeof(*ret));
@@ -337,7 +337,7 @@ ncsubproc* ncsubproc_createvp(ncplane* n, const ncsubproc_options* opts,
     return NULL;
   }
   if(opts->flags > 0){
-    logwarn(n->nc, "Provided unsupported flags %016lx\n", opts->flags);
+    logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", opts->flags);
   }
   int fd = -1;
   ncsubproc* ret = malloc(sizeof(*ret));
@@ -372,7 +372,7 @@ ncsubproc* ncsubproc_createvpe(ncplane* n, const ncsubproc_options* opts,
     return NULL;
   }
   if(opts->flags > 0){
-    logwarn(n->nc, "Provided unsupported flags %016lx\n", opts->flags);
+    logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", opts->flags);
   }
   int fd = -1;
   ncsubproc* ret = malloc(sizeof(*ret));

--- a/src/lib/fill.c
+++ b/src/lib/fill.c
@@ -146,7 +146,7 @@ calc_highgradient(cell* c, uint32_t ul, uint32_t ur, uint32_t ll,
 
 int ncplane_highgradient(ncplane* n, uint32_t ul, uint32_t ur,
                          uint32_t ll, uint32_t lr, int ystop, int xstop){
-  if(!notcurses_canutf8(n->nc)){
+  if(!notcurses_canutf8(ncplane_notcurses(n))){
     return -1;
   }
   if(check_gradient_channel_args(ul, ur, ll, lr)){
@@ -207,7 +207,7 @@ int ncplane_gradient(ncplane* n, const char* egc, uint32_t stylemask,
                      uint64_t ul, uint64_t ur, uint64_t bl, uint64_t br,
                      int ystop, int xstop){
   if(check_gradient_args(ul, ur, bl, br)){
-    logerror(n->nc, "Illegal gradient inputs\n");
+    logerror(ncplane_notcurses(n), "Illegal gradient inputs\n");
     return -1;
   }
   if(egc == NULL){
@@ -217,11 +217,11 @@ int ncplane_gradient(ncplane* n, const char* egc, uint32_t stylemask,
   ncplane_cursor_yx(n, &yoff, &xoff);
   // must be at least 1x1, with its upper-left corner at the current cursor
   if(ystop < yoff){
-    logerror(n->nc, "Ystop %d < yoff %d\n", ystop, yoff);
+    logerror(ncplane_notcurses(n), "Ystop %d < yoff %d\n", ystop, yoff);
     return -1;
   }
   if(xstop < xoff){
-    logerror(n->nc, "Xstop %d < xoff %d\n", xstop, xoff);
+    logerror(ncplane_notcurses(n), "Xstop %d < xoff %d\n", xstop, xoff);
     return -1;
   }
   ncplane_dim_yx(n, &ymax, &xmax);
@@ -267,18 +267,18 @@ int ncplane_stain(ncplane* n, int ystop, int xstop,
                   uint64_t tl, uint64_t tr, uint64_t bl, uint64_t br){
   // Can't use default or palette-indexed colors in a gradient
   if(check_gradient_args(tl, tr, bl, br)){
-    logerror(n->nc, "Illegal staining inputs\n");
+    logerror(ncplane_notcurses(n), "Illegal staining inputs\n");
     return -1;
   }
   int yoff, xoff, ymax, xmax;
   ncplane_cursor_yx(n, &yoff, &xoff);
   // must be at least 1x1, with its upper-left corner at the current cursor
   if(ystop < yoff){
-    logerror(n->nc, "Ystop %d < yoff %d\n", ystop, yoff);
+    logerror(ncplane_notcurses(n), "Ystop %d < yoff %d\n", ystop, yoff);
     return -1;
   }
   if(xstop < xoff){
-    logerror(n->nc, "Xstop %d < xoff %d\n", xstop, xoff);
+    logerror(ncplane_notcurses(n), "Xstop %d < xoff %d\n", xstop, xoff);
     return -1;
   }
   ncplane_dim_yx(n, &ymax, &xmax);
@@ -345,7 +345,7 @@ rotate_channels(ncplane* src, const cell* c, uint32_t* fchan, uint32_t* bchan){
     *bchan = *fchan;
     return 0;
   }
-  logerror(src->nc, "Invalid EGC for rotation [%s]\n", egc);
+  logerror(ncplane_notcurses(src), "Invalid EGC for rotation [%s]\n", egc);
   return -1;
 }
 
@@ -640,10 +640,10 @@ int ncplane_qrcode(ncplane* n, ncblitter_e blitter, int* ymax, int* xmax,
           .n = n,
           .blitter = blitter,
         };
-        if(ncvisual_render(n->nc, ncv, &vopts) == n){
+        if(ncvisual_render(ncplane_notcurses(n), ncv, &vopts) == n){
           ret = square;
         }
-        ncvisual_geom(n->nc, ncv, &vopts, NULL, NULL, &yscale, &xscale);
+        ncvisual_geom(ncplane_notcurses(n), ncv, &vopts, NULL, NULL, &yscale, &xscale);
       }
       ncvisual_destroy(ncv);
     }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -377,12 +377,12 @@ mbstr_find_codepoint(const char* s, char32_t cp, int* col){
 
 static inline ncplane*
 ncplane_stdplane(ncplane* n){
-  return notcurses_stdplane(n->nc);
+  return notcurses_stdplane(ncplane_notcurses(n));
 }
 
 static inline const ncplane*
 ncplane_stdplane_const(const ncplane* n){
-  return notcurses_stdplane_const(n->nc);
+  return notcurses_stdplane_const(ncplane_notcurses_const(n));
 }
 
 // load all known special keys from terminfo, and build the input sequence trie

--- a/src/lib/layout.c
+++ b/src/lib/layout.c
@@ -65,7 +65,7 @@ puttext_line(ncplane* n, ncalign_e align, const char* text, size_t* bytes){
     wchar_t w;
     const size_t consumed = mbrtowc(&w, text + b, MB_CUR_MAX, &mbstate);
     if(consumed == (size_t)-2 || consumed == (size_t)-1){
-      logerror(n->nc, "Invalid UTF-8 after %d bytes\n", b);
+      logerror(ncplane_notcurses(n), "Invalid UTF-8 after %d bytes\n", b);
       return -1;
     }
 //fprintf(stderr, "converted [%s] -> %lc\n", text + b, w);

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -301,11 +301,11 @@ ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
     opts = &zeroed;
   }
   if(opts->sectioncount <= 0 || !opts->sections){
-    logerror(n->nc, "Invalid %d-ary section information\n", opts->sectioncount);
+    logerror(ncplane_notcurses(n), "Invalid %d-ary section information\n", opts->sectioncount);
     return NULL;
   }
   if(opts->flags > NCMENU_OPTION_HIDING){
-    logwarn(n->nc, "Provided unsupported flags %016lx\n", opts->flags);
+    logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", opts->flags);
   }
   int totalheight = 1;
   int totalwidth = 2; // start with two-character margin on the left
@@ -313,7 +313,7 @@ ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
   ret->sectioncount = opts->sectioncount;
   ret->sections = NULL;
   int dimy, dimx;
-  ncplane_dim_yx(notcurses_stdplane(n->nc), &dimy, &dimx);
+  ncplane_dim_yx(notcurses_stdplane(ncplane_notcurses(n)), &dimy, &dimx);
   if(ret){
     ret->bottom = !!(opts->flags & NCMENU_OPTION_BOTTOM);
     if(dup_menu_sections(ret, opts, &totalwidth, &totalheight) == 0){
@@ -351,7 +351,7 @@ ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
     }
     free(ret);
   }
-  logerror(n->nc, "Error creating ncmenu");
+  logerror(ncplane_notcurses(n), "Error creating ncmenu");
   return NULL;
 }
 
@@ -370,7 +370,7 @@ int ncmenu_unroll(ncmenu* n, int sectionidx){
     return -1;
   }
   if(sectionidx < 0 || sectionidx >= n->sectioncount){
-    logerror(n->ncp->nc, "Unrolled invalid sectionidx %d\n", sectionidx);
+    logerror(ncplane_notcurses(n->ncp), "Unrolled invalid sectionidx %d\n", sectionidx);
     return -1;
   }
   if(n->sections[sectionidx].enabled_item_count <= 0){

--- a/src/lib/plot.h
+++ b/src/lib/plot.h
@@ -21,7 +21,7 @@ class ncppplot {
      opts = &zeroed;
    }
    if(opts->flags > NCPLOT_OPTION_DETECTMAXONLY){
-     logwarn(n->nc, "Provided unsupported flags %016lx\n", opts->flags);
+     logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", opts->flags);
    }
    //struct notcurses* nc = n->nc;
    // if miny == maxy (enabling domain detection), they both must be equal to 0

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -6,7 +6,7 @@ ncreader* ncreader_create(ncplane* n, const ncreader_options* opts){
     opts = &zeroed;
   }
   if(opts->flags > NCREADER_OPTION_CURSOR){
-    logwarn(n->nc, "Provided unsupported flags %016lx\n", opts->flags);
+    logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", opts->flags);
   }
   ncreader* nr = malloc(sizeof(*nr));
   if(nr == NULL){
@@ -73,7 +73,7 @@ ncreader_redraw(ncreader* n){
       }
     }
   }
-  if(notcurses_cursor_enable(n->ncp->nc, n->ncp->absy + n->ncp->y, n->ncp->absx + n->ncp->x)){
+  if(notcurses_cursor_enable(ncplane_notcurses(n->ncp), n->ncp->absy + n->ncp->y, n->ncp->absx + n->ncp->x)){
     ret = -1;
   }
   return ret;
@@ -187,7 +187,7 @@ int ncreader_move_down(ncreader* n){
 int ncreader_write_egc(ncreader* n, const char* egc){
   const int cols = ncstrwidth(egc);
   if(cols < 0){
-    logerror(n->ncp->nc, "Fed illegal UTF-8 [%s]\n", egc);
+    logerror(ncplane_notcurses(n->ncp), "Fed illegal UTF-8 [%s]\n", egc);
     return -1;
   }
   if(n->textarea->x >= n->textarea->lenx - cols){
@@ -387,7 +387,7 @@ void ncreader_destroy(ncreader* n, char** contents){
       *contents = ncreader_contents(n);
     }
     if(n->manage_cursor){
-      notcurses_cursor_disable(n->ncp->nc);
+      notcurses_cursor_disable(ncplane_notcurses(n->ncp));
     }
     ncplane_destroy(n->textarea);
     ncplane_destroy(n->ncp);

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -304,7 +304,7 @@ ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiertop,
     int ll = t->cbfxn(t, direction == DIRECTION_DOWN);
 //fprintf(stderr, "RETURNRETURNRETURN %p %d (%d, %d, %d) DIR %d\n", t, ll, cby, cbleny, leny, direction);
     if(ll > cbleny){
-      logwarn(nr->p->nc, "Tablet callback returned %d lines, %d allowed\n", ll, cbleny);
+      logwarn(ncplane_notcurses(nr->p), "Tablet callback returned %d lines, %d allowed\n", ll, cbleny);
       ll = cbleny;
     }
     if(ll != cbleny){
@@ -668,7 +668,7 @@ int ncreel_redraw(ncreel* nr){
   if(focused){
 //fprintf(stderr, "drawing focused tablet %p dir: %d fulcrum: %d!\n", focused, nr->direction, fulcrum);
     if(ncreel_draw_tablet(nr, focused, fulcrum, fulcrum, DIRECTION_DOWN)){
-      logerror(nr->p->nc, "Error drawing tablet\n");
+      logerror(ncplane_notcurses(nr->p), "Error drawing tablet\n");
       return -1;
     }
 //fprintf(stderr, "drew focused tablet %p -> %p lastdir: %d!\n", focused, focused->p, nr->direction);
@@ -680,33 +680,33 @@ int ncreel_redraw(ncreel* nr){
     if(nr->direction == LASTDIRECTION_DOWN){
       otherend = draw_previous_tablets(nr, otherend, &frontiertop, frontierbottom);
       if(otherend == NULL){
-        logerror(nr->p->nc, "Error drawing higher tablets\n");
+        logerror(ncplane_notcurses(nr->p), "Error drawing higher tablets\n");
         return -1;
       }
       otherend = draw_following_tablets(nr, otherend, frontiertop, &frontierbottom);
     }else{ // DIRECTION_UP
       otherend = draw_previous_tablets(nr, otherend, &frontiertop, frontierbottom);
       if(otherend == NULL){
-        logerror(nr->p->nc, "Error drawing higher tablets\n");
+        logerror(ncplane_notcurses(nr->p), "Error drawing higher tablets\n");
         return -1;
       }
       otherend = draw_following_tablets(nr, otherend, frontiertop, &frontierbottom);
     }
     if(otherend == NULL){
-      logerror(nr->p->nc, "Error drawing following tablets\n");
+      logerror(ncplane_notcurses(nr->p), "Error drawing following tablets\n");
       return -1;
     }
-//notcurses_debug(nr->p->nc, stderr);
+//notcurses_debug(ncplane_notcurses(nr->p), stderr);
     if(tighten_reel(nr)){
-      logerror(nr->p->nc, "Error tightening reel\n");
+      logerror(ncplane_notcurses(nr->p), "Error tightening reel\n");
       return -1;
     }
-//notcurses_debug(nr->p->nc, stderr);
+//notcurses_debug(ncplane_notcurses(nr->p), stderr);
   }
   nr->vft = nr->tablets; // update the visually-focused tablet pointer
 //fprintf(stderr, "DONE ARRANGING\n");
   if(draw_ncreel_borders(nr)){
-    logerror(nr->p->nc, "Error drawing reel borders\n");
+    logerror(ncplane_notcurses(nr->p), "Error drawing reel borders\n");
     return -1; // enforces specified dimensional minima
   }
   return 0;
@@ -718,7 +718,7 @@ validate_ncreel_opts(ncplane* n, const ncreel_options* ropts){
     return false;
   }
   if(ropts->flags > NCREEL_OPTION_CIRCULAR){
-    logwarn(n->nc, "Provided unsupported flags %016lx\n", ropts->flags);
+    logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", ropts->flags);
   }
   if(ropts->flags & NCREEL_OPTION_CIRCULAR){
     if(!(ropts->flags & NCREEL_OPTION_INFINITESCROLL)){
@@ -782,7 +782,7 @@ nctablet* ncreel_add(ncreel* nr, nctablet* after, nctablet *before,
   nctablet* t;
   if(after && before){
     if(after->prev != before || before->next != after){
-      logerror(nr->p->nc, "bad before (%p) / after (%p) spec\n", before, after);
+      logerror(ncplane_notcurses(nr->p), "bad before (%p) / after (%p) spec\n", before, after);
       return NULL;
     }
   }else if(!after && !before){

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -146,7 +146,7 @@ void cell_release(ncplane* n, cell* c){
 // Duplicate one cell onto another when they share a plane. Convenience wrapper.
 int cell_duplicate(ncplane* n, cell* targ, const cell* c){
   if(cell_duplicate_far(&n->pool, targ, n, c) < 0){
-    logerror(n->nc, "Failed duplicating cell");
+    logerror(ncplane_notcurses(n), "Failed duplicating cell");
     return -1;
   }
   return 0;
@@ -411,22 +411,22 @@ int ncplane_mergedown(const ncplane* restrict src, ncplane* restrict dst,
                       int dsty, int dstx){
 //fprintf(stderr, "Merging down %d/%d @ %d/%d to %d/%d\n", leny, lenx, begsrcy, begsrcx, dsty, dstx);
   if(dsty >= dst->leny || dstx >= dst->lenx){
-    logerror(dst->nc, "Dest origin %d/%d ≥ dest dimensions %d/%d\n",
+    logerror(ncplane_notcurses(dst), "Dest origin %d/%d ≥ dest dimensions %d/%d\n",
              dsty, dstx, dst->leny, dst->lenx);
     return -1;
   }
   if(dst->leny - leny < dsty || dst->lenx - lenx < dstx){
-    logerror(dst->nc, "Dest len %d/%d ≥ dest dimensions %d/%d\n",
+    logerror(ncplane_notcurses(dst), "Dest len %d/%d ≥ dest dimensions %d/%d\n",
              leny, lenx, dst->leny, dst->lenx);
     return -1;
   }
   if(begsrcy >= src->leny || begsrcx >= src->lenx){
-    logerror(dst->nc, "Source origin %d/%d ≥ source dimensions %d/%d\n",
+    logerror(ncplane_notcurses(dst), "Source origin %d/%d ≥ source dimensions %d/%d\n",
              begsrcy, begsrcx, src->leny, src->lenx);
     return -1;
   }
   if(src->leny - leny < begsrcy || src->lenx - lenx < begsrcx){
-    logerror(dst->nc, "Source len %d/%d ≥ source dimensions %d/%d\n",
+    logerror(ncplane_notcurses(dst), "Source len %d/%d ≥ source dimensions %d/%d\n",
              leny, lenx, src->leny, src->lenx);
     return -1;
   }
@@ -435,7 +435,7 @@ int ncplane_mergedown(const ncplane* restrict src, ncplane* restrict dst,
   const size_t crenderlen = sizeof(struct crender) * totalcells;
   struct crender* rvec = malloc(crenderlen);
   if(!rendfb || !rvec){
-    logerror(dst->nc, "Error allocating render state for %dx%d\n", leny, lenx);
+    logerror(ncplane_notcurses(dst), "Error allocating render state for %dx%d\n", leny, lenx);
     free(rendfb);
     free(rvec);
     return -1;
@@ -453,7 +453,7 @@ int ncplane_mergedown(const ncplane* restrict src, ncplane* restrict dst,
 }
 
 int ncplane_mergedown_simple(const ncplane* restrict src, ncplane* restrict dst){
-  notcurses* nc = src->nc;
+  const notcurses* nc = ncplane_notcurses_const(src);
   if(dst == NULL){
     dst = nc->stdplane;
   }

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -103,20 +103,20 @@ ncselector_draw(ncselector* n){
   ncplane_rounded_box_sized(n->ncp, 0, n->boxchannels, dimy - yoff, bodywidth, 0);
   if(n->title){
     n->ncp->channels = n->boxchannels;
-    if(notcurses_canutf8(n->ncp->nc)){
+    if(notcurses_canutf8(ncplane_notcurses(n->ncp))){
       ncplane_putegc_yx(n->ncp, 2, dimx - 1, "┤", NULL);
     }else{
       ncplane_putchar_yx(n->ncp, 2, dimx - 1, '|');
     }
     if(bodywidth < dimx){
-      if(notcurses_canutf8(n->ncp->nc)){
+      if(notcurses_canutf8(ncplane_notcurses(n->ncp))){
         ncplane_putegc_yx(n->ncp, 2, dimx - bodywidth, "┬", NULL);
       }else{
         ncplane_putchar_yx(n->ncp, 2, dimx - bodywidth, '-');
       }
     }
     if((n->titlecols + 4 != dimx) && n->titlecols > n->secondarycols){
-      if(notcurses_canutf8(n->ncp->nc)){
+      if(notcurses_canutf8(ncplane_notcurses(n->ncp))){
         ncplane_putegc_yx(n->ncp, 2, dimx - (n->titlecols + 4), "┴", NULL);
       }else{
         ncplane_putchar_yx(n->ncp, 2, dimx - (n->titlecols + 4), '-');
@@ -152,7 +152,7 @@ ncselector_draw(ncselector* n){
   if(n->maxdisplay && n->maxdisplay < n->itemcount){
     n->ncp->channels = n->descchannels;
     n->arrowx = bodyoffset + n->longop;
-    if(notcurses_canutf8(n->ncp->nc)){
+    if(notcurses_canutf8(ncplane_notcurses(n->ncp))){
       ncplane_putegc_yx(n->ncp, yoff, n->arrowx, "↑", NULL);
     }else{
       ncplane_putchar_yx(n->ncp, yoff, n->arrowx, '<');
@@ -195,7 +195,7 @@ ncselector_draw(ncselector* n){
   }
   if(n->maxdisplay && n->maxdisplay < n->itemcount){
     n->ncp->channels = n->descchannels;
-    if(notcurses_canutf8(n->ncp->nc)){
+    if(notcurses_canutf8(ncplane_notcurses(n->ncp))){
       ncplane_putegc_yx(n->ncp, yoff, n->arrowx, "↓", NULL);
     }else{
       ncplane_putchar_yx(n->ncp, yoff, n->arrowx, '>');
@@ -238,7 +238,7 @@ ncselector* ncselector_create(ncplane* n, const ncselector_options* opts){
   }
   unsigned itemcount = 0;
   if(opts->flags > 0){
-    logwarn(n->nc, "Provided unsupported flags %016lx\n", opts->flags);
+    logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", opts->flags);
   }
   if(opts->items){
     for(const struct ncselector_item* i = opts->items ; i->option ; ++i){
@@ -653,7 +653,7 @@ ncmultiselector_draw(ncmultiselector* n){
     if(printidx == n->current){
       n->ncp->channels = (uint64_t)channels_bchannel(n->descchannels) << 32u | channels_fchannel(n->descchannels);
     }
-    if(notcurses_canutf8(n->ncp->nc)){
+    if(notcurses_canutf8(ncplane_notcurses(n->ncp))){
       ncplane_putegc_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? "☒" : "☐", NULL);
     }else{
       ncplane_putchar_yx(n->ncp, yoff, bodyoffset, n->items[printidx].selected ? 'X' : '-');
@@ -833,7 +833,7 @@ ncmultiselector* ncmultiselector_create(ncplane* n, const ncmultiselector_option
     opts = &zeroed;
   }
   if(opts->flags > 0){
-    logwarn(n->nc, "Provided unsupported flags %016lx\n", opts->flags);
+    logwarn(ncplane_notcurses(n), "Provided unsupported flags %016lx\n", opts->flags);
   }
   unsigned itemcount = 0;
   if(opts->items){


### PR DESCRIPTION
Everywhere that someone was just freely dereferencing into `ncplane` to get the `struct notcurses* nc`, move it to `ncplane_notcurses()` or `ncplane_notcurses_const()`.