### PR TITLE
Multithreaded ncls

### DIFF
--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -143,6 +143,16 @@ namespace ncpp
 			return ncdirect_render_image (direct, file, align, blitter, scale);
 		}
 
+		struct ncplane* prep_image (const char* file, ncblitter_e blitter, ncscale_e scale) const noexcept
+		{
+			return ncdirect_render_frame (direct, file, blitter, scale);
+		}
+
+		int raster_image (struct ncplane* faken, ncalign_e align, ncblitter_e blitter, ncscale_e scale) const noexcept
+		{
+			return ncdirect_raster_frame (direct, faken, align, blitter, scale);
+		}
+
 		bool putstr (uint64_t channels, const char* utf8) const NOEXCEPT_MAYBE
 		{
 			return error_guard (ncdirect_putstr (direct, channels, utf8), -1);

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+typedef struct ncplane ncdirectv;
+
 #define API __attribute__((visibility("default")))
 
 // ncdirect_init() will call setlocale() to inspect the current locale. If
@@ -109,18 +111,9 @@ API int ncdirect_cursor_pop(struct ncdirect* n);
 
 // Display an image using the specified blitter and scaling. The image may
 // be arbitrarily many rows -- the output will scroll -- but will only occupy
-// the column of the cursor, and those to the right.
+// the column of the cursor, and those to the right. The render/raster process
+// can be split by using ncdirect_render_frame() and ncdirect_raster_frame().
 API int ncdirect_render_image(struct ncdirect* n, const char* filename,
-                              ncalign_e align, ncblitter_e blitter,
-                              ncscale_e scale);
-
-// Display an image using the specified blitter and scaling. The image may
-// be arbitrarily many rows -- the output will scroll -- but will only occupy
-// the column of the cursor, and those to the right.
-API struct ncplane* ncdirect_render_frame(struct ncdirect* n, const char* filename,
-                                          ncblitter_e blitter, ncscale_e scale);
-
-API int ncdirect_raster_frame(struct ncdirect* n, struct ncplane* faken,
                               ncalign_e align, ncblitter_e blitter,
                               ncscale_e scale);
 
@@ -198,6 +191,20 @@ ncdirect_getc_blocking(struct ncdirect* n, ncinput* ni){
 
 // Release 'nc' and any associated resources. 0 on success, non-0 on failure.
 API int ncdirect_stop(struct ncdirect* nc);
+
+// Render an image using the specified blitter and scaling, but do not write
+// the result. The image may be arbitrarily many rows -- the output will scroll
+// -- but will only occupy the column of the cursor, and those to the right.
+// To actually write (and free) this, invoke ncdirect_raster_frame().
+API ncdirectv* ncdirect_render_frame(struct ncdirect* n, const char* filename,
+                                     ncblitter_e blitter, ncscale_e scale);
+
+// Takes the result of ncdirect_render_frame() and writes it to the output. The
+// 'align', 'blitter', and 'scale' arguments must be the same as those passed
+// to ncdirect_render_frame().
+API int ncdirect_raster_frame(struct ncdirect* n, ncdirectv* faken,
+                              ncalign_e align, ncblitter_e blitter,
+                              ncscale_e scale);
 
 #undef API
 

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -114,6 +114,16 @@ API int ncdirect_render_image(struct ncdirect* n, const char* filename,
                               ncalign_e align, ncblitter_e blitter,
                               ncscale_e scale);
 
+// Display an image using the specified blitter and scaling. The image may
+// be arbitrarily many rows -- the output will scroll -- but will only occupy
+// the column of the cursor, and those to the right.
+API struct ncplane* ncdirect_render_frame(struct ncdirect* n, const char* filename,
+                                          ncblitter_e blitter, ncscale_e scale);
+
+API int ncdirect_raster_frame(struct ncdirect* n, struct ncplane* faken,
+                              ncalign_e align, ncblitter_e blitter,
+                              ncscale_e scale);
+
 // Clear the screen.
 API int ncdirect_clear(struct ncdirect* nc);
 

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -411,7 +411,7 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np, int xoff){
   return 0;
 }
 
-int ncdirect_raster_frame(ncdirect* n, struct ncplane* faken, ncalign_e align,
+int ncdirect_raster_frame(ncdirect* n, ncdirectv* faken, ncalign_e align,
                           ncblitter_e blitter, ncscale_e scale){
   auto bset = rgba_blitter_low(n->utf8, scale, true, blitter);
   if(!bset){
@@ -429,8 +429,8 @@ int ncdirect_raster_frame(ncdirect* n, struct ncplane* faken, ncalign_e align,
   return r;
 }
 
-struct ncplane* ncdirect_render_frame(ncdirect* n, const char* file,
-                                      ncblitter_e blitter, ncscale_e scale){
+ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
+                                 ncblitter_e blitter, ncscale_e scale){
   struct ncvisual* ncv = ncvisual_from_file(file);
   if(ncv == nullptr){
     return nullptr;

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -223,6 +223,9 @@ int main(int argc, char* const * argv){
   if(procs <= 0){
     procs = 4;
   }
+  if(procs > 8){
+    procs = 8;
+  }
   std::vector<std::thread> threads;
   lsContext ctx = {
     ncpp::Direct(),

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -142,11 +142,12 @@ void ncls_thread(const lsContext* ctx) {
       work.pop();
       pthread_mutex_unlock(&mtx);
       auto s = j.dir / j.p;
-      // FIXME render it
-      //ctx->nc.render_image(s.c_str(), ctx->alignment, NCBLIT_DEFAULT, NCSCALE_SCALE);
+      auto faken = ctx->nc.prep_image(s.c_str(), NCBLIT_DEFAULT, NCSCALE_SCALE);
       pthread_mutex_lock(&outmtx);
       std::cout << j.p << '\n';
-      // FIXME raster it
+      if(faken){
+        ctx->nc.raster_image(faken, ctx->alignment, NCBLIT_DEFAULT, NCSCALE_SCALE);
+      }
       pthread_mutex_unlock(&outmtx);
     }else if(!keep_working){
       pthread_mutex_unlock(&mtx);


### PR DESCRIPTION
Thread out `ncls` to perform the media decode in different threads, in parallel. Only the display needs be locked. On a directory of 200 files on my 39070X, this speeds `ncls` from ~5s to ~1s. On 75 files, we go from ~.5s to ~.2s. On a single file, we lose about 5%. To facilitate this, `ncdirect_render_image()` has been split into two helpers, `ncdirect_render_frame()` and `ncdirect_raster_frame().`