### PR TITLE
[CMake] Restore old way of importing Notcurses into a cmake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,19 +592,25 @@ configure_file(tools/notcurses++.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/notcurses++.pc
   @ONLY
 )
-install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/notcurses++.pc
-  DESTINATION ${PKGCONFIG_DIR}
-)
 
 include(CMakePackageConfigHelpers)
 configure_file(tools/version.h.in include/version.h)
 configure_file(tools/builddef.h.in include/builddef.h)
 
+configure_package_config_file(tools/NotcursesConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/notcurses/cmake
+)
+
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfigVersion.cmake
   COMPATIBILITY SameMajorVersion
 )
+
+configure_package_config_file(tools/Notcurses++Config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/Notcurses++Config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/notcurses/cmake
+  )
 
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/Notcurses++ConfigVersion.cmake
@@ -613,39 +619,26 @@ write_basic_package_version_file(
 
 # Installation
 install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfig.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses"
 )
 
-install(TARGETS notcurses
-  EXPORT "NotcursesTargets"
-  )
-
-install(EXPORT "NotcursesTargets"
-  NAMESPACE "notcurses::"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses"
-  FILE "NotcursesConfig.cmake"
-)
-
 install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/Notcurses++Config.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/Notcurses++ConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses++"
-  )
-
-install(TARGETS notcurses++
-  EXPORT "Notcurses++Targets"
-  )
-
-install(EXPORT "Notcurses++Targets"
-  NAMESPACE "notcurses++::"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses++"
-  FILE "Notcurses++Config.cmake"
   )
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/notcurses.pc
   DESTINATION ${PKGCONFIG_DIR}
 )
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/notcurses++.pc
+  DESTINATION ${PKGCONFIG_DIR}
+  )
 
 if(${USE_FFMPEG} OR ${USE_OIIO})
 file(GLOB TESTDATA CONFIGURE_DEPENDS data/*)

--- a/tools/Notcurses++Config.cmake.in
+++ b/tools/Notcurses++Config.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+set(Notcurses++_DIR "@PACKAGE_SOME_INSTALL_DIR@")
+
+# Compute paths
+get_filename_component(Notcurses_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(Notcurses++_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+set(Notcurses++_LIBRARY_DIRS "@CONF_LIBRARY_DIRS@")
+
+set(Notcurses++_LIBRARIES -lnotcurses -lnotcurses++)

--- a/tools/NotcursesConfig.cmake.in
+++ b/tools/NotcursesConfig.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+set(Notcurses_DIR "@PACKAGE_SOME_INSTALL_DIR@")
+
+# Compute paths
+get_filename_component(Notcurses_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(Notcurses_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+set(Notcurses_LIBRARY_DIRS "@CONF_LIBRARY_DIRS@")
+
+set(Notcurses_LIBRARIES -lnotcurses)


### PR DESCRIPTION
Partially reverts: c5c9432ac039fb98ef0b6888f6654f80b9973b95
Context: https://github.com/dankamongmen/notcurses/pull/1146

The above commit implemented the much more convenient way of finding and
using a package from CMake, however it broke compatibility with the way
id had been before, which defined various `Notcurses_*` variables.

Revert the `Notcurses` component to the old way and add support for
`Notcurses++` in the same fashion.

Perhaps one day we should think of implementing `find_package` support
by way of a module, which should make it possible to have the cake and
eat the cake. One day.