### PR TITLE
[C++] API sync

### DIFF
--- a/include/ncpp/Pile.hh
+++ b/include/ncpp/Pile.hh
@@ -1,0 +1,57 @@
+#ifndef __NCPP_PILE_HH
+#define __NCPP_PILE_HH
+
+#include <exception>
+#include <notcurses/notcurses.h>
+
+#include "NotCurses.hh"
+#include "Plane.hh"
+
+namespace ncpp
+{
+	class NCPP_API_EXPORT Pile : public Plane
+	{
+	public:
+		Pile (ncplane_options const* nopts, NotCurses* ncinst = nullptr)
+			: Plane (ncinst)
+		{
+			if (nopts == nullptr) {
+				throw invalid_argument ("'nopts' must be a valid pointer");
+			}
+
+			notcurses *n;
+			if (ncinst == nullptr) {
+				n = NotCurses::get_instance ();
+			} else {
+				n = *ncinst;
+			}
+
+			ncplane *pile = ncpile_create (n, nopts);
+			if (pile == nullptr) {
+				throw init_error ("Notcurses failed to create a new pile");
+			}
+
+			set_plane (pile);
+		}
+
+		bool render () const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncpile_render (to_ncplane ()), -1);
+		}
+
+		bool rasterize () const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncpile_rasterize (to_ncplane ()), -1);
+		}
+
+		bool show () const NOEXCEPT_MAYBE
+		{
+			if (!render ()) {
+				return false;
+			}
+
+			return rasterize ();
+		}
+	};
+}
+#endif

--- a/src/poc/ncpp_build.cpp
+++ b/src/poc/ncpp_build.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <ncpp/NotCurses.hh>
 #include <ncpp/Menu.hh>
+#include <ncpp/Pile.hh>
 #include <ncpp/Plane.hh>
 #include <ncpp/Reel.hh>
 #include <ncpp/MultiSelector.hh>

--- a/src/poc/ncpp_build_exceptions.cpp
+++ b/src/poc/ncpp_build_exceptions.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <ncpp/NotCurses.hh>
 #include <ncpp/Menu.hh>
+#include <ncpp/Pile.hh>
 #include <ncpp/Plane.hh>
 #include <ncpp/Reel.hh>
 #include <ncpp/MultiSelector.hh>


### PR DESCRIPTION
Added:

  * Pile: new class derived from Plane, which implements all the
    `ncpile_*` calls
  * Plane: `get_parent` (`ncplane_parent`)
  * Plane: protected constructor for use by `Pile` (or other derived
    classes which cannot provide a valid `ncplane*` when invoking parent
    constructor.
  * Plane: `set_plane` for use by the derived classes above.

Changed:

  * Plane: `to_ncplane` is a `const` method now.