### PR TITLE
Move sixels properly, and cleanly remove sixel output

### DIFF
--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -382,7 +382,15 @@ All other functions cannot fail (and return **void**).
 **ncplane_new** is defined as a deprecated wrapper around **ncplane_create**.
 It should not be used in new code.
 
+# BUGS
+
+**ncplane_at_yx** doesn't yet account for bitmap-based graphics (see
+**notcurses_visual**).
+
 # SEE ALSO
 
-**notcurses(3)**, **notcurses_cell(3)**, **notcurses_output(3)**,
-**notcurses_stdplane(3)**
+**notcurses(3)**,
+**notcurses_cell(3)**,
+**notcurses_output(3)**,
+**notcurses_stdplane(3)**,
+**notcurses_visual(3)**

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -815,6 +815,7 @@ sprixel* sprixel_create(ncplane* n, char* s, int bytes, int placey, int placex,
                         int sprixelid, int dimy, int dimx, int pixy, int pixx,
                         int parse_start);
 int sprite_wipe_cell(const notcurses* nc, sprixel* s, int y, int x);
+int sixel_delete(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
 int sprite_kitty_annihilate(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
 int sprite_kitty_init(int fd);
 int sprite_sixel_init(int fd);

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -242,7 +242,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx,
 //fprintf(stderr, "total: %d chunks = %d, s=%d,v=%d\n", total, chunks, lenx, leny);
   while(chunks--){
     if(totalout == 0){
-      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,a=T,%c=1;",
+      *parse_start = fprintf(fp, "\e_Gf=32,p=1,s=%d,v=%d,i=%d,a=T,%c=1;",
                              lenx, leny, sprixelid, chunks ? 'm' : 'q');
     }else{
       fprintf(fp, "\e_G%sm=%d;", chunks ? "" : "q=1,", chunks ? 1 : 0);
@@ -348,11 +348,6 @@ int kitty_blit(ncplane* n, int linesize, const void* data,
   return 1;
 }
 
-// clears all kitty bitmaps
-int sprite_kitty_init(int fd){
-  return tty_emit("\e_Ga=d\e\\", fd);
-}
-
 // removes the kitty bitmap graphic identified by s->id
 int sprite_kitty_annihilate(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
   (void)p;
@@ -361,4 +356,21 @@ int sprite_kitty_annihilate(const notcurses* nc, const ncpile* p, FILE* out, spr
     return 0;
   }
   return 0;
+}
+
+int kitty_draw(const notcurses* nc, const ncpile* p, sprixel* s, FILE* out){
+  (void)nc;
+  (void)p;
+  (void)out;
+  int ret = 0;
+  if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){
+    ret = -1;
+  }
+  s->invalidated = SPRIXEL_QUIESCENT;
+  return ret;
+}
+
+// clears all kitty bitmaps
+int sprite_kitty_init(int fd){
+  return tty_emit("\e_Ga=d\e\\", fd);
 }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -242,7 +242,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx,
 //fprintf(stderr, "total: %d chunks = %d, s=%d,v=%d\n", total, chunks, lenx, leny);
   while(chunks--){
     if(totalout == 0){
-      *parse_start = fprintf(fp, "\e_Gf=32,p=1,s=%d,v=%d,i=%d,a=T,%c=1;",
+      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,a=T,%c=1;",
                              lenx, leny, sprixelid, chunks ? 'm' : 'q');
     }else{
       fprintf(fp, "\e_G%sm=%d;", chunks ? "" : "q=1,", chunks ? 1 : 0);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -694,6 +694,7 @@ int ncplane_destroy(ncplane* ncp){
   if(ncp->sprite){
     sprixel_hide(ncp->sprite);
   }
+  free(ncp->tacache);
 //notcurses_debug(ncplane_notcurses(ncp), stderr);
   int ret = 0;
   // dissolve our binding from behind (->bprev is either NULL, or its

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1933,12 +1933,11 @@ int ncplane_box(ncplane* n, const nccell* ul, const nccell* ur,
 static void
 move_bound_planes(ncplane* n, int dy, int dx){
   while(n){
+    if(n->sprite){
+      sprixel_movefrom(n->sprite, n->absy, n->absx);
+    }
     n->absy += dy;
     n->absx += dx;
-    // FIXME do these only if we actually changed location
-    if(n->sprite){
-      sprixel_invalidate(n->sprite);
-    }
     move_bound_planes(n->blist, dy, dx);
     n = n->bnext;
   }
@@ -1951,12 +1950,11 @@ int ncplane_move_yx(ncplane* n, int y, int x){
   int dy, dx; // amount moved
   dy = (n->boundto->absy + y) - n->absy;
   dx = (n->boundto->absx + x) - n->absx;
+  if(n->sprite){
+    sprixel_movefrom(n->sprite, n->absy, n->absx);
+  }
   n->absx += dx;
   n->absy += dy;
-  // FIXME do these only if we actually changed location
-  if(n->sprite){
-    sprixel_invalidate(n->sprite);
-  }
   move_bound_planes(n->blist, dy, dx);
   return 0;
 }

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -478,6 +478,24 @@ int sixel_blit(ncplane* n, int linesize, const void* data,
   return r;
 }
 
+int sixel_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
+  if(s->invalidated == SPRIXEL_MOVED){
+    for(int yy = s->movedfromy ; yy < s->movedfromy + s->dimy ; ++yy){
+      for(int xx = s->movedfromx ; xx < s->movedfromx + s->dimx ; ++xx){
+        if(yy < n->rstate.y || yy >= n->rstate.y + s->dimy ||
+           xx < n->rstate.x || xx >= n->rstate.x + s->dimx){
+        }
+        p->crender[yy * p->dimx + xx].s.damaged = 1;
+      }
+    }
+  }
+  if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){
+    return -1;
+  }
+  s->invalidated = SPRIXEL_QUIESCENT;
+  return 0;
+}
+
 int sprite_sixel_init(int fd){
   // \e[?8452: DECSDM private "sixel scrolling" mode keeps the sixel from
   // scrolling, but puts it at the current cursor location (as opposed to

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -22,7 +22,10 @@ void sprixel_movefrom(sprixel* s, int y, int x){
 void sprixel_hide(sprixel* s){
   // guard so that a double call doesn't drop core on s->n->sprite
   if(s->invalidated != SPRIXEL_HIDE){
+//fprintf(stderr, "HIDING %d\n", s->id);
     s->invalidated = SPRIXEL_HIDE;
+    s->movedfromy = ncplane_abs_y(s->n);
+    s->movedfromx = ncplane_abs_x(s->n);
     s->n->sprite = NULL;
     s->n = NULL;
   }

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -7,10 +7,25 @@ void sprixel_free(sprixel* s){
   }
 }
 
+// store the original (absolute) coordinates from which we moved, so that
+// we can invalidate them in sprite_draw().
+void sprixel_movefrom(sprixel* s, int y, int x){
+  if(s->invalidated != SPRIXEL_HIDE){
+    if(s->invalidated != SPRIXEL_MOVED){
+      s->invalidated = SPRIXEL_MOVED;
+      s->movedfromy = y;
+      s->movedfromx = x;
+    }
+  }
+}
+
 void sprixel_hide(sprixel* s){
-  s->invalidated = SPRIXEL_HIDE;
-  s->n->sprite = NULL;
-  s->n = NULL;
+  // guard so that a double call doesn't drop core on s->n->sprite
+  if(s->invalidated != SPRIXEL_HIDE){
+    s->invalidated = SPRIXEL_HIDE;
+    s->n->sprite = NULL;
+    s->n = NULL;
+  }
 }
 
 void sprixel_invalidate(sprixel* s){
@@ -83,6 +98,12 @@ int sprite_wipe_cell(const notcurses* nc, sprixel* s, int ycell, int xcell){
   if(r == 0){
     s->invalidated = SPRIXEL_INVALIDATED;
   }
+  return r;
+}
+
+// precondition: s->invalidated is SPRIXEL_INVALIDATED or SPRIXEL_MOVED.
+int sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
+  int r = n->tcache.pixel_draw(n, p, s, out);
   return r;
 }
 

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -351,6 +351,7 @@ query_sixel(tinfo* ti, int fd){
             pixel_init = ti->pixel_init = sprite_sixel_init;
             ti->pixel_draw = sixel_draw;
             ti->sixel_maxx = ti->sixel_maxy = 0;
+            ti->pixel_destroy = sixel_delete;
           }
         }
         break;

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -63,6 +63,7 @@ apply_term_heuristics(tinfo* ti, const char* termname){
     ti->pixel_cell_wipe = sprite_kitty_cell_wipe;
     ti->pixel_destroy = sprite_kitty_annihilate;
     ti->pixel_init = sprite_kitty_init;
+    ti->pixel_draw = kitty_draw;
     set_pixel_blitter(kitty_blit);
   /*}else if(strstr(termname, "alacritty")){
     ti->sextants = true; // alacritty https://github.com/alacritty/alacritty/issues/4409 */
@@ -348,6 +349,7 @@ query_sixel(tinfo* ti, int fd){
             ti->sixel_supported = true;
             ti->color_registers = 256;  // assumed default [shrug]
             pixel_init = ti->pixel_init = sprite_sixel_init;
+            ti->pixel_draw = sixel_draw;
             ti->sixel_maxx = ti->sixel_maxy = 0;
           }
         }


### PR DESCRIPTION
Actively clean up sixel output when they're removed or moved. This fixes:

* the `pixels` PoC for sixel (#1487)
* movement of sixels, as seen in the `intro` demo (#1449)
* cleanup of sixels, as seen in the `keller` demo

Unfortunately, it adds significant flicker to the sixel case (kitty still works fine) when streaming, as seen in the `xray` demo, the `yield` demo, and `ncplayer`. I think I know how to fix that up (need to inhibit clearing when streaming, as well as applying the TAM), which I'll do next.