### PR TITLE
[C++] API sync

### DIFF
--- a/include/ncpp/NotCurses.hh
+++ b/include/ncpp/NotCurses.hh
@@ -121,6 +121,11 @@ namespace ncpp
 
 		bool stop ();
 
+		bool can_sextant () const noexcept
+		{
+			return notcurses_cansextant (nc);
+		}
+
 		bool can_utf8 () const noexcept
 		{
 			return notcurses_canutf8 (nc);
@@ -281,6 +286,16 @@ namespace ncpp
 		bool align (int availcols, ncalign_e align, int cols) const NOEXCEPT_MAYBE
 		{
 			return error_guard (notcurses_align (availcols, align, cols), -INT_MAX);
+		}
+
+		bool linesigs_enable () const NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_linesigs_enable (nc), -1);
+		}
+
+		bool linesigs_disable () const NOEXCEPT_MAYBE
+		{
+			return error_guard (notcurses_linesigs_disable (nc), -1);
 		}
 
 		ncstats* stats_alloc () const noexcept

--- a/include/ncpp/Pile.hh
+++ b/include/ncpp/Pile.hh
@@ -52,6 +52,26 @@ namespace ncpp
 
 			return rasterize ();
 		}
+
+		static Plane* top_with (const Plane& plane) noexcept
+		{
+			ncplane* ret = ncpile_top (const_cast<Plane&>(plane));
+			if (ret == nullptr) {
+				return nullptr;
+			}
+
+			return map_plane (ret);
+		}
+
+		static Plane* bottom_with (const Plane& plane) noexcept
+		{
+			ncplane* ret = ncpile_bottom (const_cast<Plane&>(plane));
+			if (ret == nullptr) {
+				return nullptr;
+			}
+
+			return map_plane (ret);
+		}
 	};
 }
 #endif

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -179,6 +179,11 @@ namespace ncpp
 			return plane;
 		}
 
+		bool resize_maximize () const NOEXCEPT_MAYBE
+		{
+			return error_guard (ncplane_resize_maximize (plane), -1);
+		}
+
 		bool resize_realign () const NOEXCEPT_MAYBE
 		{
 			return error_guard (ncplane_resize_realign (plane), -1);
@@ -281,6 +286,16 @@ namespace ncpp
 			ncplane_erase (plane);
 		}
 
+		int get_abs_x () const noexcept
+		{
+			return ncplane_abs_x (plane);
+		}
+
+		int get_abs_y () const noexcept
+		{
+			return ncplane_abs_y (plane);
+		}
+
 		int get_x () const noexcept
 		{
 			return ncplane_x (plane);
@@ -314,6 +329,11 @@ namespace ncpp
 		int get_dim_y () const noexcept
 		{
 			return ncplane_dim_y (plane);
+		}
+
+		void get_abs_yx (int* y, int* x) const noexcept
+		{
+			ncplane_abs_yx (plane, y, x);
 		}
 
 		void get_yx (int *y, int *x) const noexcept
@@ -964,13 +984,12 @@ namespace ncpp
 			return error_guard_cond<bool, bool> (ret, ret);
 		}
 
-		bool at_cursor (Cell &c) const NOEXCEPT_MAYBE
+		int at_cursor (Cell &c) const NOEXCEPT_MAYBE
 		{
-			bool ret = ncplane_at_cursor_cell (plane, c) < 0;
-			return error_guard_cond<bool, bool> (ret, ret);
+			return error_guard<int>(ncplane_at_cursor_cell (plane, c), -1);
 		}
 
-		bool at_cursor (Cell *c) const noexcept
+		int at_cursor (Cell *c) const noexcept
 		{
 			if (c == nullptr)
 				return false;
@@ -1033,6 +1052,12 @@ namespace ncpp
 
 		// Some Cell APIs go here since they act on individual panels even though it may seem weird at points (e.g.
 		// release)
+
+		int load_egc32 (Cell &cell, uint32_t egc) const NOEXCEPT_MAYBE
+		{
+			int ret = cell_load_egc32 (plane, cell, egc);
+			return error_guard_cond<int> (ret, ret != 1);
+		}
 
 		int load (Cell &cell, const char *gcluster) const NOEXCEPT_MAYBE
 		{
@@ -1139,7 +1164,7 @@ namespace ncpp
 			ncplane_translate (src.plane, dst.plane, y, x);
 		}
 
-		bool translate_abs (int *y = nullptr, int *x = nullptr) const noexcept
+		bool translate_abs (int *y = nullptr, int *x = nullptr) const NOEXCEPT_MAYBE
 		{
 			return error_guard<bool, bool> (ncplane_translate_abs (plane, y, x), false);
 		}
@@ -1192,6 +1217,11 @@ namespace ncpp
 		{
 			int ret = ncplane_qrcode (plane, blitter, ymax, xmax, data, len);
 			return error_guard_cond<int> (ret, ret < 0);
+		}
+
+		bool is_descendant_of (const Plane& ancestor) const noexcept
+		{
+			return ncplane_descendant_p (plane, ancestor) != 0;
 		}
 
 		bool is_fg_default () const noexcept

--- a/include/ncpp/Progbar.hh
+++ b/include/ncpp/Progbar.hh
@@ -1,0 +1,60 @@
+#ifndef __NCPP_PROGBAR_HH
+#define __NCPP_PROGBAR_HH
+
+#include <exception>
+#include <notcurses/notcurses.h>
+
+#include "NotCurses.hh"
+#include "Plane.hh"
+
+namespace ncpp
+{
+	class NCPP_API_EXPORT Progbar : public Root
+	{
+	public:
+		Progbar (Plane& n, const ncprogbar_options* opts)
+			: Root (nullptr)
+		{
+			if (opts == nullptr) {
+				throw invalid_argument ("Argument 'opts' must be a valid pointer");
+			}
+
+			progbar = ncprogbar_create (n, opts);
+			if (progbar == nullptr) {
+				throw init_error ("Notcurses failed to create ncprogbar");
+			}
+		}
+
+		~Progbar ()
+		{
+			if (!is_notcurses_stopped ()) {
+				ncprogbar_destroy (progbar);
+			}
+		}
+
+		Plane* get_plane () const noexcept
+		{
+			ncplane *ret = ncprogbar_plane (progbar);
+			if (ret == nullptr) {
+				return nullptr;
+			}
+
+			return Plane::map_plane (ret);
+		}
+
+		void set_progress (double p) const noexcept
+		{
+			ncprogbar_set_progress (progbar, p);
+		}
+
+		double get_progress () const noexcept
+		{
+			return ncprogbar_progress (progbar);
+		}
+
+	private:
+		ncprogbar *progbar = nullptr;
+	};
+}
+
+#endif // __NCPP_PROGBAR_HH

--- a/src/pocpp/ncpp_build.cpp
+++ b/src/pocpp/ncpp_build.cpp
@@ -19,6 +19,7 @@
 #include <ncpp/Plot.hh>
 #include <ncpp/FDPlane.hh>
 #include <ncpp/Subproc.hh>
+#include <ncpp/Progbar.hh>
 
 using namespace ncpp;
 

--- a/src/pocpp/ncpp_build_exceptions.cpp
+++ b/src/pocpp/ncpp_build_exceptions.cpp
@@ -20,6 +20,7 @@
 #include <ncpp/Plot.hh>
 #include <ncpp/FDPlane.hh>
 #include <ncpp/Subproc.hh>
+#include <ncpp/Progbar.hh>
 
 using namespace ncpp;
 


### PR DESCRIPTION
After a long delay, apologies :)

Added:
  * NotCurses: `can_sextant` (`notcurses_cansextant`)
  * Notcurses: `linesigs_enable` (`notcurses_linesigs_enable`)
  * Notcurses: `linesigs_disable` (`notcurses_linesigs_disable`)
  * Pile: `top_with` (`ncpile_top`)
  * Pile: `bottom_with` (`ncpile_bottom`)
  * Plane: `resize_maximize` (`ncplane_resize_maximize`)
  * Plane: `get_abs_x` (`ncplane_abs_x`)
  * Plane: `get_abs_y` (`ncplane_abs_y`)
  * Plane: `get_abs_yx` (`ncplane_abs_yx`)
  * Plane: `load_egc32` (`cell_load_egc32`)
  * Plane: `is_descendant_of` (`ncplane_descendant_p`)
  * Progbar: new class, wraps `ncprogbar_*`

Changed:
  * Plane (ABI break): `at_cursor` overloads now return `int` where
    before they returned `bool` because the underlying Notcurses API
    only signalled the operation status with the return value while now
    it returns actual information.