### PR TITLE
cope with situations where /dev/tty is not actually a TTY

### DIFF
--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -934,6 +934,12 @@ get_tty_fd(notcurses* nc, FILE* ttyfp){
     fd = open("/dev/tty", O_RDWR | O_CLOEXEC);
     if(fd < 0){
       loginfo(nc, "Error opening /dev/tty (%s)\n", strerror(errno));
+    }else{
+      if(!isatty(fd)){
+        loginfo(nc, "File descriptor for /dev/tty (%d) is not actually a TTY\n", fd);
+        close(fd);
+        fd = -1;
+      }
     }
   }
   return fd;


### PR DESCRIPTION
this can happen in situations where a child process is not running in a
session group associated with a TTY, such as on a build server.

this should resolve the crashing testsuite on alpine's x86 buildserver.