### PR TITLE
release.sh: no more context-free regexing

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -27,8 +27,9 @@ for i in doc/man/man*/*.md cffi/notcurses-*.md ; do
   sed -i -e "s/% v$OLDVERSION/% v$VERSION/" "$i"
 done
 sed -i -e "s/(v$OLDVERSION)/(v$VERSION)/" doc/man/index.html
-#BUMP="cffi/setup.py rust/Cargo.toml rust/build/build.rs"
-exit
+sed -i -e "s/version=\"$OLDVERSION\"/version=\"$VERSION\"/" cffi/setup.py
+sed -i -e "s/^version = \"$OLDVERSION\"$/version = \"$VERSION\"/" rust/Cargo.toml
+sed -i -e "s/atleast_version(\"$OLDVERSION\")/atleast_version(\"$VERSION\")/" rust/build/build.rs
 
 BUILDDIR="build-$VERSION"
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -16,11 +16,19 @@ vi NEWS.md
 
 git clean -f -d -x
 
-# bump version numbers wherever they occur (wherever we enumerate them, anyway)
-BUMP="CMakeLists.txt doc/Doxyfile doc/man/man*/* doc/man/index.html cffi/setup.py cffi/notcurses-pydemo.1.md rust/Cargo.toml rust/build/build.rs"
-for i in $BUMP ; do
-  sed -i -e "s/$OLDVERSION/$VERSION/g" $i
+# Doing general context-free regexery has led several times to heartache. We
+# thus do tightly-coupled, context-sensitive seds for each class of files.
+# Please don't add version numbers where they're not necessary.
+# FIXME we ought probably verify that there has been an actual change, as these
+#       will surely otherwise go out of date.
+sed -i -e "s/\(project(notcurses VERSION \)$OLDVERSION/\1$VERSION/" CMakeLists.txt
+sed -i -e "s/\(PROJECT_NUMBER *= \)$OLDVERSION/\1$VERSION/" doc/Doxyfile
+for i in doc/man/man*/*.md cffi/notcurses-*.md ; do
+  sed -i -e "s/% v$OLDVERSION/% v$VERSION/" "$i"
 done
+sed -i -e "s/(v$OLDVERSION)/(v$VERSION)/" doc/man/index.html
+#BUMP="cffi/setup.py rust/Cargo.toml rust/build/build.rs"
+exit
 
 BUILDDIR="build-$VERSION"
 


### PR DESCRIPTION
I ought be ashamed for ever having written such carefree code. Replace context-free whole-file `sed`s in `release.sh` with more targeted ones. This still isn't as robust as I'd like it, but it's better than it was.

thanks to @joeyslalom for the inspiration to do this!