### PR TITLE
Progress bars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 2.1.1 (not yet released)
+  * Progress bars via `ncprogbar`. Standard widget API.
+
 * 2.1.0 (2020-12-13)
   * `cell` has been renamed `nccell`. The old name has been kept as an alias,
     but ought be considered deprecated. It will be removed in Notcurses 3.0.

--- a/USAGE.md
+++ b/USAGE.md
@@ -2388,7 +2388,7 @@ are recommended if you provide custom EGCs.
 ```
 // Takes ownership of the ncplane 'n', which will be destroyed by
 // ncprogbar_destroy(). The progress bar is initially at 0%.
-struct ncuplot* ncprogbar_create(struct ncplane* n, const ncprogbar_options* opts);
+struct ncprogbar* ncprogbar_create(struct ncplane* n, const ncprogbar_options* opts);
 
 // Return a reference to the ncprogbar's underlying ncplane.
 #define NCPROGBAR_OPTION_RETROGRADE        0x0001u // proceed left/down

--- a/USAGE.md
+++ b/USAGE.md
@@ -2380,10 +2380,6 @@ lower values. The procession will take place along the longer dimension (at
 the time of each redraw), with the horizontal length scaled by 2 for
 purposes of comparison. I.e. for a plane of 20 rows and 50 columns, the
 progress will be to the right (50 > 40) or left with `OPTION_RETROGRADE`.
-If `NCPROGBAR_OPTION_LOCK_ORIENTATION` is provided, the initial orientation
-is locked in, despite any resizes. It locks horizontal progression by
-default; `NCPROGBAR_OPTION_FORCE_VERTICAL` locks vertical progression. These
-are recommended if you provide custom EGCs.
 
 ```
 // Takes ownership of the ncplane 'n', which will be destroyed by
@@ -2392,22 +2388,15 @@ struct ncprogbar* ncprogbar_create(struct ncplane* n, const ncprogbar_options* o
 
 // Return a reference to the ncprogbar's underlying ncplane.
 #define NCPROGBAR_OPTION_RETROGRADE        0x0001u // proceed left/down
-#define NCPROGBAR_OPTION_LOCK_ORIENTATION  0x0002u // lock in orientation
-#define NCPROGBAR_OPTION_FORCE_VERTICAL    0x0003u // lock in vert
 
 typedef struct ncprogbar_options {
   // channels for the maximum and minimum points. linear interpolation will be
   // applied across the domain between these two.
   uint64_t maxchannels;
   uint64_t minchannels;
-  // provide NULL for default (geometric) glyphs. otherwise, provide one or
-  // more EGCs to be used for the progress bar. the last EGC provided will be
-  // at the head of the progress. the first will be used for the entirety of
-  // the tail. i.e. "▃▅🭂🭍" might yield "▃▃▃▃▅🭂🭍". note that such a set of EGCs
-  // would not work well for a vertical progress bar.
-  const char egcs;
   uint64_t flags;
 } ncprogbar_options;
+
 struct ncplane* ncprogbar_plane(struct ncprogbar* n);
 
 // Set the progress bar's completion, a double 0 <= 'p' <= 1.

--- a/doc/man/index.html
+++ b/doc/man/index.html
@@ -57,6 +57,7 @@
    <a href="notcurses_palette.3.html">notcurses_palette</a>—operations on notcurses palettes<br/>
    <a href="notcurses_plane.3.html">notcurses_plane</a>—operations on <tt>ncplane</tt> objects<br/>
    <a href="notcurses_plot.3.html">notcurses_plot</a>—drawing histograms and lineplots<br/>
+   <a href="notcurses_progbar.3.html">notcurses_plot</a>—drawing progress bars<br/>
    <a href="notcurses_reader.3.html">notcurses_reader</a>—high-level widget for collecting input<br/>
    <a href="notcurses_refresh.3.html">notcurses_refresh</a>—refresh an externally-damaged display<br/>
    <a href="notcurses_render.3.html">notcurses_render</a>—sync the physical display<br/>

--- a/doc/man/man3/notcurses.3.md
+++ b/doc/man/man3/notcurses.3.md
@@ -100,6 +100,7 @@ A few high-level widgets are included, all built atop ncplanes:
 * **notcurses_menu(3)** for menu bars at the top or bottom of the screen
 * **notcurses_multiselector(3)** for selecting one or more items from a set
 * **notcurses_plot(3)** for drawing histograms and lineplots
+* **notcurses_progbar(3)** for drawing progress bars
 * **notcurses_reader(3)** for free-form input data
 * **notcurses_reel(3)** for hierarchal display of data
 * **notcurses_selector(3)** for selecting one item from a set
@@ -156,6 +157,7 @@ order to turn most error returns into exceptions.
 **notcurses_palette(3)**,
 **notcurses_plane(3)**,
 **notcurses_plot(3)**,
+**notcurses_progbar(3)**,
 **notcurses_reader(3)**,
 **notcurses_reel(3)**,
 **notcurses_refresh(3)**,

--- a/doc/man/man3/notcurses_progbar.3.md
+++ b/doc/man/man3/notcurses_progbar.3.md
@@ -18,7 +18,6 @@ struct ncprogbar;
 typedef struct ncprogbar_options {
   uint64_t maxchannels;
   uint64_t minchannels;
-  const char egcs;
   uint64_t flags;
 } ncprogbar_options;
 ```

--- a/doc/man/man3/notcurses_progbar.3.md
+++ b/doc/man/man3/notcurses_progbar.3.md
@@ -11,6 +11,8 @@ notcurses_progbar - high level widget for progress bars
 **#include <notcurses/notcurses.h>**
 
 ```c
+struct ncprogbar;
+
 #define NCPROGBAR_OPTION_RETROGRADE        0x0001u // proceed left/down
 #define NCPROGBAR_OPTION_LOCK_ORIENTATION  0x0002u // lock in orientation
 #define NCPROGBAR_OPTION_FORCE_VERTICAL    0x0003u // lock in vert
@@ -23,7 +25,7 @@ typedef struct ncprogbar_options {
 } ncprogbar_options;
 ```
 
-**struct ncuplot* ncprogbar_create(struct ncplane* ***n***, const ncprogbar_options* ***opts***)**
+**struct ncprogbar* ncprogbar_create(struct ncplane* ***n***, const ncprogbar_options* ***opts***)**
 
 **struct ncplane* ncprogbar_plane(struct ncprogbar* ***n***)**
 

--- a/doc/man/man3/notcurses_progbar.3.md
+++ b/doc/man/man3/notcurses_progbar.3.md
@@ -14,8 +14,6 @@ notcurses_progbar - high level widget for progress bars
 struct ncprogbar;
 
 #define NCPROGBAR_OPTION_RETROGRADE        0x0001u // proceed left/down
-#define NCPROGBAR_OPTION_LOCK_ORIENTATION  0x0002u // lock in orientation
-#define NCPROGBAR_OPTION_FORCE_VERTICAL    0x0003u // lock in vert
 
 typedef struct ncprogbar_options {
   uint64_t maxchannels;
@@ -40,11 +38,9 @@ typedef struct ncprogbar_options {
 These functions draw progress bars in any of four directions. The progress
 measure is a **double** between zero and one, inclusive, provided to
 **ncprogbar_set_progress**. This will be scaled to the size of the provided
-ncplane ***n***. By default, the axis of progression is the longer element
-of the plane's geometry, but it can be explicitly chosen with
-**NCPROGBAR_OPTION_LOCK_ORIENTATION** and **NCPROGBAR_OPTION_FORCE_VERTICAL**.
-Horizontal bars proceed to the right by default, and vertical bars proceed up.
-This can be changed with **NCPROGBAR_OPTION_RETROGRADE**.
+ncplane ***n***. The axis of progression is the longer element of the plane's
+geometry. Horizontal bars proceed to the right by default, and vertical bars
+proceed up. This can be changed with **NCPROGBAR_OPTION_RETROGRADE**.
 
 # NOTES
 

--- a/doc/man/man3/notcurses_progbar.3.md
+++ b/doc/man/man3/notcurses_progbar.3.md
@@ -1,0 +1,72 @@
+% notcurses_progbar(3)
+% nick black <nickblack@linux.com>
+% v2.0.11
+
+# NAME
+
+notcurses_progbar - high level widget for progress bars
+
+# SYNOPSIS
+
+**#include <notcurses/notcurses.h>**
+
+```c
+#define NCPROGBAR_OPTION_RETROGRADE        0x0001u // proceed left/down
+#define NCPROGBAR_OPTION_LOCK_ORIENTATION  0x0002u // lock in orientation
+#define NCPROGBAR_OPTION_FORCE_VERTICAL    0x0003u // lock in vert
+
+typedef struct ncprogbar_options {
+  uint64_t maxchannels;
+  uint64_t minchannels;
+  const char egcs;
+  uint64_t flags;
+} ncprogbar_options;
+```
+
+**struct ncuplot* ncprogbar_create(struct ncplane* ***n***, const ncprogbar_options* ***opts***)**
+
+**struct ncplane* ncprogbar_plane(struct ncprogbar* ***n***)**
+
+**int ncprogbar_set_progress(struct ncprogbar* ***n***, double ***p***)**
+
+**double ncprogbar_progress(const struct ncprogbar* ***n***)**
+
+**void ncprogbar_destroy(struct ncprogbar* ***n***)**
+
+# DESCRIPTION
+
+These functions draw progress bars in any of four directions. The progress
+measure is a **double** between zero and one, inclusive, provided to
+**ncprogbar_set_progress**. This will be scaled to the size of the provided
+ncplane ***n***. By default, the axis of progression is the longer element
+of the plane's geometry, but it can be explicitly chosen with
+**NCPROGBAR_OPTION_LOCK_ORIENTATION** and **NCPROGBAR_OPTION_FORCE_VERTICAL**.
+Horizontal bars proceed to the right by default, and vertical bars proceed up.
+This can be changed with **NCPROGBAR_OPTION_RETROGRADE**.
+
+# NOTES
+
+**ncprogbar_create** takes ownership of ***n*** in all cases. On failure,
+***n*** will be destroyed immediately. It is otherwise destroyed by
+**ncprogbar_destroy**.
+
+# RETURN VALUES
+
+**ncprogbar_plane** returns the **ncplane** on which the progress bar is drawn.
+**ncprogbar_progress** returns the current progress, a value between zero and
+one, inclusive. They cannot fail.
+
+**ncprogbar_set_progress** returns -1 if ***p*** is less than zero or greater
+than one, or if there is an internal error redrawing the progress bar. It
+returns 0 otherwise.
+
+# BUGS
+
+Whether progression is to the left or right by default probably ought be an
+aspect of the current locale.
+
+# SEE ALSO
+
+**notcurses(3)**,
+**notcurses_plane(3)**,
+**notcurses_visual(3)**

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3039,7 +3039,8 @@ API int ncmenu_destroy(struct ncmenu* n);
 
 typedef struct ncprogbar_options {
   // channels for the maximum and minimum points. linear interpolation will be
-  // applied across the domain between these two.
+  // applied across the domain between these two. for both channels, both min
+  // and max must either be RGB, or both default, and alphas must match.
   uint64_t maxchannels;
   uint64_t minchannels;
   // provide NULL for default (geometric) glyphs. otherwise, provide one or

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3053,7 +3053,7 @@ typedef struct ncprogbar_options {
 
 // Takes ownership of the ncplane 'n', which will be destroyed by
 // ncprogbar_destroy(). The progress bar is initially at 0%.
-API struct ncuplot* ncprogbar_create(struct ncplane* n, const ncprogbar_options* opts)
+API struct ncprogbar* ncprogbar_create(struct ncplane* n, const ncprogbar_options* opts)
   __attribute__ ((nonnull (1)));
 
 // Return a reference to the ncprogbar's underlying ncplane.

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3028,14 +3028,8 @@ API int ncmenu_destroy(struct ncmenu* n);
 // the time of each redraw), with the horizontal length scaled by 2 for
 // purposes of comparison. I.e. for a plane of 20 rows and 50 columns, the
 // progress will be to the right (50 > 40) or left with OPTION_RETROGRADE.
-// If NCPROGBAR_OPTION_LOCK_ORIENTATION is provided, the initial orientation
-// is locked in, despite any resizes. It locks horizontal progression by
-// default; NCPROGBAR_OPTION_FORCE_VERTICAL locks vertical progression. These
-// are recommended if you provide custom EGCs.
 
 #define NCPROGBAR_OPTION_RETROGRADE        0x0001u // proceed left/down
-#define NCPROGBAR_OPTION_LOCK_ORIENTATION  0x0002u // lock in orientation
-#define NCPROGBAR_OPTION_FORCE_VERTICAL    0x0003u // lock in vert
 
 typedef struct ncprogbar_options {
   // channels for the maximum and minimum points. linear interpolation will be

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3037,12 +3037,6 @@ typedef struct ncprogbar_options {
   // and max must either be RGB, or both default, and alphas must match.
   uint64_t maxchannels;
   uint64_t minchannels;
-  // provide NULL for default (geometric) glyphs. otherwise, provide one or
-  // more EGCs to be used for the progress bar. the last EGC provided will be
-  // at the head of the progress. the first will be used for the entirety of
-  // the tail. i.e. "▃▅🭂🭍" might yield "▃▃▃▃▅🭂🭍". note that such a set of EGCs
-  // would not work well for a vertical progress bar.
-  const char egcs;
   uint64_t flags;
 } ncprogbar_options;
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3032,11 +3032,7 @@ API int ncmenu_destroy(struct ncmenu* n);
 #define NCPROGBAR_OPTION_RETROGRADE        0x0001u // proceed left/down
 
 typedef struct ncprogbar_options {
-  // channels for the maximum and minimum points. linear interpolation will be
-  // applied across the domain between these two. for both channels, both min
-  // and max must either be RGB, or both default, and alphas must match.
-  uint64_t maxchannels;
-  uint64_t minchannels;
+  uint64_t channels; // channels for the progress bar
   uint64_t flags;
 } ncprogbar_options;
 

--- a/src/lib/fill.c
+++ b/src/lib/fill.c
@@ -115,8 +115,7 @@ check_gradient_channel_args(uint32_t ul, uint32_t ur, uint32_t bl, uint32_t br){
 // - all foregrounds must have the same alpha
 // - all backgrounds must have the same alpha
 // - palette-indexed color must not be used
-static bool
-check_gradient_args(uint64_t ul, uint64_t ur, uint64_t bl, uint64_t br){
+bool check_gradient_args(uint64_t ul, uint64_t ur, uint64_t bl, uint64_t br){
   if(check_gradient_channel_args(channels_fchannel(ul), channels_fchannel(ur),
                                  channels_fchannel(bl), channels_fchannel(br))){
     return true;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -221,6 +221,13 @@ typedef struct ncmenu {
   bool bottom;              // are we on the bottom (vs top)?
 } ncmenu;
 
+typedef struct ncprogbar {
+  ncplane* ncp;
+  double progress;          // on the range [0, 1]
+  uint64_t maxchannels;
+  uint64_t minchannels;
+} ncprogbar;
+
 // terminfo cache
 typedef struct tinfo {
   unsigned colors;// number of colors terminfo reported usable for this screen

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1074,6 +1074,17 @@ int ncinputlayer_init(ncinputlayer* nilayer, FILE* infp);
 // FIXME absorb into ncinputlayer_init()
 int cbreak_mode(int ttyfd, const struct termios* tpreserved);
 
+// Given the four channels arguments, verify that:
+//
+// - if any is default foreground, all are default foreground
+// - if any is default background, all are default background
+// - all foregrounds must have the same alpha
+// - all backgrounds must have the same alpha
+// - palette-indexed color must not be used
+//
+// If you only want to check n < 4 channels, just duplicate one.
+bool check_gradient_args(uint64_t ul, uint64_t ur, uint64_t bl, uint64_t br);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -226,6 +226,12 @@ typedef struct ncprogbar {
   double progress;          // on the range [0, 1]
   uint64_t maxchannels;
   uint64_t minchannels;
+  enum {                    // dynamic unless locked into one direction
+    PROGRESS_DYNAMIC,
+    PROGRESS_VERT,
+    PROGRESS_HORIZ,
+  } direction;
+  bool retrograde;
 } ncprogbar;
 
 // terminfo cache

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -224,8 +224,7 @@ typedef struct ncmenu {
 typedef struct ncprogbar {
   ncplane* ncp;
   double progress;          // on the range [0, 1]
-  uint64_t maxchannels;
-  uint64_t minchannels;
+  uint64_t channels;        // channels for the drawn bar
   bool retrograde;
 } ncprogbar;
 

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -226,11 +226,6 @@ typedef struct ncprogbar {
   double progress;          // on the range [0, 1]
   uint64_t maxchannels;
   uint64_t minchannels;
-  enum {                    // dynamic unless locked into one direction
-    PROGRESS_DYNAMIC,
-    PROGRESS_VERT,
-    PROGRESS_HORIZ,
-  } direction;
   bool retrograde;
 } ncprogbar;
 

--- a/src/lib/progbar.c
+++ b/src/lib/progbar.c
@@ -13,22 +13,13 @@ ncprogbar* ncprogbar_create(ncplane* n, const ncprogbar_options* opts){
     logerror(ncplane_notcurses(n), "Illegal progbar colors\n");
     return NULL;
   }
-  if(opts->flags > (NCPROGBAR_OPTION_FORCE_VERTICAL << 1u)){
+  if(opts->flags > (NCPROGBAR_OPTION_RETROGRADE << 1u)){
     logwarn(ncplane_notcurses(n), "Invalid flags %016lx\n", opts->flags);
   }
   ncprogbar* ret = malloc(sizeof(*ret));
   ret->ncp = n;
   ret->maxchannels = opts->maxchannels;
   ret->minchannels = opts->minchannels;
-  if(opts->flags & NCPROGBAR_OPTION_LOCK_ORIENTATION){
-    if(opts->flags & NCPROGBAR_OPTION_FORCE_VERTICAL){
-      ret->direction = PROGRESS_VERT;
-    }else{
-      ret->direction = PROGRESS_HORIZ;
-    }
-  }else{
-    ret->direction = PROGRESS_DYNAMIC;
-  }
   ret->retrograde = opts->flags & NCPROGBAR_OPTION_RETROGRADE;
   return ret;
 }
@@ -48,16 +39,10 @@ progbar_redraw(ncprogbar* n){
   // get current dimensions; they might have changed
   int dimy, dimx;
   ncplane_dim_yx(ncprogbar_plane(n), &dimy, &dimx);
-  if(n->direction == PROGRESS_DYNAMIC){
-    if(dimx > dimy){
-      direction = n->retrograde ? DIR_LEFT : DIR_RIGHT;
-    }else{
-      direction = n->retrograde ? DIR_DOWN : DIR_UP;
-    }
-  }else if(n->direction == PROGRESS_VERT){
-    direction = n->retrograde ? DIR_DOWN : DIR_UP;
-  }else{ // PROGRESS_HORIZ
+  if(dimx > dimy){
     direction = n->retrograde ? DIR_LEFT : DIR_RIGHT;
+  }else{
+    direction = n->retrograde ? DIR_DOWN : DIR_UP;
   }
   const bool horizontal = (direction == DIR_LEFT || direction == DIR_RIGHT);
   int delt, range;

--- a/src/lib/progbar.c
+++ b/src/lib/progbar.c
@@ -5,21 +5,14 @@ ncprogbar* ncprogbar_create(ncplane* n, const ncprogbar_options* opts){
   ncprogbar_options default_opts;
   if(opts == NULL){
     memset(&default_opts, 0, sizeof(default_opts));
-    default_opts.minchannels = CHANNELS_RGB_INITIALIZER(0x3d, 0x3d, 0x3d, 0, 0, 0);
-    default_opts.maxchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0xee, 0xe0, 0, 0, 0);
     opts = &default_opts;
-  }
-  if(check_gradient_args(opts->minchannels, opts->maxchannels, opts->minchannels, opts->maxchannels)){
-    logerror(ncplane_notcurses(n), "Illegal progbar colors\n");
-    return NULL;
   }
   if(opts->flags > (NCPROGBAR_OPTION_RETROGRADE << 1u)){
     logwarn(ncplane_notcurses(n), "Invalid flags %016lx\n", opts->flags);
   }
   ncprogbar* ret = malloc(sizeof(*ret));
   ret->ncp = n;
-  ret->maxchannels = opts->maxchannels;
-  ret->minchannels = opts->minchannels;
+  ret->channels = opts->channels;
   ret->retrograde = opts->flags & NCPROGBAR_OPTION_RETROGRADE;
   return ret;
 }
@@ -30,35 +23,25 @@ ncplane* ncprogbar_plane(ncprogbar* n){
 
 static int
 progbar_redraw(ncprogbar* n){
-  enum {
-    DIR_UP,
-    DIR_RIGHT,
-    DIR_DOWN,
-    DIR_LEFT
-  } direction;
   // get current dimensions; they might have changed
   int dimy, dimx;
   ncplane_dim_yx(ncprogbar_plane(n), &dimy, &dimx);
-  if(dimx > dimy){
-    direction = n->retrograde ? DIR_LEFT : DIR_RIGHT;
-  }else{
-    direction = n->retrograde ? DIR_DOWN : DIR_UP;
-  }
-  const bool horizontal = (direction == DIR_LEFT || direction == DIR_RIGHT);
+  const bool horizontal = dimx > dimy;
   int delt, range;
   if(horizontal){
     range = dimx;
-    delt = n->retrograde ? 1 : -1;
+    delt = -1;
   }else{
     range = dimy;
-    delt = n->retrograde ? -1 : 1;
+    delt = 1;
   }
   double progress = n->progress * range;
   if(n->retrograde){
     progress = range - progress;
+    delt *= -1;
   }
+  ncplane_set_channels(ncprogbar_plane(n), n->channels);
   while(progress > 0 && progress < range){
-    // FIXME lerp min->max
     if(ncplane_putegc_yx(ncprogbar_plane(n), 0, progress, "█", NULL) <= 0){
       return -1;
     }

--- a/src/lib/progbar.c
+++ b/src/lib/progbar.c
@@ -1,0 +1,47 @@
+#include <string.h>
+#include "internal.h"
+
+ncprogbar* ncprogbar_create(ncplane* n, const ncprogbar_options* opts){
+  ncprogbar_options default_opts;
+  if(opts == NULL){
+    memset(&default_opts, 0, sizeof(default_opts));
+    opts = &default_opts;
+    // FIXME need sensible default channels
+  }
+  if(opts->flags > (NCPROGBAR_OPTION_FORCE_VERTICAL << 1u)){
+    logwarn(ncplane_notcurses(n), "Invalid flags %016lx\n", opts->flags);
+  }
+  ncprogbar* ret = malloc(sizeof(*ret));
+  ret->ncp = n;
+  ret->maxchannels = opts->maxchannels;
+  ret->minchannels = opts->minchannels;
+  return ret;
+}
+
+ncplane* ncprogbar_plane(ncprogbar* n){
+  return n->ncp;
+}
+
+static int
+progbar_redraw(ncprogbar* n){
+  // FIXME
+  return 0;
+}
+
+int ncprogbar_set_progress(ncprogbar* n, double p){
+  if(p < 0 || p > 1){
+    logerror(ncplane_notcurses(ncprogbar_plane(n)), "Invalid progress %g\n", p);
+    return -1;
+  }
+  n->progress = p;
+  return progbar_redraw(n);
+}
+
+double ncprogbar_progress(const ncprogbar* n){
+  return n->progress;
+}
+
+void ncprogbar_destroy(ncprogbar* n){
+  ncplane_destroy(n->ncp);
+  free(n);
+}

--- a/src/lib/progbar.c
+++ b/src/lib/progbar.c
@@ -59,7 +59,9 @@ progbar_redraw(ncprogbar* n){
   }
   while(progress > 0 && progress < range){
     // FIXME lerp min->max
-    ncplane_putchar_yx(ncprogbar_plane(n), 0, progress, 'X');
+    if(ncplane_putegc_yx(ncprogbar_plane(n), 0, progress, "█", NULL) <= 0){
+      return -1;
+    }
     progress += delt;
   }
   return 0;

--- a/src/lib/progbar.c
+++ b/src/lib/progbar.c
@@ -5,8 +5,9 @@ ncprogbar* ncprogbar_create(ncplane* n, const ncprogbar_options* opts){
   ncprogbar_options default_opts;
   if(opts == NULL){
     memset(&default_opts, 0, sizeof(default_opts));
+    default_opts.minchannels = CHANNELS_RGB_INITIALIZER(0x3d, 0x3d, 0x3d, 0, 0, 0);
+    default_opts.maxchannels = CHANNELS_RGB_INITIALIZER(0xe0, 0xee, 0xe0, 0, 0, 0);
     opts = &default_opts;
-    // FIXME need sensible default channels
   }
   if(opts->flags > (NCPROGBAR_OPTION_FORCE_VERTICAL << 1u)){
     logwarn(ncplane_notcurses(n), "Invalid flags %016lx\n", opts->flags);
@@ -15,6 +16,16 @@ ncprogbar* ncprogbar_create(ncplane* n, const ncprogbar_options* opts){
   ret->ncp = n;
   ret->maxchannels = opts->maxchannels;
   ret->minchannels = opts->minchannels;
+  if(opts->flags & NCPROGBAR_OPTION_LOCK_ORIENTATION){
+    if(opts->flags & NCPROGBAR_OPTION_FORCE_VERTICAL){
+      ret->direction = PROGRESS_VERT;
+    }else{
+      ret->direction = PROGRESS_HORIZ;
+    }
+  }else{
+    ret->direction = PROGRESS_DYNAMIC;
+  }
+  ret->retrograde = opts->flags & NCPROGBAR_OPTION_RETROGRADE;
   return ret;
 }
 
@@ -24,6 +35,32 @@ ncplane* ncprogbar_plane(ncprogbar* n){
 
 static int
 progbar_redraw(ncprogbar* n){
+  enum {
+    DIR_UP,
+    DIR_RIGHT,
+    DIR_DOWN,
+    DIR_LEFT
+  } direction;
+  // get current dimensions; they might have changed
+  int dimy, dimx;
+  ncplane_dim_yx(ncprogbar_plane(n), &dimy, &dimx);
+  if(n->direction == PROGRESS_DYNAMIC){
+    if(dimx > dimy){
+      direction = n->retrograde ? DIR_LEFT : DIR_RIGHT;
+    }else{
+      direction = n->retrograde ? DIR_DOWN : DIR_UP;
+    }
+  }else if(n->direction == PROGRESS_VERT){
+    direction = n->retrograde ? DIR_DOWN : DIR_UP;
+  }else{ // PROGRESS_HORIZ
+    direction = n->retrograde ? DIR_LEFT : DIR_RIGHT;
+  }
+  int range;
+  if(direction == DIR_UP || direction == DIR_DOWN){
+    range = dimy;
+  }else{
+    range = dimx;
+  }
   // FIXME
   return 0;
 }

--- a/src/poc/progbar.c
+++ b/src/poc/progbar.c
@@ -76,6 +76,15 @@ int main(void){
     return EXIT_FAILURE;
   }
   ncprogbar_destroy(ncp);
+  ncp = pbar_make(nc, 0);
+  if(ncp == NULL){
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
+  }
+  if(pbar_fill(nc, ncp)){
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
+  }
   notcurses_stop(nc);
   return EXIT_SUCCESS;
 }

--- a/src/poc/progbar.c
+++ b/src/poc/progbar.c
@@ -16,7 +16,7 @@ pbar_fill(struct notcurses* nc, struct ncprogbar* pbar){
   const uint64_t deadline = startns + delay;
   do{
     uint64_t curns = ts_to_ns(&cur);
-    if(ncprogbar_set_progress(pbar, (curns - startns) / delay)){
+    if(ncprogbar_set_progress(pbar, (curns - startns) / (double)delay)){
       return -1;
     }
     notcurses_render(nc);

--- a/src/poc/progbar.c
+++ b/src/poc/progbar.c
@@ -1,0 +1,60 @@
+#include <stdlib.h>
+#include <notcurses/notcurses.h>
+
+static uint64_t
+ts_to_ns(const struct timespec* ts){
+  return ts->tv_sec * 1000000000 + ts->tv_nsec;
+}
+
+static const uint64_t delay = 10000000000ull;
+
+static int
+pbar_fill(struct notcurses* nc, struct ncprogbar* pbar){
+  struct timespec cur;
+  clock_gettime(CLOCK_MONOTONIC, &cur);
+  const uint64_t startns = ts_to_ns(&cur);
+  const uint64_t deadline = startns + delay;
+  do{
+    uint64_t curns = ts_to_ns(&cur);
+    if(ncprogbar_set_progress(pbar, (curns - startns) / delay)){
+      return -1;
+    }
+    notcurses_render(nc);
+    clock_gettime(CLOCK_MONOTONIC, &cur);
+  }while(ts_to_ns(&cur) < deadline);
+  return 0;
+}
+
+int main(void){
+  struct notcurses* nc = notcurses_init(NULL, NULL);
+  if(nc == NULL){
+    return EXIT_FAILURE;
+  }
+  int dimy, dimx;
+  struct ncplane* std = notcurses_stddim_yx(nc, &dimy, &dimx);
+  struct ncplane_options nopts = {
+    .y = dimy / 2,
+    .x = NCALIGN_CENTER,
+    .rows = 1,
+    .cols = dimx - 20,
+    .name = "pbar",
+    .flags = NCPLANE_OPTION_HORALIGNED,
+  };
+  struct ncplane* pbar = ncplane_create(std, &nopts);
+  if(pbar == NULL){
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
+  }
+  struct ncprogbar* ncp = ncprogbar_create(pbar, NULL);
+  if(ncp == NULL){
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
+  }
+  if(pbar_fill(nc, ncp)){
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
+  }
+  ncprogbar_destroy(ncp);
+  notcurses_stop(nc);
+  return EXIT_SUCCESS;
+}

--- a/src/poc/progbar.c
+++ b/src/poc/progbar.c
@@ -54,6 +54,7 @@ pbar_make(struct notcurses* nc, uint64_t flags){
   struct ncprogbar_options popts = {
     .flags = flags,
   };
+  channels_set_fg_rgb8(&popts.channels, 0x80, 0x22, 0x22);
   struct ncprogbar* ncp = ncprogbar_create(pbar, &popts);
   if(ncp == NULL){
     return NULL;

--- a/src/poc/progbar.c
+++ b/src/poc/progbar.c
@@ -25,11 +25,8 @@ pbar_fill(struct notcurses* nc, struct ncprogbar* pbar){
   return 0;
 }
 
-int main(void){
-  struct notcurses* nc = notcurses_init(NULL, NULL);
-  if(nc == NULL){
-    return EXIT_FAILURE;
-  }
+static struct ncprogbar*
+pbar_make(struct notcurses* nc){
   int dimy, dimx;
   struct ncplane* std = notcurses_stddim_yx(nc, &dimy, &dimx);
   struct ncplane_options nopts = {
@@ -42,10 +39,31 @@ int main(void){
   };
   struct ncplane* pbar = ncplane_create(std, &nopts);
   if(pbar == NULL){
-    notcurses_stop(nc);
-    return EXIT_FAILURE;
+    return NULL;
+  }
+  int posy, posx, pdimy, pdimx;
+  ncplane_yx(pbar, &posy, &posx);
+  ncplane_dim_yx(pbar, &pdimy, &pdimx);
+  ncplane_cursor_move_yx(std, posy - 1, posx - 1);
+  uint64_t channels = 0;
+  channels_set_fg_rgb8(&channels, 0, 0xde, 0xde);
+  if(ncplane_rounded_box(std, 0, channels, posy + pdimy, posx + pdimx, 0)){
+    ncplane_destroy(pbar);
+    return NULL;
   }
   struct ncprogbar* ncp = ncprogbar_create(pbar, NULL);
+  if(ncp == NULL){
+    return NULL;
+  }
+  return ncp;
+}
+
+int main(void){
+  struct notcurses* nc = notcurses_init(NULL, NULL);
+  if(nc == NULL){
+    return EXIT_FAILURE;
+  }
+  struct ncprogbar* ncp = pbar_make(nc);
   if(ncp == NULL){
     notcurses_stop(nc);
     return EXIT_FAILURE;

--- a/src/poc/progbar.c
+++ b/src/poc/progbar.c
@@ -26,7 +26,7 @@ pbar_fill(struct notcurses* nc, struct ncprogbar* pbar){
 }
 
 static struct ncprogbar*
-pbar_make(struct notcurses* nc){
+pbar_make(struct notcurses* nc, uint64_t flags){
   int dimy, dimx;
   struct ncplane* std = notcurses_stddim_yx(nc, &dimy, &dimx);
   struct ncplane_options nopts = {
@@ -51,7 +51,10 @@ pbar_make(struct notcurses* nc){
     ncplane_destroy(pbar);
     return NULL;
   }
-  struct ncprogbar* ncp = ncprogbar_create(pbar, NULL);
+  struct ncprogbar_options popts = {
+    .flags = flags,
+  };
+  struct ncprogbar* ncp = ncprogbar_create(pbar, &popts);
   if(ncp == NULL){
     return NULL;
   }
@@ -63,7 +66,7 @@ int main(void){
   if(nc == NULL){
     return EXIT_FAILURE;
   }
-  struct ncprogbar* ncp = pbar_make(nc);
+  struct ncprogbar* ncp = pbar_make(nc, NCPROGBAR_OPTION_RETROGRADE);
   if(ncp == NULL){
     notcurses_stop(nc);
     return EXIT_FAILURE;


### PR DESCRIPTION
Introduces new opaque type `ncprogbar` and open type `ncprogbar_options`. Follows the by-now-standardized widgets API. Add a new PoC, `progbar`, which exercises the two horizontal configurations. Closes #1202.