### PR TITLE
Pixel geometry #1380

### DIFF
--- a/TERMINALS.md
+++ b/TERMINALS.md
@@ -18,14 +18,14 @@ relies on the font. Patches to correct/complete this table are very welcome!
 | Terminal        | Pixel `TIOCGWINSZ` | `ccc` | Blocks | Recommended environment         | Notes |
 | --------------- | ------------------ | ----- | ------------------------------- | ----- |
 | Alacritty       | ✅                 |  ✅   |❌      |`TERM=alacritty` `COLORTERM=24bit` | |
-| FBterm          |                    |  ?    |?       |`TERM=fbterm`                    | 256 colors, no RGB color. |
+| FBterm          | ❌                 |  ?    |?       |`TERM=fbterm`                    | 256 colors, no RGB color. |
 | Gnome Terminal  |                    |  ❌   |✅      |`TERM=gnome` `COLORTERM=24bit`   | `ccc` support *is* available when run with `vte-256color`. |
 | Guake           |                    |  ?    |?       |                                 | |
 | ITerm2          |                    |  ?    |?       |                                 | |
 | Kitty           | ✅                 |  ✅   |✅      |`TERM=xterm-kitty`               | |
 | kmscon          |                    |  ?    |?       |`TERM=xterm-256color`            | No RGB color AFAICT, nor any distinct terminfo entry. |
 | Konsole         | ❌                 |  ❌   |?       |`TERM=konsole-direct`            | |
-| Linux console   |                    |  ✅   |see [below](#the-linux-console) |`TERM=linux` `COLORTERM=24bit`   | 8 (512 glyph fonts) or 16 (256 glyph fonts) colors max, but RGB values are downsampled to a 256-index palette. See below. |
+| Linux console   | ❌                 |  ✅   |see [below](#the-linux-console) |`TERM=linux` `COLORTERM=24bit`   | 8 (512 glyph fonts) or 16 (256 glyph fonts) colors max, but RGB values are downsampled to a 256-index palette. See below. |
 | mlterm          | ✅                 |  ❌   |?       |`TERM=mlterm-256color`           | Do not set `COLORTERM`. `mlterm-direct` gives strange results. |
 | PuTTY           |                    |  ❌   |❌      |`TERM=putty-256color` `COLORTERM=24bit` | |
 | rxvt            |                    |  ?    |?       |                                 | |

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3411,7 +3411,7 @@ struct blitset {
   const wchar_t* egcs;
   int (*blit)(struct ncplane* n, int placey, int placex, int linesize,
               const void* data, int begy, int begx, int leny, int lenx,
-              bool blendcolors);
+              unsigned blendcolors);
   const char* name;
   bool fill;
 };

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2422,17 +2422,20 @@ API void ncvisual_destroy(struct ncvisual* ncv);
 
 // extract the next frame from an ncvisual. returns 1 on end of file, 0 on
 // success, and -1 on failure.
-API int ncvisual_decode(struct ncvisual* nc);
+API int ncvisual_decode(struct ncvisual* nc)
+  __attribute__ ((nonnull (1)));
 
 // decode the next frame ala ncvisual_decode(), but if we have reached the end,
 // rewind to the first frame of the ncvisual. a subsequent 'ncvisual_render()'
 // will render the first frame, as if the ncvisual had been closed and reopened.
 // the return values remain the same as those of ncvisual_decode().
-API int ncvisual_decode_loop(struct ncvisual* nc);
+API int ncvisual_decode_loop(struct ncvisual* nc)
+  __attribute__ ((nonnull (1)));
 
 // Rotate the visual 'rads' radians. Only M_PI/2 and -M_PI/2 are
 // supported at the moment, but this will change FIXME.
-API int ncvisual_rotate(struct ncvisual* n, double rads);
+API int ncvisual_rotate(struct ncvisual* n, double rads)
+  __attribute__ ((nonnull (1)));
 
 // Resize the visual so that it is 'rows' X 'columns'. This is a lossy
 // transformation, unless the size is unchanged.
@@ -2459,11 +2462,13 @@ API int ncvisual_set_yx(const struct ncvisual* n, int y, int x, uint32_t pixel)
 // the boundaries of the frame. Returns the plane to which we drew (if ncv->n
 // is NULL, a new plane will be created).
 API struct ncplane* ncvisual_render(struct notcurses* nc, struct ncvisual* ncv,
-                                    const struct ncvisual_options* vopts);
+                                    const struct ncvisual_options* vopts)
+  __attribute__ ((nonnull (2)));
 
 // If a subtitle ought be displayed at this time, return a heap-allocated copy
 // of the UTF8 text.
-API ALLOC char* ncvisual_subtitle(const struct ncvisual* ncv);
+API ALLOC char* ncvisual_subtitle(const struct ncvisual* ncv)
+  __attribute__ ((nonnull (1)));
 
 // Called for each frame rendered from 'ncv'. If anything but 0 is returned,
 // the streaming operation ceases immediately, and that value is propagated out.

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -451,13 +451,13 @@ infoplane_notcurses(struct notcurses* nc, const fetched_info* fi, int planeheigh
     ncplane_printf_aligned(infop, 4, NCALIGN_LEFT, " RGB TERM: %s", fi->term);
     nccell c = CELL_CHAR_INITIALIZER('R');
     cell_set_styles(&c, NCSTYLE_BOLD);
-    cell_set_fg_rgb8(&c, 0xd0, 0, 0);
+    cell_set_fg_rgb8(&c, 0xf0, 0xa0, 0xa0);
     ncplane_putc_yx(infop, 4, 1, &c);
     cell_load_char(infop, &c, 'G');
-    cell_set_fg_rgb8(&c, 0, 0xd0, 0);
+    cell_set_fg_rgb8(&c, 0xa0, 0xf0, 0xa0);
     ncplane_putc_yx(infop, 4, 2, &c);
     cell_load_char(infop, &c, 'B');
-    cell_set_fg_rgb8(&c, 0, 0, 0xd);
+    cell_set_fg_rgb8(&c, 0xa0, 0xa0, 0xf0);
     ncplane_putc_yx(infop, 4, 3, &c);
     cell_set_styles(&c, NCSTYLE_NONE);
   }else{

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -559,7 +559,7 @@ neologo_present(struct ncdirect* nc, const char* nlogo){
   }
   free(lines);
   ncdirect_set_fg_rgb(nc, 0xba55d3);
-  if(notcurses_canopen_images(NULL)){
+  if(ncdirect_canopen_images(nc)){
     ncdirect_printf_aligned(nc, -1, NCALIGN_CENTER, "(no image file is known for your distro)");
   }else{
     ncdirect_printf_aligned(nc, -1, NCALIGN_CENTER, "(notcurses was compiled without image support)");
@@ -571,15 +571,16 @@ static void*
 display_thread(void* vmarshal){
   struct marshal* m = vmarshal;
   drawpalette(m->nc);
-  if(notcurses_canopen_images(NULL)){
+  if(ncdirect_canopen_images(m->nc)){
+    ncdirect_check_pixel_support(m->nc);
     if(m->logo){
       if(ncdirect_render_image(m->nc, m->logo, NCALIGN_CENTER,
-                              NCBLIT_DEFAULT, NCSCALE_SCALE_HIRES) == 0){
+                               NCBLIT_PIXEL, NCSCALE_SCALE_HIRES) == 0){
         return NULL;
       }
     }else if(m->dinfo && m->dinfo->logofile){
       if(ncdirect_render_image(m->nc, m->dinfo->logofile, NCALIGN_CENTER,
-                              NCBLIT_DEFAULT, NCSCALE_SCALE_HIRES) == 0){
+                               NCBLIT_PIXEL, NCSCALE_SCALE_HIRES) == 0){
         return NULL;
       }
     }

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -841,7 +841,7 @@ static const struct blitset notcurses_blitters[] = {
      .blit = tria_blit,      .name = "fourstep",      .fill = false, },
    { .geom = NCBLIT_BRAILLE, .width = 2, .height = 4, .egcs = L"⠀⢀⢠⢰⢸⡀⣀⣠⣰⣸⡄⣄⣤⣴⣼⡆⣆⣦⣶⣾⡇⣇⣧⣷⣿",
      .blit = braille_blit,   .name = "braille",       .fill = true,  },
-   { .geom = NCBLIT_PIXEL,   .width = 1, .height = 6, .egcs = L"",
+   { .geom = NCBLIT_PIXEL,   .width = 1, .height = 1, .egcs = L"",
      .blit = sixel_blit,     .name = "pixel",         .fill = true,  },
    { .geom = 0,              .width = 0, .height = 0, .egcs = NULL,
      .blit = NULL,           .name = NULL,            .fill = false,  },

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -35,7 +35,7 @@ trilerp(uint32_t c0, uint32_t c1, uint32_t c2){
 static inline int
 tria_blit_ascii(ncplane* nc, int placey, int placex, int linesize,
                 const void* data, int begy, int begx,
-                int leny, int lenx, bool blendcolors){
+                int leny, int lenx, unsigned blendcolors){
 //fprintf(stderr, "ASCII %d X %d @ %d X %d (%p) place: %d X %d\n", leny, lenx, begy, begx, data, placey, placex);
   const int bpp = 32;
   int dimy, dimx, x, y;
@@ -84,7 +84,7 @@ tria_blit_ascii(ncplane* nc, int placey, int placex, int linesize,
 static inline int
 tria_blit(ncplane* nc, int placey, int placex, int linesize,
           const void* data, int begy, int begx,
-          int leny, int lenx, bool blendcolors){
+          int leny, int lenx, unsigned blendcolors){
 //fprintf(stderr, "HALF %d X %d @ %d X %d (%p) place: %d X %d\n", leny, lenx, begy, begx, data, placey, placex);
   const int bpp = 32;
   int dimy, dimx, x, y;
@@ -306,7 +306,7 @@ quadrant_solver(uint32_t tl, uint32_t tr, uint32_t bl, uint32_t br,
 // FIXME we ought be able to just build up a bitstring and use it as an index!
 // FIXME pass in rgbas as array of uint32_t ala sexblitter
 static inline const char*
-qtrans_check(nccell* c, bool blendcolors,
+qtrans_check(nccell* c, unsigned blendcolors,
              const unsigned char* rgbbase_tl, const unsigned char* rgbbase_tr,
              const unsigned char* rgbbase_bl, const unsigned char* rgbbase_br){
   uint32_t tl = 0, tr = 0, bl = 0, br = 0;
@@ -418,7 +418,7 @@ qtrans_check(nccell* c, bool blendcolors,
 static inline int
 quadrant_blit(ncplane* nc, int placey, int placex, int linesize,
               const void* data, int begy, int begx,
-              int leny, int lenx, bool blendcolors){
+              int leny, int lenx, unsigned blendcolors){
   const int bpp = 32;
   int dimy, dimx, x, y;
   int total = 0; // number of cells written
@@ -501,7 +501,7 @@ generalerp(unsigned rsum, unsigned gsum, unsigned bsum, int count){
 // (all six pixels are different colors). We want to solve for the 2-partition
 // of pixels that minimizes total source distance from the resulting lerps.
 static const char*
-sex_solver(const uint32_t rgbas[6], uint64_t* channels, bool blendcolors){
+sex_solver(const uint32_t rgbas[6], uint64_t* channels, unsigned blendcolors){
   // each element within the set of 64 has an inverse element within the set,
   // for which we would calculate the same total differences, so just handle
   // the first 32. the partition[] bit masks represent combinations of
@@ -583,7 +583,7 @@ sex_solver(const uint32_t rgbas[6], uint64_t* channels, bool blendcolors){
 }
 
 static const char*
-sex_trans_check(cell* c, const uint32_t rgbas[6], bool blendcolors){
+sex_trans_check(cell* c, const uint32_t rgbas[6], unsigned blendcolors){
   // bit is *set* where sextant *is not*
   // 32: bottom right 16: bottom left
   //  8: middle right  4: middle left
@@ -641,7 +641,7 @@ sex_trans_check(cell* c, const uint32_t rgbas[6], bool blendcolors){
 static inline int
 sextant_blit(ncplane* nc, int placey, int placex, int linesize,
              const void* data, int begy, int begx,
-             int leny, int lenx, bool blendcolors){
+             int leny, int lenx, unsigned blendcolors){
   const int bpp = 32;
   int dimy, dimx, x, y;
   int total = 0; // number of cells written
@@ -710,7 +710,7 @@ fold_rgb8(unsigned* restrict r, unsigned* restrict g, unsigned* restrict b,
 static inline int
 braille_blit(ncplane* nc, int placey, int placex, int linesize,
              const void* data, int begy, int begx,
-             int leny, int lenx, bool blendcolors){
+             int leny, int lenx, unsigned blendcolors){
   const int bpp = 32;
   int dimy, dimx, x, y;
   int total = 0; // number of cells written

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -477,8 +477,13 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
   }
   int disprows, dispcols;
   if(scale != NCSCALE_NONE && scale != NCSCALE_NONE_HIRES){
-    dispcols = ncdirect_dim_x(n) * encoding_x_scale(bset);
-    disprows = ncdirect_dim_y(n) * encoding_y_scale(bset);
+    if(bset->geom != NCBLIT_PIXEL){
+      dispcols = ncdirect_dim_x(n) * encoding_x_scale(bset);
+      disprows = ncdirect_dim_y(n) * encoding_y_scale(bset);
+    }else{
+      dispcols = ncdirect_dim_x(n) * n->tcache.cellpixx;
+      disprows = ncdirect_dim_y(n) * n->tcache.cellpixy;
+    }
     if(scale == NCSCALE_SCALE || scale == NCSCALE_SCALE_HIRES){
       scale_visual(ncv, &disprows, &dispcols);
     }
@@ -501,6 +506,7 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
   };
   if(bset->geom == NCBLIT_PIXEL){
     nopts.rows = 1;
+    nopts.cols = dispcols / n->tcache.cellpixx;
   }
   auto ncdv = ncplane_new_internal(nullptr, nullptr, &nopts);
   if(!ncdv){
@@ -664,6 +670,7 @@ ncdirect* ncdirect_core_init(const char* termtype, FILE* outfp, uint64_t flags){
   if(interrogate_terminfo(&ret->tcache, shortname_term, utf8)){
     goto err;
   }
+  update_term_dimensions(ret->ctermfd, NULL, NULL, &ret->tcache);
   ncdirect_set_styles(ret, 0);
   return ret;
 

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -514,7 +514,7 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
     return nullptr;
   }
   if(ncvisual_blit(ncv, disprows, dispcols, ncdv, bset,
-                   0, 0, 0, 0, leny, lenx, false)){
+                   0, 0, 0, 0, leny, lenx, n->tcache.cellpixx)){
     ncvisual_destroy(ncv);
     free_plane(ncdv);
     return nullptr;

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -86,7 +86,7 @@ int ncdirect_clear(ncdirect* nc){
 int ncdirect_dim_x(const ncdirect* nc){
   int x;
   if(nc->ctermfd >= 0){
-    if(update_term_dimensions(nc->ctermfd, nullptr, &x) == 0){
+    if(update_term_dimensions(nc->ctermfd, nullptr, &x, NULL) == 0){
       return x;
     }
   }else{
@@ -98,7 +98,7 @@ int ncdirect_dim_x(const ncdirect* nc){
 int ncdirect_dim_y(const ncdirect* nc){
   int y;
   if(nc->ctermfd >= 0){
-    if(update_term_dimensions(nc->ctermfd, &y, nullptr) == 0){
+    if(update_term_dimensions(nc->ctermfd, &y, nullptr, NULL) == 0){
       return y;
     }
   }else{

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1206,6 +1206,9 @@ int sixel_blit(ncplane* nc, int placey, int placex, int linesize,
                const void* data, int begy, int begx,
                int leny, int lenx, unsigned cellpixx);
 
+int term_fg_rgb8(bool RGBflag, const char* setaf, int colors, FILE* out,
+                 unsigned r, unsigned g, unsigned b);
+
 typedef struct ncvisual_implementation {
   int (*visual_init)(int loglevel);
   void (*visual_printbanner)(const struct notcurses* nc);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1204,7 +1204,7 @@ ncdirect_bg_default_p(const struct ncdirect* nc){
 
 int sixel_blit(ncplane* nc, int placey, int placex, int linesize,
                const void* data, int begy, int begx,
-               int leny, int lenx, bool blendcolors);
+               int leny, int lenx, unsigned cellpixx);
 
 typedef struct ncvisual_implementation {
   int (*visual_init)(int loglevel);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -279,6 +279,11 @@ typedef struct tinfo {
   bool AMflag;    // "AM" flag for automatic movement to next line
   bool utf8;      // are we using utf-8 encoding, as hoped?
 
+  // we use the cell's size in pixels for pixel blitting. this information can
+  // be acquired on all terminals with pixel support.
+  int cellpixy;   // cell pixel height, might be 0
+  int cellpixx;   // cell pixel width, might be 0
+
   // kitty interprets an RGB background that matches the default background
   // color *as* the default background, meaning it'll be translucent if
   // background_opaque is in use. detect this, and avoid the default if so.
@@ -355,7 +360,7 @@ typedef struct notcurses {
   int cursory;    // desired cursor placement according to user.
   int cursorx;    // -1 is don't-care, otherwise moved here after each render.
 
-  pthread_mutex_t statlock;
+  pthread_mutex_t statlock; // FIXME align on cacheline
   ncstats stats;  // some statistics across the lifetime of the notcurses ctx
   ncstats stashed_stats; // retain across a notcurses_stats_reset(), to print in closing banner
 
@@ -685,7 +690,7 @@ int ncplane_resize_internal(ncplane* n, int keepy, int keepx,
                             int keepleny, int keeplenx, int yoff, int xoff,
                             int ylen, int xlen);
 
-int update_term_dimensions(int fd, int* rows, int* cols);
+int update_term_dimensions(int fd, int* rows, int* cols, tinfo* tcache);
 
 ALLOC static inline void*
 memdup(const void* src, size_t len){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -825,18 +825,28 @@ init_banner(const notcurses* nc){
     printf("\n notcurses %s by nick black et al", notcurses_version());
     term_fg_palindex(nc, stdout, nc->tcache.colors <= 256 ? 12 % nc->tcache.colors : 0x2080e0);
     if(nc->tcache.cellpixy && nc->tcache.cellpixx){
-      printf("\n  %d rows (%dpx) %d cols (%dpx) (%sB) %zuB cells %d colors%s\n",
+      printf("\n  %d rows (%dpx) %d cols (%dpx) (%sB) %zuB cells %d colors",
              nc->stdplane->leny, nc->tcache.cellpixy,
              nc->stdplane->lenx, nc->tcache.cellpixx,
              bprefix(nc->stats.fbbytes, 1, prefixbuf, 0), sizeof(nccell),
-             nc->tcache.colors, nc->tcache.RGBflag ? "+RGB" : "");
+             nc->tcache.colors);
     }else{
-      printf("\n  %d rows %d cols (%sB) %zuB cells %d colors%s\n",
+      printf("\n  %d rows %d cols (%sB) %zuB cells %d colors",
              nc->stdplane->leny, nc->stdplane->lenx,
              bprefix(nc->stats.fbbytes, 1, prefixbuf, 0), sizeof(nccell),
-             nc->tcache.colors, nc->tcache.RGBflag ? "+RGB" : "");
+             nc->tcache.colors);
     }
-    printf("  compiled with gcc-%s, %s-endian\n"
+    if(nc->tcache.RGBflag){
+      putc('+', stdout);
+      term_fg_rgb8(true, nc->tcache.setaf, nc->tcache.colors, stdout, 0xc0, 0x80, 0x80);
+      putc('R', stdout);
+      term_fg_rgb8(true, nc->tcache.setaf, nc->tcache.colors, stdout, 0x80, 0xc0, 0x80);
+      putc('G', stdout);
+      term_fg_rgb8(true, nc->tcache.setaf, nc->tcache.colors, stdout, 0x80, 0x80, 0xc0);
+      putc('B', stdout);
+      term_fg_palindex(nc, stdout, nc->tcache.colors <= 256 ? 12 % nc->tcache.colors : 0x2080e0);
+    }
+    printf("\n  compiled with gcc-%s, %s-endian\n"
            "  terminfo from %s\n",
            __VERSION__,
 #ifdef __BYTE_ORDER__

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -183,8 +183,16 @@ void ncplane_dim_yx(const ncplane* n, int* rows, int* cols){
 int update_term_dimensions(int fd, int* rows, int* cols, tinfo* tcache){
   // if we're not a real tty, we presumably haven't changed geometry, return
   if(fd < 0){
-    *rows = DEFAULT_ROWS;
-    *cols = DEFAULT_COLS;
+    if(rows){
+      *rows = DEFAULT_ROWS;
+    }
+    if(cols){
+      *cols = DEFAULT_COLS;
+    }
+    if(tcache){
+      tcache->cellpixy = 0;
+      tcache->cellpixx = 0;
+    }
     return 0;
   }
   struct winsize ws;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -23,7 +23,7 @@ notcurses_resize_internal(ncplane* pp, int* restrict rows, int* restrict cols){
   int oldcols = pile->dimx;
   *rows = oldrows;
   *cols = oldcols;
-  if(update_term_dimensions(n->ttyfd, rows, cols)){
+  if(update_term_dimensions(n->ttyfd, rows, cols, &n->tcache)){
     return -1;
   }
   *rows -= n->margin_t + n->margin_b;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -774,9 +774,8 @@ term_bg_rgb8(bool RGBflag, const char* setab, int colors, FILE* out,
   return 0;
 }
 
-static inline int
-term_fg_rgb8(bool RGBflag, const char* setaf, int colors, FILE* out,
-             unsigned r, unsigned g, unsigned b){
+int term_fg_rgb8(bool RGBflag, const char* setaf, int colors, FILE* out,
+                 unsigned r, unsigned g, unsigned b){
   // We typically want to use tputs() and tiperm() to acquire and write the
   // escapes, as these take into account terminal-specific delays, padding,
   // etc. For the case of DirectColor, there is no suitable terminfo entry, but

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -517,8 +517,6 @@ auto ncvisual_render_pixels(tinfo* tcache, ncvisual* ncv, const blitset* bset,
     if(scaling == NCSCALE_NONE || scaling == NCSCALE_NONE_HIRES){
       dispcols = ncv->cols;
       disprows = ncv->rows;
-      /*dispcols = dispcols / tcache->cellpixx + dispcols % tcache->cellpixx;
-      disprows = disprows / tcache->cellpixy + disprows % tcache->cellpixy;*/
     }else{
       ncplane_dim_yx(n, &disprows, &dispcols);
       dispcols *= tcache->cellpixx;
@@ -534,7 +532,8 @@ auto ncvisual_render_pixels(tinfo* tcache, ncvisual* ncv, const blitset* bset,
   lenx = dispcols;
 //fprintf(stderr, "blit: %dx%d <- %dx%d:%d+%d of %d/%d stride %u @%dx%d %p\n", disprows, dispcols, begy, begx, leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, placey, placex, ncv->data);
   if(ncvisual_blit(ncv, disprows, dispcols, n, bset,
-                   placey, placex, begy, begx, leny, lenx, false)){
+                   placey, placex, begy, begx, leny, lenx,
+                   ncplane_notcurses(stdn)->tcache.cellpixx)){
     ncplane_destroy(n);
     return nullptr;
   }


### PR DESCRIPTION
* Load pixel-to-cell geometry from `SIOCGWINSIZE`
* Load pixel EGCs with proper width
* Implement `NCBLIT_SCALE` and `NCBLIT_STRETCH` for pixel graphics
* Update `TERMINALS.md` with `SIOCGWINSIZE` support data
* Use `NCBLIT_PIXEL` for `ncneofetch`

Looks fucking fantastic.

![2021-03-02-075118_1048x1430_scrot](https://user-images.githubusercontent.com/143473/109651101-1a014380-7b2c-11eb-82f5-7249e1ce3906.png)
