### PR TITLE
ncplayer: respect left and right margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Wherever possible, Notcurses makes use of the Terminfo library shipped with
 NCURSES, benefiting greatly from its portability and thoroughness.
 
 Notcurses opens up advanced functionality for the interactive user on
-workstations, phones, laptops, and tablets, at the expense of e.g.
+workstations, phones, laptops, and tablets, possibly at the expense of e.g.
 some industrial and retail terminals. Fundamentally, Curses assumes the minimum
 and allows you (with effort) to step up, whereas Notcurses assumes the maximum
 and steps down (by itself) when necessary. The latter approach probably breaks
@@ -208,7 +208,7 @@ to breaking under incorrect `TERM` values. If you're not using `xterm`, your
 
 * **Q:** Can I have Notcurses without this huge multimedia stack? **A:** Yes! Build with `-DUSE_MULTIMEDIA=none`.
 
-* **Q:** In `xterm`, Alt doesn't work as expected. **A:** Check out the `eightBitInput` resource of `xterm`. Add `XTerm*eightBitInput: false` to your `$HOME/.Xresources`, and run `xrdb -a $HOME/.Xresources`.
+* **Q:** In `xterm`, Alt doesn't work as expected. **A:** Check out the `eightBitInput` resource of `xterm`. Add `XTerm*eightBitInput: false` to your `$HOME/.Xresources`, and run e.g. `xrdb -all -merge $HOME/.Xresources`.
 
 * **Q:** Notcurses looks like absolute crap in `screen`. **A:** `screen` doesn't support RGB colors (at least as of 4.08.00); if you have `COLORTERM` defined, you'll have a bad time. If you have a `screen` that was compiled with `--enable-colors256`, try exporting `TERM=screen-256color` as opposed to `TERM=screen`.
 

--- a/doc/man/man1/ncplayer.1.md
+++ b/doc/man/man1/ncplayer.1.md
@@ -8,7 +8,7 @@ ncplayer - Render images and video to a terminal
 
 # SYNOPSIS
 
-**ncplayer** [**-h**] [**-V**] [**-q**] [**-d** ***delaymult***] [**-l** ***loglevel***] [**-b** ***blitter***] [**-s** ***scalemode***] [**-k**] [**-L**] [**-a** ***align***] [**-t** ***seconds***] files
+**ncplayer** [**-h**] [**-V**] [**-q**] [**-d** ***delaymult***] [**-l** ***loglevel***] [**-b** ***blitter***] [**-s** ***scalemode***] [**-k**] [**-L**] [**-t** ***seconds***] files
 
 # DESCRIPTION
 
@@ -32,8 +32,6 @@ be any non-negative number.
 **-s** ***scalemode***: Scaling mode, one of **none**, **hires**, **scale**, **scalehi**, or **stretch**.
 
 **-b** ***blitter***: Blitter, one of **ascii**, **half**, **quad**, **sex**, **braille**, or **pixel**.
-
-**-a** ***type***: Align images on **left**, **center**, or **right**.
 
 **-m margins**: Define rendering margins (see below).
 

--- a/doc/man/man1/ncplayer.1.md
+++ b/doc/man/man1/ncplayer.1.md
@@ -8,7 +8,7 @@ ncplayer - Render images and video to a terminal
 
 # SYNOPSIS
 
-**ncplayer** [**-h**] [**-V**] [**-q**] [**-d** ***delaymult***] [**-l** ***loglevel***] [**-b** ***blitter***] [**-s** ***scalemode***] [**-k**] [**-L**] [**-t** ***seconds***] files
+**ncplayer** [**-h**] [**-V**] [**-q**] [**-d** ***delaymult***] [**-l** ***loglevel***] [**-b** ***blitter***] [**-s** ***scalemode***] [**-k**] [**-L**] [**-a** ***align***] [**-t** ***seconds***] files
 
 # DESCRIPTION
 
@@ -33,6 +33,8 @@ be any non-negative number.
 
 **-b** ***blitter***: Blitter, one of **ascii**, **half**, **quad**, **sex**, **braille**, or **pixel**.
 
+**-a** ***type***: Align images on **left**, **center**, or **right**.
+
 **-m margins**: Define rendering margins (see below).
 
 **-L**: Loop frames until a key is pressed. Not supported with **-k**.
@@ -51,7 +53,8 @@ Default margins are all 0 and default scaling is **stretch**. The full
 rendering area will thus be used. Using **-m**, margins can be supplied.
 Provide a single number to set all four margins to the same value, or four
 comma-delimited values for the top, right, bottom, and left margins
-respectively. Negative margins are illegal.
+respectively. Top and bottom margins are ignored when **-k** is used. Negative
+margins are illegal.
 
 Scaling mode **stretch** resizes the object to match the target rendering
 area exactly. Unless a blitter is specified with **-b**, **stretch** will use

--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -75,12 +75,12 @@ namespace ncpp
 
 		int get_dim_x () const NOEXCEPT_MAYBE
 		{
-			return error_guard (ncdirect_dim_x (direct), -1);
+			return error_guard<int> (ncdirect_dim_x (direct), -1);
 		}
 
 		int get_dim_y () const NOEXCEPT_MAYBE
 		{
-			return error_guard (ncdirect_dim_y (direct), -1);
+			return error_guard<int> (ncdirect_dim_y (direct), -1);
 		}
 
 		unsigned get_palette_size () const noexcept
@@ -143,9 +143,9 @@ namespace ncpp
 			return ncdirect_render_image (direct, file, align, blitter, scale);
 		}
 
-		ncdirectv* prep_image (const char* file, ncblitter_e blitter, ncscale_e scale) const noexcept
+		ncdirectv* prep_image (const char* file, ncblitter_e blitter, ncscale_e scale, int maxy, int maxx) const noexcept
 		{
-			return ncdirect_render_frame (direct, file, blitter, scale);
+			return ncdirect_render_frame (direct, file, blitter, scale, maxy, maxx);
 		}
 
 		int raster_image (ncdirectv* faken, ncalign_e align) const noexcept

--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -7,6 +7,7 @@
 
 #include "Root.hh"
 #include "Cell.hh"
+#include "NCAlign.hh"
 
 namespace ncpp
 {
@@ -138,9 +139,9 @@ namespace ncpp
 			return error_guard (ncdirect_cursor_disable (direct), -1);
 		}
 
-		int render_image (const char* file, ncalign_e align, ncblitter_e blitter, ncscale_e scale) const noexcept
+		int render_image (const char* file, NCAlign align, ncblitter_e blitter, ncscale_e scale) const noexcept
 		{
-			return ncdirect_render_image (direct, file, align, blitter, scale);
+			return ncdirect_render_image (direct, file, static_cast<ncalign_e>(align), blitter, scale);
 		}
 
 		ncdirectv* prep_image (const char* file, ncblitter_e blitter, ncscale_e scale, int maxy, int maxx) const noexcept
@@ -148,9 +149,9 @@ namespace ncpp
 			return ncdirect_render_frame (direct, file, blitter, scale, maxy, maxx);
 		}
 
-		int raster_image (ncdirectv* faken, ncalign_e align) const noexcept
+		int raster_image (ncdirectv* faken, NCAlign align) const noexcept
 		{
-			return ncdirect_raster_frame (direct, faken, align);
+			return ncdirect_raster_frame (direct, faken, static_cast<ncalign_e>(align));
 		}
 
 		bool putstr (uint64_t channels, const char* utf8) const NOEXCEPT_MAYBE

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -290,9 +290,12 @@ API int ncdirect_stop(struct ncdirect* nc);
 // Render an image using the specified blitter and scaling, but do not write
 // the result. The image may be arbitrarily many rows -- the output will scroll
 // -- but will only occupy the column of the cursor, and those to the right.
-// To actually write (and free) this, invoke ncdirect_raster_frame().
+// To actually write (and free) this, invoke ncdirect_raster_frame(). 'maxx'
+// and 'maxy', if greater than 0, are used for scaling; the terminal's geometry
+// is otherwise used.
 API ALLOC ncdirectv* ncdirect_render_frame(struct ncdirect* n, const char* filename,
-                                           ncblitter_e blitter, ncscale_e scale);
+                                           ncblitter_e blitter, ncscale_e scale,
+                                           int maxy, int maxx);
 
 // Takes the result of ncdirect_render_frame() and writes it to the output.
 API int ncdirect_raster_frame(struct ncdirect* n, ncdirectv* ncdv, ncalign_e align);

--- a/rust/src/direct/methods.rs
+++ b/rust/src/direct/methods.rs
@@ -93,8 +93,10 @@ impl NcDirect {
         filename: &str,
         blitter: NcBlitter,
         scale: NcScale,
+        maxy: i32,
+        maxx: i32,
     ) -> NcResult<&'a mut NcPlane> {
-        let res = unsafe { crate::ncdirect_render_frame(self, cstring![filename], blitter, scale) };
+        let res = unsafe { crate::ncdirect_render_frame(self, cstring![filename], blitter, scale, maxy, maxx) };
         error_ref_mut![
             res,
             &format!(

--- a/src/lib/direct.cpp
+++ b/src/lib/direct.cpp
@@ -457,7 +457,10 @@ int ncdirect_raster_frame(ncdirect* n, ncdirectv* ncdv, ncalign_e align){
 }
 
 ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
-                                 ncblitter_e blitfxn, ncscale_e scale){
+                                 ncblitter_e blitfxn, ncscale_e scale,
+                                 int ymax, int xmax){
+  int dimy = ymax > 0 ? ymax : ncdirect_dim_y(n);
+  int dimx = xmax > 0 ? xmax : ncdirect_dim_x(n);
   struct ncvisual* ncv = ncvisual_from_file(file);
   if(ncv == nullptr){
     return nullptr;
@@ -478,11 +481,11 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
   int disprows, dispcols;
   if(scale != NCSCALE_NONE && scale != NCSCALE_NONE_HIRES){
     if(bset->geom != NCBLIT_PIXEL){
-      dispcols = ncdirect_dim_x(n) * encoding_x_scale(&n->tcache, bset);
-      disprows = ncdirect_dim_y(n) * encoding_y_scale(&n->tcache, bset);
+      dispcols = dimx * encoding_x_scale(&n->tcache, bset);
+      disprows = dimy * encoding_y_scale(&n->tcache, bset);
     }else{
-      dispcols = ncdirect_dim_x(n) * n->tcache.cellpixx;
-      disprows = ncdirect_dim_y(n) * n->tcache.cellpixy;
+      dispcols = dimx * n->tcache.cellpixx;
+      disprows = dimy * n->tcache.cellpixy;
     }
     if(scale == NCSCALE_SCALE || scale == NCSCALE_SCALE_HIRES){
       scale_visual(ncv, &disprows, &dispcols);
@@ -531,7 +534,7 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
 
 int ncdirect_render_image(ncdirect* n, const char* file, ncalign_e align,
                           ncblitter_e blitfxn, ncscale_e scale){
-  auto faken = ncdirect_render_frame(n, file, blitfxn, scale);
+  auto faken = ncdirect_render_frame(n, file, blitfxn, scale, -1, -1);
   if(!faken){
     return -1;
   }

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -145,7 +145,7 @@ void ncls_thread(const lsContext* ctx) {
       work.pop();
       pthread_mutex_unlock(&mtx);
       auto s = j.dir / j.p;
-      auto faken = ctx->nc.prep_image(s.c_str(), ctx->blitter, NCSCALE_SCALE_HIRES);
+      auto faken = ctx->nc.prep_image(s.c_str(), ctx->blitter, NCSCALE_SCALE_HIRES, -1, -1);
       pthread_mutex_lock(&outmtx);
       std::cout << j.p << '\n';
       if(faken){

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -50,7 +50,7 @@ struct lsContext {
   bool recursedirs;
   bool directories;
   bool dereflinks;
-  ncalign_e alignment;
+  ncpp::NCAlign alignment;
   ncblitter_e blitter;
 };
 
@@ -182,7 +182,7 @@ int main(int argc, char* const * argv){
   bool recursedirs = false;
   bool longlisting = false;
   bool dereflinks = false;
-  ncalign_e alignment = NCALIGN_RIGHT;
+  ncpp::NCAlign alignment = ncpp::NCAlign::Right;
   ncblitter_e blitter = NCBLIT_DEFAULT;
   const struct option opts[] = {
     { "align", 1, nullptr, 'a' },
@@ -199,11 +199,11 @@ int main(int argc, char* const * argv){
         exit(EXIT_SUCCESS);
       case 'a':
         if(strcasecmp(optarg, "left") == 0){
-          alignment = NCALIGN_LEFT;
+          alignment = ncpp::NCAlign::Left;
         }else if(strcasecmp(optarg, "right") == 0){
-          alignment = NCALIGN_RIGHT;
+          alignment = ncpp::NCAlign::Right;
         }else if(strcasecmp(optarg, "center") == 0){
-          alignment = NCALIGN_CENTER;
+          alignment = ncpp::NCAlign::Center;
         }else{
           std::cerr << "Unknown alignment type: " << optarg << "\n";
           usage(std::cerr, argv[0], EXIT_FAILURE);

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -296,12 +296,13 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
   }
   {
     for(auto i = 0 ; i < argc ; ++i){
-      try{
-        dm.prep_image(argv[i], blitter, scalemode, -1,
-                      dm.get_dim_x() - (lmargin + rmargin));
-      }catch(std::exception& e){
-        // FIXME want to stop nc first :/ can't due to stdn, ugh
-        std::cerr << argv[i] << ": " << e.what() << "\n";
+      auto faken = dm.prep_image(argv[i], blitter, scalemode, -1,
+                                 dm.get_dim_x() - (lmargin + rmargin));
+      if(!faken){
+        failed = true;
+        break;
+      }
+      if(dm.raster_image(faken, NCALIGN_RIGHT)){
         failed = true;
         break;
       }

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -28,7 +28,6 @@ void usage(std::ostream& o, const char* name, int exitcode){
   o << " -t seconds: delay t seconds after each file\n";
   o << " -l loglevel: integer between 0 and 9, goes to stderr'\n";
   o << " -s scaling: one of 'none', 'hires', 'scale', 'scalehi', or 'stretch'\n";
-  o << " -a type: 'left', 'right', or 'center'\n";
   o << " -b blitter: one of 'ascii', 'half', 'quad', 'sex', 'braille', or 'pixel'\n";
   o << " -m margins: margin, or 4 comma-separated margins\n";
   o << " -d mult: non-negative floating point scale for frame time" << std::endl;
@@ -302,7 +301,8 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
         failed = true;
         break;
       }
-      if(dm.raster_image(faken, NCALIGN_RIGHT)){
+      printf("%*.*s", lmargin, lmargin, "");
+      if(dm.raster_image(faken, NCAlign::Left)){
         failed = true;
         break;
       }


### PR DESCRIPTION
When using `ncplayer -k`, the left and right margins ought be respected for at least `scale`, `scalehi`, and `stretch` (come to think of it, they ought probably be respected for `none` and `hires`, also, but that's tougher). Add `maxy` and `maxx` parameters to `ncdirect_render_frame()`, and when positive, use them rather than the screen geometry for scaling. Update C++ and Rust callers. Fix bugs in C++ `NCDirect::get_dim_y()` and `NCDirect::get_dim_x()` that were causing them to return 1 instead of the actual size. Update `ncplayer.1` man page to discuss margins and `-k`. Closes #1411 by @ivoanjo.