### PR TITLE
Sixel: set P2=1 and set raster attributes

### DIFF
--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -317,7 +317,8 @@ write_rle(int* printed, int color, FILE* fp, int seenrle, unsigned char crle){
 // Closes |fp| on all paths.
 static int
 write_sixel_data(FILE* fp, int leny, int lenx, const sixeltable* stab, int* parse_start){
-  *parse_start = fprintf(fp, "\ePq");
+  // Set P2=1, turning empty pixels transparent
+  *parse_start = fprintf(fp, "\eP0;1;0q");
   // Set Raster Attributes - pan/pad=1 (pixel aspect ratio), Ph=lenx, Pv=leny
   // using Ph/Pv causes a background to be drawn using color register 0 for all
   // unspecified pixels, which we do not want.

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -322,7 +322,7 @@ write_sixel_data(FILE* fp, int leny, int lenx, const sixeltable* stab, int* pars
   // Set Raster Attributes - pan/pad=1 (pixel aspect ratio), Ph=lenx, Pv=leny
   // using Ph/Pv causes a background to be drawn using color register 0 for all
   // unspecified pixels, which we do not want.
-  //fprintf(fp, "\"1;0;%d;%d", lenx, leny);
+  fprintf(fp, "\"1;1;%d;%d", lenx, leny);
   (void)leny;
 
   for(int i = 0 ; i < stab->colors ; ++i){


### PR DESCRIPTION
Set `P2=1`. This indicates that empty pixels should "remain at their current color". I.e. it makes them transparent.

This is in contrast to `P2=0|2`, where empty pixels are filled with the "current background color" (which is either sixel color register #0, or the current ANSI background color, depending on terminal and its sixel implementation).

Note that due to what is most likely a bug, XTerm will behave as if `P2=1` if `P2` is either left unset, or explicitly set to `0` or `2`, as long as we do **not** emit a _"Set Raster Attributes"_ command.

With `P2` being explicitly set to `1`, we can safely emit a _"Set Raster Attributes"_ command, to indicate the final image size to the terminal up front.

Also fix the `pad` parameter (horizontal aspect ratio); XTerm rejects sixels with `pan` or `pad` set to `0`.

Tested with foot and XTerm, using `notcurses-demo`. Without this PR, transparent sixels aren't rendered transparent in foot.

I'm not sure this should be merged as-is.

First, it would be better if we could set `P2=0` for sixels without any transparent pixels. Is there an (easy) way to determine that?

Second, in XTerm, the default maximum graphic size is 1000x1000 pixels (not a lot!). **Without** _Set Raster Attributes_, XTerm will clip images larger than that. But it still emits _something_. **With** _Set Raster Attributes_, XTerm will reject images larger than the maximum allowed immediately.