### PR TITLE
Work around kitty rgb/default color conflation

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -43,7 +43,8 @@ a background of RGB(0, 0, 0) will be translucent. To work around this, when
 `TERM` begins with "kitty", we detect the default background color, and when
 we would write this as RGB, we alter one of the colors by 1. See
 https://github.com/kovidgoyal/kitty/issues/3185 and
-https://github.com/dankamongmen/notcurses/issues/1117.
+https://github.com/dankamongmen/notcurses/issues/1117. This behavior can
+be demonstrated with the `kittyzapper` binary (`src/poc/kittyzapper.c`).
 
 Kitty is furthermore the only terminal I know to lack the `bce` capability, but
 Notcurses never relies on `bce` behavior.

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -595,15 +595,17 @@ ncdirect* ncdirect_init(const char* termtype, FILE* outfp, uint64_t flags){
   if(ncinputlayer_init(&ret->input, stdin)){
     goto err;
   }
+  const char* shortname_term;
   int termerr;
   if(setupterm(termtype, ret->ctermfd, &termerr) != OK){
     fprintf(stderr, "Terminfo error %d (see terminfo(3ncurses))\n", termerr);
     goto err;
   }
+  shortname_term = termname();
   if(ncvisual_init(ffmpeg_log_level(NCLOGLEVEL_SILENT))){
     goto err;
   }
-  if(interrogate_terminfo(&ret->tcache)){
+  if(interrogate_terminfo(&ret->tcache, shortname_term)){
     goto err;
   }
   ret->fgdefault = ret->bgdefault = true;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -275,6 +275,12 @@ typedef struct tinfo {
   bool AMflag;    // "AM" flag for automatic movement to next line
   char* smcup;    // enter alternate mode
   char* rmcup;    // restore primary mode
+
+  // kitty interprets an RGB background that matches the default background
+  // color *as* the default background, meaning it'll be translucent if
+  // background_opaque is in use. detect this, and avoid the default if so.
+  // bg_collides_default is either 0x0000000 or 0x1RRGGBB.
+  uint32_t bg_collides_default;
 } tinfo;
 
 typedef struct ncinputlayer {
@@ -365,7 +371,7 @@ void sigwinch_handler(int signo);
 
 void init_lang(notcurses* nc); // nc may be NULL, only used for logging
 int terminfostr(char** gseq, const char* name);
-int interrogate_terminfo(tinfo* ti);
+int interrogate_terminfo(tinfo* ti, const char* termname);
 
 int resize_callbacks_children(ncplane* n);
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1109,7 +1109,7 @@ notcurses* notcurses_init(const notcurses_options* opts, FILE* outfp){
             shortname_term ? shortname_term : "?",
             longname_term ? longname_term : "?");
   }
-  if(interrogate_terminfo(&ret->tcache)){
+  if(interrogate_terminfo(&ret->tcache, shortname_term)){
     goto err;
   }
   reset_term_attributes(ret);

--- a/src/poc/kittyzapper.c
+++ b/src/poc/kittyzapper.c
@@ -1,0 +1,24 @@
+#include <notcurses/direct.h>
+
+int main(void){
+  struct ncdirect* n = ncdirect_init(NULL, NULL, 0);
+  if(!n){
+    return EXIT_FAILURE;
+  }
+  ncdirect_fg_rgb8(n, 100, 100, 100);
+  ncdirect_bg_rgb8(n, 0xff, 0xff, 0xff);
+  printf("a");
+  ncdirect_bg_rgb8(n, 0, 0, 0);
+  printf("b");
+  printf(" ");
+  printf(" ");
+  ncdirect_bg_rgb8(n, 0, 0, 1);
+  printf("c");
+  printf(" ");
+  printf(" ");
+  ncdirect_bg_rgb8(n, 0xff, 0xff, 0xff);
+  printf("d");
+  printf("\n");
+  ncdirect_stop(n);
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
introduce terminal-specific heuristics
    
Kitty conflates an RGB background specification that aligns
with the default background color with that actual background
color. This can result in translucent background when we're
expecting opaque ones. Detect kitty (strstr check of terminal
name for "kitty"), and if it's active, mark `bg_collides_default`
with the rgb of the default background color. For now, we assume
this to be (0,0,0), but we ought improve it by determining (or
setting, if that's impossible) the precise default bg color.
Closes #1117.
