### PR TITLE
fix some dank typos

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1371,7 +1371,7 @@ DOCSET_PUBLISHER_NAME  = Publisher
 # If the GENERATE_HTMLHELP tag is set to YES then doxygen generates three
 # additional HTML index files: index.hhp, index.hhc, and index.hhk. The
 # index.hhp is a project file that can be read by Microsoft's HTML Help Workshop
-# (see: https://www.microsoft.com/en-us/download/details.aspx?id=2.2.0) on
+# (see: https://www.microsoft.com/en-us/download/details.aspx?id=21138) on
 # Windows.
 #
 # The HTML Help Workshop contains a compiler that can convert all HTML output

--- a/doc/man/man3/notcurses_cell.3.md
+++ b/doc/man/man3/notcurses_cell.3.md
@@ -35,7 +35,7 @@ typedef struct nccell {
 #define CELL_FG_PALETTE         (CELL_BG_PALETTE << 32u)
 #define CHANNEL_ALPHA_MASK      0x30000000ull
 #define CELL_ALPHA_HIGHCONTRAST 0x30000000ull
-#define CELL_ALPHA_TRANSPARENT  0x2.2.0000ull
+#define CELL_ALPHA_TRANSPARENT  0x20000000ull
 #define CELL_ALPHA_BLEND        0x10000000ull
 #define CELL_ALPHA_OPAQUE       0x00000000ull
 ```


### PR DESCRIPTION
Looks like the release process used a regex(?) to replace that included some
unintended targets.  Microsoft link broke in 2.2.0; CELL_ALPHA_TRANSPARENT
continually replaced since 2.0.1.