### PR TITLE
terminfo: ‘foot’ has sextant support

### DIFF
--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -65,6 +65,8 @@ apply_term_heuristics(tinfo* ti, const char* termname){
     ti->sextants = true; // alacritty https://github.com/alacritty/alacritty/issues/4409 */
   }else if(strstr(termname, "vte") || strstr(termname, "gnome") || strstr(termname, "xfce")){
     ti->sextants = true; // VTE has long enjoyed good sextant support
+  }else if(strncmp(termname, "foot", 4) == 0){
+    ti->sextants = true;
   }else if(strcmp(termname, "linux") == 0){
     ti->braille = false; // no braille, no sextants in linux console
   }


### PR DESCRIPTION
Foot renders all block drawing characters (including sextants) itself, and does **not** use font glyphs.

Note that there are two terminfos for foot, `foot` and `foot-direct`, hence the `strncmp()` instead of a regular `strcmp()`.

I'm not that fond of using the `TERM` name for feature detection like this, though I understand detecting sextant support is difficult. FWIW, foot can be detected by querying the "Device Attributes" (https://codeberg.org/dnkl/foot#programmatically-checking-if-running-in-foot).