### PR TITLE
Get core Sixel encoder working #1378

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -128,8 +128,6 @@ typedef struct rasterstate {
   bool bgpalelidable;
   bool fgdefelidable;
   bool bgdefelidable;
-  // are we in a pixel graphics mode?
-  bool pixelmode;
 } rasterstate;
 
 // Tablets are the toplevel entitites within an ncreel. Each corresponds to

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -97,7 +97,7 @@ extract_data_table(ncplane* nc, const uint32_t* data, int placey, int placex,
         for(int sy = visy ; sy < dimy && sy < visy + 6 ; ++sy){
           const uint32_t* rgb = (const uint32_t*)(data + (linesize * sy) + (visx));
           if(rgba_trans_p(ncpixel_a(*rgb))){
-//fprintf(stderr, "transparent\n");
+fprintf(stderr, "transparent\n");
             continue;
           }
           unsigned char comps[3];
@@ -105,6 +105,8 @@ extract_data_table(ncplane* nc, const uint32_t* data, int placey, int placex,
 //fprintf(stderr, "%d/%d/%d\n", comps[0], comps[1], comps[2]);
           if(memcmp(comps, stab->ctab->table + c * 3, 3) == 0){
             stab->data[c * stab->ctab->sixelcount + pos] |= (1u << (sy - visy));
+fprintf(stderr, "%d ", c * stab->ctab->sixelcount + pos);
+fputc(stab->data[c * stab->ctab->sixelcount + pos] + 63, stderr);
           }
         }
 //fprintf(stderr, "color %d pos %d: %u\n", c, pos, stab->data[c * stab->ctab->sixelcount + pos]);
@@ -127,7 +129,9 @@ write_sixel_data(FILE* fp, int lenx, sixeltable* stab){
     for(int i = 0 ; i < stab->ctab->colors ; ++i){
       fprintf(fp, "#%d", i);
       for(int m = p ; m < stab->ctab->sixelcount && m < p + lenx ; ++m){
-        fputc(stab->data[i * stab->ctab->sixelcount + p] + 63, fp);
+//fprintf(stderr, "%d ", i * stab->ctab->sixelcount + m);
+fputc(stab->data[i * stab->ctab->sixelcount + m] + 63, stderr);
+        fputc(stab->data[i * stab->ctab->sixelcount + m] + 63, fp);
       }
       //if(m < stab->ctab->sixelcount){ // print subband terminator
         if(i + 1 < stab->ctab->colors){


### PR DESCRIPTION
This gets our Sixel encoder engine `sixel_blit()` into some kind of working order. It's not yet integrated with the rest of our model yet, but the plans to do so are coming together. This allows us to spit an image out as pixels to a terminal supporting Sixel, sometimes (try `-s none` and `-k`). This is all still very experimental, but we're on the way =].

[![the root of the problem has been isolated](http://img.youtube.com/vi/UI9vhZycf0Y/0.jpg)](http://www.youtube.com/watch?v=UI9vhZycf0Y "put it on a platter")