### PR TITLE
Support making a color transparent in ncvisual

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,9 @@ rearrangements of Notcurses.
   * `cell_release()` and `cell_duplicate()` have been migrated to
     `nccell_release()` and `nccell_duplicate()`, respectively. The former
     forms have been deprecated, and will be removed in API3.
+  * Added `NCVISUAL_OPTION_ADDALPHA`, and the `transcolor` field to
+    `ncvisual_options`. If the former flag is used, the latter color
+    will be treated as transparent.
 
 * 2.2.5 (2021-04-04)
   * Bugfix release, no user-visible changes.

--- a/doc/man/man1/ncplayer.1.md
+++ b/doc/man/man1/ncplayer.1.md
@@ -8,7 +8,7 @@ ncplayer - Render images and video to a terminal
 
 # SYNOPSIS
 
-**ncplayer** [**-h**] [**-V**] [**-q**] [**-d** ***delaymult***] [**-l** ***loglevel***] [**-b** ***blitter***] [**-s** ***scalemode***] [**-k**] [**-L**] [**-t** ***seconds***] files
+**ncplayer** [**-h**] [**-V**] [**-q**] [**-d** ***delaymult***] [**-l** ***loglevel***] [**-b** ***blitter***] [**-s** ***scalemode***] [**-k**] [**-L**] [**-t** ***seconds***] [**-a**] files
 
 # DESCRIPTION
 
@@ -40,6 +40,8 @@ be any non-negative number.
 **-k**: Use direct mode (see **notcurses_direct(3)**). This will have the effect of leaving the output on-screen after program exit, and generating it inline (rather than clearing the screen and placing it at the top). Not supported with **-L** or **-d**.
 
 **-q**: Print neither frame/timing information along the top of the screen, nor the output summary on exit.
+
+**-a**: Treat color 0x000000 as if it were transparent.
 
 **-V**: Print the program name and version, and exit with success.
 

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -34,6 +34,7 @@ typedef enum {
 #define NCVISUAL_OPTION_BLEND      0x0002
 #define NCVISUAL_OPTION_HORALIGNED 0x0004
 #define NCVISUAL_OPTION_VERALIGNED 0x0008
+#define NCVISUAL_OPTION_ADDALPHA   0x0010
 
 struct ncvisual_options {
   struct ncplane* n;
@@ -43,6 +44,7 @@ struct ncvisual_options {
   int leny, lenx; // size of rendered section
   ncblitter_e blitter; // glyph set to use
   uint64_t flags; // bitmask over NCVISUAL_OPTION_*
+  uint32_t transcolor; // use this color for ADDALPHA
 };
 
 typedef int (*streamcb)(struct notcurses*, struct ncvisual*, void*);

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2454,6 +2454,7 @@ API ALLOC struct ncvisual* ncvisual_from_plane(const struct ncplane* n,
 #define NCVISUAL_OPTION_BLEND      0x0002ull // use CELL_ALPHA_BLEND with visual
 #define NCVISUAL_OPTION_HORALIGNED 0x0004ull // x is an alignment, not absolute
 #define NCVISUAL_OPTION_VERALIGNED 0x0008ull // y is an alignment, not absolute
+#define NCVISUAL_OPTION_ADDALPHA   0x0010ull // transcolor is in effect
 
 struct ncvisual_options {
   // if no ncplane is provided, one will be created using the exact size
@@ -2481,6 +2482,7 @@ struct ncvisual_options {
   // chosen for NCBLIT_DEFAULT.
   ncblitter_e blitter; // glyph set to use (maps input to output cells)
   uint64_t flags; // bitmask over NCVISUAL_OPTION_*
+  uint32_t transcolor; // treat this color as transparent under NCVISUAL_OPTION_ADDALPHA
 };
 
 // Create an RGBA flat array from the selected region of the ncplane 'nc'.

--- a/rust/examples/pixel-cell.rs
+++ b/rust/examples/pixel-cell.rs
@@ -51,7 +51,7 @@ fn main() -> NcResult<()> {
 
     // show the newly created ncvisual delimited with the box drawing characters
     let pixels = NcVisual::from_rgba(buffer.as_slice(), cell_y, cell_x * 4, cell_x)?;
-    let voptions = NcVisualOptions::without_plane(1, 2, 0, 0, cell_y, cell_x, NCBLIT_PIXEL, 0);
+    let voptions = NcVisualOptions::without_plane(1, 2, 0, 0, cell_y, cell_x, NCBLIT_PIXEL, 0, 0);
     pixels.render(&mut nc, &voptions)?;
 
     // FIXME: segfaults

--- a/rust/src/visual.rs
+++ b/rust/src/visual.rs
@@ -160,7 +160,7 @@ impl NcVisualOptions {
     }
 
     pub fn fullsize_pixel_without_plane(y: NcDim, x: NcDim, leny: NcDim, lenx: NcDim) -> Self {
-        Self::without_plane(y, x, 0, 0, leny, lenx, NCBLIT_PIXEL, 0)
+        Self::without_plane(y, x, 0, 0, leny, lenx, NCBLIT_PIXEL, 0, 0)
     }
 }
 

--- a/rust/src/visual.rs
+++ b/rust/src/visual.rs
@@ -105,6 +105,7 @@ impl NcVisualOptions {
         lenx: NcDim,
         blitter: NcBlitter,
         flags: u64,
+        transcolor: u32,
     ) -> Self {
         Self {
             // provided plane
@@ -123,6 +124,7 @@ impl NcVisualOptions {
             blitter,
             // bitmask over NCVISUAL_OPTION_*
             flags,
+            transcolor,
         }
     }
 
@@ -135,6 +137,7 @@ impl NcVisualOptions {
         lenx: NcDim,
         blitter: NcBlitter,
         flags: u64,
+        transcolor: u32,
     ) -> Self {
         Self {
             n: null_mut(),
@@ -152,6 +155,7 @@ impl NcVisualOptions {
             blitter,
             // bitmask over NCVISUAL_OPTION_*
             flags,
+            transcolor,
         }
     }
 

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -65,9 +65,7 @@ perframecb(struct ncvisual* ncv, struct ncvisual_options* vopts,
   // only need these two steps done once, but we can't do them in
   // main() due to the plane being created in ncvisual_stream() =[
   ncplane_set_resizecb(vopts->n, ncplane_resize_maximize);
-  // until #1518 is done, the stream isn't transparent, and thus it
-  // can obstruct the slider if there are few enough rows. FIXME
-  ncplane_move_above(vnewplane, vopts->n);
+  ncplane_move_above(vopts->n, vnewplane);
 
   struct notcurses* nc = ncplane_notcurses(vopts->n);
   static int frameno = 0;
@@ -106,7 +104,9 @@ int xray_demo(struct notcurses* nc){
     .scaling = NCSCALE_SCALE_HIRES,
     .blitter = NCBLIT_PIXEL,
     .flags = NCVISUAL_OPTION_NODEGRADE // to test for NCBLIT_PIXEL
-              | NCVISUAL_OPTION_VERALIGNED | NCVISUAL_OPTION_HORALIGNED,
+              | NCVISUAL_OPTION_VERALIGNED | NCVISUAL_OPTION_HORALIGNED
+              | NCVISUAL_OPTION_ADDALPHA,
+    .transcolor = 0,
   };
   float dm = 0;
   // returns 0 if the selected blitter isn't available

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -506,6 +506,7 @@ typedef struct {
   int begx;
   int placey;           // placement within ncplane
   int placex;
+  uint32_t transcolor;  // if non-zero, treat the lower 24 bits as a transparent color
   union { // cell vs pixel-specific arguments
     struct {
       int blendcolors;    // use CELL_ALPHA_BLEND

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1370,10 +1370,17 @@ int drop_signals(void* nc);
 void ncvisual_printbanner(const notcurses* nc);
 
 // alpha comes to us 0--255, but we have only 3 alpha values to map them to.
-// settled on experimentally.
+// settled on experimentally. if transcolor is non-zero, match its lower 24
+// bits against the color, and treat a match as transparent.
 static inline bool
-rgba_trans_p(unsigned alpha){
-  if(alpha < 192){
+rgba_trans_p(uint32_t p, uint32_t transcolor){
+  if(ncpixel_a(p) < 192){
+    return true;
+  }
+  if(transcolor && 
+      (ncpixel_r(p) == (transcolor & 0xff0000ull)) &&
+      (ncpixel_g(p) == (transcolor & 0xff00ull)) &&
+      (ncpixel_b(p) == (transcolor & 0xffull))){
     return true;
   }
   return false;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -60,7 +60,6 @@ base64_rgba3(const uint32_t* pixels, size_t pcount, char* b64, bool wipe[static 
   unsigned g = ncpixel_g(pixel);
   unsigned b = ncpixel_b(pixel);
   unsigned a = wipe[0] ? 0 : rgba_trans_p(pixel, transcolor) ? 0 : 255;
-//fprintf(stderr, "WIPE: %d %d %d\n", wipe[0], wipe[1], wipe[2]);
   b64[0] = b64subs[(r & 0xfc) >> 2];
   b64[1] = b64subs[(r & 0x3 << 4) | ((g & 0xf0) >> 4)];
   b64[2] = b64subs[((g & 0xf) << 2) | ((b & 0xc0) >> 6)];

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -53,12 +53,13 @@ b64idx(char b64){
 // is only 1 pixel available, those 32 bits become 8 bytes. (pcount + 1) * 4
 // bytes are used, plus a null terminator. we thus must receive 17.
 static inline void
-base64_rgba3(const uint32_t* pixels, size_t pcount, char* b64, bool wipe[static 3]){
+base64_rgba3(const uint32_t* pixels, size_t pcount, char* b64, bool wipe[static 3],
+             uint32_t transcolor){
   uint32_t pixel = *pixels++;
   unsigned r = ncpixel_r(pixel);
   unsigned g = ncpixel_g(pixel);
   unsigned b = ncpixel_b(pixel);
-  unsigned a = wipe[0] ? 0 : rgba_trans_p(ncpixel_a(pixel)) ? 0 : 255;
+  unsigned a = wipe[0] ? 0 : rgba_trans_p(pixel, transcolor) ? 0 : 255;
 //fprintf(stderr, "WIPE: %d %d %d\n", wipe[0], wipe[1], wipe[2]);
   b64[0] = b64subs[(r & 0xfc) >> 2];
   b64[1] = b64subs[(r & 0x3 << 4) | ((g & 0xf0) >> 4)];
@@ -77,7 +78,7 @@ base64_rgba3(const uint32_t* pixels, size_t pcount, char* b64, bool wipe[static 
   r = ncpixel_r(pixel);
   g = ncpixel_g(pixel);
   b = ncpixel_b(pixel);
-  a = wipe[1] ? 0 : rgba_trans_p(ncpixel_a(pixel)) ? 0 : 255;
+  a = wipe[1] ? 0 : rgba_trans_p(pixel, transcolor) ? 0 : 255;
   b64[5] = b64subs[b64[5] | ((r & 0xf0) >> 4)];
   b64[6] = b64subs[((r & 0xf) << 2) | ((g & 0xc0) >> 6u)];
   b64[7] = b64subs[g & 0x3f];
@@ -94,7 +95,7 @@ base64_rgba3(const uint32_t* pixels, size_t pcount, char* b64, bool wipe[static 
   r = ncpixel_r(pixel);
   g = ncpixel_g(pixel);
   b = ncpixel_b(pixel);
-  a = wipe[2] ? 0 : rgba_trans_p(ncpixel_a(pixel)) ? 0 : 255;
+  a = wipe[2] ? 0 : rgba_trans_p(pixel, transcolor) ? 0 : 255;
   b64[10] = b64subs[b64[10] | ((r & 0xc0) >> 6)];
   b64[11] = b64subs[r & 0x3f];
   b64[12] = b64subs[(g & 0xfc) >> 2];
@@ -227,7 +228,8 @@ int sprite_kitty_cell_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell
 static int
 write_kitty_data(FILE* fp, int linesize, int leny, int lenx,
                  int cols, const uint32_t* data, int cdimy, int cdimx,
-                 int sprixelid, sprixcell_e* tacache, int* parse_start){
+                 int sprixelid, sprixcell_e* tacache, int* parse_start,
+                 uint32_t transcolor){
   if(linesize % sizeof(*data)){
     fclose(fp);
     return -1;
@@ -271,7 +273,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx,
           wipe[e] = 1;
         }else{
           wipe[e] = 0;
-          if(rgba_trans_p(ncpixel_a(source[e]))){
+          if(rgba_trans_p(source[e], transcolor)){
             tacache[tyx] = SPRIXCELL_CONTAINS_TRANS;
           }
         }
@@ -279,7 +281,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx,
       }
       totalout += encodeable;
       char out[17];
-      base64_rgba3(source, encodeable, out, wipe);
+      base64_rgba3(source, encodeable, out, wipe, transcolor);
       ncfputs(out, fp);
     }
     fprintf(fp, "\e\\");
@@ -326,7 +328,8 @@ int kitty_blit(ncplane* n, int linesize, const void* data,
   // closes fp on all paths
   if(write_kitty_data(fp, linesize, leny, lenx, cols, data,
                       bargs->u.pixel.celldimy, bargs->u.pixel.celldimx,
-                      bargs->u.pixel.spx->id, tacache, &parse_start)){
+                      bargs->u.pixel.spx->id, tacache, &parse_start,
+                      bargs->transcolor)){
     if(!reuse){
       free(tacache);
     }

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -139,7 +139,7 @@ update_deets(uint32_t rgb, cdetails* deets){
 static inline int
 extract_color_table(const uint32_t* data, int linesize, int begy, int begx, int cols,
                     int leny, int lenx, int cdimy, int cdimx, sixeltable* stab,
-                    sprixcell_e* tacache){
+                    sprixcell_e* tacache, uint32_t transcolor){
   unsigned char mask = 0xc0;
   int pos = 0; // pixel position
   for(int visy = begy ; visy < (begy + leny) ; visy += 6){ // pixel row
@@ -147,7 +147,7 @@ extract_color_table(const uint32_t* data, int linesize, int begy, int begx, int 
       for(int sy = visy ; sy < (begy + leny) && sy < visy + 6 ; ++sy){ // offset within sprixel
         const uint32_t* rgb = (data + (linesize / 4 * sy) + visx);
         int txyidx = (sy / cdimy) * cols + (visx / cdimx);
-        if(rgba_trans_p(ncpixel_a(*rgb))){
+        if(rgba_trans_p(ncpixel_a(*rgb), transcolor)){
           if(tacache[txyidx] == SPRIXCELL_NORMAL){
             tacache[txyidx] = SPRIXCELL_CONTAINS_TRANS;
           }
@@ -460,7 +460,7 @@ int sixel_blit(ncplane* n, int linesize, const void* data,
   }
   if(extract_color_table(data, linesize, bargs->begy, bargs->begx, cols, leny, lenx,
                          bargs->u.pixel.celldimy, bargs->u.pixel.celldimx,
-                         &stable, tacache)){
+                         &stable, tacache, bargs->transcolor)){
     if(!reuse){
       free(tacache);
     }

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -147,7 +147,7 @@ extract_color_table(const uint32_t* data, int linesize, int begy, int begx, int 
       for(int sy = visy ; sy < (begy + leny) && sy < visy + 6 ; ++sy){ // offset within sprixel
         const uint32_t* rgb = (data + (linesize / 4 * sy) + visx);
         int txyidx = (sy / cdimy) * cols + (visx / cdimx);
-        if(rgba_trans_p(ncpixel_a(*rgb), transcolor)){
+        if(rgba_trans_p(*rgb, transcolor)){
           if(tacache[txyidx] == SPRIXCELL_NORMAL){
             tacache[txyidx] = SPRIXCELL_CONTAINS_TRANS;
           }

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -360,7 +360,8 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
     ncv = std::make_unique<Visual>(argv[i]);
     struct ncvisual_options vopts{};
     int r;
-    vopts.flags |= NCVISUAL_OPTION_HORALIGNED | NCVISUAL_OPTION_VERALIGNED;
+    vopts.flags |= NCVISUAL_OPTION_HORALIGNED | NCVISUAL_OPTION_VERALIGNED
+                | NCVISUAL_OPTION_ADDALPHA;
     vopts.y = NCALIGN_CENTER;
     vopts.x = NCALIGN_CENTER;
     vopts.n = n;

--- a/src/tests/blit.cpp
+++ b/src/tests/blit.cpp
@@ -38,6 +38,7 @@ TEST_CASE("Blitting") {
       .lenx = 4,
       .blitter = NCBLIT_1x1,
       .flags = 0,
+      .transcolor = 0,
     };
     ncblit_bgrx(data, 16, &vopts);
     for(int y = 0 ; y < 2 ; ++y){
@@ -87,6 +88,7 @@ TEST_CASE("Blitting") {
       .lenx = 4,
       .blitter = NCBLIT_1x1,
       .flags = 0,
+      .transcolor = 0,
     };
     ncblit_bgrx(data, 20, &vopts);
     for(int y = 0 ; y < 2 ; ++y){
@@ -139,6 +141,7 @@ TEST_CASE("Blitting") {
           .n = nullptr, .scaling = NCSCALE_NONE,
           .y = 0, .x = 0, .begy = 0, .begx = 0, .leny = 0, .lenx = 0,
           .blitter = NCBLIT_2x2, .flags = 0,
+          .transcolor = 0,
         };
         auto ncp = ncvisual_render(nc_, ncv, &vopts);
         ncvisual_destroy(ncv);

--- a/src/tests/pixel.cpp
+++ b/src/tests/pixel.cpp
@@ -52,6 +52,7 @@ TEST_CASE("Pixel") {
       .leny = y, .lenx = x,
       .blitter = NCBLIT_PIXEL,
       .flags = NCVISUAL_OPTION_NODEGRADE,
+      .transcolor = 0,
     };
     auto n = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != n);
@@ -89,6 +90,7 @@ TEST_CASE("Pixel") {
       .leny = y, .lenx = x,
       .blitter = NCBLIT_PIXEL,
       .flags = NCVISUAL_OPTION_NODEGRADE,
+      .transcolor = 0,
     };
     auto n = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != n);
@@ -126,6 +128,7 @@ TEST_CASE("Pixel") {
       .leny = y, .lenx = x,
       .blitter = NCBLIT_PIXEL,
       .flags = NCVISUAL_OPTION_NODEGRADE,
+      .transcolor = 0,
     };
     auto n = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != n);
@@ -171,6 +174,7 @@ TEST_CASE("Pixel") {
       .leny = y, .lenx = x,
       .blitter = NCBLIT_PIXEL,
       .flags = NCVISUAL_OPTION_NODEGRADE,
+      .transcolor = 0,
     };
     auto n = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != n);

--- a/src/tests/stacking.cpp
+++ b/src/tests/stacking.cpp
@@ -40,6 +40,7 @@ TEST_CASE("Stacking") {
     struct ncvisual_options vopts = {
       .n = top, .scaling = NCSCALE_NONE, .y = 0, .x = 0, .begy = 0, .begx = 0,
       .leny = 2, .lenx = 1, .blitter = NCBLIT_2x1, .flags = 0,
+      .transcolor = 0,
     };
     CHECK(top == ncvisual_render(nc_, ncv, &vopts));
     ncvisual_destroy(ncv);
@@ -77,6 +78,7 @@ TEST_CASE("Stacking") {
     struct ncvisual_options vopts = {
       .n = top, .scaling = NCSCALE_NONE, .y = 0, .x = 0, .begy = 0, .begx = 0,
       .leny = 2, .lenx = 1, .blitter = NCBLIT_2x1, .flags = 0,
+      .transcolor = 0,
     };
     CHECK(top == ncvisual_render(nc_, ncv, &vopts));
     ncvisual_destroy(ncv);
@@ -115,6 +117,7 @@ TEST_CASE("Stacking") {
       struct ncvisual_options vopts = {
         .n = top, .scaling = NCSCALE_NONE, .y = 0, .x = 0, .begy = 0, .begx = 0,
         .leny = 2, .lenx = 2, .blitter = NCBLIT_2x2, .flags = 0,
+        .transcolor = 0,
       };
       CHECK(top == ncvisual_render(nc_, ncv, &vopts));
       ncvisual_destroy(ncv);
@@ -156,6 +159,7 @@ TEST_CASE("Stacking") {
       struct ncvisual_options vopts = {
         .n = top, .scaling = NCSCALE_NONE, .y = 0, .x = 0, .begy = 0, .begx = 0,
         .leny = 2, .lenx = 2, .blitter = NCBLIT_2x2, .flags = 0,
+        .transcolor = 0,
       };
       CHECK(top == ncvisual_render(nc_, ncv, &vopts));
       ncvisual_destroy(ncv);

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -23,6 +23,7 @@ TEST_CASE("Visual") {
       .lenx = 2,
       .blitter = NCBLIT_1x1,
       .flags = NCVISUAL_OPTION_HORALIGNED,
+      .transcolor = 0,
     };
     auto ncv = ncvisual_from_rgba(pixels, 2, 2 * sizeof(*pixels), 2);
     REQUIRE(nullptr != ncv);
@@ -239,6 +240,7 @@ TEST_CASE("Visual") {
           .lenx = 0,
           .blitter = NCBLIT_2x2,
           .flags = 0,
+          .transcolor = 0,
         };
         auto ncvp = ncvisual_render(nc_, ncv, &vopts);
         REQUIRE(nullptr != ncvp);
@@ -283,6 +285,7 @@ TEST_CASE("Visual") {
             .lenx = 0,
             .blitter = NCBLIT_2x2,
             .flags = 0,
+            .transcolor = 0,
           };
           auto ncvp = ncvisual_render(nc_, ncv, &vopts);
           REQUIRE(nullptr != ncvp);
@@ -330,6 +333,7 @@ TEST_CASE("Visual") {
             .lenx = 0,
             .blitter = NCBLIT_2x2,
             .flags = 0,
+            .transcolor = 0,
           };
           auto ncvp = ncvisual_render(nc_, ncv, &vopts);
           REQUIRE(nullptr != ncvp);
@@ -382,6 +386,7 @@ TEST_CASE("Visual") {
             .lenx = 0,
             .blitter = NCBLIT_2x2,
             .flags = 0,
+            .transcolor = 0,
           };
           auto ncvp = ncvisual_render(nc_, ncv, &vopts);
           REQUIRE(nullptr != ncvp);
@@ -433,6 +438,7 @@ TEST_CASE("Visual") {
             .lenx = 0,
             .blitter = NCBLIT_2x2,
             .flags = 0,
+            .transcolor = 0,
           };
           auto ncvp = ncvisual_render(nc_, ncv, &vopts);
           REQUIRE(nullptr != ncvp);


### PR DESCRIPTION
With the new `NCVISUAL_OPTION_ADDALPHA` flag, a `transcolor` may be specified. Whenever this `transcolor` is found, that pixel is considered transparent. Basically it's ChromaKey in the `ncvisual` render loop. It's pretty awesome when used correctly.