### PR TITLE
Directmode streaming and Alacritty sixels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ rearrangements of Notcurses.
   * `ncplane_pixelgeom()` has been added, allowing callers to determine the
     size of the plane and cells in pixels, as well as the maximum bitmap
     size that can be displayed.
+  * added new function `ncdirect_stream()`, which does what you'd think.
 
 * 2.2.5 (2021-04-04)
   * Bugfix release, no user-visible changes.

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -90,6 +90,8 @@ notcurses_direct - minimal notcurses instances for styling text
 
 **int ncdirect_raster_frame(struct ncdirect* ***n***, ncdirectv* ***ncdv***, ncalign_e ***align***);**
 
+**int ncdirect_stream(struct ncdirect* ***n***, const char* ***filename***, ncstreamcb ***streamer***, struct ncvisual_options* ***vopts***, void* ***curry***);**
+
 **char* ncdirect_readline(struct ncdirect* ***n***, const char* ***prompt***);**
 
 # DESCRIPTION

--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -71,7 +71,7 @@ namespace ncpp
 			return error_guard<ncplane*, ncplane*> (ncvisual_render (get_notcurses (), visual, vopts), nullptr);
 		}
 
-		int stream (const ncvisual_options* vopts, float timescale, streamcb streamer, void *curry = nullptr) const NOEXCEPT_MAYBE
+		int stream (const ncvisual_options* vopts, float timescale, ncstreamcb streamer, void *curry = nullptr) const NOEXCEPT_MAYBE
 		{
 			return error_guard<int> (ncvisual_stream (get_notcurses (), visual, timescale, streamer, vopts, curry), -1);
 		}

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -300,6 +300,9 @@ API ALLOC ncdirectv* ncdirect_render_frame(struct ncdirect* n, const char* filen
 // Takes the result of ncdirect_render_frame() and writes it to the output.
 API int ncdirect_raster_frame(struct ncdirect* n, ncdirectv* ncdv, ncalign_e align);
 
+API int ncdirect_stream(struct ncdirect* n, const char* filename, ncstreamcb streamer,
+                        struct ncvisual_options* vopts, void* curry);
+
 #undef ALLOC
 #undef API
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2550,8 +2550,8 @@ API ALLOC char* ncvisual_subtitle(const struct ncvisual* ncv)
 // Called for each frame rendered from 'ncv'. If anything but 0 is returned,
 // the streaming operation ceases immediately, and that value is propagated out.
 // The recommended absolute display time target is passed in 'tspec'.
-typedef int (*streamcb)(struct ncvisual*, struct ncvisual_options*,
-                        const struct timespec*, void*);
+typedef int (*ncstreamcb)(struct ncvisual*, struct ncvisual_options*,
+                          const struct timespec*, void*);
 
 // Shut up and display my frames! Provide as an argument to ncvisual_stream().
 // If you'd like subtitles to be decoded, provide an ncplane as the curry. If the
@@ -2569,7 +2569,7 @@ API int ncvisual_simple_streamer(struct ncvisual* ncv, struct ncvisual_options* 
 // 300FPS, and a 'timescale' of 10 will result in 3FPS. It is an error to
 // supply 'timescale' less than or equal to 0.
 API int ncvisual_stream(struct notcurses* nc, struct ncvisual* ncv,
-                        float timescale, streamcb streamer,
+                        float timescale, ncstreamcb streamer,
                         const struct ncvisual_options* vopts, void* curry);
 
 // Blit a flat array 'data' of RGBA 32-bit values to the ncplane 'vopts->n',

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1138,6 +1138,7 @@ int ncdirect_stream(ncdirect* n, const char* filename, ncstreamcb streamer,
       ncvisual_destroy(ncv);
       return -1;
     }
+    ncdirect_raster_frame(n, v, (vopts->flags & NCVISUAL_OPTION_HORALIGNED) ? vopts->x : 0);
     streamer(ncv, vopts, NULL, curry);
   }while(ncvisual_decode(ncv));
   ncvisual_destroy(ncv);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -371,6 +371,12 @@ typedef struct tinfo {
   bool pixel_query_done; // have we yet performed pixel query?
   bool sextants;  // do we have (good, vetted) Unicode 13 sextant support?
   bool braille;   // do we have Braille support? (linux console does not)
+  // alacritty went rather off the reservation for their sixel support. they
+  // reply to DSA with CSI?6c, meaning VT102, but no VT102 had Sixel support,
+  // and indeed they don't respond to XTSMGRAPHICS (which we need to query
+  // after validating basic Sixel). so if the TERM variable contains
+  // "alacritty", *and* we get VT102, we go ahead and query XTSMGRAPHICS.
+  bool alacritty_sixel_hack;
 } tinfo;
 
 typedef struct ncinputlayer {

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1448,7 +1448,7 @@ typedef struct ncvisual_implementation {
   int (*visual_decode)(struct ncvisual* nc);
   int (*visual_decode_loop)(struct ncvisual* nc);
   int (*visual_stream)(notcurses* nc, struct ncvisual* ncv, float timescale,
-                       streamcb streamer, const struct ncvisual_options* vopts, void* curry);
+                       ncstreamcb streamer, const struct ncvisual_options* vopts, void* curry);
   char* (*visual_subtitle)(const struct ncvisual* ncv);
   int (*visual_resize)(struct ncvisual* ncv, int rows, int cols);
   void (*visual_destroy)(struct ncvisual* ncv);

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -847,7 +847,7 @@ int ncvisual_decode_loop(ncvisual* nc){
 }
 
 int ncvisual_stream(notcurses* nc, ncvisual* ncv, float timescale,
-                    streamcb streamer, const struct ncvisual_options* vopts,
+                    ncstreamcb streamer, const struct ncvisual_options* vopts,
                     void* curry){
   if(!visual_implementation){
     return -1;

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -377,7 +377,7 @@ err:
 // initial timestamp, and check each frame against the elapsed time to sync
 // up playback.
 int ffmpeg_stream(notcurses* nc, ncvisual* ncv, float timescale,
-                  streamcb streamer, const struct ncvisual_options* vopts,
+                  ncstreamcb streamer, const struct ncvisual_options* vopts,
                   void* curry){
   int frame = 1;
   struct timespec begin; // time we started

--- a/src/media/none.cpp
+++ b/src/media/none.cpp
@@ -51,7 +51,7 @@ int none_blit(struct ncvisual* ncv, int rows, int cols,
 }
 
 int none_stream(notcurses* nc, ncvisual* ncv, float timescale,
-                streamcb streamer, const struct ncvisual_options* vopts, void* curry){
+                ncstreamcb streamer, const struct ncvisual_options* vopts, void* curry){
   (void)nc;
   (void)ncv;
   (void)timescale;

--- a/src/media/oiio-indep.c
+++ b/src/media/oiio-indep.c
@@ -14,7 +14,7 @@ int oiio_blit_dispatch(struct ncplane* nc, const struct blitset* bset,
 }
 
 int oiio_stream(struct notcurses* nc, ncvisual* ncv, float timescale,
-                streamcb streamer, const struct ncvisual_options* vopts,
+                ncstreamcb streamer, const struct ncvisual_options* vopts,
                 void* curry){
   (void)timescale; // FIXME
   int frame = 1;


### PR DESCRIPTION
* Add an Alacritty hack to `query_sixel()`, but restrict it to cases when `TERM` contains `alacritty`. Closes #1430.
* Add `ncdirect_stream()`, which does exactly what you would think. Closes #1346.