### PR TITLE
Fix vertical alignment with ncplane_valign()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ rearrangements of Notcurses.
   * Added `notcurses_debug_caps()` to dump terminal properties, both those
     reported and those inferred, to a `FILE*`.
   * Added `NCOPTION_NO_CLEAR_BITMAPS` option for `notcurses_init()`.
+  * Added `ncplane_valign()` and `ncplane_halign()`. `ncplane_align()` is now
+    an alias for `ncplane_halign()`, and deprecated.
   * Added `NCVISUAL_OPTION_HORALIGNED` and `NCVISUAL_OPTION_VERALIGNED` flags
     for `ncvisual_render()`.
   * Added `NCPLANE_OPTION_VERALIGNED` flag for `ncplane_create()`.

--- a/USAGE.md
+++ b/USAGE.md
@@ -492,23 +492,34 @@ typedef enum {
   NCALIGN_RIGHT,
 } ncalign_e;
 
-// Return the column at which 'c' cols ought start in order to be aligned
-// according to 'align' within ncplane 'n'. Returns INT_MAX on invalid 'align'.
-// Undefined behavior on negative 'c'.
+#define NCALIGN_TOP NCALIGN_LEFT
+#define NCALIGN_BOTTOM NCALIGN_RIGHT
+
+// Return the offset into 'availu' at which 'u' ought be output given the
+// requirements of 'align'. Return -INT_MAX on invalid 'align'. Undefined
+// behavior on negative 'availu' or 'u'.
 static inline int
-ncplane_align(const struct ncplane* n, ncalign_e align, int c){
-  if(align == NCALIGN_LEFT){
+notcurses_align(int availu, ncalign_e align, int u){
+  if(align == NCALIGN_LEFT || align == NCALIGN_TOP){
     return 0;
   }
-  int cols;
-  ncplane_dim_yx(n, NULL, &cols);
   if(align == NCALIGN_CENTER){
-    return (cols - c) / 2;
-  }else if(align == NCALIGN_RIGHT){
-    return cols - c;
+    return (availu - u) / 2;
   }
-  return INT_MAX;
+  if(align == NCALIGN_RIGHT || align == NCALIGN_BOTTOM){
+    return availu - u;
+  }
+  return -INT_MAX; // invalid |align|
 }
+
+// Return the column at which 'c' cols ought start in order to be aligned
+// according to 'align' within ncplane 'n'. Return -INT_MAX on invalid
+// 'align'. Undefined behavior on negative 'c'.
+static inline int
+ncplane_align(const struct ncplane* n, ncalign_e align, int c){
+  return notcurses_align(ncplane_dim_x(n), align, c);
+}
+
 ```
 
 ## Input

--- a/doc/man/index.html
+++ b/doc/man/index.html
@@ -33,7 +33,7 @@
   </div>
   <hr>
   <iframe align="right" width="560" height="315" src="https://www.youtube.com/embed/cYhZ7myXyyg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  <h2><a href="https://nick-black.com/dankwiki/index.php/Notcurses">notcurses</a> man pages (v2.2.3)</h2>
+  <h2><a href="https://nick-black.com/dankwiki/index.php/Notcurses">notcurses</a> manual pages (v2.2.3)</h2>
   <a href="notcurses.3.html">notcurses(3)</a>—a blingful TUI library<br/>
   <h3>Executables (section 1)</h3>
   <a href="ncls.1.html">ncls</a>—list files, displaying multimedia along with them<br/>

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -308,7 +308,17 @@ namespace ncpp
 
 		int get_align (NCAlign align, int c) const NOEXCEPT_MAYBE
 		{
-			return error_guard<int> (ncplane_align (plane, static_cast<ncalign_e>(align), c), INT_MAX);
+			return error_guard<int> (ncplane_halign (plane, static_cast<ncalign_e>(align), c), INT_MAX);
+		}
+
+		int get_halign (NCAlign align, int c) const NOEXCEPT_MAYBE
+		{
+			return error_guard<int> (ncplane_halign (plane, static_cast<ncalign_e>(align), c), INT_MAX);
+		}
+
+		int get_valign (NCAlign align, int r) const NOEXCEPT_MAYBE
+		{
+			return error_guard<int> (ncplane_valign (plane, static_cast<ncalign_e>(align), r), INT_MAX);
 		}
 
 		void get_dim (int *rows, int *cols) const noexcept

--- a/rust/src/plane/methods.rs
+++ b/rust/src/plane/methods.rs
@@ -1204,12 +1204,27 @@ impl NcPlane {
     /// Returns `-`[NCRESULT_MAX][crate::NCRESULT_MAX] if
     /// [NCALIGN_UNALIGNED][crate::NCALIGN_UNALIGNED] or invalid [NcAlign].
     ///
-    /// *C style function: [ncplane_align()][crate::ncplane_align].*
+    /// *C style function: [ncplane_halign()][crate::ncplane_halign].*
     #[inline]
-    pub fn align(&mut self, align: NcAlign, cols: NcDim) -> NcResult<()> {
+    pub fn halign(&mut self, align: NcAlign, cols: NcDim) -> NcResult<()> {
         error![
-            crate::ncplane_align(self, align, cols),
-            &format!("NcPlane.align({:?}, {})", align, cols)
+            crate::ncplane_halign(self, halign, cols),
+            &format!("NcPlane.halign({:?}, {})", halign, cols)
+        ]
+    }
+
+    /// Returns the row at which `rows` rows ought start in order to be
+    /// aligned according to `align` within this NcPlane.
+    ///
+    /// Returns `-`[NCRESULT_MAX][crate::NCRESULT_MAX] if
+    /// [NCALIGN_UNALIGNED][crate::NCALIGN_UNALIGNED] or invalid [NcAlign].
+    ///
+    /// *C style function: [ncplane_valign()][crate::ncplane_valign].*
+    #[inline]
+    pub fn valign(&mut self, align: NcAlign, cols: NcDim) -> NcResult<()> {
+        error![
+            crate::ncplane_valign(self, valign, cols),
+            &format!("NcPlane.valign({:?}, {})", valign, cols)
         ]
     }
 

--- a/rust/src/plane/methods.rs
+++ b/rust/src/plane/methods.rs
@@ -1208,8 +1208,8 @@ impl NcPlane {
     #[inline]
     pub fn halign(&mut self, align: NcAlign, cols: NcDim) -> NcResult<()> {
         error![
-            crate::ncplane_halign(self, halign, cols),
-            &format!("NcPlane.halign({:?}, {})", halign, cols)
+            crate::ncplane_halign(self, align, cols),
+            &format!("NcPlane.halign({:?}, {})", align, cols)
         ]
     }
 
@@ -1223,8 +1223,8 @@ impl NcPlane {
     #[inline]
     pub fn valign(&mut self, align: NcAlign, cols: NcDim) -> NcResult<()> {
         error![
-            crate::ncplane_valign(self, valign, cols),
-            &format!("NcPlane.valign({:?}, {})", valign, cols)
+            crate::ncplane_valign(self, align, cols),
+            &format!("NcPlane.valign({:?}, {})", align, cols)
         ]
     }
 

--- a/rust/src/plane/mod.rs
+++ b/rust/src/plane/mod.rs
@@ -116,14 +116,13 @@
 //W  ncplane_y
 //W  ncplane_yx
 //
-// functions manually reimplemented: 39
+// functions manually reimplemented: 40
 // ------------------------------------------
 // (X) wont:  9
-// (+) done: 32 / 0
-// (W) wrap: 24
+// (+) done: 33 / 0
+// (W) wrap: 25
 // (#) test:  5
 // ------------------------------------------
-//W+ ncplane_align
 //W+ ncplane_bchannel
 //W+ ncplane_bg_alpha
 //W# ncplane_bg_default_p
@@ -140,6 +139,7 @@
 //W+ ncplane_fg_rgb
 //W+ ncplane_fg_rgb8
 //W+ ncplane_gradient_sized
+//W+ ncplane_halign
 // + ncplane_hline
 //W+ ncplane_perimeter
 //W+ ncplane_perimeter_double
@@ -161,6 +161,7 @@
 //W# ncplane_resize_simple
 // + ncplane_rounded_box
 // + ncplane_rounded_box_sized
+//W+ ncplane_halign
 // + ncplane_vline
 // + ncplane_vprintf
 //

--- a/rust/src/plane/reimplemented.rs
+++ b/rust/src/plane/reimplemented.rs
@@ -250,7 +250,7 @@ pub fn ncplane_resize_simple(plane: &mut NcPlane, y_len: NcDim, x_len: NcDim) ->
 /// *Method: NcPlane.[halign()][NcPlane#method.halign].*
 #[inline]
 pub fn ncplane_halign(plane: &NcPlane, align: NcAlign, cols: NcDim) -> NcIntResult {
-    crate::notcurses_halign(ncplane_dim_x(plane), align, cols)
+    crate::notcurses_align(ncplane_dim_x(plane), align, cols)
 }
 
 /// Returns the row at which `rows` rows ought start in order to be aligned
@@ -262,7 +262,7 @@ pub fn ncplane_halign(plane: &NcPlane, align: NcAlign, cols: NcDim) -> NcIntResu
 /// *Method: NcPlane.[valign()][NcPlane#method.valign].*
 #[inline]
 pub fn ncplane_valign(plane: &NcPlane, align: NcAlign, rows: NcDim) -> NcIntResult {
-    crate::notcurses_valign(ncplane_dim_y(plane), align, rows)
+    crate::notcurses_align(ncplane_dim_y(plane), align, rows)
 }
 
 // line ------------------------------------------------------------------------

--- a/rust/src/plane/reimplemented.rs
+++ b/rust/src/plane/reimplemented.rs
@@ -247,10 +247,22 @@ pub fn ncplane_resize_simple(plane: &mut NcPlane, y_len: NcDim, x_len: NcDim) ->
 /// Returns `-`[`NCRESULT_MAX`][crate::NCRESULT_MAX] if
 /// [NCALIGN_UNALIGNED][crate::NCALIGN_UNALIGNED] or invalid [NcAlign].
 ///
-/// *Method: NcPlane.[align()][NcPlane#method.align].*
+/// *Method: NcPlane.[halign()][NcPlane#method.halign].*
 #[inline]
-pub fn ncplane_align(plane: &NcPlane, align: NcAlign, cols: NcDim) -> NcIntResult {
-    crate::notcurses_align(ncplane_dim_x(plane), align, cols)
+pub fn ncplane_halign(plane: &NcPlane, align: NcAlign, cols: NcDim) -> NcIntResult {
+    crate::notcurses_halign(ncplane_dim_x(plane), align, cols)
+}
+
+/// Returns the row at which `rows` rows ought start in order to be aligned
+/// according to `align` within this NcPlane.
+///
+/// Returns `-`[`NCRESULT_MAX`][crate::NCRESULT_MAX] if
+/// [NCALIGN_UNALIGNED][crate::NCALIGN_UNALIGNED] or invalid [NcAlign].
+///
+/// *Method: NcPlane.[valign()][NcPlane#method.valign].*
+#[inline]
+pub fn ncplane_valign(plane: &NcPlane, align: NcAlign, rows: NcDim) -> NcIntResult {
+    crate::notcurses_valign(ncplane_dim_y(plane), align, rows)
 }
 
 // line ------------------------------------------------------------------------

--- a/src/demo/keller.c
+++ b/src/demo/keller.c
@@ -24,15 +24,14 @@ visualize(struct notcurses* nc, struct ncvisual* ncv){
     struct ncvisual_options vopts = {
       .scaling = NCSCALE_SCALE,
       .blitter = bs[i],
-      .y = NCALIGN_CENTER,
       .flags = NCVISUAL_OPTION_NODEGRADE | NCVISUAL_OPTION_HORALIGNED
                 | NCVISUAL_OPTION_VERALIGNED,
     };
     int scalex, scaley, truey, truex;
     ncvisual_geom(nc, ncv, &vopts, &truey, &truex, &scaley, &scalex);
     vopts.x = NCALIGN_CENTER;
-    vopts.y = (ncplane_dim_y(notcurses_stdplane(nc)) - truey / scaley) / 2;
-//fprintf(stderr, "X: %d truex: %d sclaex: %d\n", vopts.x, truex, scalex);
+    vopts.y = NCALIGN_CENTER;
+//fprintf(stderr, "X: %d truex: %d scalex: %d\n", vopts.x, truex, scalex);
     ncplane_erase(stdn);
     // if we're about to blit pixel graphics, render the screen as empty, so
     // that everything is damaged for the printing of the legend.
@@ -49,9 +48,9 @@ visualize(struct notcurses* nc, struct ncvisual* ncv){
         DEMO_RENDER(nc);
       }
       ncplane_printf_aligned(stdn, ncplane_dim_y(stdn) / 2 - 1, NCALIGN_CENTER,
-                            "%03dx%03d", truex, truey);
+                             "%03dx%03d", truex, truey);
       ncplane_printf_aligned(stdn, ncplane_dim_y(stdn) / 2 + 1, NCALIGN_CENTER,
-                            "%d:%d pixels -> cell", scalex, scaley);
+                             "%d:%d pixels -> cell", scalex, scaley);
     }
     const char* name = notcurses_str_blitter(bs[i]);
     ncplane_printf_aligned(stdn, ncplane_dim_y(stdn) / 2 - 3, NCALIGN_CENTER, "%sblitter", name);

--- a/src/demo/mojibake.c
+++ b/src/demo/mojibake.c
@@ -3417,7 +3417,7 @@ mojiplane(struct ncplane* title, int y, int rows, const char* summary){
     ncplane_destroy(n);
     return NULL;
   }
-  const int x = ncplane_align(n, NCALIGN_RIGHT, strlen(summary) + 2);
+  const int x = ncplane_halign(n, NCALIGN_RIGHT, strlen(summary) + 2);
   if(ncplane_putstr_yx(n, rows - 1, x, summary) < 0){
     ncplane_destroy(n);
     return NULL;

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -376,7 +376,7 @@ reader_demo(struct notcurses* nc){
   struct ncplane* std = notcurses_stddim_yx(nc, &dimy, &dimx);
   const int READER_COLS = 64;
   const int READER_ROWS = 8;
-  const int x = ncplane_align(std, NCALIGN_CENTER, READER_COLS);
+  const int x = ncplane_halign(std, NCALIGN_CENTER, READER_COLS);
   struct ncselector* selector = NULL;
   struct ncmultiselector* mselector = NULL;
   struct ncplane_options nopts = {

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -334,14 +334,14 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
     p->boundto = p;
   }else{ // bound to preexisting pile
     if(nopts->flags & NCPLANE_OPTION_HORALIGNED){
-      p->absx = ncplane_align(n, nopts->x, nopts->cols);
+      p->absx = ncplane_halign(n, nopts->x, nopts->cols);
       p->halign = nopts->x;
     }else{
       p->absx = nopts->x;
     }
     p->absx += n->absx;
     if(nopts->flags & NCPLANE_OPTION_VERALIGNED){
-      p->absy = ncplane_align(n, nopts->y, nopts->rows);
+      p->absy = ncplane_halign(n, nopts->y, nopts->rows);
       p->valign = nopts->y;
     }else{
       p->absy = nopts->y;
@@ -2176,11 +2176,11 @@ int ncplane_resize_realign(ncplane* n){
   }
   int xpos = ncplane_x(n);
   if(n->halign != NCALIGN_UNALIGNED){
-    xpos = ncplane_align(parent, n->halign, ncplane_dim_x(n));
+    xpos = ncplane_halign(parent, n->halign, ncplane_dim_x(n));
   }
   int ypos = ncplane_y(n);
   if(n->valign != NCALIGN_UNALIGNED){
-    ypos = ncplane_align(parent, n->valign, ncplane_dim_y(n));
+    ypos = ncplane_valign(parent, n->valign, ncplane_dim_y(n));
   }
   return ncplane_move_yx(n, ypos, xpos);
 }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -341,7 +341,7 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
     }
     p->absx += n->absx;
     if(nopts->flags & NCPLANE_OPTION_VERALIGNED){
-      p->absy = ncplane_halign(n, nopts->y, nopts->rows);
+      p->absy = ncplane_valign(n, nopts->y, nopts->rows);
       p->valign = nopts->y;
     }else{
       p->absy = nopts->y;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -921,15 +921,6 @@ emit_bg_palindex(notcurses* nc, FILE* out, const nccell* srccell){
   return 0;
 }
 
-int sprite_kitty_annihilate(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
-  (void)p;
-  (void)nc;
-  if(fprintf(out, "\e_Ga=d,d=i,i=%d\e\\", s->id) < 0){
-    return 0;
-  }
-  return 0;
-}
-
 int sprite_sixel_annihilate(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
   (void)nc;
   (void)p;

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -78,7 +78,7 @@ ncselector_draw(ncselector* n){
   int yoff = 0;
   if(n->title){
     size_t riserwidth = n->titlecols + 4;
-    int offx = ncplane_align(n->ncp, NCALIGN_RIGHT, riserwidth);
+    int offx = ncplane_halign(n->ncp, NCALIGN_RIGHT, riserwidth);
     ncplane_cursor_move_yx(n->ncp, 0, 0);
     ncplane_hline(n->ncp, &transchar, offx);
     ncplane_cursor_move_yx(n->ncp, 0, offx);
@@ -92,7 +92,7 @@ ncselector_draw(ncselector* n){
   int bodywidth = ncselector_body_width(n);
   int dimy, dimx;
   ncplane_dim_yx(n->ncp, &dimy, &dimx);
-  int xoff = ncplane_align(n->ncp, NCALIGN_RIGHT, bodywidth);
+  int xoff = ncplane_halign(n->ncp, NCALIGN_RIGHT, bodywidth);
   if(xoff){
     for(int y = yoff + 1 ; y < dimy ; ++y){
       ncplane_cursor_move_yx(n->ncp, y, 0);
@@ -572,7 +572,7 @@ ncmultiselector_draw(ncmultiselector* n){
   int yoff = 0;
   if(n->title){
     size_t riserwidth = n->titlecols + 4;
-    int offx = ncplane_align(n->ncp, NCALIGN_RIGHT, riserwidth);
+    int offx = ncplane_halign(n->ncp, NCALIGN_RIGHT, riserwidth);
     ncplane_cursor_move_yx(n->ncp, 0, 0);
     ncplane_hline(n->ncp, &transchar, offx);
     ncplane_rounded_box_sized(n->ncp, 0, n->boxchannels, 3, riserwidth, 0);
@@ -585,7 +585,7 @@ ncmultiselector_draw(ncmultiselector* n){
   int bodywidth = ncmultiselector_body_width(n);
   int dimy, dimx;
   ncplane_dim_yx(n->ncp, &dimy, &dimx);
-  int xoff = ncplane_align(n->ncp, NCALIGN_RIGHT, bodywidth);
+  int xoff = ncplane_halign(n->ncp, NCALIGN_RIGHT, bodywidth);
   if(xoff){
     for(int y = yoff + 1 ; y < dimy ; ++y){
       ncplane_cursor_move_yx(n->ncp, y, 0);

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -421,6 +421,12 @@ ncvisual* ncvisual_from_bgra(const void* bgra, int rows, int rowstride, int cols
   return ncv;
 }
 
+// by the end, disprows/dispcols refer to the number of source rows/cols (in
+// pixels), which will be mapped to a region of cells scaled by the encodings).
+// the blit will begin at placey/placex (in terms of cells). begy/begx define
+// the origin of the source region to draw (in pixels). leny/lenx defined the
+// geometry of the source region to draw, again in pixels. ncv->rows and
+// ncv->cols define the source geometry in pixels.
 ncplane* ncvisual_render_cells(notcurses* nc, ncvisual* ncv, const struct blitset* bset,
                                int placey, int placex, int begy, int begx,
                                int leny, int lenx, ncplane* n, ncscale_e scaling,
@@ -480,10 +486,10 @@ ncplane* ncvisual_render_cells(notcurses* nc, ncvisual* ncv, const struct blitse
       } // else stretch
     }
     if(flags & NCVISUAL_OPTION_HORALIGNED){
-      placex = ncplane_align(n, placex, dispcols / encoding_x_scale(&nc->tcache, bset));
+      placex = ncplane_halign(n, placex, dispcols / encoding_x_scale(&nc->tcache, bset));
     }
     if(flags & NCVISUAL_OPTION_VERALIGNED){
-      placey = ncplane_align(n, placey, disprows / encoding_y_scale(&nc->tcache, bset));
+      placey = ncplane_valign(n, placey, disprows / encoding_y_scale(&nc->tcache, bset));
     }
   }
   leny = (leny / (double)ncv->rows) * ((double)disprows);

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -351,7 +351,7 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
     ncv = std::make_unique<Visual>(argv[i]);
     struct ncvisual_options vopts{};
     int r;
-    vopts.flags |= NCVISUAL_OPTION_HORALIGNED/* | NCVISUAL_OPTION_VERALIGNED*/;
+    vopts.flags |= NCVISUAL_OPTION_HORALIGNED | NCVISUAL_OPTION_VERALIGNED;
     vopts.y = NCALIGN_CENTER;
     vopts.x = NCALIGN_CENTER;
     vopts.n = n;


### PR DESCRIPTION
Introduce `ncplane_valign()`. Deprecate `ncplane_align()` after renaming it `ncplane_halign()`. Update all callers. Use `ncplane_valign()` in all vertical alignment contexts. Fixes `ncplayer` and the `keller` demo. Closes #1468 