### PR TITLE
Preserve and preapply TA matrix

### DIFF
--- a/TERMINALS.md
+++ b/TERMINALS.md
@@ -35,7 +35,7 @@ relies on the font. Patches to correct/complete this table are very welcome!
 | st ("suckless") | ✅                 |  ✅   |?       |`TERM=st-256color` `COLORTERM=24bit` | |
 | Terminator      | ✅                 |  ?    |?       | ?                               | |
 | Terminology     | ❌                 |  ?    |?       | ?                               | |
-| Tilda           |                    |  ?    |?       | ?                               | |
+| [Tilda](https://github.com/lanoxx/tilda)           |                    |  ?    |?       | ?                               | |
 | [tmux](https://github.com/tmux/tmux/wiki)            |                    |  ❌   |n/a     |`TERM=tmux-256color` `COLORTERM=24bit` | `tmux.conf` must apply `Tc`; see below. `bce` is available with the `tmux-256color-bce` definition. |
 | [wezterm](https://github.com/wez/wezterm)         |                    |  ✅   |?       |`TERM=wezterm` `COLORTERM=24bit` | |
 | [Windows Terminal](https://github.com/microsoft/terminal)|                    |  ?    |?       | ?                               | |

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -56,6 +56,7 @@ typedef enum {
   SPRIXCELL_NORMAL,         // no transparent pixels in this cell
   SPRIXCELL_CONTAINS_TRANS, // this cell has transparent pixels
   SPRIXCELL_ANNIHILATED,    // this cell has been wiped
+  SPRIXCELL_UNHIDDEN,       // this cell needs be unwiped
 } sprixcell_e;
 
 // there is a context-wide set of displayed pixel glyphs ("sprixels"); i.e.
@@ -761,8 +762,9 @@ plane_debug(const ncplane* n, bool details){
 void sprixel_free(sprixel* s);
 void sprixel_invalidate(sprixel* s);
 void sprixel_hide(sprixel* s);
-// dimy and dimx are cell geometry, not pixel
+// takes ownership of g on success
 sprixel* sprixel_update(sprixel* s, char* g, int bytes);
+// dimy and dimx are cell geometry, not pixel. takes ownership of s on success.
 sprixel* sprixel_create(ncplane* n, char* s, int bytes, int placey, int placex,
                         int sprixelid, int dimy, int dimx, int pixy, int pixx,
                         int parse_start, sprixcell_e* tacache);
@@ -1180,7 +1182,11 @@ plane_blit_sixel(ncplane* n, char* s, int bytes, int placey, int placex,
   for(int y = placey ; y < placey + leny && y < ncplane_dim_y(n) ; ++y){
     for(int x = placex ; x < placex + lenx && x < ncplane_dim_x(n) ; ++x){
       nccell* c = ncplane_cell_ref_yx(n, y, x);
-      memcpy(&c->gcluster, &gcluster, sizeof(gcluster));
+      if(x == placex){
+        memcpy(&c->gcluster, &gcluster, sizeof(gcluster));
+      }else{
+        c->gcluster = 0;
+      }
       c->width = lenx;
     }
   }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1182,11 +1182,7 @@ plane_blit_sixel(ncplane* n, char* s, int bytes, int placey, int placex,
   for(int y = placey ; y < placey + leny && y < ncplane_dim_y(n) ; ++y){
     for(int x = placex ; x < placex + lenx && x < ncplane_dim_x(n) ; ++x){
       nccell* c = ncplane_cell_ref_yx(n, y, x);
-      if(x == placex){
-        memcpy(&c->gcluster, &gcluster, sizeof(gcluster));
-      }else{
-        c->gcluster = 0;
-      }
+      memcpy(&c->gcluster, &gcluster, sizeof(gcluster));
       c->width = lenx;
     }
   }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -238,7 +238,6 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
   int totalout = 0; // total pixels of payload out
   int y = 0; // position within source image (pixels)
   int x = 0;
-  int tyx = 0; // postition within tamatrix (cells)
   int targetout = 0; // number of pixels expected out after this chunk
 //fprintf(stderr, "total: %d chunks = %d, s=%d,v=%d\n", total, chunks, lenx, leny);
   while(chunks--){
@@ -261,26 +260,17 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
       for(int e = 0 ; e < encodeable ; ++e){
         if(x == lenx){
           x = 0;
-          if(x % cdimx){
-            ++tyx;
-          }
-          if(++y % cdimy){
-            tyx -= cols;
-          }
+          ++y;
         }
         const uint32_t* line = data + (linesize / sizeof(*data)) * y;
         source[e] = line[x];
 //fprintf(stderr, "%u/%u/%u -> %c%c%c%c %u %u %u %u\n", r, g, b, b64[0], b64[1], b64[2], b64[3], b64[0], b64[1], b64[2], b64[3]);
-        if(++x % cdimx == 0){
-          ++tyx;
-        }
+        ++x;
+        int tyx = (x / cdimx) + (y / cdimy) * cols;
         wipe[e] = (tacache[tyx] == SPRIXCELL_ANNIHILATED);
       }
       totalout += encodeable;
       char out[17];
-if(wipe[0] || wipe[1] || wipe[2]){
-fprintf(stderr, "TYX: %d lenx: %d y: %d x: %d %d %d %d\n", tyx, lenx, y, x, wipe[0], wipe[1], wipe[2]);
-}
       base64_rgba3(source, encodeable, out, wipe);
       ncfputs(out, fp);
     }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -296,6 +296,7 @@ int kitty_blit(ncplane* nc, int linesize, const void* data,
     return -1;
   }
   int parse_start = 0;
+  // closes fp on success
   sprixcell_e* tacache = write_kitty_data(fp, rows, cols, linesize, leny, lenx, data,
                                           bargs->u.pixel.sprixelid, &parse_start);
   if(tacache == NULL){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -222,13 +222,13 @@ int sprite_kitty_cell_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell
 // we can only write 4KiB at a time. we're writing base64-encoded RGBA. each
 // pixel is 4B raw (32 bits). each chunk of three pixels is then 12 bytes, or
 // 16 base64-encoded bytes. 4096 / 16 == 256 3-pixel groups, or 768 pixels.
-static int*
+static sprixcell_e*
 write_kitty_data(FILE* fp, int rows, int cols, int linesize, int leny, int lenx,
                  const uint32_t* data, int sprixelid, int* parse_start){
   if(linesize % sizeof(*data)){
     return NULL;
   }
-  int* tacache = malloc(sizeof(*tacache) * rows * cols);
+  sprixcell_e* tacache = malloc(sizeof(*tacache) * rows * cols);
   if(tacache == NULL){
     return NULL;
   }
@@ -296,8 +296,8 @@ int kitty_blit(ncplane* nc, int linesize, const void* data,
     return -1;
   }
   int parse_start = 0;
-  int* tacache = write_kitty_data(fp, rows, cols, linesize, leny, lenx, data,
-                                  bargs->u.pixel.sprixelid, &parse_start);
+  sprixcell_e* tacache = write_kitty_data(fp, rows, cols, linesize, leny, lenx, data,
+                                          bargs->u.pixel.sprixelid, &parse_start);
   if(tacache == NULL){
     fclose(fp);
     free(buf);

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -965,7 +965,7 @@ rasterize_sprixels(notcurses* nc, const ncpile* p, FILE* out){
       if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){
         return -1;
       }
-      s->invalidated = SPRIXEL_NOCHANGE;
+      s->invalidated = SPRIXEL_QUIESCENT;
       nc->rstate.hardcursorpos = true;
       parent = &s->next;
     }else if(s->invalidated == SPRIXEL_HIDE){

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -926,23 +926,7 @@ int sprite_sixel_annihilate(const notcurses* nc, const ncpile* p, FILE* out, spr
   (void)p;
   (void)out;
   (void)s;
-  /*
-  struct crender* rvec = p->crender;
-  // FIXME need to cap by ends minus bottom, right margins also
-  const int ycap = nc->stdplane->leny + nc->margin_t;
-  const int xcap = nc->stdplane->lenx + nc->margin_l;
-//fprintf(stderr, "yCAP: %d xCAP: %d\n", ycap, xcap);
-  for(int y = s->y + nc->stdplane->absy ; y < s->y + nc->stdplane->absy + s->dimy && y < ycap ; ++y){
-    const int innery = y - nc->stdplane->absy;
-    for(int x = s->x + nc->stdplane->absx ; x < s->x + nc->stdplane->absx + s->dimx && x < xcap ; ++x){
-      const int innerx = x - nc->stdplane->absx;
-      const size_t damageidx = innery * nc->lfdimx + innerx;
-//fprintf(stderr, "DAMAGING %zu %d * %d + %d (max %d/%d)\n", damageidx, innery, nc->lfdimx, innerx, ycap, xcap);
-      rvec[damageidx].s.damaged = 1;
-    }
-  }
-  */
-  return 1;
+  return 0;
 }
 
 // returns -1 on error, 0 on success, 1 on success + invalidations requiring

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -414,6 +414,7 @@ write_rle(int* printed, int color, FILE* fp, int seenrle, unsigned char crle){
 }
 
 // Emit the sprixel in its entirety, plus enable and disable pixel mode.
+// Closes |fp| on all paths.
 static int
 write_sixel_data(FILE* fp, int lenx, sixeltable* stab, int* parse_start, sprixcell_e* tacache){
   *parse_start = fprintf(fp, "\ePq");
@@ -521,7 +522,6 @@ int sixel_blit_inner(ncplane* n, int leny, int lenx, sixeltable* stab,
     if(!reuse){
       free(tacache);
     }
-    fclose(fp);
     free(buf);
     return -1;
   }
@@ -532,9 +532,7 @@ int sixel_blit_inner(ncplane* n, int leny, int lenx, sixeltable* stab,
     if(plane_blit_sixel(n, buf, size, bargs->placey, bargs->placex,
                         rows, cols, bargs->u.pixel.sprixelid, leny, lenx,
                         parse_start, tacache) < 0){
-      if(!reuse){
-        free(tacache);
-      }
+      free(tacache);
       free(buf);
       return -1;
     }

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -415,7 +415,7 @@ write_rle(int* printed, int color, FILE* fp, int seenrle, unsigned char crle){
 
 // Emit the sprixel in its entirety, plus enable and disable pixel mode.
 static int
-write_sixel_data(FILE* fp, int lenx, sixeltable* stab, int* parse_start, int* tacache){
+write_sixel_data(FILE* fp, int lenx, sixeltable* stab, int* parse_start, sprixcell_e* tacache){
   *parse_start = fprintf(fp, "\ePq");
   // Set Raster Attributes - pan/pad=1 (pixel aspect ratio), Ph=lenx, Pv=leny
   // using Ph/Pv causes a background to be drawn using color register 0 for all
@@ -496,7 +496,7 @@ int sixel_blit_inner(ncplane* nc, int leny, int lenx, sixeltable* stab,
   int parse_start = 0;
   unsigned cols = lenx / bargs->u.pixel.celldimx + !!(lenx % bargs->u.pixel.celldimx);
   unsigned rows = leny / bargs->u.pixel.celldimy + !!(leny % bargs->u.pixel.celldimy);
-  int* tacache = malloc(sizeof(*tacache) * rows * cols);
+  sprixcell_e* tacache = malloc(sizeof(*tacache) * rows * cols);
   memset(tacache, 0, sizeof(*tacache) * rows * cols);
   if(tacache == NULL){
     free(buf);

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -30,14 +30,16 @@ sprixel* sprixel_by_id(notcurses* nc, uint32_t id){
 }
 
 // s ought already have been scrubbed according to the T-A matrix
-sprixel* sprixel_update(sprixel* s, const char* g, int bytes){
+sprixel* sprixel_update(sprixel* s, char* g, int bytes){
   free(s->glyph);
   s->glyph = g;
   s->glyphlen = bytes;
   s->invalidated = SPRIXEL_INVALIDATED;
+  return s;
 }
 
-// y and x are the cell geometry, not the pixel geometry
+// 'y' and 'x' are the cell geometry, not the pixel geometry. takes
+// ownership of 's' on success.
 sprixel* sprixel_create(ncplane* n, char* s, int bytes, int placey, int placex,
                         int sprixelid, int dimy, int dimx, int pixy, int pixx,
                         int parse_start, sprixcell_e* tacache){

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -83,11 +83,11 @@ int sprite_wipe_cell(const notcurses* nc, sprixel* s, int ycell, int xcell){
     return -1;
   }
   if(s->tacache[s->dimx * ycell + xcell] == 2){
-fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
+//fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 0; // already annihilated
   }
   s->tacache[s->dimx * ycell + xcell] = 2;
-fprintf(stderr, "WIPING %d %d/%d\n", s->id, ycell, xcell);
+//fprintf(stderr, "WIPING %d %d/%d\n", s->id, ycell, xcell);
   int r = nc->tcache.pixel_cell_wipe(nc, s, ycell, xcell);
   if(r == 0){
     s->invalidated = SPRIXEL_INVALIDATED;

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -29,10 +29,18 @@ sprixel* sprixel_by_id(notcurses* nc, uint32_t id){
   return NULL;
 }
 
+// s ought already have been scrubbed according to the T-A matrix
+sprixel* sprixel_update(sprixel* s, const char* g, int bytes){
+  free(s->glyph);
+  s->glyph = g;
+  s->glyphlen = bytes;
+  s->invalidated = SPRIXEL_INVALIDATED;
+}
+
 // y and x are the cell geometry, not the pixel geometry
 sprixel* sprixel_create(ncplane* n, char* s, int bytes, int placey, int placex,
                         int sprixelid, int dimy, int dimx, int pixy, int pixx,
-                        int parse_start, int* tacache){
+                        int parse_start, sprixcell_e* tacache){
   sprixel* ret = malloc(sizeof(sprixel));
   if(ret){
     ret->glyph = s;
@@ -73,11 +81,11 @@ int sprite_wipe_cell(const notcurses* nc, sprixel* s, int ycell, int xcell){
     return -1;
   }
   if(s->tacache[s->dimx * ycell + xcell] == 2){
-//fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
+fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 0; // already annihilated
   }
   s->tacache[s->dimx * ycell + xcell] = 2;
-//fprintf(stderr, "WIPING %d %d/%d\n", s->id, ycell, xcell);
+fprintf(stderr, "WIPING %d %d/%d\n", s->id, ycell, xcell);
   int r = nc->tcache.pixel_cell_wipe(nc, s, ycell, xcell);
   if(r == 0){
     s->invalidated = SPRIXEL_INVALIDATED;

--- a/src/media/ffmpeg.cpp
+++ b/src/media/ffmpeg.cpp
@@ -394,13 +394,6 @@ int ffmpeg_stream(notcurses* nc, ncvisual* ncv, float timescale,
     // all media when we loop =[. we seem to be accurate enough now with the
     // tbase/ppd. see https://github.com/dankamongmen/notcurses/issues/1352.
     double tbase = av_q2d(ncv->details->fmtctx->streams[ncv->details->stream_index]->time_base);
-    /*int64_t ts = ncv->details->frame->best_effort_timestamp;
-    if(frame == 1 && ts){
-      usets = true;
-    }*/
-    if(activevopts.n){
-      ncplane_erase(activevopts.n); // new frame could be partially transparent
-    }
     // decay the blitter explicitly, so that the callback knows the blitter it
     // was actually rendered with
     auto bset = rgba_blitter(nc, &activevopts);
@@ -419,15 +412,8 @@ int ffmpeg_stream(notcurses* nc, ncvisual* ncv, float timescale,
     ++frame;
     uint64_t duration = ncv->details->frame->pkt_duration * tbase * NANOSECS_IN_SEC;
     double schedns = nsbegin;
-    /*if(usets){
-      if(tbase == 0){
-        tbase = duration;
-      }
-      schedns += ts * (tbase * timescale) * NANOSECS_IN_SEC;
-    }else{*/
-      sum_duration += (duration * timescale);
-      schedns += sum_duration;
-    //}
+    sum_duration += (duration * timescale);
+    schedns += sum_duration;
     struct timespec abstime;
     ns_to_timespec(schedns, &abstime);
     int r;


### PR DESCRIPTION
When a new bitmap is blitted onto a plane, the old TA matrix (well, the A component, anyway) remains applicable (the T component needs be rebuilt, but we're not building it yet in any case). Preserve the TA matrix, and use it to precut the new bitmap. Using this method, we don't need to recut the new bitmap after displaying, don't need to reproduce the EGC seen "over" the bitmap, and we eliminate all Sixel flicker =]. w00t w00t! Closes #1457. Closes #1454.

Needs more testing. There's definitely some problems in here; sixel wiping still doesn't work (prewipe *does*, though), and I think it works badly on Kitty for some reason. But the overall approach is there.