### PR TITLE
notcurses-view: add -t option for timed display

### DIFF
--- a/doc/man/man1/notcurses-view.1.md
+++ b/doc/man/man1/notcurses-view.1.md
@@ -8,7 +8,7 @@ notcurses-view - Render images and video to a terminal
 
 # SYNOPSIS
 
-**notcurses-view** [**-h**] [**-q**] [**-d delaymult**] [**-l loglevel**] [**-s scalemode**] [**-k**] [**-L**] files
+**notcurses-view** [**-h**] [**-q**] [**-d** ***delaymult***] [**-l** ***loglevel***] [**-s** ***scalemode***] [**-k**] [**-L**] [**-t** ***seconds***] files
 
 # DESCRIPTION
 
@@ -19,13 +19,18 @@ fill the rendering area, and the **sexblitter** blitter is used for a
 
 # OPTIONS
 
-**-d delaymult**: Apply a rational multiplier to the framerate.
+**-d** ***delaymult***: Apply a non-negative rational multiplier to the delayscale.
+Only applies to multiframe media such as video and animated images.
 
-**-l loglevel**: Log everything (high log level) or nothing (log level 0) to stderr.
+**-t** ***seconds***: Delay **seconds** after each file. If this option is used,
+the "press any key to continue" prompt will not be displayed. **seconds** may
+be any non-negative number.
 
-**-s scalemode**: Scaling mode, one of **none**, **scale**, or **stretch**.
+**-l** ***loglevel***: Log everything (high log level) or nothing (log level 0) to stderr.
 
-**-b blitter**: Blitter, one of **ascii**, **halfblocks**, **quadblitter**,
+**-s** ***scalemode***: Scaling mode, one of **none**, **scale**, or **stretch**.
+
+**-b** ***blitter***: Blitter, one of **ascii**, **halfblocks**, **quadblitter**,
 **sexblitter**, or **braille**.
 
 **-m margins**: Define rendering margins (see below).

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -320,26 +320,34 @@ auto main(int argc, char** argv) -> int {
         if(r == 0){
           vopts.blitter = marsh.blitter;
           if(!loop){
-            stdn->printf(0, NCAlign::Center, "press key to advance");
-            if(!nc.render()){
-              failed = true;
-              break;
-            }
-            char32_t ie = nc.getc(true);
-            if(ie == (char32_t)-1){
-              failed = true;
-              break;
-            }else if(ie == 'q'){
-              goto done;
-            }else if(ie >= '0' && ie <= '8'){
-              --i; // rerun same input with the new blitter
-              vopts.blitter = blitter = static_cast<ncblitter_e>(ie - '0');
-            }else if(ie == NCKey::Resize){
-              --i; // rerun with the new size
-              if(!nc.refresh(&dimy, &dimx)){
+            if(displaytime < 0){
+              stdn->printf(0, NCAlign::Center, "press key to advance");
+              if(!nc.render()){
                 failed = true;
                 break;
               }
+              char32_t ie = nc.getc(true);
+              if(ie == (char32_t)-1){
+                failed = true;
+                break;
+              }else if(ie == 'q'){
+                goto done;
+              }else if(ie >= '0' && ie <= '8'){
+                --i; // rerun same input with the new blitter
+                vopts.blitter = blitter = static_cast<ncblitter_e>(ie - '0');
+              }else if(ie == NCKey::Resize){
+                --i; // rerun with the new size
+                if(!nc.refresh(&dimy, &dimx)){
+                  failed = true;
+                  break;
+                }
+              }
+            }else{
+              // FIXME do we still want to honor keybindings when timing out?
+              struct timespec ts;
+              ts.tv_sec = displaytime;
+              ts.tv_nsec = (displaytime - ts.tv_sec) * NANOSECS_IN_SEC;
+              clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);
             }
           }else{
             ncv->decode_loop();


### PR DESCRIPTION
When the -t switch is provided to notcurses-view, its floating-point argument is the number of seconds for which we delay after showing an image. When this is used, the standard "press any key to continue" prompt is not displayed, and indeed keybindings are not honored. This can be used for a slideshow, or just for fullscreen display involving no user interaction. It does not apply in the case of -L for looping. Closes #1229.

Requested by @kusky3.