### PR TITLE
Add ncls binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,19 @@ target_link_libraries(notcurses-input
     notcurses++
 )
 
+# ncls
+file(GLOB LSSRC CONFIGURE_DEPENDS src/ls/*.cpp)
+add_executable(ncls ${LSSRC})
+target_include_directories(ncls
+  PRIVATE
+    include
+    "${PROJECT_BINARY_DIR}/include"
+)
+target_link_libraries(ncls
+  PRIVATE
+    notcurses++
+)
+
 # notcurses-tetris
 file(GLOB TETRISSRC CONFIGURE_DEPENDS src/tetris/*.cpp)
 add_executable(notcurses-tetris ${TETRISSRC})
@@ -665,6 +678,7 @@ install(FILES ${MARKDOWN} DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 install(TARGETS notcurses-demo DESTINATION bin)
 install(TARGETS notcurses-input DESTINATION bin)
+install(TARGETS ncls DESTINATION bin)
 install(TARGETS ncneofetch DESTINATION bin)
 install(TARGETS notcurses-tetris DESTINATION bin)
 if(${USE_FFMPEG} OR ${USE_OIIO})

--- a/doc/man/man1/ncls.1.md
+++ b/doc/man/man1/ncls.1.md
@@ -1,0 +1,43 @@
+% ncls(1)
+% nick black <nickblack@linux.com>
+% v2.0.2
+
+# NAME
+
+ncls - List paths with rendering of multimedia
+
+# SYNOPSIS
+
+**ncls** [**-h**] [**-d**] [**-l**] [**-R**] [ paths ]
+
+# DESCRIPTION
+
+**ncls** uses a multimedia-enabled notcurses to list paths, similarly to the
+**ls(1)** command, rendering images and videos to a terminal.
+
+# OPTIONS
+
+**-d**: list directories themselves, not their contents.
+
+**-l**: use a long listing format.
+
+**-R**: list subdirectories recursively.
+
+**-h**: Print help information, and exit with success.
+
+paths: Run on the specified paths. If none are supplied, run on the current
+directory.
+
+# NOTES
+
+Optimal display requires a terminal advertising the **rgb** terminfo(5)
+capability, or that the environment variable **COLORTERM** is defined to
+**24bit** (and that the terminal honors this variable), along with a
+fixed-width font with good coverage of the Unicode Block Drawing Characters.
+
+# SEE ALSO
+
+**notcurses(3)**,
+**notcurses_visual(3)**,
+**terminfo(5)**,
+**unicode(7)**

--- a/doc/man/man1/ncls.1.md
+++ b/doc/man/man1/ncls.1.md
@@ -8,7 +8,7 @@ ncls - List paths with rendering of multimedia
 
 # SYNOPSIS
 
-**ncls** [**-h**] [**-d**] [**-l**] [**-R**] [ paths ]
+**ncls** [**-h**] [**-d**] [**-l**] [**-L**] [**-R**] [ paths ]
 
 # DESCRIPTION
 
@@ -20,6 +20,8 @@ ncls - List paths with rendering of multimedia
 **-d**: list directories themselves, not their contents.
 
 **-l**: use a long listing format.
+
+**-L**: when showing file information for a symbolic link, show information for  the file the link references rather than for the link itself.
 
 **-R**: list subdirectories recursively.
 

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -61,6 +61,13 @@ handle_dir(const char* p, const struct stat* st, bool longlisting,
 }
 
 static int
+handle_deref(const char* p, const struct stat* st, bool longlisting,
+             bool recursedirs, bool directories){
+  // FIXME dereference and rerun on target
+  return 0;
+}
+
+static int
 handle_path(const char* p, bool longlisting, bool recursedirs,
             bool directories, bool dereflinks, bool toplevel){
   struct stat st;
@@ -71,12 +78,11 @@ handle_path(const char* p, bool longlisting, bool recursedirs,
   if((st.st_mode & S_IFMT) == S_IFDIR){
     return handle_dir(p, &st, longlisting, recursedirs, directories, toplevel);
   }else if((st.st_mode & S_IFMT) == S_IFLNK){
-    // FIXME deal with dereflinks
-    return handle_inode(p, &st, longlisting);
-  }else{
-    return handle_inode(p, &st, longlisting);
+    if(toplevel && dereflinks){
+      return handle_deref(p, &st, longlisting, recursedirs, directories);
+    }
   }
-  return 0;
+  return handle_inode(p, &st, longlisting);
 }
 
 static int

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <ncpp/NotCurses.hh>
+#include <ncpp/Direct.hh>
 
 static void
 usage(std::ostream& os, const char* name, int code){
@@ -20,6 +20,7 @@ usage(std::ostream& os, const char* name, int code){
 
 // context as configured on the command line
 struct lsContext {
+  ncpp::Direct nc;
   bool longlisting;
   bool recursedirs;
   bool directories;
@@ -33,6 +34,7 @@ handle_path(const char* p, const lsContext& ctx, bool toplevel);
 static int
 handle_inode(const char* p, const struct stat* st, const lsContext& ctx){
   std::cout << p << std::endl; // FIXME handle symlink (dereflinks)
+  ctx.nc.render_image(p, NCALIGN_RIGHT, NCBLIT_DEFAULT, NCSCALE_STRETCH);
   return 0;
 }
 
@@ -107,6 +109,7 @@ list_paths(const char* const * argv, const lsContext& ctx){
 
 int main(int argc, char* const * argv){
   lsContext ctx = {
+    .nc = ncpp::Direct(),
     .longlisting = false,
     .recursedirs = false,
     .directories = false,

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -1,5 +1,7 @@
 #include <cstdlib>
 #include <iostream>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <ncpp/NotCurses.hh>
 
@@ -8,24 +10,86 @@ usage(std::ostream& os, const char* name, int code){
   os << "usage: " << name << " -h | [ -lR ] paths...\n";
   os << " -d: list directories themselves, not their contents\n";
   os << " -l: use a long listing format\n";
+  os << " -L: dereference symlink arguments\n";
   os << " -R: list subdirectories recursively\n";
   os << " -h: print usage information\n";
   os << std::flush;
   exit(code);
 }
 
-int main(int argc, char** argv){
+// handle a single inode of arbitrary type
+static int
+handle_inode(const char* p, const struct stat* st, bool longlisting){
+  return 0;
+}
+
+// if |directories| is true, only print details of |p|, and return. otherwise,
+// if |recursedirs| or |toplevel| is set, we will recurse, passing false as
+// toplevel (but preserving |recursedirs|).
+static int
+handle_dir(const char* p, const struct stat* st, bool longlisting,
+           bool recursedirs, bool directories, bool toplevel){
+  if(directories){
+    return handle_inode(p, st, longlisting);
+  }
+  std::cout << "DIRECTORY: " << p << std::endl; // FIXME handle directory (recursedirs, directories)
+  return 0;
+}
+
+// handle a directory path *listed on the command line*.
+static inline int
+handle_cmdline_dir(const char* p, const struct stat* st, bool longlisting,
+                   bool recursedirs, bool directories){
+  return handle_dir(p, st, longlisting, recursedirs, directories, true);
+}
+
+static int
+handle_path(const char* p, bool longlisting, bool recursedirs,
+            bool directories, bool dereflinks){
+  struct stat st;
+  if(stat(p, &st)){
+    std::cerr << "Error running stat(" << p << "): " << strerror(errno) << std::endl;
+    return -1;
+  }
+  if((st.st_mode & S_IFMT) == S_IFDIR){
+    return handle_cmdline_dir(p, &st, longlisting, recursedirs, directories);
+  }else if((st.st_mode & S_IFMT) == S_IFLNK){
+    std::cout << p << std::endl; // FIXME handle symlink (dereflinks)
+  }else if((st.st_mode & S_IFMT) == S_IFREG){
+    std::cout << p << std::endl; // FIXME handle normal file
+  }else{
+    // FIXME handle weirdo
+  }
+  return 0;
+}
+
+static int
+list_paths(const char* const * argv, bool longlisting, bool recursedirs,
+           bool directories, bool dereflinks){
+  int ret = 0;
+  while(*argv){
+    ret |= handle_path(*argv, longlisting, recursedirs, directories, dereflinks);
+    ++argv;
+  }
+  return ret;
+}
+
+int main(int argc, char* const * argv){
   bool longlisting = false;
   bool recursedirs = false;
   bool directories = false;
+  bool dereflinks = false;
   int c;
-  while((c = getopt(argc, argv, "dhlR")) != -1){
+  while((c = getopt(argc, argv, "dhlLR")) != -1){
     switch(c){
       case 'd':
         directories = true;
         break;
       case 'l':
         longlisting = true;
+        break;
+      case 'L':
+        dereflinks = true;
         break;
       case 'R':
         recursedirs = true;
@@ -38,10 +102,8 @@ int main(int argc, char** argv){
         break;
     }
   }
-  // FIXME if argv[optind] == nullptr, pass "."
-  while(argv[optind]){
-    std::cout << "arg: " << argv[optind] << std::endl;
-    ++optind;
-  }
+  static const char* const default_args[] = { ".", nullptr };
+  list_paths(argv[optind] ? argv + optind : default_args, longlisting,
+             recursedirs, directories, dereflinks);
   return EXIT_SUCCESS;
 }

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -5,16 +5,31 @@
 
 static void
 usage(std::ostream& os, const char* name, int code){
-  os << "usage: " << name << " -h | paths...\n";
+  os << "usage: " << name << " -h | [ -lR ] paths...\n";
+  os << " -d: list directories themselves, not their contents\n";
+  os << " -l: use a long listing format\n";
+  os << " -R: list subdirectories recursively\n";
   os << " -h: print usage information\n";
   os << std::flush;
   exit(code);
 }
 
 int main(int argc, char** argv){
+  bool longlisting = false;
+  bool recursedirs = false;
+  bool directories = false;
   int c;
-  while((c = getopt(argc, argv, "h")) != -1){
+  while((c = getopt(argc, argv, "dhlR")) != -1){
     switch(c){
+      case 'd':
+        directories = true;
+        break;
+      case 'l':
+        longlisting = true;
+        break;
+      case 'R':
+        recursedirs = true;
+        break;
       case 'h':
         usage(std::cout, argv[0], EXIT_SUCCESS);
         break;
@@ -23,6 +38,7 @@ int main(int argc, char** argv){
         break;
     }
   }
+  // FIXME if argv[optind] == nullptr, pass "."
   while(argv[optind]){
     std::cout << "arg: " << argv[optind] << std::endl;
     ++optind;

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -1,0 +1,31 @@
+#include <cstdlib>
+#include <iostream>
+#include <unistd.h>
+#include <ncpp/NotCurses.hh>
+
+static void
+usage(std::ostream& os, const char* name, int code){
+  os << "usage: " << name << " -h | paths...\n";
+  os << " -h: print usage information\n";
+  os << std::flush;
+  exit(code);
+}
+
+int main(int argc, char** argv){
+  int c;
+  while((c = getopt(argc, argv, "h")) != -1){
+    switch(c){
+      case 'h':
+        usage(std::cout, argv[0], EXIT_SUCCESS);
+        break;
+      default:
+        usage(std::cerr, argv[0], EXIT_FAILURE);
+        break;
+    }
+  }
+  while(argv[optind]){
+    std::cout << "arg: " << argv[optind] << std::endl;
+    ++optind;
+  }
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
`ncls` lists files and such, displaying images when it can. It's pretty cool. Inspired by `lsix`, which does the same using Sixel, except we can actually run on most terminals. Closes #693 . Adds manual page and installation.