### PR TITLE
Library split done right

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,6 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-# Passes -Wl,-no-as-needed to linker steps, necessary to reliably link
-# libnotcurses.so into executables...for now. This is grotesque. FIXME
-set(CMAKE_LINK_WHAT_YOU_USE ON)
 
 include(CTest)
 include(GNUInstallDirs)
@@ -602,7 +599,7 @@ target_include_directories(ncls
 )
 tarGET_Link_libraries(ncls
   PRIVATE
-    notcurses
+    notcurses++
 )
 
 ############################################################################

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,10 @@ rearrangements of Notcurses.
   * Notcurses has been split into two libraries, `notcurses-core` and
     `notcurses`. The latter contains the heavyweight multimedia code,
     so that applications which don't need this functionality can link against
-    only the former. `pkg-config` support is present for both.
+    only the former. `pkg-config` support is present for both. If using only
+    `notcurses_core`, use the new functions `notcurses_core_init()` and/or
+    `ncdirect_core_init()` in place of `ncdirect_init()` and
+    `notcurses_init()`, or your program is unlikely to link.
   * The `notcurses-view` binary has been renamed `ncplayer`.
 
 * 2.1.5 (2021-01-15):

--- a/USAGE.md
+++ b/USAGE.md
@@ -23,9 +23,14 @@ unified commentary, consider the [paperback](https://www.amazon.com/dp/B086PNVNC
 
 A program wishing to use Notcurses will need to link it, ideally using the
 output of `pkg-config --libs notcurses`. It is advised to compile with the
-output of `pkg-config --cflags notcurses`. To use the minimal core Notcurses,
-without multimedia support, use `pkg-config --libs notcurses-core` etc. If
-using CMake, a support file is provided, and can be accessed as `Notcurses`.
+output of `pkg-config --cflags notcurses`. If using CMake, a support file is
+provided, and can be accessed as `Notcurses`.
+
+If your program makes no use of multimedia, you might want to link with only
+the core Notcurses, and thus incur far fewer dependencies. To use the minimal
+core Notcurses, use `pkg-config --libs notcurses-core` etc. In place of
+`notcurses_init()` and/or `ncdirect_init()` (see below), you must also use
+`notcurses_core_init()` and/or `ncdirect_core_init()`, or linking will fail.
 
 Before calling into Notcurses—and usually as one of the first calls of the
 program—be sure to call `setlocale(3)` with an appropriate UTF-8 locale. It is
@@ -142,6 +147,10 @@ int notcurses_lex_margins(const char* op, notcurses_options* opts);
 // which case /dev/tty will be opened. Returns NULL on error, including any
 // failure initializing terminfo.
 struct notcurses* notcurses_init(const notcurses_options* opts, FILE* fp);
+
+// The same as notcurses_init(), but without any multimedia functionality,
+// allowing for a svelter binary. Link with notcurses-core if this is used.
+struct notcurses* notcurses_core_init(const notcurses_options* opts, FILE* fp);
 
 // Destroy a Notcurses context.
 int notcurses_stop(struct notcurses* nc);
@@ -312,6 +321,10 @@ struct ncdirect; // minimal state for a terminal
 // NCDIRECT_OPTION_*.
 // Returns NULL on error, including any failure initializing terminfo.
 struct ncdirect* ncdirect_init(const char* termtype, FILE* fp, uint64_t flags);
+
+// The same as ncdirect_init(), but without any multimedia functionality,
+// allowing for a svelter binary. Link with notcurses-core if this is used.
+struct ncdirect* ncdirect_core_init(const char* termtype, FILE* fp, uint64_t flags);
 
 // ncdirect_init() will call setlocale() to inspect the current locale. If
 // that locale is "C" or "POSIX", it will call setlocale(LC_ALL, "") to set

--- a/doc/man/index.html
+++ b/doc/man/index.html
@@ -43,6 +43,7 @@
    <a href="notcurses_capabilities.3.html">notcurses_capabilities</a>—runtime capability detection<br/>
    <a href="notcurses_cell.3.html">notcurses_cell</a>—operations on <tt>nccell</tt> objects<br/>
    <a href="notcurses_channels.3.html">notcurses_channels</a>—operations on the <tt>channel</tt> type<br/>
+   <a href="notcurses_core.3.html">notcurses_core</a>—linking against a minimal Notcurses<br/>
    <a href="notcurses_directmode.3.html">notcurses_directmode</a>—minimal notcurses instances for styling text<br/>
    <a href="notcurses_fade.3.html">notcurses_fade</a>—fading and pulsing for <tt>ncplane</tt>s<br/>
    <a href="notcurses_fds.3.html">notcurses_fds</a>—dumping file descriptors/subprocesses to <tt>ncplane</tt>s<br/>

--- a/doc/man/man3/notcurses_core.3.md
+++ b/doc/man/man3/notcurses_core.3.md
@@ -1,0 +1,53 @@
+% notcurses_core(3)
+% nick black <nickblack@linux.com>
+% v2.1.5
+
+# NAME
+
+notcurses_core - minimal Notcurses linkage
+
+# SYNOPSIS
+
+**#include <notcurses/notcurses.h>**
+
+**-lnotcurses-core**
+
+**struct notcurses* notcurses_core_init(const notcurses_options* ***opts***, FILE* ***fp***);**
+
+**struct ncdirect* ncdirect_core_init(const char* ***termtype***, FILE* ***fp***, uint64_t ***flags***);**
+
+# DESCRIPTION
+
+If your binary has no use for the multimedia capabilities of Notcurses,
+consider linking directly to **libnotcurses-core** rather than
+**libnotcurses**. This ought greatly reduce the dependency burden of
+Notcurses.
+
+If using **libnotcurses-core**, **notcurses_core_init** must be
+used in the place of **notcurses_init**, and **ncdirect_core_init** must
+be used in the place of **ncdirect_init**. Failure to do will usually
+result in an error during linking. At worst, you'll end up with the
+unnecessary dependencies in your binary after all.
+
+# BUGS
+
+This all ought be handled by the toolchain. It's stupid for users to have
+to think about this.
+
+# NOTES
+
+If Notcurses was built with **USE_MULTIMEDIA=none**, **libnotcurses** will
+have no multimedia dependencies, and thus this won't save anything. It's
+still best to explicitly use **libnotcurses-core** when appropriate, to
+avoid picking up the dependency chain on systems where it *is* being used.
+
+# RETURN VALUES
+
+The same as **notcurses_init** and **ncdirect_init**.
+
+# SEE ALSO
+
+**notcurses(3)**,
+**notcurses_direct(3)**,
+**notcurses_init(3)**,
+utf8(7)

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -44,6 +44,10 @@ typedef struct ncplane ncdirectv;
 // Returns NULL on error, including any failure initializing terminfo.
 API struct ncdirect* ncdirect_init(const char* termtype, FILE* fp, uint64_t flags);
 
+// The same as ncdirect_init(), but without any multimedia functionality,
+// allowing for a svelter binary. Link with notcurses-core if this is used.
+API struct ncdirect* ncdirect_core_init(const char* termtype, FILE* fp, uint64_t flags);
+
 // Direct mode. This API can be used to colorize and stylize output generated
 // outside of notcurses, without ever calling notcurses_render(). These should
 // not be intermixed with standard Notcurses rendering.

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -892,6 +892,10 @@ API const char* notcurses_str_scalemode(ncscale_e scalemode);
 // failure initializing terminfo.
 API struct notcurses* notcurses_init(const notcurses_options* opts, FILE* fp);
 
+// The same as notcurses_init(), but without any multimedia functionality,
+// allowing for a svelter binary. Link with notcurses-core if this is used.
+API struct notcurses* notcurses_core_init(const notcurses_options* opts, FILE* fp);
+
 // Destroy a Notcurses context.
 API int notcurses_stop(struct notcurses* nc);
 

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -621,7 +621,7 @@ ncdirect_stop_minimal(void* vnc){
   return ret;
 }
 
-ncdirect* ncdirect_init(const char* termtype, FILE* outfp, uint64_t flags){
+ncdirect* ncdirect_core_init(const char* termtype, FILE* outfp, uint64_t flags){
   if(flags > (NCDIRECT_OPTION_NO_QUIT_SIGHANDLERS << 1)){ // allow them through with warning
     logwarn((struct notcurses*)NULL, "Passed unsupported flags 0x%016jx\n", (uintmax_t)flags);
   }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1060,15 +1060,12 @@ int drop_signals(void* nc);
 void ncvisual_printbanner(const notcurses* nc);
 
 typedef struct ncvisual_implementation {
-  int (*ncvisual_init)(int loglevel);
-  int (*ncvisual_decode)(struct ncvisual*);
+  void (*ncvisual_printbanner)(const struct notcurses* nc);
   int (*ncvisual_blit)(struct ncvisual* ncv, int rows, int cols, ncplane* n,
                        const struct blitset* bset, int placey, int placex,
                        int begy, int begx, int leny, int lenx,
                        bool blendcolors);
   struct ncvisual* (*ncvisual_create)(void);
-  struct ncvisual* (*ncvisual_from_file)(const char* s);
-  void (*ncvisual_printbanner)(const struct notcurses* nc);
   // ncv constructors other than ncvisual_from_file() need to set up the
   // AVFrame* 'frame' according to their own data, which is assumed to
   // have been prepared already in 'ncv'.
@@ -1078,7 +1075,7 @@ typedef struct ncvisual_implementation {
   bool canopen_videos;
 } ncvisual_implementation;
 
-// overriden by strong symbol in libnotcurses.so if built with multimedia
+// assigned by libnotcurses.so if linked with multimedia
 extern const ncvisual_implementation* visual_implementation
   __attribute__ ((visibility("default")));
 

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1080,7 +1080,13 @@ typedef struct ncvisual_implementation {
 
 // overriden by strong symbol in libnotcurses.so if built with multimedia
 extern const ncvisual_implementation* visual_implementation
- __attribute__ ((visibility("default")));
+  __attribute__ ((visibility("default")));
+
+struct ncvisual* ncvisual_from_file(const char* filename)
+  __attribute__ ((visibility("default")));
+
+struct ncdirect* ncdirect_core_init(const char* termtype, FILE* outfp, uint64_t flags)
+  __attribute__ ((visibility("default")));
 
 #ifdef __cplusplus
 }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -882,7 +882,8 @@ int ncinputlayer_init(ncinputlayer* nilayer, FILE* infp){
 }
 
 // initialize a recursive mutex lock in a way that works on both glibc + musl
-int recursive_lock_init(pthread_mutex_t *lock){
+static int
+recursive_lock_init(pthread_mutex_t *lock){
 #ifndef __GLIBC__
 #define PTHREAD_MUTEX_RECURSIVE_NP PTHREAD_MUTEX_RECURSIVE
 #endif
@@ -905,7 +906,7 @@ int recursive_lock_init(pthread_mutex_t *lock){
 #endif
 }
 
-notcurses* notcurses_init(const notcurses_options* opts, FILE* outfp){
+notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   notcurses_options defaultopts;
   memset(&defaultopts, 0, sizeof(defaultopts));
   if(!opts){

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -4,7 +4,8 @@
 #include "visual-details.h"
 #include "internal.h"
 
-const __attribute__ ((weak)) ncvisual_implementation* visual_implementation = nullptr;
+const __attribute__ ((weak))
+ncvisual_implementation* visual_implementation = nullptr;
 
 auto ncvisual_decode(ncvisual* nc) -> int {
   int ret = -1;
@@ -47,7 +48,8 @@ auto ncvisual_init(int loglevel) -> int {
   return ret;
 }
 
-auto ncvisual_from_file(const char* filename) -> ncvisual* {
+auto __attribute__ ((weak))
+ncvisual_from_file(const char* filename) -> ncvisual* {
   ncvisual* ret = nullptr;
   if(visual_implementation){
     ret = visual_implementation->ncvisual_from_file(filename);

--- a/src/media/ffmpeg.cpp
+++ b/src/media/ffmpeg.cpp
@@ -289,7 +289,7 @@ auto ffmpeg_create() -> ncvisual* {
   return nc;
 }
 
-ncvisual* ffmpeg_from_file(const char* filename) {
+ncvisual* ncvisual_from_file(const char* filename) {
   AVStream* st;
   ncvisual* ncv = ffmpeg_create();
   if(ncv == nullptr){
@@ -571,9 +571,9 @@ auto ffmpeg_init(int loglevel) -> int {
 
 void ffmpeg_printbanner(const notcurses* nc __attribute__ ((unused))){
   printf("  avformat %u.%u.%u avutil %u.%u.%u swscale %u.%u.%u\n",
-        LIBAVFORMAT_VERSION_MAJOR, LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO,
-        LIBAVUTIL_VERSION_MAJOR, LIBAVUTIL_VERSION_MINOR, LIBAVUTIL_VERSION_MICRO,
-        LIBSWSCALE_VERSION_MAJOR, LIBSWSCALE_VERSION_MINOR, LIBSWSCALE_VERSION_MICRO);
+         LIBAVFORMAT_VERSION_MAJOR, LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO,
+         LIBAVUTIL_VERSION_MAJOR, LIBAVUTIL_VERSION_MINOR, LIBAVUTIL_VERSION_MICRO,
+         LIBSWSCALE_VERSION_MAJOR, LIBSWSCALE_VERSION_MINOR, LIBSWSCALE_VERSION_MICRO);
 }
 
 auto ffmpeg_details_destroy(ncvisual_details* deets) -> void {
@@ -594,7 +594,7 @@ const static ncvisual_implementation ffmpeg_impl = {
   .ncvisual_decode = ffmpeg_decode,
   .ncvisual_blit = ffmpeg_blit,
   .ncvisual_create = ffmpeg_create,
-  .ncvisual_from_file = ffmpeg_from_file,
+  .ncvisual_from_file = ncvisual_from_file,
   .ncvisual_printbanner = ffmpeg_printbanner,
   .ncvisual_details_seed = ffmpeg_details_seed,
   .ncvisual_details_destroy = ffmpeg_details_destroy,

--- a/src/media/oiio.cpp
+++ b/src/media/oiio.cpp
@@ -28,14 +28,14 @@ oiio_details_init(void) -> ncvisual_details* {
 }
 
 static inline auto
-oiio_details_destroy(ncvisual_details* deets) -> void {
+ncvisual_details_destroy(ncvisual_details* deets) -> void {
   if(deets->image){
     deets->image->close();
   }
   delete deets;
 }
 
-auto oiio_create() -> ncvisual* {
+auto ncvisual_create() -> ncvisual* {
   auto nc = new ncvisual{};
   if((nc->details = oiio_details_init()) == nullptr){
     delete nc;
@@ -44,8 +44,8 @@ auto oiio_create() -> ncvisual* {
   return nc;
 }
 
-ncvisual* oiio_from_file(const char* filename) {
-  ncvisual* ncv = oiio_create();
+ncvisual* ncvisual_from_file(const char* filename) {
+  ncvisual* ncv = ncvisual_create();
   if(ncv == nullptr){
     return nullptr;
   }
@@ -252,32 +252,29 @@ auto ncvisual_rotate(ncvisual* ncv, double rads) -> int {
 }
 */
 
-auto oiio_details_seed(ncvisual* ncv) -> void {
+auto ncvisual_details_seed(ncvisual* ncv) -> void {
   (void)ncv;
   // FIXME?
 }
 
-int oiio_init(int loglevel) {
+int ncvisual_init(int loglevel __attribute__ ((unused))) {
   // FIXME set OIIO global attribute "debug" based on loglevel
-  (void)loglevel;
   // FIXME check OIIO_VERSION_STRING components against linked openimageio_version()
   return 0; // allow success here
 }
 
 // FIXME would be nice to have OIIO::attributes("libraries") in here
-void oiio_printbanner(const notcurses* nc __attribute__ ((unused))){
+void ncvisual_printbanner(const notcurses* nc __attribute__ ((unused))){
   printf("  openimageio %s\n", OIIO_VERSION_STRING);
 }
 
 const static ncvisual_implementation oiio_impl = {
-  .ncvisual_init = oiio_init,
-  .ncvisual_decode = oiio_decode,
+  .ncvisual_printbanner = ncvisual_printbanner,
   .ncvisual_blit = oiio_blit,
-  .ncvisual_create = oiio_create,
-  .ncvisual_from_file = oiio_from_file,
-  .ncvisual_printbanner = oiio_printbanner,
-  .ncvisual_details_seed = oiio_details_seed,
-  .ncvisual_details_destroy = oiio_details_destroy,
+  .ncvisual_create = ncvisual_create,
+  .ncvisual_details_seed = ncvisual_details_seed,
+  .ncvisual_details_destroy = ncvisual_details_destroy,
+  .ncvisual_decode = oiio_decode,
   .canopen_images = true,
   .canopen_videos = false,
 };

--- a/src/media/oiio.cpp
+++ b/src/media/oiio.cpp
@@ -28,14 +28,14 @@ oiio_details_init(void) -> ncvisual_details* {
 }
 
 static inline auto
-ncvisual_details_destroy(ncvisual_details* deets) -> void {
+oiio_details_destroy(ncvisual_details* deets) -> void {
   if(deets->image){
     deets->image->close();
   }
   delete deets;
 }
 
-auto ncvisual_create() -> ncvisual* {
+auto oiio_create() -> ncvisual* {
   auto nc = new ncvisual{};
   if((nc->details = oiio_details_init()) == nullptr){
     delete nc;
@@ -45,7 +45,7 @@ auto ncvisual_create() -> ncvisual* {
 }
 
 ncvisual* ncvisual_from_file(const char* filename) {
-  ncvisual* ncv = ncvisual_create();
+  ncvisual* ncv = oiio_create();
   if(ncv == nullptr){
     return nullptr;
   }
@@ -65,7 +65,7 @@ spec.width << "@" << spec.nchannels << " (" << spec.format << ")" << std::endl;*
   return ncv;
 }
 
-int oiio_decode(ncvisual* nc) {
+int ncvisual_decode(ncvisual* nc) {
 //fprintf(stderr, "current subimage: %d frame: %p\n", nc->details->image->current_subimage(), nc->details->frame.get());
   const auto &spec = nc->details->image->spec_dimensions(nc->details->framenum);
   if(nc->details->frame){
@@ -252,7 +252,7 @@ auto ncvisual_rotate(ncvisual* ncv, double rads) -> int {
 }
 */
 
-auto ncvisual_details_seed(ncvisual* ncv) -> void {
+auto oiio_details_seed(ncvisual* ncv) -> void {
   (void)ncv;
   // FIXME?
 }
@@ -264,16 +264,16 @@ int ncvisual_init(int loglevel __attribute__ ((unused))) {
 }
 
 // FIXME would be nice to have OIIO::attributes("libraries") in here
-void ncvisual_printbanner(const notcurses* nc __attribute__ ((unused))){
+void oiio_printbanner(const notcurses* nc __attribute__ ((unused))){
   printf("  openimageio %s\n", OIIO_VERSION_STRING);
 }
 
 const static ncvisual_implementation oiio_impl = {
-  .ncvisual_printbanner = ncvisual_printbanner,
+  .ncvisual_printbanner = oiio_printbanner,
   .ncvisual_blit = oiio_blit,
-  .ncvisual_create = ncvisual_create,
-  .ncvisual_details_seed = ncvisual_details_seed,
-  .ncvisual_details_destroy = ncvisual_details_destroy,
+  .ncvisual_create = oiio_create,
+  .ncvisual_details_seed = oiio_details_seed,
+  .ncvisual_details_destroy = oiio_details_destroy,
   .canopen_images = true,
   .canopen_videos = false,
 };

--- a/src/media/oiio.cpp
+++ b/src/media/oiio.cpp
@@ -274,7 +274,6 @@ const static ncvisual_implementation oiio_impl = {
   .ncvisual_create = ncvisual_create,
   .ncvisual_details_seed = ncvisual_details_seed,
   .ncvisual_details_destroy = ncvisual_details_destroy,
-  .ncvisual_decode = oiio_decode,
   .canopen_images = true,
   .canopen_videos = false,
 };

--- a/src/media/shim.c
+++ b/src/media/shim.c
@@ -1,0 +1,10 @@
+#include "notcurses/direct.h"
+#include "internal.h"
+
+ncdirect* ncdirect_init(const char* termtype, FILE* outfp, uint64_t flags){
+  return ncdirect_core_init(termtype, outfp, flags);
+}
+
+notcurses* notcurses_init(const notcurses_options* opts, FILE* outfp){
+  return notcurses_core_init(opts, outfp);
+}

--- a/src/poc/cjkscroll.c
+++ b/src/poc/cjkscroll.c
@@ -7,7 +7,7 @@ int main(void){
   notcurses_options nopts = {
     .flags = NCOPTION_INHIBIT_SETLOCALE,
   };
-  struct notcurses* nc = notcurses_init(&nopts, NULL);
+  struct notcurses* nc = notcurses_core_init(&nopts, NULL);
   if(nc == NULL){
     return EXIT_FAILURE;
   }

--- a/src/poc/direct-input.c
+++ b/src/poc/direct-input.c
@@ -4,7 +4,7 @@
 #include <notcurses/direct.h>
 
 int main(void){
-  struct ncdirect* n = ncdirect_init(NULL, NULL, 0);
+  struct ncdirect* n = ncdirect_core_init(NULL, NULL, 0);
   if(n == NULL){
     return EXIT_FAILURE;
   }

--- a/src/poc/direct.c
+++ b/src/poc/direct.c
@@ -14,7 +14,7 @@ int main(void){
     return EXIT_FAILURE;
   }
   struct ncdirect* n; // see bug #391
-  if((n = ncdirect_init(NULL, NULL, 0)) == NULL){
+  if((n = ncdirect_core_init(NULL, NULL, 0)) == NULL){
     return EXIT_FAILURE;
   }
   int dimy = ncdirect_dim_y(n);

--- a/src/poc/dirgb.c
+++ b/src/poc/dirgb.c
@@ -56,7 +56,7 @@ int main(void){
   if(!setlocale(LC_ALL, "")){
     return EXIT_FAILURE;
   }
-  struct ncdirect* nc = ncdirect_init(NULL, stdout, 0);
+  struct ncdirect* nc = ncdirect_core_init(NULL, stdout, 0);
   if(!nc){
     return EXIT_FAILURE;
   }

--- a/src/poc/dirlines.c
+++ b/src/poc/dirlines.c
@@ -6,7 +6,7 @@ int main(void){
   if(!setlocale(LC_ALL, "")){
     return EXIT_FAILURE;
   }
-  struct ncdirect* n = ncdirect_init(NULL, stdout, 0);
+  struct ncdirect* n = ncdirect_core_init(NULL, stdout, 0);
   putchar('\n');
   for(int i = 0 ; i < 15 ; ++i){
     uint64_t c1 = 0, c2 = 0;

--- a/src/poc/fileroller.c
+++ b/src/poc/fileroller.c
@@ -45,7 +45,7 @@ int main(int argc, char** argv){
     .flags = NCOPTION_INHIBIT_SETLOCALE |
               NCOPTION_SUPPRESS_BANNERS,
   };
-  struct notcurses* nc = notcurses_init(&opts, NULL);
+  struct notcurses* nc = notcurses_core_init(&opts, NULL);
   struct ncplane* n = notcurses_stdplane(nc);
   ncplane_set_scrolling(n, true);
   while(*++argv){

--- a/src/poc/gradients.c
+++ b/src/poc/gradients.c
@@ -72,7 +72,7 @@ int main(void){
   struct notcurses_options opts = {
     .flags = NCOPTION_INHIBIT_SETLOCALE,
   };
-  struct notcurses* nc = notcurses_init(&opts, NULL);
+  struct notcurses* nc = notcurses_core_init(&opts, NULL);
   if(nc == NULL){
     return EXIT_FAILURE;
   }

--- a/src/poc/kittyzapper.c
+++ b/src/poc/kittyzapper.c
@@ -1,7 +1,7 @@
 #include <notcurses/direct.h>
 
 int main(void){
-  struct ncdirect* n = ncdirect_init(NULL, NULL, 0);
+  struct ncdirect* n = ncdirect_core_init(NULL, NULL, 0);
   if(!n){
     return EXIT_FAILURE;
   }

--- a/src/poc/menu.c
+++ b/src/poc/menu.c
@@ -66,7 +66,7 @@ int main(void){
   notcurses_options opts = {
     .flags = NCOPTION_INHIBIT_SETLOCALE,
   };
-  struct notcurses* nc = notcurses_init(&opts, NULL);
+  struct notcurses* nc = notcurses_core_init(&opts, NULL);
   if(nc == NULL){
     return EXIT_FAILURE;
   }

--- a/src/poc/pixels.c
+++ b/src/poc/pixels.c
@@ -11,7 +11,7 @@ int main(void){
     .tv_sec = 1,
     .tv_nsec = 500000000,
   };
-  struct notcurses* nc = notcurses_init(&opts, NULL);
+  struct notcurses* nc = notcurses_core_init(&opts, NULL);
   int dimy, dimx;
   struct ncplane* std = notcurses_stddim_yx(nc, &dimy, &dimx);
   struct ncvisual* ncv = ncvisual_from_plane(std, NCBLIT_2x1, 0, 0, dimy / 2, dimx / 2);

--- a/src/poc/procroller.c
+++ b/src/poc/procroller.c
@@ -46,7 +46,7 @@ int main(int argc, char** argv){
     .flags = NCOPTION_INHIBIT_SETLOCALE |
               NCOPTION_SUPPRESS_BANNERS,
   };
-  struct notcurses* nc = notcurses_init(&opts, NULL);
+  struct notcurses* nc = notcurses_core_init(&opts, NULL);
   if(nc == NULL){
     return EXIT_FAILURE;
   }

--- a/src/poc/progbar.c
+++ b/src/poc/progbar.c
@@ -110,7 +110,7 @@ pbar_make(struct notcurses* nc, uint64_t flags){
 }
 
 int main(void){
-  struct notcurses* nc = notcurses_init(NULL, NULL);
+  struct notcurses* nc = notcurses_core_init(NULL, NULL);
   if(nc == NULL){
     return EXIT_FAILURE;
   }

--- a/src/poc/rgb.c
+++ b/src/poc/rgb.c
@@ -11,7 +11,7 @@ int main(void){
   struct notcurses_options opts = {
     .flags = NCOPTION_INHIBIT_SETLOCALE | NCOPTION_NO_ALTERNATE_SCREEN,
   };
-  struct notcurses* nc = notcurses_init(&opts, NULL);
+  struct notcurses* nc = notcurses_core_init(&opts, NULL);
   if(nc == NULL){
     return EXIT_FAILURE;
   }

--- a/src/poc/rtl.c
+++ b/src/poc/rtl.c
@@ -5,7 +5,7 @@ int main(void){
   struct notcurses_options opts = {
     .flags = NCOPTION_NO_ALTERNATE_SCREEN,
   };
-  struct notcurses* nc = notcurses_init(&opts, NULL);
+  struct notcurses* nc = notcurses_core_init(&opts, NULL);
   if(!nc){
     return EXIT_FAILURE;
   }

--- a/src/poc/scroll.c
+++ b/src/poc/scroll.c
@@ -7,7 +7,7 @@ int main(void){
   struct notcurses_options opts = {
     .flags = NCOPTION_INHIBIT_SETLOCALE,
   };
-  struct notcurses* nc = notcurses_init(&opts, NULL);
+  struct notcurses* nc = notcurses_core_init(&opts, NULL);
   if(nc == NULL){
     return EXIT_FAILURE;
   }

--- a/src/poc/sgr-direct.c
+++ b/src/poc/sgr-direct.c
@@ -8,7 +8,7 @@ int main(void){
   if(!setlocale(LC_ALL, "")){
     return EXIT_FAILURE;
   }
-  struct ncdirect* nc = ncdirect_init(NULL, stdout, 0);
+  struct ncdirect* nc = ncdirect_core_init(NULL, stdout, 0);
   if(!nc){
     return EXIT_FAILURE;
   }

--- a/src/poc/sgr-full.c
+++ b/src/poc/sgr-full.c
@@ -6,7 +6,7 @@ int main(void){
   struct notcurses_options nopts = {
     .flags = NCOPTION_NO_ALTERNATE_SCREEN,
   };
-  struct notcurses* nc = notcurses_init(&nopts, NULL);
+  struct notcurses* nc = notcurses_core_init(&nopts, NULL);
   if(nc == NULL){
     return EXIT_FAILURE;
   }

--- a/src/poc/zalgo.c
+++ b/src/poc/zalgo.c
@@ -5,7 +5,7 @@ int main(void){
   struct notcurses_options nops = {
     .flags = NCOPTION_NO_ALTERNATE_SCREEN,
   };
-  struct notcurses* nc = notcurses_init(&nops, NULL);
+  struct notcurses* nc = notcurses_core_init(&nops, NULL);
   struct ncplane* n = notcurses_stdplane(nc);
   const int y = 10;
   ncplane_putstr_aligned(n, y + 0, NCALIGN_CENTER, "Pack my box with five dozen liquor jugs.");


### PR DESCRIPTION
Add new functions `ncdirect_core_init()` and `notcurses_core_init()`. If linking only against `libnotcurses-core`, these functions ought be used. `ncdirect_init()` and `notcurses_init()` are now shims provided by the media-enable `libnotcurses`, thus neatly solving the problem of `libnotcurses` lacking any symbols called by user code (and thus not being included into binaries, resulting in failures using media). Add full documentation for use of `notcurses-core`. Migrate to `notcurses-core` in all PoCs which can do so. Add new `notcurses_core.3` man page. This is the final form of the library split, I think.