### PR TITLE
sixel: use Set Raster Attributes to configure image size

### DIFF
--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -161,8 +161,12 @@ write_rle(FILE* fp, int seenrle, unsigned char crle){
 
 // Emit the sprixel in its entirety, plus enable and disable pixel mode.
 static int
-write_sixel_data(FILE* fp, int lenx, sixeltable* stab){
+write_sixel_data(FILE* fp, int leny, int lenx, sixeltable* stab){
   fprintf(fp, "\e[?80h\ePq"); // FIXME pixelon
+
+  // Set Raster Attributes - pan/pad=1 (pixel aspect ratio), Ph=lenx, Pv=leny
+  fprintf(fp, "\"1;1;%d;%d", lenx, leny);
+
   for(int i = 0 ; i < stab->ctab->colors ; ++i){
     const unsigned char* rgb = stab->ctab->table + i * 5;
     fprintf(fp, "#%d;2;%u;%u;%u", i, rgb[0], rgb[1], rgb[2]);
@@ -210,7 +214,7 @@ write_sixel_data(FILE* fp, int lenx, sixeltable* stab){
 // are programmed as a set of registers, which are then referenced by the
 // stacks. There is also a RLE component, handled in rasterization.
 // A pixel block is indicated by setting cell_pixels_p().
-int sixel_blit_inner(ncplane* nc, int placey, int placex, int lenx,
+int sixel_blit_inner(ncplane* nc, int placey, int placex, int leny, int lenx,
                      sixeltable* stab, unsigned cellpixx){
   char* buf = NULL;
   size_t size = 0;
@@ -218,7 +222,7 @@ int sixel_blit_inner(ncplane* nc, int placey, int placex, int lenx,
   if(fp == NULL){
     return -1;
   }
-  if(write_sixel_data(fp, lenx, stab)){
+  if(write_sixel_data(fp, leny, lenx, stab)){
     fclose(fp);
     free(buf);
     return -1;
@@ -255,7 +259,7 @@ int sixel_blit(ncplane* nc, int placey, int placex, int linesize,
     free(stable.data);
     return -1;
   }
-  int r = sixel_blit_inner(nc, placey, placex, lenx, &stable, cellpixx);
+  int r = sixel_blit_inner(nc, placey, placex, leny, lenx, &stable, cellpixx);
   free(stable.data);
   free(ctab);
   return r;


### PR DESCRIPTION
This lets the terminal allocate the image once, instead of dynamically resizing the image as the sixel data is emitted.

Note that this isn’t limiting the sixel size - if the sixel ends up being larger than advertised here, the terminal is required to resize the image to fit the entire sixel (i.e. you cannot use this to crop the image to something that isn’t a multiple of 6).