### PR TITLE
Elide unnecessary sprixel invalidations

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -56,7 +56,8 @@ typedef enum {
 typedef enum {
   SPRIXCELL_NORMAL,         // no transparent pixels in this cell
   SPRIXCELL_CONTAINS_TRANS, // this cell has transparent pixels
-  SPRIXCELL_ANNIHILATED,    // this cell has been wiped
+  SPRIXCELL_ALL_TRANS,      // all pixels are naturally transparent
+  SPRIXCELL_ANNIHILATED,    // this cell has been wiped (all trans)
 } sprixcell_e;
 
 // there is a context-wide set of displayed pixel glyphs ("sprixels"); i.e.
@@ -831,7 +832,7 @@ int sprite_kitty_cell_wipe(const notcurses* nc, sprixel* s, int y, int x);
 int sixel_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell);
 int sprite_destroy(const struct notcurses* nc, const struct ncpile* p, FILE* out, sprixel* s);
 void sprixel_free(sprixel* s);
-void sprixel_invalidate(sprixel* s);
+void sprixel_invalidate(sprixel* s, int y, int x);
 void sprixel_movefrom(sprixel* s, int y, int x);
 void sprixel_hide(sprixel* s);
 int sprite_draw(const notcurses* n, const ncpile *p, sprixel* s, FILE* out);
@@ -848,7 +849,6 @@ int sprite_kitty_annihilate(const notcurses* nc, const ncpile* p, FILE* out, spr
 int sprite_kitty_init(int fd);
 int sprite_sixel_init(int fd);
 int sprite_init(const notcurses* nc);
-void sprixel_invalidate(sprixel* s);
 int kitty_shutdown(int fd);
 int sixel_shutdown(int fd);
 sprixel* sprixel_by_id(const notcurses* nc, uint32_t id);

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -1084,7 +1084,7 @@ rasterize_core(notcurses* nc, const ncpile* p, FILE* out, unsigned phase){
         }
 //fprintf(stderr, "RAST %08x [%s] to %d/%d cols: %u %016lx\n", srccell->gcluster, pool_extended_gcluster(&nc->pool, srccell), y, x, srccell->width, srccell->channels);
         if(rvec[damageidx].sprixel){
-          sprixel_invalidate(rvec[damageidx].sprixel);
+          sprixel_invalidate(rvec[damageidx].sprixel, y, x);
         }
         if(term_putc(out, &nc->pool, srccell)){
           return -1;

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -60,9 +60,17 @@ void sprixel_hide(sprixel* s){
   }
 }
 
-void sprixel_invalidate(sprixel* s){
-  if(s->invalidated != SPRIXEL_HIDE){
-    s->invalidated = SPRIXEL_INVALIDATED;
+// y and x are absolute coordinates
+void sprixel_invalidate(sprixel* s, int y, int x){
+//fprintf(stderr, "INVALIDATING AT %d/%d\n", y, x);
+  if(s->invalidated != SPRIXEL_HIDE && s->n){
+    int localy = y - s->n->absy;
+    int localx = x - s->n->absx;
+//fprintf(stderr, "INVALIDATING AT %d/%d (%d/%d) TAM: %d\n", y, x, localy, localx, s->n->tacache[localy * s->dimx + localx]);
+    if(s->n->tacache[localy * s->dimx + localx] != SPRIXCELL_ALL_TRANS &&
+       s->n->tacache[localy * s->dimx + localx] != SPRIXCELL_ALL_TRANS){
+      s->invalidated = SPRIXEL_INVALIDATED;
+    }
   }
 }
 

--- a/src/lib/stats.c
+++ b/src/lib/stats.c
@@ -94,7 +94,7 @@ void summarize_stats(notcurses* nc){
     qprefix(stats->raster_ns, NANOSECS_IN_SEC, totalbuf, 0);
     qprefix(stats->raster_min_ns, NANOSECS_IN_SEC, minbuf, 0);
     qprefix(stats->raster_max_ns, NANOSECS_IN_SEC, maxbuf, 0);
-    qprefix(stats->raster_ns / stats->writeouts, NANOSECS_IN_SEC, avgbuf, 0);
+    qprefix(stats->writeouts ? stats->raster_ns / stats->writeouts : 0, NANOSECS_IN_SEC, avgbuf, 0);
     fprintf(stderr, "%ju raster%s, %ss (%ss min, %ss avg, %ss max)\n",
             stats->writeouts, stats->writeouts == 1 ? "" : "s",
             totalbuf, minbuf, avgbuf, maxbuf);


### PR DESCRIPTION
When the damaged cell of a sprixel is actually entirely transparent (or annihilated), there's no need to invalidate it. Check for this in the TAM in sprixel_invalidate(). Good optimization, and eliminates a lot of the flicker in `xray` on Kitty described in #1522.