### PR TITLE
Basic kitty pixel graphics support

### DIFF
--- a/src/lib/blitset.h
+++ b/src/lib/blitset.h
@@ -44,4 +44,6 @@ ncplot_defblitter(const notcurses* nc){
   return NCBLIT_1x1;
 }
 
+void set_pixel_blitter(blitter blitfxn);
+
 #endif

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -457,7 +457,7 @@ int ncdirect_raster_frame(ncdirect* n, ncdirectv* ncdv, ncalign_e align){
 }
 
 ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
-                                 ncblitter_e blitter, ncscale_e scale){
+                                 ncblitter_e blitfxn, ncscale_e scale){
   struct ncvisual* ncv = ncvisual_from_file(file);
   if(ncv == nullptr){
     return nullptr;
@@ -470,7 +470,7 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
     return nullptr;
   }
 //fprintf(stderr, "render %d/%d to %d+%d scaling: %d\n", ncv->rows, ncv->cols, leny, lenx, scale);
-  auto bset = rgba_blitter_low(&n->tcache, scale, true, blitter);
+  auto bset = rgba_blitter_low(&n->tcache, scale, true, blitfxn);
   if(!bset){
     ncvisual_destroy(ncv);
     return nullptr;
@@ -524,8 +524,8 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
 }
 
 int ncdirect_render_image(ncdirect* n, const char* file, ncalign_e align,
-                          ncblitter_e blitter, ncscale_e scale){
-  auto faken = ncdirect_render_frame(n, file, blitter, scale);
+                          ncblitter_e blitfxn, ncscale_e scale){
+  auto faken = ncdirect_render_frame(n, file, blitfxn, scale);
   if(!faken){
     return -1;
   }

--- a/src/lib/fill.c
+++ b/src/lib/fill.c
@@ -574,7 +574,7 @@ qrcode_cols(int version){
 }
 
 int ncplane_qrcode(ncplane* n, int* ymax, int* xmax, const void* data, size_t len){
-  const ncblitter_e blitter = NCBLIT_2x1;
+  const ncblitter_e blitfxn = NCBLIT_2x1;
   const int MAX_QR_VERSION = 40; // QR library only supports up to 40
   if(*ymax <= 0 || *xmax <= 0){
     return -1;
@@ -639,7 +639,7 @@ int ncplane_qrcode(ncplane* n, int* ymax, int* xmax, const void* data, size_t le
         ret = square;
         struct ncvisual_options vopts = {
           .n = n,
-          .blitter = blitter,
+          .blitter = blitfxn,
         };
         if(ncvisual_render(ncplane_notcurses(n), ncv, &vopts) == n){
           ret = square;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -1,0 +1,7 @@
+#include "internal.h"
+
+int kitty_blit(ncplane* nc, int placey, int placex, int linesize,
+               const void* data, int begy, int begx,
+               int leny, int lenx, unsigned cellpixx){
+  return 0;
+}

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -38,7 +38,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, const uint32_t* dat
       unsigned b = ncpixel_b(pixel);
       unsigned char b64[4] = {
         b64subs[((r & 0xfc) >> 2)],
-        b64subs[((r & 0x3 << 2) | ((g & 0xf0) >> 4))],
+        b64subs[((r & 0x3 << 4) | ((g & 0xf0) >> 4))],
         b64subs[(((g & 0xf) << 2) | ((b & 0xc0) >> 6))],
         b64subs[(b & 0x3f)]
       };

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -1,7 +1,62 @@
 #include "internal.h"
 
+// we can only write 4KiB at a time
+static int
+write_kitty_data(FILE* fp, int linesize, int leny, int lenx, const uint32_t* data){
+  if(linesize % sizeof(*data)){
+    return -1;
+  }
+  fprintf(fp, "\e_Gf=24,s=%d,v=%d;", lenx, leny);
+  for(int y = 0 ; y < leny ; ++y){
+    const uint32_t* line = data + linesize / sizeof(*data);
+    for(int x = 0 ; x < lenx ; ++x){
+      uint32_t pixel = line[x];
+      fprintf(fp, "%u%u%u", ncpixel_r(pixel), ncpixel_g(pixel), ncpixel_b(pixel));
+    }
+  }
+  fprintf(fp, "\e\\");
+  // FIXME need to base64 encode this
+  if(fclose(fp) == EOF){
+    return -1;
+  }
+  return 0;
+}
+
+// Kitty graphics blitter. Kitty can take in up to 4KiB at a time of (optionally
+// deflate-compressed) 24bit RGB.
+int kitty_blit_inner(ncplane* nc, int placey, int placex, int linesize,
+                     int leny, int lenx, unsigned cellpixx, const void* data){
+  char* buf = NULL;
+  size_t size = 0;
+  FILE* fp = open_memstream(&buf, &size);
+  if(fp == NULL){
+    return -1;
+  }
+  if(write_kitty_data(fp, linesize, leny, lenx, data)){
+    fclose(fp);
+    free(buf);
+    return -1;
+  }
+  nccell* c = ncplane_cell_ref_yx(nc, placey, placex);
+  unsigned width = lenx / cellpixx + !!(lenx % cellpixx);
+fprintf(stderr, "SIZE: %zu WIDTH: %u\n", size, width);
+  if(pool_blit_direct(&nc->pool, c, buf, size, width) < 0){
+    free(buf);
+    return -1;
+  }
+  free(buf);
+  return 1;
+}
+
+
 int kitty_blit(ncplane* nc, int placey, int placex, int linesize,
                const void* data, int begy, int begx,
                int leny, int lenx, unsigned cellpixx){
-  return 0;
+  (void)begy;
+  (void)begx;
+  int r = kitty_blit_inner(nc, placey, placex, linesize, leny, lenx, cellpixx, data);
+  if(r < 0){
+    return -1;
+  }
+  return r;
 }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -6,10 +6,11 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, const uint32_t* dat
   if(linesize % sizeof(*data)){
     return -1;
   }
+  // FIXME must write m=1 for initial chunks, m=0 for final (assuming > 1)
   fprintf(fp, "\e_Gf=24,s=%d,v=%d;", lenx, leny);
   // FIXME need to base64 encode payload. each 3B RGB goes to a 4B base64
   for(int y = 0 ; y < leny ; ++y){
-    const uint32_t* line = data + linesize / sizeof(*data);
+    const uint32_t* line = data + (linesize / sizeof(*data)) * y;
     for(int x = 0 ; x < lenx ; ++x){
       uint32_t pixel = line[x];
       unsigned r = ncpixel_r(pixel);
@@ -21,6 +22,8 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, const uint32_t* dat
         (((g & 0xf) << 2) | ((b & 0xc0) >> 6)) + 'A',
         (b & 0x3f) + 'A'
       };
+// this isn't the correct base64 distribution FIXME
+fprintf(stderr, "%u/%u/%u -> %c%c%c%c %u %u %u %u\n", r, g, b, b64[0], b64[1], b64[2], b64[3], b64[0], b64[1], b64[2], b64[3]);
       fprintf(fp, "%c%c%c%c", b64[0], b64[1], b64[2], b64[3]);
     }
   }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -1,33 +1,54 @@
 #include "internal.h"
 
+static unsigned const char b64subs[] =
+ "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
 // we can only write 4KiB at a time
 static int
 write_kitty_data(FILE* fp, int linesize, int leny, int lenx, const uint32_t* data){
+#define KITTY_MAXLEN 4096 // 4096B maximum payload
   if(linesize % sizeof(*data)){
     return -1;
   }
-  // FIXME must write m=1 for initial chunks, m=0 for final (assuming > 1)
-  fprintf(fp, "\e_Gf=24,s=%d,v=%d;", lenx, leny);
-  // FIXME need to base64 encode payload. each 3B RGB goes to a 4B base64
-  for(int y = 0 ; y < leny ; ++y){
-    const uint32_t* line = data + (linesize / sizeof(*data)) * y;
-    for(int x = 0 ; x < lenx ; ++x){
+  int total = leny * lenx * 4; // 3B RGB -> 4B Base64, total bytes
+  int chunks = (total + (KITTY_MAXLEN - 1)) / KITTY_MAXLEN;
+  int totalout = 0; // total bytes of payload out
+  int y = 0;
+  int x = 0;
+  int targetout = 0;
+//fprintf(stderr, "total: %d chunks = %d, s=%d,v=%d\n", total, chunks, lenx, leny);
+  while(chunks--){
+    if(totalout == 0){
+      fprintf(fp, "\e_Gf=24,s=%d,v=%d,a=T%s;", lenx, leny, chunks > 1 ? ",m=1" : "");
+    }else{
+      fprintf(fp, "\e_Gm=%d;", chunks ? 1 : 0);
+    }
+    if((targetout += KITTY_MAXLEN) > total){
+      targetout = total;
+    }
+    while(totalout < targetout){
+      if(x == lenx){
+        x = 0;
+        ++y;
+      }
+      const uint32_t* line = data + (linesize / sizeof(*data)) * y;
       uint32_t pixel = line[x];
       unsigned r = ncpixel_r(pixel);
       unsigned g = ncpixel_g(pixel);
       unsigned b = ncpixel_b(pixel);
       unsigned char b64[4] = {
-        ((r & 0xfc) >> 2) + 'A',
-        ((r & 0x3 << 2) | ((g & 0xf0) >> 4)) + 'A',
-        (((g & 0xf) << 2) | ((b & 0xc0) >> 6)) + 'A',
-        (b & 0x3f) + 'A'
+        b64subs[((r & 0xfc) >> 2)],
+        b64subs[((r & 0x3 << 2) | ((g & 0xf0) >> 4))],
+        b64subs[(((g & 0xf) << 2) | ((b & 0xc0) >> 6))],
+        b64subs[(b & 0x3f)]
       };
-// this isn't the correct base64 distribution FIXME
-fprintf(stderr, "%u/%u/%u -> %c%c%c%c %u %u %u %u\n", r, g, b, b64[0], b64[1], b64[2], b64[3], b64[0], b64[1], b64[2], b64[3]);
+//fprintf(stderr, "%u/%u/%u -> %c%c%c%c %u %u %u %u\n", r, g, b, b64[0], b64[1], b64[2], b64[3], b64[0], b64[1], b64[2], b64[3]);
       fprintf(fp, "%c%c%c%c", b64[0], b64[1], b64[2], b64[3]);
+      totalout += 4;
+      ++x;
     }
+    fprintf(fp, "\e\\");
   }
-  fprintf(fp, "\e\\");
   if(fclose(fp) == EOF){
     return -1;
   }
@@ -65,6 +86,7 @@ int kitty_blit(ncplane* nc, int placey, int placex, int linesize,
                int leny, int lenx, unsigned cellpixx){
   (void)begy;
   (void)begx;
+//fprintf(stderr, "s=%d,v=%d\n", lenx, leny);
   int r = kitty_blit_inner(nc, placey, placex, linesize, leny, lenx, cellpixx, data);
   if(r < 0){
     return -1;

--- a/src/lib/plot.h
+++ b/src/lib/plot.h
@@ -43,12 +43,12 @@ class ncppplot {
      return false;
    }
    const notcurses* notc = ncplane_notcurses(n);
-   ncblitter_e blitter = opts ? opts->gridtype : NCBLIT_DEFAULT;
-   if(blitter == NCBLIT_DEFAULT){
-     blitter = ncplot_defblitter(notc);
+   ncblitter_e blitfxn = opts ? opts->gridtype : NCBLIT_DEFAULT;
+   if(blitfxn == NCBLIT_DEFAULT){
+     blitfxn = ncplot_defblitter(notc);
    }
    bool degrade_blitter = !(opts && (opts->flags & NCPLOT_OPTION_NODEGRADE));
-   auto bset = lookup_blitset(&notc->tcache, blitter, degrade_blitter);
+   auto bset = lookup_blitset(&notc->tcache, blitfxn, degrade_blitter);
    if(bset == nullptr){
      ncplane_destroy(n);
      return false;

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -58,6 +58,9 @@ apply_term_heuristics(tinfo* ti, const char* termname){
     // be RGB(0, 0, 0) (the default). we could also just set it, i guess.
     ti->bg_collides_default = 0x1000000;
     ti->sextants = true; // work since bugfix in 0.19.3
+    ti->pixel_query_done = true;
+    ti->sixel_supported = true;
+    set_pixel_blitter(kitty_blit);
   /*}else if(strstr(termname, "alacritty")){
     ti->sextants = true; // alacritty https://github.com/alacritty/alacritty/issues/4409 */
   }else if(strstr(termname, "vte") || strstr(termname, "gnome") || strstr(termname, "xfce")){

--- a/src/lib/visual.cpp
+++ b/src/lib/visual.cpp
@@ -72,14 +72,14 @@ auto ncvisual_geom(const notcurses* nc, const ncvisual* n,
                    const struct ncvisual_options* vopts,
                    int* y, int* x, int* toy, int* tox) -> int {
   const ncscale_e scale = vopts ? vopts->scaling : NCSCALE_NONE;
-  ncblitter_e blitter;
+  ncblitter_e blitfxn;
   if(!vopts || vopts->blitter == NCBLIT_DEFAULT){
-    blitter = ncvisual_media_defblitter(nc, scale);
+    blitfxn = ncvisual_media_defblitter(nc, scale);
   }else{
-    blitter = vopts->blitter;
+    blitfxn = vopts->blitter;
   }
   const bool maydegrade = !(vopts && (vopts->flags & NCVISUAL_OPTION_NODEGRADE));
-  const struct blitset* bset = lookup_blitset(&nc->tcache, blitter, maydegrade);
+  const struct blitset* bset = lookup_blitset(&nc->tcache, blitfxn, maydegrade);
   if(!bset){
     return -1;
   }


### PR DESCRIPTION
* When we've determined kitty, insert the `kitty_blit()` function (we really ought do proper detection of kitty graphics as discussed in the documentation)
* Blit kitty graphics, using RGB24 -> base64 with payloads not exceeding 4KiB per chunk (closes #1095)