### PR TITLE
Implement XTSMGRAPHICS query

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -293,6 +293,7 @@ typedef struct tinfo {
   // bg_collides_default is either 0x0000000 or 0x1RRGGBB.
   uint32_t bg_collides_default;
   pthread_mutex_t pixel_query; // only query for pixel support once
+  int color_registers; // sixel color registers (post pixel_query_done)
   bool sixel_supported;  // do we support sixel (post pixel_query_done)?
   bool pixel_query_done; // have we yet performed pixel query?
   bool sextants;  // do we have (good, vetted) Unicode 13 sextant support?


### PR DESCRIPTION
Query (if Sixel support is determined) XTSMGRAPHICS for the number of color registers. We also query for supported pixel geometry, but the returned value is strange, and thus we don't yet use it.