### PR TITLE
NCVISUAL_OPTION_HORALIGNED

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ rearrangements of Notcurses.
   * Added `NCVISUAL_OPTION_HORALIGNED` flag for `ncvisual_render()`.
   * Added the `nctabbed` widget for multiplexing planes data with navigational
     tabs. Courtesy Łukasz Drukała, in his first contribution.
+  * Removed **notcurses_canpixel()**, which was obsoleted by
+    **notcurses_check_pixel_support()**.
 
 * 2.2.3 (2021-03-08)
   * Implemented **EXPERIMENTAL** `NCBLIT_PIXEL` for terminals reporting Sixel

--- a/USAGE.md
+++ b/USAGE.md
@@ -298,9 +298,6 @@ bool notcurses_canchangecolor(const struct notcurses* nc);
 // Is our encoding UTF-8? Requires LANG being set to a UTF-8 locale.
 bool notcurses_canutf8(const struct notcurses* nc);
 
-// Can we blit pixel graphics?
-bool notcurses_canpixel(const struct notcurses* nc);
-
 // Can we draw sextants? This requires Unicode 13.
 bool notcurses_cansextants(const struct notcurses* nc);
 

--- a/cffi/src/notcurses/build_notcurses.py
+++ b/cffi/src/notcurses/build_notcurses.py
@@ -94,7 +94,6 @@ bool notcurses_canchangecolor(const struct notcurses* nc);
 bool notcurses_canopen_images(const struct notcurses* nc);
 bool notcurses_canopen_videos(const struct notcurses* nc);
 bool notcurses_canutf8(const struct notcurses* nc);
-bool notcurses_canpixel(const struct notcurses* nc);
 int notcurses_mouse_enable(struct notcurses* n);
 int notcurses_mouse_disable(struct notcurses* n);
 int ncplane_destroy(struct ncplane* ncp);

--- a/doc/man/man3/notcurses_capabilities.3.md
+++ b/doc/man/man3/notcurses_capabilities.3.md
@@ -30,7 +30,7 @@ notcurses_capabilities - runtime capability detection
 
 **bool notcurses_canbraille(const struct notcurses* ***nc***);**
 
-**bool notcurses_canpixel(const struct notcurses* ***nc***);**
+**int notcurses_check_pixel_support(struct notcurses* ***nc***);**
 
 # DESCRIPTION
 
@@ -65,12 +65,12 @@ UTF-8 encoding, and the locale was successfully loaded.
 **notcurses_cansextant** returns **true** if the heuristics suggest
 that the terminal can properly render Unicode 13 sextants.
 
-**notcurses_canpixel** returns **true** if the terminal advertises
-support for pixel graphics (e.g. Sixel). This function will not return **true**
-until **notcurses_check_pixel_support** is called, and successfully returns.
-
 **notcurses_canbraille** returns **true** if Braille is expected to work on the
 terminal.
+
+**notcurses_check_pixel_support** returns 1 if bitmap support (via any
+mechanism) is detected; **NCBLIT_PIXEL** can be used after such a return.
+It returns 0 a lack of bitmap support was confirmed, and -1 on error.
 
 # NOTES
 

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -145,6 +145,24 @@ geometry of same. **flags** is a bitfield over:
 **data** using **NCBLIT_2x1** (this is the only blitter that will work with QR
 Code scanners, due to its 1:1 aspect ratio).
 
+# OPTIONS
+
+**begy** and **begx** specify the upper left corner of the image to start
+drawing. **leny** and **lenx** specify the area of the subimage drawn.
+**leny** and/or **lenx** may be specified as a negative number to draw
+through the bottom right corner of the image.
+
+The **n** field specifies the plane to use. If this is **NULL**, a new plane
+will be created, having the precise geometry necessary to blit the specified
+section of the image. This might be larger (or smaller) than the visual area.
+
+**y** and **x** have different meanings depending on whether or not **n** was
+**NULL**. If not (drawing onto a preexisting plane), they specify where in
+the plane to start drawing. If **n** was **NULL** (new plane), they specify
+the origin of the new plane relative to the standard plane. If the **flags**
+field contains **NCVISUAL_OPTION_HORALIGNED**, the **x** parameter is
+interpreted as an **ncalign_e** rather than an absolute position.
+
 # BLITTERS
 
 The different **ncblitter_e** values select from among available glyph sets:
@@ -271,6 +289,9 @@ Bad font support can ruin **NCBLIT_2x2**, **NCBLIT_3x2**, **NCBLIT_4x1**,
 **NCBLIT_BRAILLE**, and **NCBLIT_8x1**. Braille glyphs ought ideally draw only
 the raised dots, rather than drawing all eight dots with two different styles.
 It's often best for the emulator to draw these glyphs itself.
+
+**ncvisual_render** ought be able to create new planes in piles other than
+the standard pile. This ought become a reality soon.
 
 # SEE ALSO
 

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -93,8 +93,6 @@ typedef int (*streamcb)(struct notcurses*, struct ncvisual*, void*);
 
 **int ncplane_qrcode(struct ncplane* ***n***, int* ***ymax***, int* ***xmax***, const void* ***data***, size_t ***len***)**
 
-**int notcurses_check_pixel_support(struct notcurses* ***nc***);**
-
 # DESCRIPTION
 
 An **ncvisual** is a virtual pixel framebuffer. They can be created from
@@ -254,10 +252,6 @@ in the specified configuration. If UTF8 is not enabled, this will always be
 aspect-preserving **NCBLIT_2x1** will be returned. If sextants are available
 (see **notcurses_cansextant**), this will be **NCBLIT_3x2**, or otherwise
 **NCBLIT_2x2**.
-
-**notcurses_check_pixel_support** returns 1 if bitmap support (via any
-mechanism) is detected; **NCBLIT_PIXEL** can be used after such a return.
-It returns 0 a lack of bitmap support was confirmed, and -1 on error.
 
 # NOTES
 

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -255,6 +255,10 @@ aspect-preserving **NCBLIT_2x1** will be returned. If sextants are available
 (see **notcurses_cansextant**), this will be **NCBLIT_3x2**, or otherwise
 **NCBLIT_2x2**.
 
+**notcurses_check_pixel_support** returns 1 if bitmap support (via any
+mechanism) is detected; **NCBLIT_PIXEL** can be used after such a return.
+It returns 0 a lack of bitmap support was confirmed, and -1 on error.
+
 # NOTES
 
 Multimedia decoding requires that Notcurses be built with either FFmpeg or

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1243,9 +1243,6 @@ API bool notcurses_cansextant(const struct notcurses* nc);
 // Can we reliably use Unicode Braille?
 API bool notcurses_canbraille(const struct notcurses* nc);
 
-// Can we blit to pixel graphics?
-API bool notcurses_canpixel(const struct notcurses* nc);
-
 // This function must successfully return before NCBLIT_PIXEL is available.
 // Returns -1 on error, 0 for no support, or 1 if pixel output is supported.
 // Must not be called concurrently with either input or rasterization.

--- a/rust/src/bindings.rs
+++ b/rust/src/bindings.rs
@@ -675,7 +675,6 @@ pub use ffi::{
     notcurses_canopen_images,
     notcurses_canopen_videos,
     notcurses_cansextant,
-    notcurses_canpixel,
     notcurses_cantruecolor,
     notcurses_canutf8,
     notcurses_cursor_disable,

--- a/rust/src/notcurses/methods.rs
+++ b/rust/src/notcurses/methods.rs
@@ -196,15 +196,6 @@ impl Notcurses {
         unsafe { crate::notcurses_canopen_videos(self) }
     }
 
-    /// Returns true if pixel graphics are supported.
-    ///
-    /// See [NCBLIT_PIXEL][crate::NCBLIT_PIXEL].
-    ///
-    /// *C style function: [notcurses_canpixel()][crate::notcurses_canpixel].*
-    pub fn canpixel(&self) -> bool {
-        unsafe { crate::notcurses_canpixel(self) }
-    }
-
     /// Returns true if we can reliably use Unicode 13 sextants.
     ///
     /// *C style function: [notcurses_cansextant()][crate::notcurses_cansextant].*

--- a/rust/src/notcurses/mod.rs
+++ b/rust/src/notcurses/mod.rs
@@ -30,7 +30,6 @@
 // fmt notcurses_canfade
 // fmt notcurses_canopen_images
 // fmt notcurses_canopen_videos
-// fmt notcurses_canpixel
 // fmt notcurses_cansextant
 // fmt notcurses_cantruecolor
 // fmt notcurses_canutf8

--- a/rust/src/notcurses/test/reimplemented.rs
+++ b/rust/src/notcurses/test/reimplemented.rs
@@ -67,17 +67,6 @@ fn notcurses_canopen_videos() {
 
 #[test]
 #[serial]
-fn notcurses_canpixel() {
-    unsafe {
-        let nc = notcurses_init_test();
-        let res = crate::notcurses_canpixel(nc);
-        notcurses_stop(nc);
-        print!("[{}] ", res);
-    }
-}
-
-#[test]
-#[serial]
 fn notcurses_cansextant() {
     unsafe {
         let nc = notcurses_init_test();

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -42,6 +42,7 @@ const demoresult* demoresult_lookup(int idx){
   return &results[idx];
 }
 
+// FIXME change to unique_ptr
 char* find_data(const char* datum){
   char* path = malloc(strlen(datadir) + 1 + strlen(datum) + 1);
   strcpy(path, datadir);

--- a/src/demo/keller.c
+++ b/src/demo/keller.c
@@ -25,11 +25,11 @@ visualize(struct notcurses* nc, struct ncvisual* ncv){
       .scaling = NCSCALE_SCALE,
       .blitter = bs[i],
       .y = 1,
-      .flags = NCVISUAL_OPTION_NODEGRADE,
+      .flags = NCVISUAL_OPTION_NODEGRADE | NCVISUAL_OPTION_HORALIGNED,
     };
     int scalex, scaley, truey, truex;
     ncvisual_geom(nc, ncv, &vopts, &truey, &truex, &scaley, &scalex);
-    vopts.x = (ncplane_dim_x(notcurses_stdplane(nc)) - truex / scalex) / 2;
+    vopts.x = NCALIGN_CENTER;
     vopts.y = (ncplane_dim_y(notcurses_stdplane(nc)) - truey / scaley) / 2;
 //fprintf(stderr, "X: %d truex: %d sclaex: %d\n", vopts.x, truex, scalex);
     ncplane_erase(stdn);

--- a/src/demo/normal.c
+++ b/src/demo/normal.c
@@ -112,8 +112,9 @@ rotate_visual(struct notcurses* nc, struct ncplane* n, int dy, int dx){
     }
     int vy, vx, vyscale, vxscale;
     ncvisual_geom(nc, ncv, &vopts, &vy, &vx, &vyscale, &vxscale);
-    vopts.x = (dimx - (vx / vxscale)) / 2;
+    vopts.x = NCALIGN_CENTER;
     vopts.y = (dimy - (vy / vyscale)) / 2;
+    vopts.flags |= NCVISUAL_OPTION_HORALIGNED;
     struct ncplane* newn;
     if((newn = ncvisual_render(nc, ncv, &vopts)) == NULL){
       r = -1;

--- a/src/demo/yield.c
+++ b/src/demo/yield.c
@@ -47,7 +47,7 @@ int yield_demo(struct notcurses* nc){
   // run closer to twenty seconds. 11/50 it is, then. pixels are different.
   // it would be nice to hit this all with a rigor stick. yes, the 1 makes
   // all the difference in cells v pixels. FIXME
-  const long threshold_painted = total * (10 + !notcurses_canpixel(nc)) / 50;
+  const long threshold_painted = total * (10 + (notcurses_check_pixel_support(nc) <= 0)) / 50;
   const int MAXITER = 256;
   timespec_div(&demodelay, MAXITER, &scaled);
   long tfilled = 0;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2042,10 +2042,6 @@ bool notcurses_canchangecolor(const notcurses* nc){
   return true;
 }
 
-bool notcurses_canpixel(const notcurses* nc){
-  return nc->tcache.sixel_supported;
-}
-
 palette256* palette256_new(notcurses* nc){
   palette256* p = malloc(sizeof(*p));
   if(p){

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -558,14 +558,17 @@ ncplane* ncvisual_render(notcurses* nc, ncvisual* ncv, const struct ncvisual_opt
   int begx = vopts ? vopts->begx : 0;
 //fprintf(stderr, "blit %dx%d+%dx%d %p\n", begy, begx, leny, lenx, ncv->data);
   if(begy < 0 || begx < 0 || lenx < -1 || leny < -1){
+    logerror(nc, "Invalid geometry for visual %d %d %d %d\n", begy, begx, leny, lenx);
     return NULL;
   }
 //fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d\n", ncv->data, ncv->rows, ncv->cols);
   if(ncv->data == NULL){
+    logerror(nc, "No data in visual\n");
     return NULL;
   }
 //fprintf(stderr, "blit %d/%d to %dx%d+%dx%d scaling: %d\n", ncv->rows, ncv->cols, begy, begx, leny, lenx, vopts ? vopts->scaling : 0);
   if(begx >= ncv->cols || begy >= ncv->rows){
+    logerror(nc, "Visual too large %d > %d or %d > %d\n", begy, ncv->rows, begx, ncv->cols);
     return NULL;
   }
   if(lenx == 0){ // 0 means "to the end"; use all available source material
@@ -576,13 +579,16 @@ ncplane* ncvisual_render(notcurses* nc, ncvisual* ncv, const struct ncvisual_opt
   }
 //fprintf(stderr, "blit %d/%d to %dx%d+%dx%d scaling: %d\n", ncv->rows, ncv->cols, begy, begx, leny, lenx, vopts ? vopts->scaling : 0);
   if(lenx <= 0 || leny <= 0){ // no need to draw zero-size object, exit
+    logerror(nc, "Zero-size object %d %d\n", leny, lenx);
     return NULL;
   }
   if(begx + lenx > ncv->cols || begy + leny > ncv->rows){
+    logerror(nc, "Geometry too large %d > %d or %d > %d\n", begy + leny, ncv->rows, begx + lenx, ncv->cols);
     return NULL;
   }
   const struct blitset* bset = rgba_blitter(nc, vopts);
   if(!bset){
+    logerror(nc, "Couldn't get a blitter for %d\n", vopts ? vopts->blitter : NCBLIT_DEFAULT);
     return NULL;
   }
 //fprintf(stderr, "beg/len: %d %d %d %d scale: %d/%d\n", begy, leny, begx, lenx, encoding_y_scale(bset), encoding_x_scale(bset));

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -16,6 +16,9 @@ int ncvisual_decode(ncvisual* nc){
 int ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
                   const struct blitset* bset, int leny, int lenx,
                   const blitterargs* barg){
+  if(barg->placex < 0 || barg->placey < 0){
+    return -1;
+  }
   int ret = -1;
   if(visual_implementation){
     if(visual_implementation->visual_blit(ncv, rows, cols, n, bset,
@@ -472,8 +475,7 @@ ncplane* ncvisual_render_cells(notcurses* nc, ncvisual* ncv, const struct blitse
       } // else stretch
     }
     if(flags & NCVISUAL_OPTION_HORALIGNED){
-      // FIXME this only centers
-      placex = (ncplane_dim_x(n) - dispcols / encoding_x_scale(&nc->tcache, bset)) / 2;
+      placex = ncplane_align(n, placex, dispcols / encoding_x_scale(&nc->tcache, bset));
     }
   }
   leny = (leny / (double)ncv->rows) * ((double)disprows);

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -463,14 +463,16 @@ ncplane* ncvisual_render_cells(notcurses* nc, ncvisual* ncv, const struct blitse
       ncplane_dim_yx(n, &disprows, &dispcols);
       dispcols *= encoding_x_scale(&nc->tcache, bset);
       disprows *= encoding_y_scale(&nc->tcache, bset);
+      if(!(flags & NCVISUAL_OPTION_HORALIGNED)){
+        dispcols -= placex;
+      }
       disprows -= placey;
-      dispcols -= placex;
       if(scaling == NCSCALE_SCALE || scaling == NCSCALE_SCALE_HIRES){
         scale_visual(ncv, &disprows, &dispcols);
       } // else stretch
     }
     if(flags & NCVISUAL_OPTION_HORALIGNED){
-      placex = (ncplane_dim_x(n) - dispcols) / 2;
+      placex = (ncplane_dim_x(n) - dispcols / encoding_x_scale(&nc->tcache, bset)) / 2;
     }
   }
   leny = (leny / (double)ncv->rows) * ((double)disprows);

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -349,6 +349,8 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
     ncv = std::make_unique<Visual>(argv[i]);
     struct ncvisual_options vopts{};
     int r;
+    vopts.flags |= NCVISUAL_OPTION_HORALIGNED;
+    vopts.x = NCALIGN_CENTER;
     vopts.n = n;
     vopts.scaling = scalemode;
     vopts.blitter = blitter;

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -60,6 +60,7 @@ TEST_CASE("DirectMode") {
 
   SUBCASE("LoadImage") {
     CHECK(0 == ncdirect_render_image(nc_, find_data("changes.jpg"), NCALIGN_LEFT, NCBLIT_1x1, NCSCALE_STRETCH));
+    CHECK(0 == ncdirect_render_image(nc_, find_data("worldmap.png"), NCALIGN_RIGHT, NCBLIT_1x1, NCSCALE_SCALE));
   }
 #endif
 

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -49,13 +49,27 @@ TEST_CASE("DirectMode") {
     }
   }
 
+#ifndef NOTCURSES_USE_MULTIMEDIA
+  SUBCASE("VisualDisabled"){
+    CHECK(!ncdirect_canopen_images(nc_));
+  }
+#else
+  SUBCASE("ImagesEnabled"){
+    CHECK(ncdirect_canopen_images(nc_));
+  }
+
+  SUBCASE("LoadImage") {
+    CHECK(0 == ncdirect_render_image(nc_, find_data("changes.jpg"), NCALIGN_LEFT, NCBLIT_1x1, NCSCALE_STRETCH));
+  }
+#endif
+
   CHECK(0 == ncdirect_stop(nc_));
 
   // make sure that we can pass undefined flags and still create the ncdirect
   SUBCASE("FutureFlags") {
-    nc_ = ncdirect_init(NULL, stdout, ~0ULL);
-    REQUIRE(nullptr != nc_);
-    CHECK(0 == ncdirect_stop(nc_));
+    auto fnc = ncdirect_init(NULL, stdout, ~0ULL);
+    REQUIRE(nullptr != fnc);
+    CHECK(0 == ncdirect_stop(fnc));
   }
 
 }


### PR DESCRIPTION
Introduce+implement `NCVISUAL_OPTION_HORALIGNED` flag for `ncvisual_options`, which allows the `x` field to be interpreted as an alignment. Closes #1443 .