### PR TITLE
[Misc] A hodgepodge of tiny changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,22 +601,46 @@ include(CMakePackageConfigHelpers)
 configure_file(tools/version.h.in include/version.h)
 configure_file(tools/builddef.h.in include/builddef.h)
 
-configure_package_config_file(tools/NotcursesConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfig.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/notcurses/cmake
-)
-
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfigVersion.cmake
   COMPATIBILITY SameMajorVersion
 )
 
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/Notcurses++ConfigVersion.cmake
+  COMPATIBILITY SameMajorVersion
+  )
+
 # Installation
 install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfig.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses"
 )
+
+install(TARGETS notcurses
+  EXPORT "NotcursesTargets"
+  )
+
+install(EXPORT "NotcursesTargets"
+  NAMESPACE "notcurses::"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses"
+  FILE "NotcursesConfig.cmake"
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/Notcurses++ConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses++"
+  )
+
+install(TARGETS notcurses++
+  EXPORT "Notcurses++Targets"
+  )
+
+install(EXPORT "Notcurses++Targets"
+  NAMESPACE "notcurses++::"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses++"
+  FILE "Notcurses++Config.cmake"
+  )
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/notcurses.pc

--- a/doc/man/man3/notcurses_cell.3.md
+++ b/doc/man/man3/notcurses_cell.3.md
@@ -56,9 +56,9 @@ typedef struct cell {
 
 **unsigned cell_styles(const cell* ***c***);**
 
-**void cell_styles_on(cell* ***c***, unsigned ***stylebits***);**
+**void cell_on_styles(cell* ***c***, unsigned ***stylebits***);**
 
-**void cell_styles_off(cell* ***c***, unsigned ***stylebits***);**
+**void cell_off_styles(cell* ***c***, unsigned ***stylebits***);**
 
 **void cell_set_fg_default(cell* ***c***);**
 
@@ -74,7 +74,7 @@ typedef struct cell {
 
 **char* cell_strdup(const struct ncplane* ***n***, const cell* ***c***);**
 
-**int cell_load_simple(struct ncplane* ***n***, cell* ***c***, char ***ch***);**
+**int cell_load_char(struct ncplane* ***n***, cell* ***c***, char ***ch***);**
 
 **char* cell_extract(const struct ncplane* ***n***, const cell* ***c***, uint16_t* ***stylemask***, uint64_t* ***channels***);**
 

--- a/tools/NotcursesConfig.cmake.in
+++ b/tools/NotcursesConfig.cmake.in
@@ -1,9 +1,0 @@
-@PACKAGE_INIT@
-set(Notcurses_DIR "@PACKAGE_SOME_INSTALL_DIR@")
-
-# Compute paths
-get_filename_component(Notcurses_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(Notcurses_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
-set(Notcurses_LIBRARY_DIRS "@CONF_LIBRARY_DIRS@")
-
-set(Notcurses_LIBRARIES -lnotcurses)


### PR DESCRIPTION
CMake:
  Simplify cmake target+version config generation and make it actually
  work.  With the changes it is now possible to detect and use
  `Notcurses` in the following way:

     find_package(Notcurses REQUIRED)
     ...
     target_link_libraries(myapp PRIVATE notcurses::notcurses)

  Also, added the same CMake configuration for `Notcurses++`, to be used
  in the following way:

     find_package(Notcurses REQUIRED
     find_package(Notcurses++ REQUIRED)
     ...
     target_link_libraries(myapp PRIVATE notcurses++::notcurses++)

Docs:
  `notcurses_cell(3)`: `cell_styles_{on,off} -> cell_{on,off}_styles`
  and `cell_load_simple` -> `cell_load_char`

C++ API:
  * Plane: added constructors taking `ncplane_options const&` instead of
    the multitude of individual parameters
  * Plane: drop `struct` when `ncplane_options` is used.
  * Plane: added `strdup` (`cell_strdup`)
  * Plane: added `extract` (`cell_extract`)