### PR TITLE
Sixel fixel

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -759,6 +759,10 @@ plane_debug(const ncplane* n, bool details){
   }
 }
 
+// nulls out a cell from a kitty bitmap via changing the alpha value
+// throughout to 0. the same trick doesn't work on sixel, but there we
+// can just print directly over the bitmap.
+int sprite_kitty_cell_wipe(const notcurses* nc, sprixel* s, int y, int x);
 void sprixel_free(sprixel* s);
 void sprixel_invalidate(sprixel* s);
 void sprixel_hide(sprixel* s);
@@ -1337,9 +1341,6 @@ static inline bool
 ncdirect_bg_default_p(const struct ncdirect* nc){
   return channels_bg_default_p(ncdirect_channels(nc));
 }
-
-int sprite_sixel_cell_wipe(const notcurses* nc, sprixel* s, int y, int x);
-int sprite_kitty_cell_wipe(const notcurses* nc, sprixel* s, int y, int x);
 
 int sixel_blit(ncplane* nc, int linesize, const void* data,
                int leny, int lenx, const blitterargs* bargs);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -763,6 +763,7 @@ plane_debug(const ncplane* n, bool details){
 // throughout to 0. the same trick doesn't work on sixel, but there we
 // can just print directly over the bitmap.
 int sprite_kitty_cell_wipe(const notcurses* nc, sprixel* s, int y, int x);
+int sprite_destroy(const struct notcurses* nc, const struct ncpile* p, FILE* out, sprixel* s);
 void sprixel_free(sprixel* s);
 void sprixel_invalidate(sprixel* s);
 void sprixel_hide(sprixel* s);
@@ -776,7 +777,6 @@ API int sprite_wipe_cell(const notcurses* nc, sprixel* s, int y, int x);
 int sprite_kitty_annihilate(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
 int sprite_kitty_init(int fd);
 int sprite_sixel_init(int fd);
-int sprite_sixel_annihilate(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
 int sprite_init(const notcurses* nc);
 void sprixel_invalidate(sprixel* s);
 sprixel* sprixel_by_id(notcurses* nc, uint32_t id);

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -925,14 +925,6 @@ emit_bg_palindex(notcurses* nc, FILE* out, const nccell* srccell){
   return 0;
 }
 
-int sprite_sixel_annihilate(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
-  (void)nc;
-  (void)p;
-  (void)out;
-  (void)s;
-  return 0;
-}
-
 // returns -1 on error, 0 on success, 1 on success + invalidations requiring
 // a subsequent repass by the rasterizer.
 static int
@@ -958,7 +950,7 @@ rasterize_sprixels(notcurses* nc, const ncpile* p, FILE* out){
       parent = &s->next;
     }else if(s->invalidated == SPRIXEL_HIDE){
 //fprintf(stderr, "OUGHT HIDE %d [%dx%d @ %d/%d] %p\n", s->id, s->dimy, s->dimx, s->y, s->x, s);
-      int r = nc->tcache.pixel_destroy(nc, p, out, s);
+      int r = sprite_destroy(nc, p, out, s);
       if(r < 0){
         return -1;
       }else if(r > 0){

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -151,7 +151,7 @@ extract_color_table(const uint32_t* data, int linesize, int begy, int begx, int 
         }
         int txyidx = (sy / cdimy) * cols + (visx / cdimx);
         if(tacache[txyidx] == SPRIXCELL_ANNIHILATED){
-//fprintf(stderr, "TRANS SKIP %d %d %d %d\n", visy, visx, sy, txyidx);
+//fprintf(stderr, "TRANS SKIP %d %d %d %d (cell: %d %d)\n", visy, visx, sy, txyidx, sy / cdimy, visx / cdimx);
           continue;
         }
         unsigned char comps[RGBSIZE];

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -71,9 +71,6 @@ int sprite_wipe_cell(const notcurses* nc, sprixel* s, int ycell, int xcell){
   if(s->invalidated == SPRIXEL_HIDE){ // no need to do work if we're killing it
     return 0;
   }
-  if(!nc->tcache.pixel_cell_wipe){
-    return 0;
-  }
   if(ycell >= s->dimy || ycell < 0){
     logerror(nc, "Bad y coordinate %d (%d)\n", ycell, s->dimy);
     return -1;
@@ -82,11 +79,16 @@ int sprite_wipe_cell(const notcurses* nc, sprixel* s, int ycell, int xcell){
     logerror(nc, "Bad x coordinate %d (%d)\n", xcell, s->dimx);
     return -1;
   }
-  if(s->tacache[s->dimx * ycell + xcell] == 2){
+  if(s->tacache[s->dimx * ycell + xcell] == SPRIXCELL_ANNIHILATED){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 0; // already annihilated
   }
-  s->tacache[s->dimx * ycell + xcell] = 2;
+  // mark the cell as annihilated whether we actually scrubbed it or not,
+  // so that we use this fact should we move to another frame
+  s->tacache[s->dimx * ycell + xcell] = SPRIXCELL_ANNIHILATED;
+  if(!nc->tcache.pixel_cell_wipe){ // sixel has no cell wiping
+    return -1;
+  }
 //fprintf(stderr, "WIPING %d %d/%d\n", s->id, ycell, xcell);
   int r = nc->tcache.pixel_cell_wipe(nc, s, ycell, xcell);
   if(r == 0){

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -103,3 +103,10 @@ int sprite_init(const notcurses* nc){
   }
   return nc->tcache.pixel_init(nc->ttyfd);
 }
+
+int sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
+  if(!nc->tcache.pixel_destroy){
+    return 0;
+  }
+  return nc->tcache.pixel_destroy(nc, p, out, s);
+}

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -349,7 +349,6 @@ query_sixel(tinfo* ti, int fd){
             ti->color_registers = 256;  // assumed default [shrug]
             ti->pixel_destroy = sprite_sixel_annihilate;
             pixel_init = ti->pixel_init = sprite_sixel_init;
-            ti->pixel_cell_wipe = sprite_sixel_cell_wipe;
             ti->sixel_maxx = ti->sixel_maxy = 0;
           }
         }

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -347,7 +347,6 @@ query_sixel(tinfo* ti, int fd){
           if(!ti->sixel_supported){
             ti->sixel_supported = true;
             ti->color_registers = 256;  // assumed default [shrug]
-            ti->pixel_destroy = sprite_sixel_annihilate;
             pixel_init = ti->pixel_init = sprite_sixel_init;
             ti->sixel_maxx = ti->sixel_maxy = 0;
           }


### PR DESCRIPTION
Experimentation and consultation with @dnkl (a gentleman and a scholar) confirm that you can't do cell scrubbing in Sixel. Fine. Abandon the idea, but continue to pipe the T-A matrix through. Rasterize sprixels prior to rasterizing cells instead. This fixes all remaining problems with `ncplayer` and `notcurses-demo`. It breaks the  `pixels` demo on Sixel, but we'll attend to that. Abstract out `sprite_desroy()`. Fix up the [xray] demo.

Drop a gem on 'em!

Closes #1464. Closes #1388.