### PR TITLE
Transparent blitter stacking

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: debian-unstable
 
 steps:
 - name: debian-build
-  image: dankamongmen/unstable_builder:2021-01-02a
+  image: dankamongmen/unstable_builder:2021-02-01a
   commands:
     - export LANG=en_US.UTF-8
     - mkdir build
@@ -66,7 +66,7 @@ name: ubuntu-focal
 
 steps:
 - name: ubuntu-build
-  image: dankamongmen/hirsute:2021-01-02a
+  image: dankamongmen/hirsute:2021-02-01a
   commands:
     - export LANG=es_ES.UTF-8
     - mkdir build

--- a/doc/man/man3/notcurses_render.3.md
+++ b/doc/man/man3/notcurses_render.3.md
@@ -121,5 +121,6 @@ purposes of color blending.
 **notcurses_plane(3)**,
 **notcurses_refresh(3)**,
 **notcurses_stats(3)**,
+**notcurses_visual(3)**,
 **console_codes(4)**,
 **utf-8(7)**

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -159,7 +159,39 @@ The different **ncblitter_e** values select from among available glyph sets:
 * **NCBLIT_SIXEL**: Not yet implemented.
 
 **NCBLIT_4x1** and **NCBLIT_8x1** are intended for use with plots, and are
-not really applicable for general visuals.
+not really applicable for general visuals. **NCBLIT_BRAILLE** doesn't tend
+to work out very well for images, but (depending on the font) can be very
+good for plots.
+
+In the absence of scaling, for a given set of pixels, more rows and columns in
+the blitter will result in a smaller output image. An image rendered with
+**NCBLIT_1x1** will be twice as tall as the same image rendered with
+**NCBLIT_2x1**, which will be twice as wide as the same image rendered with
+**NCBLIT_2x2**. The same image rendered with **NCBLIT_3x2** will be one-third
+as tall and one-half as wide as the original **NCBLIT_1x1** render (again, this
+depends on **NCSCALE_NONE**). If the output size is held constant (using for
+instance **NCSCALE_SCALE_HIRES** and a large image), more rows and columns will
+result in more effective resolution.
+
+Assuming a cell is twice as tall as it is wide, **NCBLIT_1x1** (and indeed
+any NxN blitter) will stretch an image by a factor of 2 in the vertical
+dimension. **NCBLIT_2x1** will not distort the image whatsoever, as it maps a
+vector two pixels high and one pixel wide to a single cell. **NCBLIT_3x2** will
+stretch an image by a factor of 1.5.
+
+The cell's dimension in pixels is ideally evenly divisible by the blitter
+geometry. If **NCBLIT_3x2** is used together with a cell 8 pixels wide and
+14 pixels tall, two of the vertical segments will be 5 pixels tall, while one
+will be 4 pixels tall. Such unequal distributions are more likely with larger
+blitter geometries. Likewise, there are only ever two colors available to us in
+a given cell. **NCBLIT_1x1** and **NCBLIT_2x2** can be perfectly represented
+with two colors per cell. Blitters of higher geometry are increasingly likely
+to require some degree of interpolation. Transparency is always honored with
+complete fidelity.
+
+Finally, rendering operates slightly differently when two planes have both been
+blitted, and one lies atop the other. See **notcurses_render(3)** for more
+information.
 
 # RETURN VALUES
 
@@ -210,11 +242,14 @@ radians for **rads**, but this will change soon.
 among terminals.
 
 Bad font support can ruin **NCBLIT_2x2**, **NCBLIT_3x2**, **NCBLIT_4x1**,
-**NCBLIT_BRAILLE**, and **NCBLIT_8x1**.
+**NCBLIT_BRAILLE**, and **NCBLIT_8x1**. Braille glyphs ought ideally draw only
+the raised dots, rather than drawing all eight dots with two different styles.
+It's often best for the emulator to draw these glyphs itself.
 
 # SEE ALSO
 
 **notcurses(3)**,
 **notcurses_capabilities(3)**,
 **notcurses_plane(3)**,
+**notcurses_render(3)**,
 **utf-8(7)**

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -591,20 +591,20 @@ typedef struct nccell {
   // can be determined by checking whether ->gcluster is zero.
   uint8_t width;              // 1B → 6B (8 bits of EGC column width)
   uint16_t stylemask;         // 2B → 8B (16 bits of NCSTYLE_* attributes)
-  // (channels & 0x8000000000000000ull): reserved, must be 0
+  // (channels & 0x8000000000000000ull): blitted to upper-left quadrant
   // (channels & 0x4000000000000000ull): foreground is *not* "default color"
   // (channels & 0x3000000000000000ull): foreground alpha (2 bits)
   // (channels & 0x0800000000000000ull): foreground uses palette index
-  // (channels & 0x0400000000000000ull): entirely foreground (used for optimization in rasterization)
-  // (channels & 0x0300000000000000ull): reserved, must be 0
-  // (channels & 0x00ffffff00000000ull): foreground in 3x8 RGB (rrggbb)
+  // (channels & 0x0400000000000000ull): blitted to upper-right quadrant
+  // (channels & 0x0200000000000000ull): blitted to lower-left quadrant
+  // (channels & 0x0100000000000000ull): blitted to lower-right quadrant
+  // (channels & 0x00ffffff00000000ull): foreground in 3x8 RGB (rrggbb) / pindex
   // (channels & 0x0000000080000000ull): reserved, must be 0
   // (channels & 0x0000000040000000ull): background is *not* "default color"
   // (channels & 0x0000000030000000ull): background alpha (2 bits)
   // (channels & 0x0000000008000000ull): background uses palette index
-  // (channels & 0x0000000004000000ull): drawn by ncvisual (used to trigger blitter stacking)
-  // (channels & 0x0000000003000000ull): reserved, must be 0
-  // (channels & 0x0000000000ffffffull): background in 3x8 RGB (rrggbb)
+  // (channels & 0x0000000007000000ull): reserved, must be 0
+  // (channels & 0x0000000000ffffffull): background in 3x8 RGB (rrggbb) / pindex
   // At render time, these 24-bit values are quantized down to terminal
   // capabilities, if necessary. There's a clear path to 10-bit support should
   // we one day need it, but keep things cagey for now. "default color" is

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -15,7 +15,7 @@
 #include <stdbool.h>
 // take host byte order and turn it into network (reverse on LE, no-op on BE),
 // then reverse that, guaranteeing LE. htole(x) == ltohe(x).
-#ifdef __linux__
+#if defined(__linux__) || defined(__gnu_hurd__)
 #include <byteswap.h>
 #define htole(x) (bswap_32(htonl(x)))
 #else

--- a/rust/src/bindings.rs
+++ b/rust/src/bindings.rs
@@ -54,7 +54,6 @@ pub use ffi::{
 // CELL_FG_ALPHA_MASK,
 // CELL_FG_PALETTE,
 // CELL_FG_RGB_MASK,
-// CELL_NOBACKGROUND_MASK,
 
 #[doc(inline)]
 pub use ffi::{

--- a/rust/src/cells/mod.rs
+++ b/rust/src/cells/mod.rs
@@ -279,11 +279,6 @@ pub const NCCELL_FG_PALETTE: u64 = crate::bindings::ffi::CELL_FG_PALETTE;
 /// NOTE: When working with a single [`NcChannel`] use [`NCCELL_BG_RGB_MASK`];
 pub const NCCELL_FG_RGB_MASK: u64 = crate::bindings::ffi::CELL_FG_RGB_MASK;
 
-/// Indicates the glyph is entirely foreground
-///
-/// See the detailed diagram at [`NcChannelPair`][crate::NcChannelPair]
-pub const NCCELL_NOBACKGROUND_MASK: u64 = crate::bindings::ffi::CELL_NOBACKGROUND_MASK;
-
 // NcEgc
 //
 /// Extended Grapheme Cluster. A 32-bit [`char`]-like type

--- a/rust/src/channel/mod.rs
+++ b/rust/src/channel/mod.rs
@@ -191,7 +191,6 @@ pub type NcAlphaBits = u32;
 /// - [`NCCELL_FG_ALPHA_MASK`][crate::NCCELL_FG_ALPHA_MASK]
 /// - [`NCCELL_FG_PALETTE`][crate::NCCELL_FG_PALETTE]
 /// - [`NCCELL_FG_RGB_MASK`][crate::NCCELL_FG_RGB_MASK]
-/// - [`NCCELL_NOBACKGROUND_MASK`][crate::NCCELL_NOBACKGROUND_MASK]
 ///
 pub type NcChannelPair = u64;
 

--- a/src/demo/intro.c
+++ b/src/demo/intro.c
@@ -124,11 +124,16 @@ int intro(struct notcurses* nc){
     }
   }
   ncplane_off_styles(ncp, NCSTYLE_BOLD);
-  const wchar_t wstr[] = L"▏▁ ▂ ▃ ▄ ▅ ▆ ▇ █ █ ▇ ▆ ▅ ▄ ▃ ▂ ▁▕";
-  if(ncplane_putwstr_aligned(ncp, rows / 2 - 6, NCALIGN_CENTER, wstr) < 0){
+  const wchar_t nwstr[] = L"▏▁ ▂ ▃ ▄ ▅ ▆ ▇ █ █ ▇ ▆ ▅ ▄ ▃ ▂ ▁▕";
+  if(ncplane_putwstr_aligned(ncp, rows / 2 - 6, NCALIGN_CENTER, nwstr) < 0){
     return -1;
   }
-  const wchar_t iwstr[] = L"▏█ ▇ ▆ ▅ ▄ ▃ ▂ ▁ ▁ ▂ ▃ ▄ ▅ ▆ ▇ █▕";
+  const wchar_t* iwstr;
+  if(notcurses_cansextant(nc)){
+    iwstr = L"▏▔ 🮂 🮃 ▀ 🮄 🮅 🮆 █ █ 🮆 🮅 🮄 ▀ 🮃 🮂 ▔▕";
+  }else{
+    iwstr = L"▏█ ▇ ▆ ▅ ▄ ▃ ▂ ▁ ▁ ▂ ▃ ▄ ▅ ▆ ▇ █▕";
+  }
   if(ncplane_putwstr_aligned(ncp, rows / 2 + 1, NCALIGN_CENTER, iwstr) < 0){
     return -1;
   }

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -128,13 +128,14 @@ tria_blit(ncplane* nc, int placey, int placex, int linesize,
         if(ffmpeg_trans_p(rgbbase_up[3]) && ffmpeg_trans_p(rgbbase_down[3])){
           cell_set_fg_alpha(c, CELL_ALPHA_TRANSPARENT);
         }else if(ffmpeg_trans_p(rgbbase_up[3])){ // down has the color
-          if(cell_load(nc, c, "\u2584") <= 0){ // lower half block
+          if(pool_blit_direct(&nc->pool, c, "\u2584", strlen("\u2584"), 1) <= 0){
             return -1;
           }
           cell_set_fg_rgb8(c, rgbbase_down[0], rgbbase_down[1], rgbbase_down[2]);
           ++total;
         }else{ // up has the color
-          if(cell_load(nc, c, "\u2580") <= 0){ // upper half block
+          // upper half block
+          if(pool_blit_direct(&nc->pool, c, "\u2580", strlen("\u2580"), 1) <= 0){
             return -1;
           }
           cell_set_fg_rgb8(c, rgbbase_up[0], rgbbase_up[1], rgbbase_up[2]);
@@ -144,13 +145,13 @@ tria_blit(ncplane* nc, int placey, int placex, int linesize,
         if(memcmp(rgbbase_up, rgbbase_down, 3) == 0){
           cell_set_fg_rgb8(c, rgbbase_down[0], rgbbase_down[1], rgbbase_down[2]);
           cell_set_bg_rgb8(c, rgbbase_down[0], rgbbase_down[1], rgbbase_down[2]);
-          if(cell_load(nc, c, " ") <= 0){ // only need the background
+          if(pool_blit_direct(&nc->pool, c, " ", 1, 1) <= 0){
             return -1;
           }
         }else{
           cell_set_fg_rgb8(c, rgbbase_up[0], rgbbase_up[1], rgbbase_up[2]);
           cell_set_bg_rgb8(c, rgbbase_down[0], rgbbase_down[1], rgbbase_down[2]);
-          if(cell_load(nc, c, "\u2580") <= 0){ // upper half block
+          if(pool_blit_direct(&nc->pool, c, "\u2580", strlen("\u2580"), 1) <= 0){
             return -1;
           }
         }

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -391,6 +391,7 @@ qtrans_check(nccell* c, bool blendcolors,
   }else if(blendcolors){
     cell_set_fg_alpha(c, CELL_ALPHA_BLEND);
   }
+//fprintf(stderr, "QBQ: 0x%x\n", cell_blittedquadrants(c));
   return egc;
 }
 
@@ -610,6 +611,7 @@ sex_trans_check(cell* c, const uint32_t rgbas[6], bool blendcolors){
     cell_set_blitquadrants(c, !(transstring & 5u), !(transstring & 10u),
                               !(transstring & 20u), !(transstring & 40u));
   }
+//fprintf(stderr, "SEX-BQ: 0x%x\n", cell_blittedquadrants(c));
   return egc;
 }
 

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -125,6 +125,7 @@ tria_blit(ncplane* nc, int placey, int placex, int linesize,
       }
       if(ffmpeg_trans_p(rgbbase_up[3]) || ffmpeg_trans_p(rgbbase_down[3])){
         cell_set_bg_alpha(c, CELL_ALPHA_TRANSPARENT);
+        cell_set_blitted(c);
         if(ffmpeg_trans_p(rgbbase_up[3]) && ffmpeg_trans_p(rgbbase_down[3])){
           cell_set_fg_alpha(c, CELL_ALPHA_TRANSPARENT);
         }else if(ffmpeg_trans_p(rgbbase_up[3])){ // down has the color
@@ -433,6 +434,8 @@ quadrant_blit(ncplane* nc, int placey, int placex, int linesize,
           cell_set_bg_alpha(c, CELL_ALPHA_BLEND);
           cell_set_fg_alpha(c, CELL_ALPHA_BLEND);
         }
+      }else{
+        cell_set_blitted(c);
       }
       if(*egc){
         if(pool_blit_direct(&nc->pool, c, egc, strlen(egc), 1) <= 0){
@@ -632,6 +635,8 @@ sextant_blit(ncplane* nc, int placey, int placex, int linesize,
       const char* egc = sex_trans_check(rgbas, &c->channels, blendcolors);
       if(egc == NULL){
         egc = sex_solver(rgbas, &c->channels, blendcolors);
+      }else{
+        cell_set_blitted(c);
       }
 //fprintf(stderr, "sex EGC: %s channels: %016lx\n", egc, c->channels);
       if(*egc){

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -852,11 +852,15 @@ cell_nobackground_p(const nccell* c){
   return (c->channels & CELL_NOBACKGROUND_MASK) == CELL_NOBACKGROUND_MASK;
 }
 
-// True iff the cell was blitted as part of an ncvisual, and has a transparent
-// background (being the only case where CELL_BLITTERSTACK_MASK bits are set).
-static inline bool
-cell_blitted_p(const nccell* c){
-  return c->channels & CELL_BLITTERSTACK_MASK; // any of the four bits is fine
+// Returns a number 0 <= n <= 15 representing the four quadrants, and which (if
+// any) are occupied due to blitting with a transparent background. The mapping
+// is {tl, tr, bl, br}.
+static inline unsigned
+cell_blittedquadrants(const nccell* c){
+  return ((c->channels & 0x8000000000000000ull) ? 1 : 0) |
+         ((c->channels & 0x0400000000000000ull) ? 2 : 0) |
+         ((c->channels & 0x0200000000000000ull) ? 4 : 0) |
+         ((c->channels & 0x0100000000000000ull) ? 8 : 0);
 }
 
 // Set this whenever blitting an ncvisual, when we have a transparent
@@ -866,10 +870,10 @@ static inline void
 cell_set_blitquadrants(nccell* c, unsigned tl, unsigned tr, unsigned bl, unsigned br){
   // FIXME want a static assert that these four constants OR together to
   // equal CELL_BLITTERSTACK_MASK, bah
-  c->channels |= tl ? 0x8000000000000000ull : 0;
-  c->channels |= tr ? 0x0400000000000000ull : 0;
-  c->channels |= bl ? 0x0200000000000000ull : 0;
-  c->channels |= br ? 0x0100000000000000ull : 0;
+  c->channels |= (tl ? 0x8000000000000000ull : 0);
+  c->channels |= (tr ? 0x0400000000000000ull : 0);
+  c->channels |= (bl ? 0x0200000000000000ull : 0);
+  c->channels |= (br ? 0x0100000000000000ull : 0);
 }
 
 // Destroy a plane and all its bound descendants.

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -312,7 +312,8 @@ paint(const ncplane* p, struct crender* rvec, int dstleny, int dstlenx,
       // Evaluate the background first, in case we have HIGHCONTRAST fg text.
       if(cell_bg_alpha(targc) > CELL_ALPHA_OPAQUE){
         const nccell* vis = &p->fb[nfbcellidx(p, y, x)];
-        if(!((!crender->s.blittedquads) & cell_blittedquadrants(vis))){
+//fprintf(stderr, "y/x: %d/%d crenderbq: 0x%x visbq: 0x%x\n", y, x, crender->s.blittedquads, cell_blittedquadrants(vis));
+        if(!((~crender->s.blittedquads) & cell_blittedquadrants(vis))){
           if(cell_bg_default_p(vis)){
             vis = &p->basecell;
           }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -334,6 +334,7 @@ paint(const ncplane* p, struct crender* rvec, int dstleny, int dstlenx,
         // if the following is true, we're a real glyph, and not the right-hand
         // side of a wide glyph (nor the null codepoint).
         if( (targc->gcluster = vis->gcluster) ){ // index copy only
+          crender->blitterstacked = cell_blitted_p(vis);
           // we can't plop down a wide glyph if the next cell is beyond the
           // screen, nor if we're bisected by a higher plane.
           if(cell_double_wide_p(vis)){

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -312,8 +312,11 @@ paint(const ncplane* p, struct crender* rvec, int dstleny, int dstlenx,
       // Evaluate the background first, in case we have HIGHCONTRAST fg text.
       if(cell_bg_alpha(targc) > CELL_ALPHA_OPAQUE){
         const nccell* vis = &p->fb[nfbcellidx(p, y, x)];
-//fprintf(stderr, "y/x: %d/%d crenderbq: 0x%x visbq: 0x%x\n", y, x, crender->s.blittedquads, cell_blittedquadrants(vis));
-        if(!((~crender->s.blittedquads) & cell_blittedquadrants(vis))){
+        // to be on the blitter stacking path, we need
+        //  1) crender->s.blittedquads to be non-zero
+        //  2) cell_blittedquadrants(vis) to be non-zero
+        //  3) somewhere crender is 0, blittedquads is 1
+        if(!crender->s.blittedquads || !((~crender->s.blittedquads) & cell_blittedquadrants(vis))){
           if(cell_bg_default_p(vis)){
             vis = &p->basecell;
           }

--- a/tests/channel.cpp
+++ b/tests/channel.cpp
@@ -1,5 +1,8 @@
 #include "main.h"
 
+// These tests primarily check against expected constant values, which is
+// useful in terms of maintaining ABI, but annoying when they do change.
+
 TEST_CASE("ChannelGetRGB") {
   const struct t {
     uint32_t channel;

--- a/tests/stacking.cpp
+++ b/tests/stacking.cpp
@@ -154,11 +154,9 @@ TEST_CASE("Stacking") {
       .leny = 2, .lenx = 2, .blitter = NCBLIT_2x2, .flags = 0,
     };
     CHECK(top == ncvisual_render(nc_, ncv, &vopts));
-    /*
-cell c = CELL_TRIVIAL_INITIALIZER;
-ncplane_at_yx_cell(top, 0, 0, &c);
-fprintf(stderr, "[[[%s]]] %016lx\n", cell_extended_gcluster(top, &c), c.channels);
-*/
+//cell c = CELL_TRIVIAL_INITIALIZER;
+//ncplane_at_yx_cell(top, 0, 0, &c);
+//fprintf(stderr, "[[[%s]]] %016lx\n", cell_extended_gcluster(top, &c), c.channels);
     ncvisual_destroy(ncv);
 
     // create an ncvisual of 2 rows, 2 columns, with the tr, bl 0xffffff

--- a/tests/stacking.cpp
+++ b/tests/stacking.cpp
@@ -64,6 +64,43 @@ TEST_CASE("Stacking") {
     ncplane_destroy(top);
   }
 
+  SUBCASE("StackedQuad") {
+    struct ncplane_options opts = {
+      0, 0, 1, 1, nullptr, "top", nullptr, 0,
+    };
+    auto top = ncplane_create(n_, &opts);
+    REQUIRE(nullptr != top);
+    // create an ncvisual of 2 rows, 2 columns, with the top 0xffffff
+    const uint32_t topv[] = {htole(0xffffffff), htole(0xffffffff), htole(0), htole(0)};
+    auto ncv = ncvisual_from_rgba(topv, 2, 8, 2);
+    REQUIRE(nullptr != ncv);
+    struct ncvisual_options vopts = {
+      .n = top, .scaling = NCSCALE_NONE, .y = 0, .x = 0, .begy = 0, .begx = 0,
+      .leny = 2, .lenx = 2, .blitter = NCBLIT_2x2, .flags = 0,
+    };
+    CHECK(top == ncvisual_render(nc_, ncv, &vopts));
+    ncvisual_destroy(ncv);
+
+    // create an ncvisual of 2 rows, 2 columns, with the bottom 0xffffff
+    const uint32_t botv[] = {htole(0), htole(0), htole(0xffffffff), htole(0xffffffff)};
+    ncv = ncvisual_from_rgba(botv, 2, 8, 2);
+    REQUIRE(nullptr != ncv);
+    vopts.n = n_;
+    CHECK(n_ == ncvisual_render(nc_, ncv, &vopts));
+    ncvisual_destroy(ncv);
+
+    CHECK(0 == notcurses_render(nc_));
+    uint64_t channels;
+    auto egc = notcurses_at_yx(nc_, 0, 0, nullptr, &channels);
+    REQUIRE(nullptr != egc);
+    // ought yield space with white background FIXME currently just yields
+    // an upper half block
+    CHECK(0 == strcmp("\u2580", egc));
+    CHECK(0xffffff == channels_fg_rgb(channels));
+    CHECK(0xffffff == channels_bg_rgb(channels));
+    ncplane_destroy(top);
+  }
+
   // common teardown
   CHECK(0 == notcurses_stop(nc_));
 }

--- a/tests/stacking.cpp
+++ b/tests/stacking.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Stacking") {
     ncplane_destroy(top);
   }
 
-  SUBCASE("StackedQuad") {
+  SUBCASE("StackedQuadHalves") {
     struct ncplane_options opts = {
       0, 0, 1, 1, nullptr, "top", nullptr, 0,
     };
@@ -96,6 +96,43 @@ TEST_CASE("Stacking") {
     // ought yield space with white background FIXME currently just yields
     // an upper half block
     CHECK(0 == strcmp("\u2580", egc));
+    CHECK(0xffffff == channels_fg_rgb(channels));
+    CHECK(0xffffff == channels_bg_rgb(channels));
+    ncplane_destroy(top);
+  }
+
+  SUBCASE("StackedQuadCrossed") {
+    struct ncplane_options opts = {
+      0, 0, 1, 1, nullptr, "top", nullptr, 0,
+    };
+    auto top = ncplane_create(n_, &opts);
+    REQUIRE(nullptr != top);
+    // create an ncvisual of 2 rows, 2 columns, with the tl, br 0xffffff
+    const uint32_t topv[] = {htole(0xffffffff), htole(0), htole(0), htole(0xffffffff)};
+    auto ncv = ncvisual_from_rgba(topv, 2, 8, 2);
+    REQUIRE(nullptr != ncv);
+    struct ncvisual_options vopts = {
+      .n = top, .scaling = NCSCALE_NONE, .y = 0, .x = 0, .begy = 0, .begx = 0,
+      .leny = 2, .lenx = 2, .blitter = NCBLIT_2x2, .flags = 0,
+    };
+    CHECK(top == ncvisual_render(nc_, ncv, &vopts));
+    ncvisual_destroy(ncv);
+
+    // create an ncvisual of 2 rows, 2 columns, with the tr, bl 0xffffff
+    const uint32_t botv[] = {htole(0), htole(0xffffffff), htole(0xffffffff), htole(0)};
+    ncv = ncvisual_from_rgba(botv, 2, 8, 2);
+    REQUIRE(nullptr != ncv);
+    vopts.n = n_;
+    CHECK(n_ == ncvisual_render(nc_, ncv, &vopts));
+    ncvisual_destroy(ncv);
+
+    CHECK(0 == notcurses_render(nc_));
+    uint64_t channels;
+    auto egc = notcurses_at_yx(nc_, 0, 0, nullptr, &channels);
+    REQUIRE(nullptr != egc);
+    // ought yield space with white background FIXME currently just yields
+    // an upper half block
+    CHECK(0 == strcmp("\u259a", egc)); // quadrant upper left and lower right
     CHECK(0xffffff == channels_fg_rgb(channels));
     CHECK(0xffffff == channels_bg_rgb(channels));
     ncplane_destroy(top);

--- a/tests/stacking.cpp
+++ b/tests/stacking.cpp
@@ -35,16 +35,16 @@ TEST_CASE("Stacking") {
     REQUIRE(nullptr != top);
     CHECK(0 == ncplane_set_fg_rgb(top, 0xffffff));
     CHECK(0 == ncplane_set_fg_rgb(n_, 0xffffff));
-    CHECK(1 == ncplane_putwc(top, L'\u2580'));
-    CHECK(1 == ncplane_putwc(n_, L'\u2584'));
+    CHECK(1 == ncplane_putwc(top, L'\u2580')); // upper half block
+    CHECK(1 == ncplane_putwc(n_, L'\u2584')); // lower half block
     CHECK(0 == notcurses_render(nc_));
     uint64_t channels;
     auto egc = notcurses_at_yx(nc_, 0, 0, nullptr, &channels);
     REQUIRE(nullptr != egc);
     // ought yield space with white background
-    WARN(0 == strcmp(" ", egc));
-    WARN(0xffffff == channels_fg_rgb(channels));
-    WARN(0xffffff == channels_bg_rgb(channels));
+    CHECK(0 == strcmp(" ", egc));
+    CHECK(0xffffff == channels_fg_rgb(channels));
+    CHECK(0xffffff == channels_bg_rgb(channels));
     ncplane_destroy(top);
   }
 


### PR DESCRIPTION
the basic problem can be stated thus: imagine we have two images, both two pixels tall and one pixel wide. image 1 is
above image 2. image 1 is a transparent pixel and a white pixel. image 2 is a blue pixel and a red pixel. what ought be the output? i'd think a blue pixel atop a white pixel, but the result could have been a red pixel atop a white pixel, because rendering is solved in terms of *foreground and background*, but here we want rendering in terms of *occupied geometry*.

as described at length in #1068 , the solution is to encode occupied area in the `nccell`, using previously-unused bits of the channels. when these bits are in play, render in terms of geometry. careful coding means we only do extra work when affected by this (infrequent) problem, and we require no extra state. there is no measurable delay in `notcurses-demo`.

this was important to fix because it otherwise causes clutter around sprites.

unit tests were added for this problem. they went from failure to success over the course of the fix.

Closes #1068.