### PR TITLE
Planepiles, part 2 of 3

### DIFF
--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -19,6 +19,9 @@ ncpile_debug(const ncpile* p, FILE* debugfp){
     if(n->above != prev){
       fprintf(stderr, " WARNING: expected ->above %p, got %p\n", prev, n->above);
     }
+    if(ncplane_pile_const(n) != p){
+      fprintf(stderr, " WARNING: expected pile %p, got %p\n", p, ncplane_pile_const(n));
+    }
     prev = n;
     n = n->below;
     ++planeidx;

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -2,6 +2,7 @@
 
 static void
 ncpile_debug(const ncpile* p, FILE* debugfp){
+  fprintf(debugfp, "  -=+********************** %16p pile *************************+=-\n", p);
   const ncplane* n = p->top;
   const ncplane* prev = NULL;
   int planeidx = 0;

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -10,8 +10,8 @@ ncpile_debug(const ncpile* p, FILE* debugfp){
     fprintf(debugfp, "%04d off y: %3d x: %3d geom y: %3d x: %3d curs y: %3d x: %3d %p %.8s\n",
             planeidx, n->absy, n->absx, n->leny, n->lenx, n->y, n->x, n, n->name);
     if(n->boundto || n->bnext || n->bprev || n->blist){
-      fprintf(debugfp, " bound %p → %p ← %p binds %p\n",
-              n->boundto, n->bnext, n->bprev, n->blist);
+      fprintf(debugfp, " bound %p ← %p → %p binds %p\n",
+              n->boundto, n->bprev, n->bnext, n->blist);
     }
     if(n->bprev && (*n->bprev != n)){
       fprintf(stderr, " WARNING: expected *->bprev %p, got %p\n", n, *n->bprev);
@@ -37,7 +37,11 @@ void notcurses_debug(notcurses* nc, FILE* debugfp){
   const ncpile* p0 = p;
   do{
     ncpile_debug(p0, debugfp);
+    const ncpile* prev = p0;
     p0 = p0->next;
+    if(p0->prev != prev){
+      fprintf(stderr, "WARNING: expected ->prev %p, got %p\n", prev, p0->prev);
+    }
   }while(p != p0);
   fprintf(debugfp, " ******************************************************************************\n");
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -73,8 +73,8 @@ typedef struct ncplane {
   // and is the only stack which is rendered. each stack has its own z-axis.
   struct ncplane* above; // plane above us, NULL if we're on top
   struct ncplane* below; // plane below us, NULL if we're on bottom
-  struct ncplane* bnext; // next in the bound list of plane to which we are bound
-  struct ncplane** bprev;// link to us iff we're bound, NULL otherwise
+  struct ncplane* bnext; // next in the blist iff we're bound, NULL otherwise
+  struct ncplane** bprev;// blist link to us iff we're bound, NULL otherwise
   struct ncplane* blist; // head of list of bound planes
   // a root plane is bound to itself. every other plane has a path to its
   // stack's root via boundto. the standard plane is always bound to itself.

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -301,7 +301,6 @@ typedef struct ncdirect {
 typedef struct ncpile {
   ncplane* top;     // topmost plane, never NULL
   ncplane* bottom;  // bottommost plane, never NULL 
-  ncplane* root;    // first plane of the root set
   struct notcurses* nc; // notcurses context
   struct ncpile *prev, *next; // circular list
 } ncpile;

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -908,7 +908,7 @@ TEST_CASE("NCPlane") {
     ncplane_yx(nsub, &absy, &absx);
     CHECK(1 == absy); // actually at 2, 2
     CHECK(1 == absx);
-    ncplane_reparent(nsub, nullptr);
+    ncplane_reparent(nsub, nsub);
     ncplane_yx(nsub, &absy, &absx);
     CHECK(2 == absy); // now we recognize 2, 2
     CHECK(2 == absx);

--- a/tests/ncplane.cpp
+++ b/tests/ncplane.cpp
@@ -551,6 +551,7 @@ TEST_CASE("NCPlane") {
     CHECK(0 == testcell.gcluster);
     CHECK(0 == testcell.stylemask);
     CHECK(0 == testcell.channels);
+    cell_release(n_, &testcell);
     int dimy, dimx;
     ncplane_dim_yx(n_, &dimy, &dimx);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 1, dimx - strlen(STR2)));
@@ -588,6 +589,7 @@ TEST_CASE("NCPlane") {
     CHECK(0 == testcell.gcluster);
     CHECK(0 == testcell.stylemask);
     CHECK(0 == testcell.channels);
+    cell_release(n_, &testcell);
     int dimy, dimx;
     ncplane_dim_yx(n_, &dimy, &dimx);
     REQUIRE(0 == ncplane_cursor_move_yx(n_, 1, dimx - mbstowcs(nullptr, STR2, 0)));
@@ -897,11 +899,14 @@ TEST_CASE("NCPlane") {
       .x = 1,
       .rows = 2,
       .cols = 2,
-      nullptr, nullptr, nullptr, 0,
+      nullptr, "ndom", nullptr, 0,
     };
     struct ncplane* ndom = ncplane_create(n_, &nopts);
+    CHECK(ncplane_pile(ndom) == ncplane_pile(n_));
     REQUIRE(ndom);
+    nopts.name = "sub";
     struct ncplane* nsub = ncplane_create(ndom, &nopts);
+    CHECK(ncplane_pile(nsub) == ncplane_pile(ndom));
     REQUIRE(nsub);
     int absy, absx;
     CHECK(0 == notcurses_render(nc_));
@@ -909,13 +914,14 @@ TEST_CASE("NCPlane") {
     CHECK(1 == absy); // actually at 2, 2
     CHECK(1 == absx);
     ncplane_reparent(nsub, nsub);
+    CHECK(ncplane_pile(nsub) != ncplane_pile(ndom));
     ncplane_yx(nsub, &absy, &absx);
-    CHECK(2 == absy); // now we recognize 2, 2
-    CHECK(2 == absx);
+    CHECK(1 == absy); // now truly at 1, 1
+    CHECK(1 == absx);
     CHECK(0 == ncplane_move_yx(ndom, 0, 0));
     ncplane_yx(nsub, &absy, &absx);
-    CHECK(2 == absy); // still at 2, 2
-    CHECK(2 == absx);
+    CHECK(1 == absy); // still at 1, 1
+    CHECK(1 == absx);
   }
 
   SUBCASE("NoReparentStdPlane") {


### PR DESCRIPTION
More planepiles work (#1078)

* Some missed bookkeeping from #1133 
* Improve `notcurses_debug()` thoroughness
* Kill unnecessary `root` member from `ncpile`
* Use recursive mutex for `pilelock` to simplify `notcurses_drop_planes()` / `notcurses_stop()`
* Unit test for reparenting to new pile