### PR TITLE
Sixel relaxation

### DIFF
--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -155,17 +155,6 @@ tria_blit(ncplane* nc, int linesize, const void* data, int begy, int begx,
   return total;
 }
 
-// get a non-negative "distance" between two rgb values
-static inline uint32_t
-rgb_diff(unsigned r1, unsigned g1, unsigned b1, unsigned r2, unsigned g2, unsigned b2){
-  uint32_t distance = 0;
-  distance += r1 > r2 ? r1 - r2 : r2 - r1;
-  distance += g1 > g2 ? g1 - g2 : g2 - g1;
-  distance += b1 > b2 ? b1 - b2 : b2 - b1;
-//fprintf(stderr, "RGBDIFF %u %u %u %u %u %u: %u\n", r1, g1, b1, r2, g2, b2, distance);
-  return distance;
-}
-
 // once we find the closest pair of colors, we need look at the other two
 // colors, and determine whether either belongs with us rather with them.
 // if so, take the closer, and trilerp it in with us. otherwise, lerp the

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1228,6 +1228,17 @@ rgba_trans_p(unsigned alpha){
   return false;
 }
 
+// get a non-negative "manhattan distance" between two rgb values
+static inline uint32_t
+rgb_diff(unsigned r1, unsigned g1, unsigned b1, unsigned r2, unsigned g2, unsigned b2){
+  uint32_t distance = 0;
+  distance += r1 > r2 ? r1 - r2 : r2 - r1;
+  distance += g1 > g2 ? g1 - g2 : g2 - g1;
+  distance += b1 > b2 ? b1 - b2 : b2 - b1;
+//fprintf(stderr, "RGBDIFF %u %u %u %u %u %u: %u\n", r1, g1, b1, r2, g2, b2, distance);
+  return distance;
+}
+
 static inline uint64_t
 ncdirect_channels(const ncdirect* nc){
   return nc->channels;

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -181,26 +181,26 @@ unzip_color(const uint32_t* data, int linesize, int begy, int begx,
   int didx = ctable_to_dtable(crec);
   unsigned char* srcsixels = stab->data + stab->sixelcount * didx;
   unsigned char* dstsixels = stab->data + stab->sixelcount * stab->colors;
-fprintf(stderr, "counts: src: %d dst: %d\n", deets->count, targdeets->count);
+fprintf(stderr, "counts: src: %d dst: %d src: %p dst: %p\n", deets->count, targdeets->count, srcsixels, dstsixels);
   int sixel = 0;
+int totalcount = 0;
   memset(deets, 0, sizeof(*deets));
   for(int visy = begy ; visy < (begy + leny) ; visy += 6){
     for(int visx = begx ; visx < (begx + lenx) ; visx += 1, ++sixel){
       if(srcsixels[sixel]){
         for(int sy = visy ; sy < (begy + leny) && sy < visy + 6 ; ++sy){
           if(srcsixels[sixel] & (1u << (sy - visy))){
+            ++totalcount;
             const uint32_t* rgb = (const uint32_t*)(data + (linesize / 4 * sy) + visx);
             unsigned char comps[RGBSIZE];
             break_sixel_comps(comps, *rgb, 0xff);
             if(comps[0] > r || comps[1] > g || comps[2] > b){
-              ++targdeets->count;
               dstsixels[sixel] |= (1u << (sy - visy));
               srcsixels[sixel] &= ~(1u << (sy - visy));
               update_deets(*rgb, targdeets);
 //fprintf(stderr, "%u/%u/%u comps: [%u/%u/%u]\n", r, g, b, comps[0], comps[1], comps[2]);
 //fprintf(stderr, "match sixel %d %u %u\n", sixel, srcsixels[sixel], 1u << (sy - visy));
             }else{
-              ++deets->count;
               update_deets(*rgb, deets);
             }
           }
@@ -208,7 +208,7 @@ fprintf(stderr, "counts: src: %d dst: %d\n", deets->count, targdeets->count);
       }
     }
   }
-fprintf(stderr, "counts: src: %d dst: %d\n", deets->count, targdeets->count);
+fprintf(stderr, "counts: src: %d dst: %d total: %d\n", deets->count, targdeets->count, totalcount);
 }
 
 // relax segment |coloridx|. we must have room for a new color. we find the
@@ -423,7 +423,7 @@ int sixel_blit(ncplane* nc, int linesize, const void* data, int begy, int begx,
     free(stable.deets);
     return -1;
   }
-  refine_color_table(data, linesize, begy, begx, leny, lenx, &stable);
+  //refine_color_table(data, linesize, begy, begx, leny, lenx, &stable);
   int r = sixel_blit_inner(nc, leny, lenx, &stable, bargs);
   free(stable.data);
   free(stable.deets);

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -415,8 +415,8 @@ int sixel_blit(ncplane* nc, int linesize, const void* data, int begy, int begx,
     return -1;
   }
   // stable.table doesn't need initializing; we start from the bottom
-  memset(stable.data, 0, sixelcount * bargs->pixel.colorregs);
-  memset(stable.deets, 0, sizeof(*stable.deets) * bargs->pixel.colorregs);
+  memset(stable.data, 0, sixelcount * colorregs);
+  memset(stable.deets, 0, sizeof(*stable.deets) * colorregs);
   if(extract_color_table(data, linesize, begy, begx, leny, lenx, &stable)){
     free(stable.table);
     free(stable.data);

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -123,6 +123,9 @@ extract_color_table(const uint32_t* data, int linesize, int begy, int begx,
           return -1;
         }
         stab->data[c * stab->sixelcount + pos] |= (1u << (sy - visy));
+        stab->deets[c].sums[0] += ncpixel_r(*rgb);
+        stab->deets[c].sums[1] += ncpixel_g(*rgb);
+        stab->deets[c].sums[2] += ncpixel_b(*rgb);
         comps[0] = ss(ncpixel_r(*rgb), 0xff);
         comps[1] = ss(ncpixel_g(*rgb), 0xff);
         comps[2] = ss(ncpixel_b(*rgb), 0xff);
@@ -147,9 +150,6 @@ extract_color_table(const uint32_t* data, int linesize, int begy, int begx,
             stab->deets[c].lo[2] = comps[2];
           }
         }
-        stab->deets[c].sums[0] += comps[0];
-        stab->deets[c].sums[1] += comps[1];
-        stab->deets[c].sums[2] += comps[2];
         ++stab->deets[c].count;
 //fprintf(stderr, "color %d pos %d: 0x%x\n", c, pos, stab->data[c * stab->sixelcount + pos]);
 //fprintf(stderr, " sums: %u %u %u count: %d r/g/b: %u %u %u\n", stab->deets[c].sums[0], stab->deets[c].sums[1], stab->deets[c].sums[2], stab->deets[c].count, ncpixel_r(*rgb), ncpixel_g(*rgb), ncpixel_b(*rgb));


### PR DESCRIPTION
My attempt at an inverse median cut algorithm. Blows up our time-to-render by about 60%, but gives a much better image quality, though still inferior to libsixel. Old is on left, new is on right:

![2021-03-16-224753_1581x658_scrot](https://user-images.githubusercontent.com/143473/111407034-a6be0c80-86a9-11eb-8908-d95165419a3e.png)

I think I'm going to add code to use libsixel when it's available, and this will be our fallback. Closes #1391.