### PR TITLE
Marginalized planes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@ rearrangements of Notcurses.
     tabs. Courtesy Łukasz Drukała, in his first contribution.
   * Removed **notcurses_canpixel()**, which was obsoleted by
     **notcurses_check_pixel_support()**.
+  * Added `NCPLANE_OPTION_MARGINALIZED` flag for `ncplane_create()`. Added
+    the `ncplane_resize_marginalized()` resize callback. This allows you to
+    have automatic resizing with a margin relative to some parent plane.
 
 * 2.2.3 (2021-03-08)
   * Implemented **EXPERIMENTAL** `NCBLIT_PIXEL` for terminals reporting Sixel

--- a/USAGE.md
+++ b/USAGE.md
@@ -783,7 +783,7 @@ int ncplane_resize_maximize(struct ncplane* n);
 // Suitable for use as a 'resizecb' with planes created with
 // NCPLANE_OPTION_MARGINALIZED. This will resize the plane 'n' against its
 // parent, attempting to enforce the supplied margins.
-int ncplane_resize_marginalize(struct ncplane* n);
+int ncplane_resize_marginalized(struct ncplane* n);
 
 // Suitable for use as a 'resizecb'. This will realign the plane 'n' against
 // its parent, using the alignment specified at ncplane_create()-time.

--- a/USAGE.md
+++ b/USAGE.md
@@ -731,16 +731,24 @@ When an `ncplane` is no longer needed, free it with
 #define NCPLANE_OPTION_HORALIGNED 0x0001ull
 // Vertical alignment relative to the parent plane. Use ncalign_e for 'y'.
 #define NCPLANE_OPTION_VERALIGNED 0x0002ull
+// Maximize relative to the parent plane, modulo the provided margins. The
+// margins are best-effort; the plane will always be at least 1 column by
+// 1 row. If the margins can be effected, the plane will be sized to all
+// remaining space. 'y' and 'x' are overloaded as the top and left margins
+// when this flag is used. 'rows' and 'cols' must be 0 when this flag is
+// used. This flag is exclusive with both of the alignment flags.
+#define NCPLANE_OPTION_MARGINALIZED 0x0004ull
 
 typedef struct ncplane_options {
   int y;            // vertical placement relative to parent plane
   int x;            // horizontal placement relative to parent plane
-  int rows;         // number of rows, must be positive
-  int cols;         // number of columns, must be positive
+  int rows;         // rows, must be positive (unless NCPLANE_OPTION_MARGINALIZED)
+  int cols;         // columns, must be positive (unless NCPLANE_OPTION_MARGINALIZED)
   void* userptr;    // user curry, may be NULL
   const char* name; // name (used only for debugging), may be NULL
   int (*resizecb)(struct ncplane*); // callback when parent is resized
   uint64_t flags;   // closure over NCPLANE_OPTION_*
+  int margin_b, margin_r; // margins (require NCPLANE_OPTION_MARGINALIZED)
 } ncplane_options;
 
 // Create a new ncplane bound to plane 'n', at the offset 'y'x'x' (relative to
@@ -768,8 +776,17 @@ void ncplane_set_resizecb(struct ncplane* n, int(*resizecb)(struct ncplane*));
 // Returns the ncplane's current resize callback.
 int (*ncplane_resizecb(const struct ncplane* n))(struct ncplane*);
 
-// Suitable for use as a 'resizecb'. This will realign the plane 'n' against its
-// parent, using the alignment specified at ncplane_create()-time.
+// Suitable for use as a 'resizecb', this will resize the plane to the visual
+// region's size. It is used for the standard plane.
+int ncplane_resize_maximize(struct ncplane* n);
+
+// Suitable for use as a 'resizecb' with planes created with
+// NCPLANE_OPTION_MARGINALIZED. This will resize the plane 'n' against its
+// parent, attempting to enforce the supplied margins.
+int ncplane_resize_marginalize(struct ncplane* n);
+
+// Suitable for use as a 'resizecb'. This will realign the plane 'n' against
+// its parent, using the alignment specified at ncplane_create()-time.
 int ncplane_resize_realign(struct ncplane* n);
 
 // Get the plane to which the plane 'n' is bound, if any.

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -50,7 +50,7 @@ typedef struct ncplane_options {
 
 **int ncplane_resize_maximize(struct ncplane* ***n***);**
 
-**int ncplane_resize_marginalize(struct ncplane* ***n***);**
+**int ncplane_resize_marginalized(struct ncplane* ***n***);**
 
 **void ncplane_set_resizecb(struct ncplane* ***n***, int(*resizecb)(struct ncplane*));**
 
@@ -240,7 +240,7 @@ will be interpreted as top and left margins. ***margin_b*** and ***margin_r***
 will be interpreted as bottom and right margins. The plane will take the maximum
 space possible subject to its parent planes and these margins. The plane cannot
 become smaller than 1x1 (the margins are best-effort).
-**ncplane_resize_marginalize** should usually be used together with this flag,
+**ncplane_resize_marginalized** should usually be used together with this flag,
 so that the plane is automatically resized.
 
 **ncplane_reparent** detaches the plane ***n*** from any plane to which it is

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -92,6 +92,8 @@ namespace ncpp
 				.name = nullptr,
 				.resizecb = nullptr,
 				.flags = 0,
+				.margin_b = 0,
+				.margin_r = 0,
 			};
 			plane = ncplane_create (
 				notcurses_stdplane(get_notcurses ()),
@@ -1310,6 +1312,8 @@ namespace ncpp
 				.name = nullptr,
 				.resizecb = nullptr,
 				.flags = 0,
+				.margin_b = 0,
+				.margin_r = 0,
 			};
 			return create_plane (n, nopts);
 		}
@@ -1324,6 +1328,8 @@ namespace ncpp
 				opaque,
 				nullptr,
 				nullptr,
+				0,
+				0,
 				0,
 			};
 			return create_plane (n, nopts);

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1173,7 +1173,7 @@ API int ncplane_resize_maximize(struct ncplane* n);
 // Suitable for use as a 'resizecb' with planes created with
 // NCPLANE_OPTION_MARGINALIZED. This will resize the plane 'n' against its
 // parent, attempting to enforce the supplied margins.
-API int ncplane_resize_marginalize(struct ncplane* n);
+API int ncplane_resize_marginalized(struct ncplane* n);
 
 // Suitable for use as a 'resizecb'. This will realign the plane 'n' against
 // its parent, using the alignment specified at ncplane_create()-time.

--- a/rust/src/plane/methods.rs
+++ b/rust/src/plane/methods.rs
@@ -29,6 +29,8 @@ impl NcPlaneOptions {
         cols: NcDim,
         resizecb: Option<NcResizeCb>,
         flags: u64,
+        margin_b: NcOffset,
+        margin_r: NcOffset,
     ) -> Self {
         NcPlaneOptions {
             y: y as i32,
@@ -39,6 +41,8 @@ impl NcPlaneOptions {
             name: null(),
             resizecb: crate::ncresizecb_to_c(resizecb),
             flags,
+            margin_b: margin_b as i32,
+            margin_r: margin_r as i32,
         }
     }
 
@@ -64,6 +68,8 @@ impl NcPlaneOptions {
             name: null(),
             resizecb: crate::ncresizecb_to_c(resizecb),
             flags,
+            0,
+            0,
         }
     }
 }

--- a/rust/src/plane/methods.rs
+++ b/rust/src/plane/methods.rs
@@ -13,7 +13,7 @@ use crate::{
 impl NcPlaneOptions {
     /// New NcPlaneOptions using the horizontal x.
     pub fn new(y: NcOffset, x: NcOffset, rows: NcDim, cols: NcDim) -> Self {
-        Self::with_flags(y, x, rows, cols, None, 0)
+        Self::with_flags(y, x, rows, cols, None, 0, 0, 0)
     }
 
     /// New NcPlaneOptions with horizontal alignment.
@@ -68,8 +68,8 @@ impl NcPlaneOptions {
             name: null(),
             resizecb: crate::ncresizecb_to_c(resizecb),
             flags,
-            0,
-            0,
+            margin_b: 0,
+            margin_r: 0,
         }
     }
 }

--- a/src/demo/keller.c
+++ b/src/demo/keller.c
@@ -33,20 +33,11 @@ visualize(struct notcurses* nc, struct ncvisual* ncv){
     vopts.y = NCALIGN_CENTER;
 //fprintf(stderr, "X: %d truex: %d scalex: %d\n", vopts.x, truex, scalex);
     ncplane_erase(stdn);
-    // if we're about to blit pixel graphics, render the screen as empty, so
-    // that everything is damaged for the printing of the legend.
-    if(vopts.blitter == NCBLIT_PIXEL){
-      DEMO_RENDER(nc);
-    }
     struct ncplane* n;
     if((n = ncvisual_render(nc, ncv, &vopts)) == NULL){
       ncplane_printf_aligned(stdn, ncplane_dim_y(stdn) / 2 - 1, NCALIGN_CENTER, "not available");
     }else{
-      // FIXME shouldn't need this once z-axis is united with bitmap graphics
       ncplane_move_below(n, stdn);
-      if(vopts.blitter == NCBLIT_PIXEL){
-        DEMO_RENDER(nc);
-      }
       ncplane_printf_aligned(stdn, ncplane_dim_y(stdn) / 2 - 1, NCALIGN_CENTER,
                              "%03dx%03d", truex, truey);
       ncplane_printf_aligned(stdn, ncplane_dim_y(stdn) / 2 + 1, NCALIGN_CENTER,

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -94,6 +94,8 @@ typedef struct ncplane {
   // plane is bound, but absx/absy are always relative to the terminal origin.
   // they must thus be translated by any function which moves a parent plane.
   int absx, absy;        // origin of the plane relative to the pile's origin
+                         //  also used as left and top margin on resize by
+                         //  ncplane_resize_marginalized()
   int lenx, leny;        // size of the plane, [0..len{x,y}) is addressable
   egcpool pool;          // attached storage pool for UTF-8 EGCs
   uint64_t channels;     // works the same way as cells
@@ -122,6 +124,7 @@ typedef struct ncplane {
   ncalign_e halign;      // relative to parent plane, for automatic realignment
   ncalign_e valign;      // relative to parent plane, for automatic realignment
   uint16_t stylemask;    // same deal as in a cell
+  int margin_b, margin_r;// bottom and right margins, stored for resize
   bool scrolling;        // is scrolling enabled? always disabled by default
 } ncplane;
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -415,7 +415,7 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
     pthread_mutex_unlock(&nc->pilelock);
   }
   loginfo(nc, "Created new %dx%d plane \"%s\" @ %dx%d\n",
-          nopts->rows, nopts->cols, p->name ? p->name : "", p->absy, p->absx);
+          p->leny, p->lenx, p->name ? p->name : "", p->absy, p->absx);
   return p;
 }
 
@@ -1993,7 +1993,7 @@ void ncplane_erase(ncplane* n){
   // wiped out by the egcpool_dump(). do a duplication (to get the stylemask
   // and channels), and then reload.
   char* egc = cell_strdup(n, &n->basecell);
-  memset(n->fb, 0, sizeof(*n->fb) * n->lenx * n->leny);
+  memset(n->fb, 0, sizeof(*n->fb) * n->leny * n->lenx);
   egcpool_dump(&n->pool);
   egcpool_init(&n->pool);
   // we need to zero out the EGC before handing this off to cell_load, but

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2184,9 +2184,27 @@ int (*ncplane_resizecb(const ncplane* n))(ncplane*){
 }
 
 int ncplane_resize_marginalized(ncplane* n){
-  (void)n;// FIXME uhhh do something here
-fprintf(stderr, "NEED TO RESIZE THIS MARGINALIZED-ASS PLANE\n");
-  return 0;
+  const ncplane* parent = ncplane_parent_const(n);
+  // a marginalized plane cannot be larger than its oppressor plane =]
+  int maxy, maxx;
+  if(parent == n){ // root plane, need to use pile size
+    return 0; // FIXME
+  }else{
+    ncplane_dim_yx(parent, &maxy, &maxx);
+  }
+  if((maxy -= n->margin_b) < 1){
+    maxy = 1;
+  }
+  if((maxx -= n->margin_r) < 1){
+    maxx = 1;
+  }
+  // FIXME mix in top/left margins (absy/absx)
+  int oldy, oldx;
+  ncplane_dim_yx(n, &oldy, &oldx); // current dimensions of 'n'
+  int keepleny = oldy > maxy ? maxy : oldy;
+  int keeplenx = oldx > maxx ? maxx : oldx;
+  // FIXME place it according to top/left
+  return ncplane_resize_internal(n, 0, 0, keepleny, keeplenx, 0, 0, maxy, maxx);
 }
 
 int ncplane_resize_maximize(ncplane* n){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -416,6 +416,7 @@ const ncplane* notcurses_stdplane_const(const notcurses* nc){
 }
 
 ncplane* ncplane_create(ncplane* n, const ncplane_options* nopts){
+fprintf(stderr, "nopts: %p name: %s\n", nopts, nopts->name);
   return ncplane_new_internal(ncplane_notcurses(n), n, nopts);
 }
 
@@ -473,6 +474,7 @@ inline int ncplane_cursor_move_yx(ncplane* n, int y, int x){
 }
 
 ncplane* ncplane_dup(const ncplane* n, void* opaque){
+fprintf(stderr, "FUCXK ME IN THE ASS\n");
   int dimy = n->leny;
   int dimx = n->lenx;
   // if we're duping the standard plane, we need adjust for marginalia
@@ -2152,13 +2154,17 @@ int (*ncplane_resizecb(const ncplane* n))(ncplane*){
   return n->resizecb;
 }
 
+int ncplane_resize_marginalize(ncplane* n){
+  (void)n;// FIXME uhhh do something here
+  return 0;
+}
+
 int ncplane_resize_maximize(ncplane* n){
-  const ncpile* pile = ncplane_pile(n);
+  const ncpile* pile = ncplane_pile(n); // FIXME should be taken against parent
   const int rows = pile->dimy;
   const int cols = pile->dimx;
   int oldy, oldx;
   ncplane_dim_yx(n, &oldy, &oldx); // current dimensions of 'n'
-//fprintf(stderr, "CURRENT: %d/%d TERM: %d/%d\n", oldy, oldx, rows, cols);
   int keepleny = oldy > rows ? rows : oldy;
   int keeplenx = oldx > cols ? cols : oldx;
   return ncplane_resize_internal(n, 0, 0, keepleny, keeplenx, 0, 0, rows, cols);
@@ -2166,6 +2172,7 @@ int ncplane_resize_maximize(ncplane* n){
 
 int ncplane_resize_realign(ncplane* n){
   const ncplane* parent = ncplane_parent_const(n);
+  // FIXME this *should* be allowed for other root planes, though, right?
   if(parent == n){ // somehow got stdplane, should never get here
     logerror(ncplane_notcurses(n), "Passed the standard plane");
     return -1;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -320,14 +320,6 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
   if(p == NULL){
     return NULL;
   }
-  size_t fbsize = sizeof(*p->fb) * (nopts->rows * nopts->cols);
-  if((p->fb = malloc(fbsize)) == NULL){
-    logerror(nc, "Error allocating cellmatrix (r=%d, c=%d)\n",
-             nopts->rows, nopts->cols);
-    free(p);
-    return NULL;
-  }
-  memset(p->fb, 0, fbsize);
   p->scrolling = false;
   if(nopts->flags & NCPLANE_OPTION_MARGINALIZED){
     p->margin_b = nopts->margin_b;
@@ -348,6 +340,14 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
     p->leny = nopts->rows;
     p->lenx = nopts->cols;
   }
+  size_t fbsize = sizeof(*p->fb) * (p->leny * p->lenx);
+  if((p->fb = malloc(fbsize)) == NULL){
+    logerror(nc, "Error allocating cellmatrix (r=%d, c=%d)\n",
+             p->leny, p->lenx);
+    free(p);
+    return NULL;
+  }
+  memset(p->fb, 0, fbsize);
   p->x = p->y = 0;
   p->logrow = 0;
   p->sprite = NULL;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -958,7 +958,7 @@ rasterize_sprixels(notcurses* nc, const ncpile* p, FILE* out){
       ncplane_yx(s->n, &y, &x);
       y += s->y;
       x += s->x;
-//fprintf(stderr, "DRAWING BITMAP AT %d/%d\n", y + nc->stdplane->absy, x + nc->stdplane->absx);
+//fprintf(stderr, "DRAWING BITMAP %d AT %d/%d\n", s->id, y + nc->stdplane->absy, x + nc->stdplane->absx);
       if(goto_location(nc, out, y + nc->stdplane->absy, x + nc->stdplane->absx)){
         return -1;
       }

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -61,19 +61,26 @@ sprixel* sprixel_create(ncplane* n, const char* s, int bytes, int placey, int pl
 }
 
 int sprite_wipe_cell(const notcurses* nc, sprixel* s, int ycell, int xcell){
+  if(s->invalidated == SPRIXEL_HIDE){ // no need to do work if we're killing it
+    return 0;
+  }
   if(!nc->tcache.pixel_cell_wipe){
     return 0;
   }
-  if(ycell >= s->dimy){
+  if(ycell >= s->dimy || ycell < 0){
+    logerror(nc, "Bad y coordinate %d (%d)\n", ycell, s->dimy);
     return -1;
   }
-  if(xcell >= s->dimx){
+  if(xcell >= s->dimx || xcell < 0){
+    logerror(nc, "Bad x coordinate %d (%d)\n", xcell, s->dimx);
     return -1;
   }
   if(s->tacache[s->dimx * ycell + xcell] == 2){
+//fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 0; // already annihilated
   }
   s->tacache[s->dimx * ycell + xcell] = 2;
+//fprintf(stderr, "WIPING %d %d/%d\n", s->id, ycell, xcell);
   int r = nc->tcache.pixel_cell_wipe(nc, s, ycell, xcell);
   if(r == 0){
     s->invalidated = SPRIXEL_INVALIDATED;

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -346,7 +346,7 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
   // leave a line at the bottom. perhaps one day we'll put information there.
   // for now, this keeps us from scrolling when we use bitmaps.
   nopts.margin_b = 1;
-  nopts.resizecb = ncplane_resize_marginalize;
+  nopts.resizecb = ncplane_resize_marginalized;
   nopts.flags = NCPLANE_OPTION_MARGINALIZED;
   auto n = ncplane_create(*stdn, &nopts);
   if(!n){

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -346,11 +346,8 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
   nopts.rows = dimy - 1; // don't want kitty to scroll on pixels FIXME
   nopts.cols = dimx;
   nopts.resizecb = ncplane_resize_maximize;
-  struct ncplane* n = ncplane_create(*stdn, &nopts); // FIXME make c++ style
-  if(!n){
-    return -1;
-  }
-  ncplane_move_bottom(n);
+  auto n = std::make_unique<Plane>(*stdn, &nopts);
+  n->move_bottom();
   for(auto i = 0 ; i < argc ; ++i){
     std::unique_ptr<Visual> ncv;
     ncv = std::make_unique<Visual>(argv[i]);
@@ -359,13 +356,13 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
     vopts.flags |= NCVISUAL_OPTION_HORALIGNED | NCVISUAL_OPTION_VERALIGNED;
     vopts.y = NCALIGN_CENTER;
     vopts.x = NCALIGN_CENTER;
-    vopts.n = n;
+    vopts.n = *n;
     vopts.scaling = scalemode;
     vopts.blitter = blitter;
     if(vopts.blitter == NCBLIT_PIXEL){
       notcurses_check_pixel_support(nc);
     }
-    ncplane_erase(n);
+    n->erase();
     do{
       struct marshal marsh = {
         .subtitle_plane = nullptr,

--- a/src/pocpp/reader.cpp
+++ b/src/pocpp/reader.cpp
@@ -46,6 +46,7 @@ auto main(int argc, const char** argv) -> int {
     .name = "read",
     .resizecb = nullptr,
     .flags = 0,
+    .margin_b = 0, .margin_r = 0,
   };
   struct ncplane* rp = ncplane_create(**n, &nopts);
   ncplane_set_base(rp, "░", 0, 0);

--- a/src/pocpp/reel.cpp
+++ b/src/pocpp/reel.cpp
@@ -222,6 +222,7 @@ int main(int argc, char** argv){
     .name = "reel",
     .resizecb = resize_reel,
     .flags = NCPLANE_OPTION_HORALIGNED,
+    .margin_b = 0, .margin_r = 0,
   };
   n = ncplane_create(nstd, &nopts);
   if(!n){

--- a/src/tests/blit.cpp
+++ b/src/tests/blit.cpp
@@ -23,6 +23,7 @@ TEST_CASE("Blitting") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != ncp);
@@ -71,6 +72,7 @@ TEST_CASE("Blitting") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != ncp);

--- a/src/tests/cell.cpp
+++ b/src/tests/cell.cpp
@@ -162,6 +162,7 @@ TEST_CASE("Cell") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto np = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != np);
@@ -201,6 +202,7 @@ TEST_CASE("Cell") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto np = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != np);
@@ -240,6 +242,7 @@ TEST_CASE("Cell") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto np = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != np);
@@ -279,6 +282,7 @@ TEST_CASE("Cell") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto np = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != np);
@@ -319,6 +323,7 @@ TEST_CASE("Cell") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto np = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != np);

--- a/src/tests/fills.cpp
+++ b/src/tests/fills.cpp
@@ -44,6 +44,7 @@ TEST_CASE("Fills") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* pfn = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != pfn);
@@ -76,6 +77,7 @@ TEST_CASE("Fills") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* pfn = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != pfn);
@@ -95,6 +97,7 @@ TEST_CASE("Fills") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* pfn = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != pfn);
@@ -366,6 +369,7 @@ TEST_CASE("Fills") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* p1 = ncplane_create(n_, &nopts);
     REQUIRE(p1);
@@ -410,6 +414,7 @@ TEST_CASE("Fills") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto p1 = ncplane_create(n_, &nopts);
     REQUIRE(p1);
@@ -464,6 +469,7 @@ TEST_CASE("Fills") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* p1 = ncplane_create(n_, &nopts);
     REQUIRE(p1);
@@ -482,6 +488,7 @@ TEST_CASE("Fills") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto p2 = ncplane_create(n_, &n2opts);
     REQUIRE(p2);
@@ -523,6 +530,7 @@ TEST_CASE("Fills") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* p1 = ncplane_create(n_, &nopts);
     REQUIRE(p1);
@@ -541,6 +549,7 @@ TEST_CASE("Fills") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto p2 = ncplane_create(n_, &n2opts);
     REQUIRE(p2);

--- a/src/tests/geom.cpp
+++ b/src/tests/geom.cpp
@@ -33,6 +33,7 @@ TEST_CASE("Geometry") {
         .name = nullptr,
         .resizecb = nullptr,
         .flags = 0,
+        .margin_b = 0, .margin_r = 0,
       };
       auto n = ncplane_create(n_, &nopts);
       REQUIRE(n);
@@ -79,6 +80,7 @@ TEST_CASE("Geometry") {
         .name = nullptr,
         .resizecb = nullptr,
         .flags = 0,
+        .margin_b = 0, .margin_r = 0,
       };
       auto n = ncplane_create(n_, &nopts);
       REQUIRE(n);

--- a/src/tests/layout.cpp
+++ b/src/tests/layout.cpp
@@ -21,6 +21,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -45,6 +46,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -69,6 +71,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -94,6 +97,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -120,6 +124,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -146,6 +151,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -172,6 +178,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -199,6 +206,7 @@ TEST_CASE("TextLayout") {
         .name = nullptr,
         .resizecb = nullptr,
         .flags = 0,
+        .margin_b = 0, .margin_r = 0,
       };
       auto sp = ncplane_create(n_, &nopts);
       REQUIRE(sp);
@@ -227,6 +235,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -255,6 +264,7 @@ TEST_CASE("TextLayout") {
         .name = nullptr,
         .resizecb = nullptr,
         .flags = 0,
+        .margin_b = 0, .margin_r = 0,
       };
       auto sp = ncplane_create(n_, &nopts);
       REQUIRE(sp);
@@ -281,6 +291,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -307,6 +318,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -333,6 +345,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -359,6 +372,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -385,6 +399,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -411,6 +426,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -438,6 +454,7 @@ TEST_CASE("TextLayout") {
         .name = nullptr,
         .resizecb = nullptr,
         .flags = 0,
+        .margin_b = 0, .margin_r = 0,
       };
       auto sp = ncplane_create(n_, &nopts);
       REQUIRE(sp);
@@ -466,6 +483,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -492,6 +510,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -526,6 +545,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -560,6 +580,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);
@@ -597,6 +618,7 @@ TEST_CASE("TextLayout") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto sp = ncplane_create(n_, &nopts);
     REQUIRE(sp);

--- a/src/tests/notcurses.cpp
+++ b/src/tests/notcurses.cpp
@@ -80,6 +80,7 @@ TEST_CASE("NotcursesBase") {
           .name = nullptr,
           .resizecb = nullptr,
           .flags = 0,
+          .margin_b = 0, .margin_r = 0,
         };
         planes[idx] = ncplane_create(notcurses_stdplane(nc_), &nopts);
         REQUIRE(planes[idx]);

--- a/src/tests/piles.cpp
+++ b/src/tests/piles.cpp
@@ -13,6 +13,7 @@ TEST_CASE("Piles") {
   SUBCASE("SmallerPileRender") {
     struct ncplane_options nopts = {
       1, 1, dimy - 2, dimx - 2, nullptr, "small", nullptr, 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto np = ncpile_create(nc_, &nopts);
     REQUIRE(nullptr != np);
@@ -49,7 +50,7 @@ TEST_CASE("Piles") {
   // create a plane bigger than the standard plane, and render it as a pile
   SUBCASE("BiggerPileRender") {
     struct ncplane_options nopts = {
-      -1, -1, dimy + 2, dimx + 2, nullptr, "big", nullptr, 0,
+      -1, -1, dimy + 2, dimx + 2, nullptr, "big", nullptr, 0, 0, 0,
     };
     auto np = ncpile_create(nc_, &nopts);
     REQUIRE(nullptr != np);
@@ -86,7 +87,7 @@ TEST_CASE("Piles") {
   // create a new pile, and rotate subplanes through the root set
   SUBCASE("ShufflePile") {
     struct ncplane_options nopts = {
-      1, 1, dimy - 2, dimx - 2, nullptr, "new1", nullptr, 0,
+      1, 1, dimy - 2, dimx - 2, nullptr, "new1", nullptr, 0, 0, 0,
     };
     auto n1 = ncpile_create(nc_, &nopts);
     REQUIRE(nullptr != n1);
@@ -131,7 +132,7 @@ TEST_CASE("Piles") {
 
   SUBCASE("ShufflePileFamilies") {
     struct ncplane_options nopts = {
-      1, 1, dimy - 2, dimx - 2, nullptr, "new1", nullptr, 0,
+      1, 1, dimy - 2, dimx - 2, nullptr, "new1", nullptr, 0, 0, 0,
     };
     auto n1 = ncpile_create(nc_, &nopts);
     REQUIRE(nullptr != n1);
@@ -175,6 +176,7 @@ TEST_CASE("Piles") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto gen1 = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != gen1);
@@ -223,6 +225,7 @@ TEST_CASE("Piles") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto gen1 = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != gen1);

--- a/src/tests/pixel.cpp
+++ b/src/tests/pixel.cpp
@@ -28,6 +28,7 @@ TEST_CASE("Pixel") {
     REQUIRE(ncv);
     struct ncvisual_options vopts{};
     vopts.blitter = NCBLIT_PIXEL;
+    vopts.flags = NCVISUAL_OPTION_NODEGRADE;
     auto newn = ncvisual_render(nc_, ncv, &vopts);
     CHECK(newn);
     CHECK(0 == notcurses_render(nc_));
@@ -148,6 +149,29 @@ TEST_CASE("Pixel") {
     ncvisual_destroy(ncv);
     CHECK(0 == notcurses_render(nc_));
   }
+
+#ifdef NOTCURSES_USE_MULTIMEDIA
+  SUBCASE("PixelWipeScreen") {
+    auto ncv = ncvisual_from_file(find_data("worldmap.png"));
+    REQUIRE(ncv);
+    struct ncvisual_options vopts{};
+    vopts.blitter = NCBLIT_PIXEL;
+    vopts.flags = NCVISUAL_OPTION_NODEGRADE;
+    auto newn = ncvisual_render(nc_, ncv, &vopts);
+    CHECK(newn);
+    CHECK(0 == notcurses_render(nc_));
+    const auto s = newn->sprite;
+    for(int y = 0 ; y < s->dimy ; ++y){
+      for(int x = 0 ; x < s->dimx ; ++x){
+        CHECK(0 == sprite_wipe_cell(nc_, s, y, x));
+        CHECK(0 == notcurses_render(nc_));
+      }
+    }
+    ncplane_destroy(newn);
+    CHECK(0 == notcurses_render(nc_));
+    ncvisual_destroy(ncv);
+  }
+#endif
 
   CHECK(!notcurses_stop(nc_));
 }

--- a/src/tests/plane.cpp
+++ b/src/tests/plane.cpp
@@ -382,6 +382,7 @@ TEST_CASE("Plane") {
       .cols = x,
       .userptr = sentinel,
       .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);
@@ -405,6 +406,7 @@ TEST_CASE("Plane") {
       .rows = y,
       .cols = x,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);
@@ -430,6 +432,7 @@ TEST_CASE("Plane") {
       .rows = y,
       .cols = x,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ncp = ncpile_create(nc_, &nopts);
     REQUIRE(ncp);
@@ -461,6 +464,7 @@ TEST_CASE("Plane") {
       .rows = maxy,
       .cols = maxx,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* newp = ncplane_create(n_, &nopts);
     REQUIRE(newp);
@@ -507,6 +511,7 @@ TEST_CASE("Plane") {
       .rows = maxy,
       .cols = maxx,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* newp = ncplane_create(n_, &nopts);
     REQUIRE(newp);
@@ -751,6 +756,7 @@ TEST_CASE("Plane") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);
@@ -773,6 +779,7 @@ TEST_CASE("Plane") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);
@@ -827,6 +834,7 @@ TEST_CASE("Plane") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     REQUIRE(n);
@@ -856,6 +864,7 @@ TEST_CASE("Plane") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ndom = ncplane_create(n_, &nopts);
     REQUIRE(ndom);
@@ -879,6 +888,7 @@ TEST_CASE("Plane") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ndom = ncplane_create(n_, &nopts);
     REQUIRE(ndom);
@@ -904,6 +914,7 @@ TEST_CASE("Plane") {
       .userptr = nullptr,
       .name = "ndom",
       .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ndom = ncplane_create(n_, &nopts);
     CHECK(ncplane_pile(ndom) == ncplane_pile(n_));
@@ -944,6 +955,7 @@ TEST_CASE("Plane") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ndom = ncplane_create(n_, &nopts);
     REQUIRE(ndom);
@@ -958,6 +970,7 @@ TEST_CASE("Plane") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = "new1", .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto n1 = ncplane_create(n_, &nopts);
     REQUIRE(n1);

--- a/src/tests/plot.cpp
+++ b/src/tests/plot.cpp
@@ -149,6 +149,7 @@ TEST_CASE("Plot") {
     ncplane_options nopts = {
       .y = 1, .x = 1, .rows = 6, .cols = 50,
       .userptr = nullptr, .name = "plot", .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);
@@ -180,6 +181,7 @@ TEST_CASE("Plot") {
     ncplane_options nopts = {
       .y = 1, .x = 1, .rows = 1, .cols = 9,
       .userptr = nullptr, .name = "plot", .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);
@@ -206,6 +208,7 @@ TEST_CASE("Plot") {
     ncplane_options nopts = {
       .y = 1, .x = 1, .rows = 1, .cols = 9,
       .userptr = nullptr, .name = "plot", .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);
@@ -229,6 +232,7 @@ TEST_CASE("Plot") {
     ncplane_options nopts = {
       .y = 1, .x = 1, .rows = 1, .cols = 16,
       .userptr = nullptr, .name = "plot", .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);
@@ -255,6 +259,7 @@ TEST_CASE("Plot") {
     ncplane_options nopts = {
       .y = 1, .x = 1, .rows = 1, .cols = 25,
       .userptr = nullptr, .name = "plot", .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);

--- a/src/tests/progbar.cpp
+++ b/src/tests/progbar.cpp
@@ -26,6 +26,7 @@ TEST_CASE("ProgressBar") {
       .name = "pbar",
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     const char* egcs[] = { " ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "▀" };
     auto n = ncplane_create(n_, &nopts);
@@ -55,6 +56,7 @@ TEST_CASE("ProgressBar") {
       .name = "pbar",
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     const char* egcs[] = { " ", "▔", "🮂", "🮃", "▀", "🮄", "🮅", "🮆", "▀"};
     auto n = ncplane_create(n_, &nopts);
@@ -91,6 +93,7 @@ TEST_CASE("ProgressBar") {
       .name = "pbar",
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     const char* egcs[] = { " ", "▏", "▎", "▍", "▌", "▋", "▊", "▉" };
     auto n = ncplane_create(n_, &nopts);
@@ -130,6 +133,7 @@ TEST_CASE("ProgressBar") {
       .name = "pbar",
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     const char* egcs[] = { " ", "🮇", "🮇", "🮈", "▐", "🮉", "🮊", "🮋" };
     auto n = ncplane_create(n_, &nopts);

--- a/src/tests/reader.cpp
+++ b/src/tests/reader.cpp
@@ -23,6 +23,7 @@ TEST_CASE("Readers") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(notcurses_stdplane(nc_), &nopts);
     uint64_t echannels = CHANNELS_RGB_INITIALIZER(0xff, 0x44, 0xff, 0, 0, 0);

--- a/src/tests/reel.cpp
+++ b/src/tests/reel.cpp
@@ -299,6 +299,7 @@ TEST_CASE("Reels") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != ncp);

--- a/src/tests/resize.cpp
+++ b/src/tests/resize.cpp
@@ -29,6 +29,7 @@ TEST_CASE("Resize") {
       .rows = y,
       .cols = x,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* testn = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != testn);
@@ -53,6 +54,7 @@ TEST_CASE("Resize") {
       .rows = y,
       .cols = x,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* testn = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != testn);

--- a/src/tests/rotate.cpp
+++ b/src/tests/rotate.cpp
@@ -60,6 +60,7 @@ TEST_CASE("Rotate") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* testn = ncplane_create(n_, &nopts);
     uint64_t channels = 0;
@@ -94,6 +95,7 @@ TEST_CASE("Rotate") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* testn = ncplane_create(n_, &nopts);
     REQUIRE(0 < ncplane_gradient_sized(testn, " ", 0, ul, ur, ll, lr, 8, 16));
@@ -112,6 +114,7 @@ TEST_CASE("Rotate") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* testn = ncplane_create(n_, &nopts);
     REQUIRE(0 < ncplane_gradient_sized(testn, " ", 0, ul, ur, ll, lr, 8, 32));
@@ -130,6 +133,7 @@ TEST_CASE("Rotate") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* testn = ncplane_create(n_, &nopts);
     REQUIRE(0 < ncplane_gradient_sized(testn, " ", 0, ul, ur, ll, lr, 8, 16));
@@ -148,6 +152,7 @@ TEST_CASE("Rotate") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* testn = ncplane_create(n_, &nopts);
     REQUIRE(0 < ncplane_gradient_sized(testn, " ", 0, ul, ur, ll, lr, 8, 32));

--- a/src/tests/scrolling.cpp
+++ b/src/tests/scrolling.cpp
@@ -25,6 +25,7 @@ TEST_CASE("Scrolling") {
       .rows = 2,
       .cols = 20,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     REQUIRE(n);
@@ -54,6 +55,7 @@ TEST_CASE("Scrolling") {
       .rows = 2,
       .cols = 20,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     REQUIRE(n);
@@ -75,6 +77,7 @@ TEST_CASE("Scrolling") {
       .rows = 2,
       .cols = 20,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     REQUIRE(n);
@@ -102,6 +105,7 @@ TEST_CASE("Scrolling") {
       .rows = 2,
       .cols = 20,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     REQUIRE(n);
@@ -141,6 +145,7 @@ TEST_CASE("Scrolling") {
       .rows = 4,
       .cols = 20,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     REQUIRE(n);
@@ -165,6 +170,7 @@ TEST_CASE("Scrolling") {
       .rows = 2,
       .cols = 20,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     REQUIRE(n);
@@ -225,6 +231,7 @@ TEST_CASE("Scrolling") {
       .rows = 2,
       .cols = 20,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     REQUIRE(n);

--- a/src/tests/selector.cpp
+++ b/src/tests/selector.cpp
@@ -19,6 +19,7 @@ TEST_CASE("Selectors") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     struct ncselector* ncs = ncselector_create(n, &opts);
@@ -43,6 +44,7 @@ TEST_CASE("Selectors") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     struct ncselector* ncs = ncselector_create(n, &opts);
@@ -66,6 +68,7 @@ TEST_CASE("Selectors") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     struct ncselector* ncs = ncselector_create(n, &opts);
@@ -89,6 +92,7 @@ TEST_CASE("Selectors") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     struct ncselector* ncs = ncselector_create(n, &opts);
@@ -118,6 +122,7 @@ TEST_CASE("Selectors") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     struct ncselector* ncs = ncselector_create(n, &opts);
@@ -140,6 +145,7 @@ TEST_CASE("Selectors") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     struct ncselector* ncs = ncselector_create(n, &opts);
@@ -171,6 +177,7 @@ TEST_CASE("Selectors") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     struct ncselector* ncs = ncselector_create(n, &opts);
@@ -217,6 +224,7 @@ TEST_CASE("Selectors") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     struct ncselector* ncs = ncselector_create(n, &opts);
@@ -268,6 +276,7 @@ TEST_CASE("Selectors") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     struct ncselector* ncs = ncselector_create(n, &opts);

--- a/src/tests/stacking.cpp
+++ b/src/tests/stacking.cpp
@@ -29,6 +29,7 @@ TEST_CASE("Stacking") {
   SUBCASE("LowerAtopUpperWhite") {
     struct ncplane_options opts = {
       0, 0, 1, 1, nullptr, "top", nullptr, 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto top = ncplane_create(n_, &opts);
     REQUIRE(nullptr != top);
@@ -65,7 +66,7 @@ TEST_CASE("Stacking") {
 
   SUBCASE("UpperAtopLowerWhite") {
     struct ncplane_options opts = {
-      0, 0, 1, 1, nullptr, "top", nullptr, 0,
+      0, 0, 1, 1, nullptr, "top", nullptr, 0, 0, 0,
     };
     auto top = ncplane_create(n_, &opts);
     REQUIRE(nullptr != top);
@@ -102,7 +103,7 @@ TEST_CASE("Stacking") {
 
   SUBCASE("StackedQuadHalves") {
     struct ncplane_options opts = {
-      0, 0, 1, 1, nullptr, "top", nullptr, 0,
+      0, 0, 1, 1, nullptr, "top", nullptr, 0, 0, 0,
     };
     auto top = ncplane_create(n_, &opts);
     REQUIRE(nullptr != top);
@@ -141,7 +142,7 @@ TEST_CASE("Stacking") {
     ncplane_erase(n_);
     notcurses_refresh(nc_, nullptr, nullptr);
     struct ncplane_options opts = {
-      0, 0, 1, 1, nullptr, "top", nullptr, 0,
+      0, 0, 1, 1, nullptr, "top", nullptr, 0, 0, 0,
     };
     auto top = ncplane_create(n_, &opts);
     REQUIRE(nullptr != top);

--- a/src/tests/tabbed.cpp
+++ b/src/tests/tabbed.cpp
@@ -16,7 +16,8 @@ TEST_CASE("Tabbed") {
   SUBCASE("CreateNullOpts") {
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != ncp);
@@ -39,7 +40,8 @@ TEST_CASE("Tabbed") {
     };
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     auto nt = nctabbed_create(ncp, &opts);
@@ -54,7 +56,8 @@ TEST_CASE("Tabbed") {
   SUBCASE("Add") {
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     auto nt = nctabbed_create(ncp, nullptr);
@@ -108,7 +111,8 @@ TEST_CASE("Tabbed") {
   SUBCASE("Del") {
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     auto nt = nctabbed_create(ncp, nullptr);
@@ -154,7 +158,8 @@ TEST_CASE("Tabbed") {
   SUBCASE("Move") {
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     auto nt = nctabbed_create(ncp, nullptr);
@@ -207,7 +212,8 @@ TEST_CASE("Tabbed") {
   SUBCASE("Rotate") {
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     auto nt = nctabbed_create(ncp, nullptr);
@@ -240,7 +246,8 @@ TEST_CASE("Tabbed") {
   SUBCASE("MoveLeftRight") {
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     auto nt = nctabbed_create(ncp, nullptr);
@@ -305,7 +312,8 @@ TEST_CASE("Tabbed") {
   SUBCASE("Select") {
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     auto nt = nctabbed_create(ncp, nullptr);
@@ -332,7 +340,8 @@ TEST_CASE("Tabbed") {
   SUBCASE("NextPrev") {
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     auto nt = nctabbed_create(ncp, nullptr);
@@ -364,7 +373,8 @@ TEST_CASE("Tabbed") {
   SUBCASE("Setters") {
     struct ncplane_options nopts = {
       .y = 1, .x = 2, .rows = ncplane_dim_y(n_) - 2, .cols = ncplane_dim_x(n_) - 4,
-      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0
+      .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto ncp = ncplane_create(n_, &nopts);
     auto nt = nctabbed_create(ncp, nullptr);

--- a/src/tests/tree.cpp
+++ b/src/tests/tree.cpp
@@ -103,6 +103,7 @@ TEST_CASE("Tree") {
     const ncplane_options nopts = {
       .y = 0, .x = 0, .rows = 3, .cols = ncplane_dim_y(n_),
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto treen = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != treen);
@@ -125,6 +126,7 @@ TEST_CASE("Tree") {
     const ncplane_options nopts = {
       .y = 0, .x = 0, .rows = 3, .cols = ncplane_dim_y(n_),
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto treen = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != treen);

--- a/src/tests/wide.cpp
+++ b/src/tests/wide.cpp
@@ -230,6 +230,7 @@ TEST_CASE("Wide") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* ncp = ncplane_create(n_, &nopts);
     REQUIRE(ncp);
@@ -357,6 +358,7 @@ TEST_CASE("Wide") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n = ncplane_create(n_, &nopts);
     REQUIRE(n);
@@ -404,6 +406,7 @@ TEST_CASE("Wide") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* p = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != p);
@@ -453,6 +456,7 @@ TEST_CASE("Wide") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* topp = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != topp);
@@ -607,6 +611,7 @@ TEST_CASE("Wide") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* topp = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != topp);
@@ -762,6 +767,7 @@ TEST_CASE("Wide") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* topp = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != topp);
@@ -956,6 +962,7 @@ TEST_CASE("Wide") {
       .name = nullptr,
       .resizecb = nullptr,
       .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto high = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != high);

--- a/src/tests/zaxis.cpp
+++ b/src/tests/zaxis.cpp
@@ -32,6 +32,7 @@ TEST_CASE("ZAxis") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* np = ncplane_create(n_, &nopts);
     REQUIRE(np);
@@ -49,6 +50,7 @@ TEST_CASE("ZAxis") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* np = ncplane_create(n_, &nopts);
     REQUIRE(np);
@@ -66,6 +68,7 @@ TEST_CASE("ZAxis") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* np = ncplane_create(n_, &nopts);
     REQUIRE(np);
@@ -89,6 +92,7 @@ TEST_CASE("ZAxis") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* np = ncplane_create(n_, &nopts);
     REQUIRE(np);
@@ -121,6 +125,7 @@ TEST_CASE("ZAxis") {
       .rows = 2,
       .cols = 2,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     struct ncplane* n2 = ncplane_create(n_, &nopts);
     REQUIRE(1 == cell_load(n2, &c, "y"));
@@ -152,6 +157,7 @@ TEST_CASE("ZAxis") {
       .rows = 1,
       .cols = 1,
       .userptr = nullptr, .name = nullptr, .resizecb = nullptr, .flags = 0,
+      .margin_b = 0, .margin_r = 0,
     };
     auto p = ncplane_create(n_, &nopts);
     REQUIRE(nullptr != p);


### PR DESCRIPTION
Add a new flag for `ncplane_create()`, `NCPLANE_OPTION_MARGINALIZED`. When this flag is used, the size and placement of a plane are determined by provided margins relative to its parent plane. It's not quite done, but this gets enough of it done for `ncplayer` to use it (Closes #1432). Migrate `ncplayer` over to a marginalized display plane, to keep its bottom line free across resizes (necessary to keep bitmaps from scrolling). Implement `ncplane_resize_marginalized()` to recalculate margins and placement on a resize event.