### PR TITLE
Multipile resize support #1172

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
     - cd build
     - cmake .. -DCMAKE_BUILD_TYPE=Release
     - make -j2
-    - env TERM=xterm make test
+    - env TERM=xterm ctest -V
     - make install
     - cd ../cffi
     - LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
@@ -32,7 +32,7 @@ steps:
     - cd build
     - cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_MULTIMEDIA=none ..
     - make -j2
-    - env TERM=xterm make test
+    - env TERM=xterm ctest -V
     - make install
     - ldconfig
     - cd ../cffi
@@ -54,4 +54,4 @@ steps:
     - cd build
     - cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MULTIMEDIA=oiio ..
     - make -j2
-    - env TERM=xterm make test
+    - env TERM=xterm ctest -V

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1066,8 +1066,6 @@ int ncinputlayer_init(ncinputlayer* nilayer, FILE* infp);
 // FIXME absorb into ncinputlayer_init()
 int cbreak_mode(int ttyfd, const struct termios* tpreserved);
 
-int resize_callbacks_children(ncplane* n);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -68,23 +68,27 @@ typedef struct ncplane {
   // they must thus be translated by any function which moves a parent plane.
   int absx, absy;        // origin of the plane relative to the screen
   int lenx, leny;        // size of the plane, [0..len{x,y}) is addressable
-  // a notcurses context is made up of stacks, each rooted by a plane which is
-  // bound to no other plane. the main stack is rooted by the standard plane,
-  // and is the only stack which is rendered. each stack has its own z-axis.
-  struct ncplane* above; // plane above us, NULL if we're on top
-  struct ncplane* below; // plane below us, NULL if we're on bottom
-  struct ncplane* bnext; // next in the blist iff we're bound, NULL otherwise
-  struct ncplane** bprev;// blist link to us iff we're bound, NULL otherwise
-  struct ncplane* blist; // head of list of bound planes
-  // a root plane is bound to itself. every other plane has a path to its
-  // stack's root via boundto. the standard plane is always bound to itself.
-  struct ncplane* boundto;
   egcpool pool;          // attached storage pool for UTF-8 EGCs
   uint64_t channels;     // works the same way as cells
+
+  // a notcurses context is made up of piles, each rooted by one or more root
+  // planes. each pile has its own (totally ordered) z-axis.
+  struct ncpile* pile;   // pile of which we are a part
+  struct ncplane* above; // plane above us, NULL if we're on top
+  struct ncplane* below; // plane below us, NULL if we're on bottom
+
+  // every plane is bound to some other plane, unless it is a root plane of a
+  // pile. a pile has a set of one or more root planes, all of them siblings.
+  // root planes are bound to themselves. the standard plane is always a root
+  // plane (since it cannot be reparented). a path exists to a root plane.
+  struct ncplane* bnext;  // next in the blist
+  struct ncplane** bprev; // blist link back to us
+  struct ncplane* blist;  // head of list of bound planes
+  struct ncplane* boundto;// plane to which we are bound (ourself for roots)
+
   void* userptr;         // slot for the user to stick some opaque pointer
   int (*resizecb)(struct ncplane*); // callback after parent is resized
   cell basecell;         // cell written anywhere that fb[i].gcluster == 0
-  struct ncpile* pile;   // pile of which we are a part
   char* name;            // used only for debugging
   ncalign_e align;       // relative to parent plane, for automatic realignment
   uint16_t stylemask;    // same deal as in a cell
@@ -351,9 +355,11 @@ typedef struct notcurses {
 
 void sigwinch_handler(int signo);
 
-void init_lang(struct notcurses* nc); // nc may be NULL, only used for logging
+void init_lang(notcurses* nc); // nc may be NULL, only used for logging
 int terminfostr(char** gseq, const char* name);
 int interrogate_terminfo(tinfo* ti);
+
+int resize_callbacks_children(ncplane* n);
 
 // Search the provided multibyte (UTF8) string 's' for the provided unicode
 // codepoint 'cp'. If found, return the column offset of the EGC in which the

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2325,7 +2325,8 @@ ncplane* ncplane_reparent_family(ncplane* n, ncplane* newparent){
   }
   n->boundto = newparent;
   if(n == n->boundto){ // we're a new root plane
-    n->bnext = NULL; // bprev is set in make_ncpile()
+    n->bnext = NULL;
+    n->bprev = NULL;
     pthread_mutex_lock(&ncplane_notcurses(n)->pilelock);
     if(ncplane_pile(n)->top == NULL){ // did we just empty our pile?
       ncpile_destroy(ncplane_pile(n));

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2325,8 +2325,7 @@ ncplane* ncplane_reparent_family(ncplane* n, ncplane* newparent){
   }
   n->boundto = newparent;
   if(n == n->boundto){ // we're a new root plane
-    n->bnext = NULL;
-    n->bprev = NULL;
+    n->bnext = NULL; // bprev is set in make_ncpile()
     pthread_mutex_lock(&ncplane_notcurses(n)->pilelock);
     if(ncplane_pile(n)->top == NULL){ // did we just empty our pile?
       ncpile_destroy(ncplane_pile(n));

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -6,8 +6,8 @@
 #include "internal.h"
 
 // Check whether the terminal geometry has changed, and if so, copies what can
-// be copied from the old stdplane. Assumes that the screen is always anchored at
-// the same origin. Also syncs up lastframe.
+// be copied from the old lastframe. Assumes that the screen is always anchored
+// at the same origin.
 static int
 notcurses_resize_internal(ncplane* pp, int* restrict rows, int* restrict cols){
   notcurses* n = ncplane_notcurses(pp);

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -30,23 +30,23 @@ notcurses_resize_internal(ncplane* pp, int* restrict rows, int* restrict cols){
   if(*rows <= 0){
     *rows = 1;
   }
-  *cols -= n->margin_l + n->margin_r;
+  *cols -= nc->margin_l + nc->margin_r;
   if(*cols <= 0){
     *cols = 1;
   }
-  if(*rows != n->lfdimy || *cols != n->lfdimx){
-    n->lfdimy = *rows;
-    n->lfdimx = *cols;
-    const size_t size = sizeof(*n->lastframe) * (n->lfdimy * n->lfdimx);
-    cell* fb = realloc(n->lastframe, size);
+  if(*rows != nc->lfdimy || *cols != nc->lfdimx){
+    nc->lfdimy = *rows;
+    nc->lfdimx = *cols;
+    const size_t size = sizeof(*nc->lastframe) * (nc->lfdimy * nc->lfdimx);
+    cell* fb = realloc(nc->lastframe, size);
     if(fb == NULL){
       return -1;
     }
-    n->lastframe = fb;
+    nc->lastframe = fb;
     // FIXME more memset()tery than we need, both wasting work and wrecking
     // damage detection for the upcoming render
-    memset(n->lastframe, 0, size);
-    egcpool_dump(&n->pool);
+    memset(nc->lastframe, 0, size);
+    egcpool_dump(&nc->pool);
   }
 //fprintf(stderr, "r: %d or: %d c: %d oc: %d\n", *rows, oldrows, *cols, oldcols);
   if(*rows == oldrows && *cols == oldcols){
@@ -994,7 +994,7 @@ home_cursor(notcurses* nc, bool flush){
 }
 
 int notcurses_refresh(notcurses* nc, int* restrict dimy, int* restrict dimx){
-  if(notcurses_resize(nc, dimy, dimx)){
+  if(notcurses_resize(nc->stdplane, dimy, dimx)){
     return -1;
   }
   if(nc->lfdimx == 0 || nc->lfdimy == 0){

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -30,23 +30,23 @@ notcurses_resize_internal(ncplane* pp, int* restrict rows, int* restrict cols){
   if(*rows <= 0){
     *rows = 1;
   }
-  *cols -= nc->margin_l + nc->margin_r;
+  *cols -= n->margin_l + n->margin_r;
   if(*cols <= 0){
     *cols = 1;
   }
-  if(*rows != nc->lfdimy || *cols != nc->lfdimx){
-    nc->lfdimy = *rows;
-    nc->lfdimx = *cols;
-    const size_t size = sizeof(*nc->lastframe) * (nc->lfdimy * nc->lfdimx);
-    cell* fb = realloc(nc->lastframe, size);
+  if(*rows != n->lfdimy || *cols != n->lfdimx){
+    n->lfdimy = *rows;
+    n->lfdimx = *cols;
+    const size_t size = sizeof(*n->lastframe) * (n->lfdimy * n->lfdimx);
+    cell* fb = realloc(n->lastframe, size);
     if(fb == NULL){
       return -1;
     }
-    nc->lastframe = fb;
+    n->lastframe = fb;
     // FIXME more memset()tery than we need, both wasting work and wrecking
     // damage detection for the upcoming render
-    memset(nc->lastframe, 0, size);
-    egcpool_dump(&nc->pool);
+    memset(n->lastframe, 0, size);
+    egcpool_dump(&n->pool);
   }
 //fprintf(stderr, "r: %d or: %d c: %d oc: %d\n", *rows, oldrows, *cols, oldcols);
   if(*rows == oldrows && *cols == oldcols){
@@ -994,7 +994,7 @@ home_cursor(notcurses* nc, bool flush){
 }
 
 int notcurses_refresh(notcurses* nc, int* restrict dimy, int* restrict dimx){
-  if(notcurses_resize(nc->stdplane, dimy, dimx)){
+  if(notcurses_resize(nc, dimy, dimx)){
     return -1;
   }
   if(nc->lfdimx == 0 || nc->lfdimy == 0){


### PR DESCRIPTION
This adapts `notcurses_resize()` to a multipile world. Closes #1172.