### PR TITLE
sixel: don’t emit DECGNL after the last row

### DIFF
--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -194,7 +194,9 @@ write_sixel_data(FILE* fp, int lenx, sixeltable* stab){
       if(i + 1 < stab->ctab->colors){
         fputc('$', fp);
       }else{
-        fputc('-', fp);
+        if(p + lenx < stab->ctab->sixelcount){
+          fputc('-', fp);
+        }
       }
     }
     p += lenx;


### PR DESCRIPTION
Emitting `DECGNL` is the sixel equivalent of printing `\n`, and can cause the terminal content to scroll.