### PR TITLE
Render multiple motherfuckin' piles (part 3 of 3)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -280,12 +280,6 @@ rearrangements of Notcurses.
 * 1.6.10 (2020-08-01)
   * The `egc` member of `ncreader_options` is now `const`.
 
-* 1.6.9 (2020-07-26)
-  * No user-visible changes.
-
-* 1.6.8 (2020-07-26)
-  * No user-visible changes.
-
 * 1.6.7 (2020-07-26)
   * GNU libunistring is now required to build/load Notcurses.
   * Added `ncmenu_mouse_selection()`. Escape now closes an unrolled menu
@@ -296,14 +290,8 @@ rearrangements of Notcurses.
     using setuptools. CMake no longer installs it.
   * Added `notcurses_lex_blitter()` and `notcurses_str_scalemode()`.
 
-* 1.6.5 (2020-07-19)
-  * No user-visible changes.
-
 * 1.6.4 (2020-07-19)
   * Added `notcurses_str_blitter()`.
-
-* 1.6.3 (2020-07-16)
-  * No user-visible changes.
 
 * 1.6.2 (2020-07-15)
   * The option `NCOPTION_NO_FONT_CHANGES` has been added. This will cause
@@ -464,9 +452,6 @@ rearrangements of Notcurses.
   * `qprefix()` and `bprefix()` now take a `uintmax_t` in place of an
     `unsigned`, to match `ncprefix`.
 
-* 1.4.1 (2020-05-11)
-  * No user-visible changes (fixed two unit tests).
-
 * 1.4.0 (2020-05-10)
   * `ncplane_content()` was added. It allows all non-null glyphs of a plane to
     be returned as a nul-terminated, heap-allocated string.
@@ -545,12 +530,6 @@ rearrangements of Notcurses.
     through use of `ncplane_set_scrolling(true)`, output past the end of the
     last line will now result in the top line of the plane being lost, all
     other lines moved up one, and the bottom line cleared.
-
-* 1.3.0 (2020-04-12)
-  * No user-visible changes
-
-* 1.2.9 (2020-04-11)
-  * No user-visible changes
 
 * 1.2.8 (2020-04-10)
   * `notcurses-tetris` now happily continues if it can't load its background.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ rearrangements of Notcurses.
 * 2.0.8 (not yet released)
   * The MAJOR, MINOR, and PATH versions are now available as preprocessor
     numeric defines, fit for comparisons at the cpp level.
+  * Add new function `ncplane_reparent_family()`, which reparents a plane and
+    its bindtree (all planes bound to the plane, recursively).
+    `ncplane_reparent()` now reparents only the specified plane; any planes
+    bound to it are reparented to its old parent.
   * Move to a multipile model. For full details, consult
       https://groups.google.com/g/notcurses/c/knB4ojndv8A and
       https://github.com/dankamongmen/notcurses/issues/1078 and
@@ -16,6 +20,9 @@ rearrangements of Notcurses.
       `ncpile_create()`. The returned plane will be the top, bottom, and root
       of a new plane. Alternatively, use `ncplane_reparent()` or
       `ncplane_reparent_family()` with the source equal to the destination.
+    * Add new function `ncpile_render()`, which renders the pile containing the
+      specified plane to the specified buffer. Add new function
+      `notcurses_rasterize()` to rasterize the specified buffer to output.
 
 * 2.0.7 (2020-11-21)
   * The `horiz` union of `ncplane_options` has been discarded; the `int x`

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,6 @@ rearrangements of Notcurses.
     * Add new function `ncpile_render()`, which renders the pile containing the
       specified plane to the specified buffer. Add new function
       `ncpile_rasterize()` to rasterize the specified buffer to output.
-  * `notcurses_render_to_buffer()` has been deprecated. Use `ncpile_render()`.
 
 * 2.0.7 (2020-11-21)
   * The `horiz` union of `ncplane_options` has been discarded; the `int x`

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,8 @@ rearrangements of Notcurses.
       `ncplane_reparent_family()` with the source equal to the destination.
     * Add new function `ncpile_render()`, which renders the pile containing the
       specified plane to the specified buffer. Add new function
-      `notcurses_rasterize()` to rasterize the specified buffer to output.
+      `ncpile_rasterize()` to rasterize the specified buffer to output.
+  * `notcurses_render_to_buffer()` has been deprecated. Use `ncpile_render()`.
 
 * 2.0.7 (2020-11-21)
   * The `horiz` union of `ncplane_options` has been discarded; the `int x`

--- a/USAGE.md
+++ b/USAGE.md
@@ -166,6 +166,15 @@ Only upon a call to `notcurses_render` will the visible terminal display be
 updated to reflect the changes:
 
 ```c
+// Renders the pile of which 'n' is a part. Rendering this pile again will blow
+// away the render. To actually write out the render, call ncpile_rasterize().
+int ncpile_render(struct ncplane* n);
+
+// Make the physical screen match the last rendered frame from the pile of
+// which 'n' is a part. This is a blocking call. Don't call this before the
+// pile has been rendered (doing so will likely result in a blank screen).
+int ncpile_rasterize(struct ncplane* n);
+
 // Make the physical screen match the virtual screen. Changes made to the
 // virtual screen (i.e. most other calls) will not be visible until after a
 // successful call to notcurses_render().

--- a/cffi/src/notcurses/build_notcurses.py
+++ b/cffi/src/notcurses/build_notcurses.py
@@ -53,6 +53,8 @@ void notcurses_version_components(int* major, int* minor, int* patch, int* tweak
 int notcurses_lex_margins(const char* op, notcurses_options* opts);
 int notcurses_stop(struct notcurses*);
 int notcurses_render(struct notcurses* nc);
+int ncpile_render(struct ncplane* n);
+int ncpile_rasterize(struct ncplane* n);
 int notcurses_render_to_buffer(struct notcurses* nc, char** buf, size_t* buflen);
 int notcurses_render_to_file(struct notcurses* nc, FILE* fp);
 struct ncplane* notcurses_stdplane(struct notcurses*);

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -195,11 +195,6 @@ namespace ncpp
 			return error_guard (notcurses_render (nc), -1);
 		}
 
-		bool render_to_buffer (char** buf, size_t* buflen) const NOEXCEPT_MAYBE
-		{
-			return error_guard (notcurses_render_to_buffer (nc, buf, buflen), -1);
-		}
-
 		bool render_to_file (FILE* fp) const NOEXCEPT_MAYBE
 		{
 			return error_guard (notcurses_render_to_file (nc, fp), -1);

--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -195,6 +195,11 @@ namespace ncpp
 			return error_guard (notcurses_render (nc), -1);
 		}
 
+		bool render_to_buffer (char** buf, size_t* buflen) const NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_render_to_buffer (nc, buf, buflen), -1);
+		}
+
 		bool render_to_file (FILE* fp) const NOEXCEPT_MAYBE
 		{
 			return error_guard (notcurses_render_to_file (nc, fp), -1);

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -841,16 +841,24 @@ API struct notcurses* notcurses_init(const notcurses_options* opts, FILE* fp);
 // Destroy a Notcurses context.
 API int notcurses_stop(struct notcurses* nc);
 
-// Make the physical screen match the virtual screen. Changes made to the
-// virtual screen (i.e. most other calls) will not be visible until after a
-// successful call to notcurses_render().
+// Renders the pile of which 'n' is a part. Rendering this pile again will blow
+// away the render. To actually write out the render, call ncpile_rasterize().
+API int ncpile_render(struct ncplane* n);
+
+// Make the physical screen match the last rendered frame from the pile of
+// which 'n' is a part. This is a blocking call. Don't call this before the
+// pile has been rendered (doing so will likely result in a blank screen).
+API int ncpile_rasterize(struct ncplane* n);
+
+// Renders and rasterizes the standard pile in one shot. Blocking call.
 API int notcurses_render(struct notcurses* nc);
 
 // Perform the rendering and rasterization portion of notcurses_render(), but
 // do not write the resulting buffer out to the terminal. Using this function,
 // the user can control the writeout process, and render a second frame while
 // writing another. The returned buffer must be freed by the caller.
-API int notcurses_render_to_buffer(struct notcurses* nc, char** buf, size_t* buflen);
+API int notcurses_render_to_buffer(struct notcurses* nc, char** buf, size_t* buflen)
+  __attribute__ ((deprecated));
 
 // Write the last rendered frame, in its entirety, to 'fp'. If
 // notcurses_render() has not yet been called, nothing will be written.

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -857,8 +857,7 @@ API int notcurses_render(struct notcurses* nc);
 // do not write the resulting buffer out to the terminal. Using this function,
 // the user can control the writeout process, and render a second frame while
 // writing another. The returned buffer must be freed by the caller.
-API int notcurses_render_to_buffer(struct notcurses* nc, char** buf, size_t* buflen)
-  __attribute__ ((deprecated));
+API int notcurses_render_to_buffer(struct notcurses* nc, char** buf, size_t* buflen);
 
 // Write the last rendered frame, in its entirety, to 'fp'. If
 // notcurses_render() has not yet been called, nothing will be written.

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -96,11 +96,11 @@ typedef struct ncplane {
 // current presentation state of the terminal. it is carried across render
 // instances. initialize everything to 0 on a terminal reset / startup.
 typedef struct renderstate {
-  // we assemble the encoded output in a POSIX memstream, and keep it around
-  // between uses. this could be a problem if it ever tremendously spiked, but
-  // that's a highly unlikely situation.
-  char* mstream;  // buffer for rendering memstream, see open_memstream(3)
-  FILE* mstreamfp;// FILE* for rendering memstream
+  // we assemble the encoded (rasterized) output in a POSIX memstream, and keep
+  // it around between uses. this could be a problem if it ever tremendously
+  // spiked, but that's a highly unlikely situation.
+  char* mstream;  // buffer for rasterizing memstream, see open_memstream(3)
+  FILE* mstreamfp;// FILE* for rasterizing memstream
   size_t mstrsize;// size of rendering memstream
 
   // the current cursor position. this is independent of whether the cursor is
@@ -298,20 +298,13 @@ typedef struct ncdirect {
   uint64_t flags;            // copied in ncdirect_init() from param
 } ncdirect;
 
-// A rendering context/result, suitable for reuse across many rendering
-// operations. A pile's planes are rendered down into a single virtual plane,
-// which can be (relative to the last rendered plane, common across the
-// notcurses context) rasterized to the actual terminal.
-typedef struct ncrender {
-  char* buf;
-  size_t buflen;
-} ncrender;
-
 typedef struct ncpile {
-  ncplane* top;     // topmost plane, never NULL
-  ncplane* bottom;  // bottommost plane, never NULL 
-  struct notcurses* nc; // notcurses context
+  ncplane* top;               // topmost plane, never NULL
+  ncplane* bottom;            // bottommost plane, never NULL
+  struct notcurses* nc;       // notcurses context
   struct ncpile *prev, *next; // circular list
+  size_t crenderlen;          // size of crender array in bytes
+  struct crender* crender;    // crender array
 } ncpile;
 
 // the standard pile can be reached through ->stdplane.

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -298,6 +298,15 @@ typedef struct ncdirect {
   uint64_t flags;            // copied in ncdirect_init() from param
 } ncdirect;
 
+// A rendering context/result, suitable for reuse across many rendering
+// operations. A pile's planes are rendered down into a single virtual plane,
+// which can be (relative to the last rendered plane, common across the
+// notcurses context) rasterized to the actual terminal.
+typedef struct ncrender {
+  char* buf;
+  size_t buflen;
+} ncrender;
+
 typedef struct ncpile {
   ncplane* top;     // topmost plane, never NULL
   ncplane* bottom;  // bottommost plane, never NULL 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -271,6 +271,7 @@ ncpile_destroy(ncpile* pile){
   if(pile){
     pile->prev->next = pile->next;
     pile->next->prev = pile->prev;
+    free(pile->crender);
     free(pile);
   }
 }
@@ -315,6 +316,8 @@ make_ncpile(notcurses* nc, ncplane* n){
     n->pile = ret;
     n->above = NULL;
     n->below = NULL;
+    ret->crenderlen = 0;
+    ret->crender = NULL;
   }
   return ret;
 }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -1037,15 +1037,12 @@ int notcurses_render_to_file(notcurses* nc, FILE* fp){
 // locking down the EGC, the attributes, and the channels for each cell.
 static int
 notcurses_render_internal(notcurses* nc, struct crender* rvec){
-  int dimy, dimx;
-  ncplane_dim_yx(nc->stdplane, &dimy, &dimx);
   ncplane* p = ncplane_pile(nc->stdplane)->top;
   while(p){
     paint(p, rvec, nc->stdplane->leny, nc->stdplane->lenx,
           nc->stdplane->absy, nc->stdplane->absx);
     p = p->below;
   }
-  postpaint(nc->lastframe, dimy, dimx, rvec, &nc->pool);
   return 0;
 }
 
@@ -1061,6 +1058,7 @@ int notcurses_render(notcurses* nc){
   if(notcurses_render_internal(nc, crender) == 0){
     clock_gettime(CLOCK_MONOTONIC, &rasterdone);
     update_render_stats(&rasterdone, &start, &nc->stats);
+    postpaint(nc->lastframe, dimy, dimx, crender, &nc->pool);
     bytes = notcurses_rasterize(nc, crender, nc->rstate.mstreamfp);
   }
   update_render_bytes(&nc->stats, bytes);
@@ -1089,6 +1087,7 @@ int notcurses_render_to_buffer(notcurses* nc, char** buf, size_t* buflen){
   if(notcurses_render_internal(nc, crender) == 0){
     clock_gettime(CLOCK_MONOTONIC, &rasterdone);
     update_render_stats(&rasterdone, &start, &nc->stats);
+    postpaint(nc->lastframe, dimy, dimx, crender, &nc->pool);
     bytes = notcurses_rasterize_inner(nc, crender, nc->rstate.mstreamfp);
   }
   update_render_bytes(&nc->stats, bytes);


### PR DESCRIPTION
Closes #1135. Adds `ncpile_render()` and `ncpile_rasterize()`. Rewrite `notcurses_render()` in terms of `ncpile_render()` + `ncpile_rasterize()`. `crender` is now per-pile, and maintained across render calls.

I think I still need to add unit tests, whoops.