### PR TITLE
Add José to Cargo.toml, copy LICENSE #1163

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@
 </p>
 
 birthed screaming into this world by [nick black](https://nick-black.com/dankwiki/index.php/Hack_on) (<nickblack@linux.com>).
-C++ wrappers by [marek habersack](http://twistedcode.net/blog/) (<grendel@twistedcode.net>). the Notcurses API
-is stable as of version 2.0.
+* c++ wrappers by [marek habersack](http://twistedcode.net/blog/) (<grendel@twistedcode.net>)
+* rust wrappers by José Luis Cruz (<joseluis@andamira.net>)
+* python wrappers by igo95862 (<igo95862@yandex.ru>)
 
 for more information, see [dankwiki](https://nick-black.com/dankwiki/index.php/Notcurses)
 and the [man pages](https://notcurses.com/notcurses). there's also a reference

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "libnotcurses-sys"
 version = "2.1.7"
-authors = ["nick black <dankamongmen@gmail.com>"]
+authors = [
+    "nick black <dankamongmen@gmail.com>",
+		"José Luis Cruz <joseluis@andamira.net>"
+]
 license = "Apache-2.0"
 edition = "2018"
 description = "Low-level Rust bindings for the notcurses C library."


### PR DESCRIPTION
* Fedora requires the license to be present in the source archive. Since the rust package is built from the crate and not the greater notcurses tarball, this means copying `LICENSE` into `rust/`. See #1163 
* Add José Luis Cruz to `Authors`; this code is surely more his now than mine.
* Add @joseluis and @igo95862 to `README.md`, and break out wrappers into a list