### PR TITLE
Support high-res blitters even without stretching

### DIFF
--- a/doc/man/man1/notcurses-view.1.md
+++ b/doc/man/man1/notcurses-view.1.md
@@ -28,7 +28,7 @@ be any non-negative number.
 
 **-l** ***loglevel***: Log everything (high log level) or nothing (log level 0) to stderr.
 
-**-s** ***scalemode***: Scaling mode, one of **none**, **scale**, or **stretch**.
+**-s** ***scalemode***: Scaling mode, one of **none**, **hires**, **scale**, **scalehi**, or **stretch**.
 
 **-b** ***blitter***: Blitter, one of **ascii**, **halfblocks**, **quadblitter**,
 **sexblitter**, or **braille**.

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -14,6 +14,8 @@ typedef enum {
   NCSCALE_NONE,
   NCSCALE_SCALE,
   NCSCALE_STRETCH,
+  NCSCALE_NONE_HIRES,
+  NCSCALE_SCALE_HIRES,
 } ncscale_e;
 
 typedef enum {

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -78,11 +78,15 @@ typedef enum {
 // How to scale an ncvisual during rendering. NCSCALE_NONE will apply no
 // scaling. NCSCALE_SCALE scales a visual to the plane's size, maintaining
 // aspect ratio. NCSCALE_STRETCH stretches and scales the image in an
-// attempt to fill the entirety of the plane.
+// attempt to fill the entirety of the plane. NCSCALE_NONE_HIRES and
+// NCSCALE_SCALE_HIRES behave like their counterparts, but admit blitters
+// which don't preserve aspect ratio.
 typedef enum {
   NCSCALE_NONE,
   NCSCALE_SCALE,
   NCSCALE_STRETCH,
+  NCSCALE_NONE_HIRES,
+  NCSCALE_SCALE_HIRES,
 } ncscale_e;
 
 // Returns the number of columns occupied by a multibyte (UTF-8) string, or
@@ -1192,6 +1196,9 @@ API bool notcurses_canopen_videos(const struct notcurses* nc);
 
 // Is our encoding UTF-8? Requires LANG being set to a UTF8 locale.
 API bool notcurses_canutf8(const struct notcurses* nc);
+
+// Can we reliably use Unicode 13 sextants?
+API bool notcurses_cansextant(const struct notcurses* nc);
 
 // Can we blit to Sixel?
 API bool notcurses_cansixel(const struct notcurses* nc);

--- a/src/demo/eagle.c
+++ b/src/demo/eagle.c
@@ -42,7 +42,7 @@ zoom_map(struct notcurses* nc, const char* map, int* ret){
   // but *do* explicitly supply NCBLIT_2x2 since we're not scaling.
   struct ncvisual_options vopts = {
     .y = 1,
-    .blitter = ncvisual_media_defblitter(nc, NCSCALE_NONE),
+    .blitter = ncvisual_media_defblitter(nc, NCSCALE_NONE_HIRES),
   };
   if(ncvisual_geom(nc, ncv, &vopts, &vheight, &vwidth, &yscale, &xscale)){
     ncvisual_destroy(ncv);

--- a/src/demo/eagle.c
+++ b/src/demo/eagle.c
@@ -42,7 +42,7 @@ zoom_map(struct notcurses* nc, const char* map, int* ret){
   // but *do* explicitly supply NCBLIT_2x2 since we're not scaling.
   struct ncvisual_options vopts = {
     .y = 1,
-    .blitter = ncvisual_media_defblitter(nc, NCSCALE_NONE_HIRES),
+    .blitter = NCBLIT_2x2,
   };
   if(ncvisual_geom(nc, ncv, &vopts, &vheight, &vwidth, &yscale, &xscale)){
     ncvisual_destroy(ncv);
@@ -52,8 +52,8 @@ zoom_map(struct notcurses* nc, const char* map, int* ret){
   // we start at the lower left corner of the outzoomed map
   int placey, placex; // dimensions of true display
   notcurses_term_dim_yx(nc, &placey, &placex);
-  float delty = 3;
-  float deltx = 3;
+  float delty = 2 + yscale;
+  float deltx = 2 + xscale;
   float truey = placey;
   float truex = placex;
   if(truey > truex){

--- a/src/demo/intro.c
+++ b/src/demo/intro.c
@@ -7,10 +7,16 @@ fader(struct notcurses* nc, struct ncplane* ncp, void* curry){
   int* flipmode = curry;
   int rows, cols;
   ncplane_dim_yx(ncp, &rows, &cols);
+  const bool smallscreen = rows < 26;
+  const int row1 = rows - 10 + smallscreen;
+  const int row2 = 6 - smallscreen; // box always starts on 4; don't stomp riser
   int startx = (cols - (centercols - 2)) / 2;
+  ncplane_set_fg_rgb8(ncp, 0xd0, 0xf0, 0xd0);
   for(int x = startx ; x < startx + centercols - 2 ; ++x){
-    ncplane_set_fg_rgb8(ncp, 0xd0, 0xf0, 0xd0);
-    if(ncplane_putwc_yx(ncp, rows - 10, x, x % 2 == *flipmode % 2 ? L'◪' : L'◩') <= 0){
+    if(ncplane_putwc_yx(ncp, row1, x, x % 2 != *flipmode % 2 ? L'◪' : L'◩') <= 0){
+      return -1;
+    }
+    if(ncplane_putwc_yx(ncp, row2, x, x % 2 == *flipmode % 2 ? L'◪' : L'◩') <= 0){
       return -1;
     }
   }

--- a/src/demo/unicodeblocks.c
+++ b/src/demo/unicodeblocks.c
@@ -51,10 +51,10 @@ pbar_make(struct notcurses* nc, int row){
     return NULL;
   }
   struct ncprogbar_options popts = {0};
-  channel_set_rgb8(&popts.ulchannel, 0x80, 0x22, 0x80);
-  channel_set_rgb8(&popts.urchannel, 0x80, 0x22, 0x80);
-  channel_set_rgb8(&popts.blchannel, 0x80, 0x22, 0x22);
-  channel_set_rgb8(&popts.brchannel, 0x80, 0x22, 0x22);
+  channel_set_rgb8(&popts.ulchannel, 0x22, 0x22, 0x80);
+  channel_set_rgb8(&popts.urchannel, 0x22, 0x22, 0x80);
+  channel_set_rgb8(&popts.blchannel, 0x80, 0x80, 0x22);
+  channel_set_rgb8(&popts.brchannel, 0x80, 0x80, 0x22);
   struct ncprogbar* ncp = ncprogbar_create(pbar, &popts);
   if(ncp == NULL){
     return NULL;

--- a/src/lib/blitset.h
+++ b/src/lib/blitset.h
@@ -44,7 +44,7 @@ rgba_blitter_default(bool utf8, ncscale_e scale, bool sextants){
   if(!utf8){
     return NCBLIT_1x1;
   }
-  if(scale != NCSCALE_STRETCH){
+  if(scale == NCSCALE_NONE || scale == NCSCALE_SCALE){
     return NCBLIT_2x1;
   }
   if(!sextants){

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -471,10 +471,10 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
     return nullptr;
   }
   int disprows, dispcols;
-  if(scale != NCSCALE_NONE){
+  if(scale != NCSCALE_NONE && scale != NCSCALE_NONE_HIRES){
     dispcols = ncdirect_dim_x(n) * encoding_x_scale(bset);
     disprows = ncdirect_dim_y(n) * encoding_y_scale(bset);
-    if(scale == NCSCALE_SCALE){
+    if(scale == NCSCALE_SCALE || scale == NCSCALE_SCALE_HIRES){
       scale_visual(ncv, &disprows, &dispcols);
     }
   }else{

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -366,11 +366,6 @@ typedef struct notcurses {
   bool libsixel;  // do we have Sixel support?
 } notcurses;
 
-static inline bool
-notcurses_cansextant(const notcurses* nc){
-  return nc->tcache.sextants;
-}
-
 #include "blitset.h"
 
 void sigwinch_handler(int signo);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2111,6 +2111,10 @@ bool notcurses_canutf8(const notcurses* nc){
   return nc->utf8;
 }
 
+bool notcurses_cansextant(const notcurses* nc){
+  return nc->tcache.sextants && nc->utf8;
+}
+
 bool notcurses_canfade(const notcurses* nc){
   return nc->tcache.CCCflag || nc->tcache.RGBflag;
 }
@@ -2403,6 +2407,10 @@ lex_long(const char* op, int* i, char** endptr){
 int notcurses_lex_scalemode(const char* op, ncscale_e* scalemode){
   if(strcasecmp(op, "stretch") == 0){
     *scalemode = NCSCALE_STRETCH;
+  }else if(strcasecmp(op, "scalehi") == 0){
+    *scalemode = NCSCALE_SCALE_HIRES;
+  }else if(strcasecmp(op, "hires") == 0){
+    *scalemode = NCSCALE_NONE_HIRES;
   }else if(strcasecmp(op, "scale") == 0){
     *scalemode = NCSCALE_SCALE;
   }else if(strcasecmp(op, "none") == 0){
@@ -2420,6 +2428,10 @@ const char* notcurses_str_scalemode(ncscale_e scalemode){
     return "scale";
   }else if(scalemode == NCSCALE_NONE){
     return "none";
+  }else if(scalemode == NCSCALE_NONE_HIRES){
+    return "hires";
+  }else if(scalemode == NCSCALE_SCALE_HIRES){
+    return "scalehi";
   }
   return NULL;
 }

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -35,7 +35,7 @@ auto ncvisual_geom(const notcurses* nc, const ncvisual* n,
   if(n){
     if(scale == NCSCALE_NONE || scale == NCSCALE_NONE_HIRES){
       *y = n->rows;
-      *x = n->cols * encoding_x_scale(bset);
+      *x = n->cols;// * encoding_x_scale(bset);
     }else{
       int rows = vopts->n ? ncplane_dim_y(vopts->n) : ncplane_dim_y(nc->stdplane);
       int cols = vopts->n ? ncplane_dim_x(vopts->n) : ncplane_dim_x(nc->stdplane);
@@ -407,8 +407,8 @@ auto ncvisual_render(notcurses* nc, ncvisual* ncv,
 //fprintf(stderr, "INPUT N: %p\n", vopts ? vopts->n : nullptr);
   if((n = (vopts ? vopts->n : nullptr)) == nullptr){ // create plane
     if(!vopts || vopts->scaling == NCSCALE_NONE || vopts->scaling == NCSCALE_NONE_HIRES){
-      dispcols = ncv->cols * encoding_x_scale(bset);
-      disprows = ncv->rows * encoding_y_scale(bset);
+      dispcols = ncv->cols;// * encoding_x_scale(bset);
+      disprows = ncv->rows;// * encoding_y_scale(bset);
     }else{
       notcurses_term_dim_yx(nc, &disprows, &dispcols);
       dispcols *= encoding_x_scale(bset);
@@ -435,8 +435,8 @@ auto ncvisual_render(notcurses* nc, ncvisual* ncv,
     placex = 0;
   }else{
     if(!vopts || vopts->scaling == NCSCALE_NONE || vopts->scaling == NCSCALE_NONE_HIRES){
-      dispcols = ncv->cols * encoding_x_scale(bset);
-      disprows = ncv->rows * encoding_y_scale(bset);
+      dispcols = ncv->cols;// * encoding_x_scale(bset);
+      disprows = ncv->rows;// * encoding_y_scale(bset);
     }else{
       ncplane_dim_yx(n, &disprows, &dispcols);
       dispcols *= encoding_x_scale(bset);

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -34,7 +34,7 @@ auto ncvisual_geom(const notcurses* nc, const ncvisual* n,
   }
   if(n){
     if(scale == NCSCALE_NONE || scale == NCSCALE_NONE_HIRES){
-      *y = n->rows * encoding_y_scale(bset);
+      *y = n->rows;
       *x = n->cols * encoding_x_scale(bset);
     }else{
       int rows = vopts->n ? ncplane_dim_y(vopts->n) : ncplane_dim_y(nc->stdplane);
@@ -406,9 +406,9 @@ auto ncvisual_render(notcurses* nc, ncvisual* ncv,
   ncplane* n = nullptr;
 //fprintf(stderr, "INPUT N: %p\n", vopts ? vopts->n : nullptr);
   if((n = (vopts ? vopts->n : nullptr)) == nullptr){ // create plane
-    if(!vopts || vopts->scaling == NCSCALE_NONE){
-      dispcols = ncv->cols;
-      disprows = ncv->rows;
+    if(!vopts || vopts->scaling == NCSCALE_NONE || vopts->scaling == NCSCALE_NONE_HIRES){
+      dispcols = ncv->cols * encoding_x_scale(bset);
+      disprows = ncv->rows * encoding_y_scale(bset);
     }else{
       notcurses_term_dim_yx(nc, &disprows, &dispcols);
       dispcols *= encoding_x_scale(bset);

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -33,16 +33,16 @@ auto ncvisual_geom(const notcurses* nc, const ncvisual* n,
     x = &fauxx;
   }
   if(n){
-    if(scale == NCSCALE_NONE){
-      *y = n->rows;
-      *x = n->cols;
+    if(scale == NCSCALE_NONE || scale == NCSCALE_NONE_HIRES){
+      *y = n->rows * encoding_y_scale(bset);
+      *x = n->cols * encoding_x_scale(bset);
     }else{
       int rows = vopts->n ? ncplane_dim_y(vopts->n) : ncplane_dim_y(nc->stdplane);
       int cols = vopts->n ? ncplane_dim_x(vopts->n) : ncplane_dim_x(nc->stdplane);
       *y = rows * encoding_y_scale(bset);
       *x = cols * encoding_x_scale(bset);
     }
-    if(scale == NCSCALE_SCALE){
+    if(scale == NCSCALE_SCALE || scale == NCSCALE_SCALE_HIRES){
       scale_visual(n, y, x);
     }
   }
@@ -413,7 +413,7 @@ auto ncvisual_render(notcurses* nc, ncvisual* ncv,
       notcurses_term_dim_yx(nc, &disprows, &dispcols);
       dispcols *= encoding_x_scale(bset);
       disprows *= encoding_y_scale(bset);
-      if(vopts->scaling == NCSCALE_SCALE){
+      if(vopts->scaling == NCSCALE_SCALE || vopts->scaling == NCSCALE_SCALE_HIRES){
         scale_visual(ncv, &disprows, &dispcols);
       }
     }
@@ -434,16 +434,16 @@ auto ncvisual_render(notcurses* nc, ncvisual* ncv,
     placey = 0;
     placex = 0;
   }else{
-    if(!vopts || vopts->scaling == NCSCALE_NONE){
-      dispcols = ncv->cols;
-      disprows = ncv->rows;
+    if(!vopts || vopts->scaling == NCSCALE_NONE || vopts->scaling == NCSCALE_NONE_HIRES){
+      dispcols = ncv->cols * encoding_x_scale(bset);
+      disprows = ncv->rows * encoding_y_scale(bset);
     }else{
       ncplane_dim_yx(n, &disprows, &dispcols);
       dispcols *= encoding_x_scale(bset);
       disprows *= encoding_y_scale(bset);
       disprows -= placey;
       dispcols -= placex;
-      if(vopts->scaling == NCSCALE_SCALE){
+      if(vopts->scaling == NCSCALE_SCALE || vopts->scaling == NCSCALE_SCALE_HIRES){
         scale_visual(ncv, &disprows, &dispcols);
       }
     }

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -142,11 +142,11 @@ void ncls_thread(const lsContext* ctx) {
       work.pop();
       pthread_mutex_unlock(&mtx);
       auto s = j.dir / j.p;
-      auto faken = ctx->nc.prep_image(s.c_str(), NCBLIT_DEFAULT, NCSCALE_SCALE);
+      auto faken = ctx->nc.prep_image(s.c_str(), NCBLIT_DEFAULT, NCSCALE_SCALE_HIRES);
       pthread_mutex_lock(&outmtx);
       std::cout << j.p << '\n';
       if(faken){
-        ctx->nc.raster_image(faken, ctx->alignment, NCBLIT_DEFAULT, NCSCALE_SCALE);
+        ctx->nc.raster_image(faken, ctx->alignment, NCBLIT_DEFAULT, NCSCALE_SCALE_HIRES);
       }
       pthread_mutex_unlock(&outmtx);
     }else if(!keep_working){

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -24,7 +24,7 @@ void usage(std::ostream& o, const char* name, int exitcode){
   o << " -L: loop frames\n";
   o << " -t seconds: delay t seconds after each file\n";
   o << " -l loglevel: integer between 0 and 9, goes to stderr'\n";
-  o << " -s scaletype: one of 'none', 'scale', or 'stretch'\n";
+  o << " -s scaletype: one of 'none', 'hires', 'scale', 'scalehi', or 'stretch'\n";
   o << " -b blitter: 'ascii', 'halfblock', 'quadblitter', 'sexblitter', or 'braille'\n";
   o << " -m margins: margin, or 4 comma-separated margins\n";
   o << " -d mult: non-negative floating point scale for frame time" << std::endl;
@@ -189,7 +189,7 @@ auto handle_opts(int argc, char** argv, notcurses_options& opts, bool* quiet,
         break;
       case 's':
         if(notcurses_lex_scalemode(optarg, scalemode)){
-          std::cerr << "Scaling type should be one of stretch, scale, none (got "
+          std::cerr << "Scaling type should be one of stretch, scale, scalehi, hires, none (got "
                     << optarg << ")" << std::endl;
           usage(std::cerr, argv[0], EXIT_FAILURE);
         }


### PR DESCRIPTION
Adds two new scaling types, `NCSCALE_NONE_HIRES` and `NCSCALE_SCALE_HIRES`. These will scale as their original versions do, but can still use high-resolution blitters (`NCBLIT_2x2` and `NCBLIT_3x2`) that don't preserve aspect ratio. Closes #1250.