### PR TITLE
[ncplayer] direct-mode multiframe

### DIFF
--- a/doc/man/man1/ncplayer.1.md
+++ b/doc/man/man1/ncplayer.1.md
@@ -53,8 +53,8 @@ Default margins are all 0 and default scaling is **stretch**. The full
 rendering area will thus be used. Using **-m**, margins can be supplied.
 Provide a single number to set all four margins to the same value, or four
 comma-delimited values for the top, right, bottom, and left margins
-respectively. Top and bottom margins are ignored when **-k** is used. Negative
-margins are illegal.
+respectively. Top, right, and bottom margins are ignored when **-k** is used.
+Negative margins are illegal.
 
 Scaling mode **stretch** resizes the object to match the target rendering
 area exactly. Unless a blitter is specified with **-b**, **stretch** will use
@@ -88,7 +88,8 @@ fixed-width font with good coverage of the Unicode Block Drawing Characters.
 # BUGS
 
 Direct mode is kinda fundamentally suboptimal for multiframe media, and
-is not yet supported with **-L** nor **-d**.
+is not yet supported with **-L** nor **-d**. Top, right, and bottom
+margins are ignored without warning when using direct mode.
 
 # SEE ALSO
 

--- a/doc/man/man1/ncplayer.1.md
+++ b/doc/man/man1/ncplayer.1.md
@@ -27,7 +27,7 @@ Only applies to multiframe media such as video and animated images. Not supporte
 the "press any key to continue" prompt will not be displayed. **seconds** may
 be any non-negative number.
 
-**-l** ***loglevel***: Log everything (high log level) or nothing (log level 0) to stderr.
+**-l** ***loglevel***: Log between everything (loglevel 8) and nothing (loglevel 0) to stderr.
 
 **-s** ***scalemode***: Scaling mode, one of **none**, **hires**, **scale**, **scalehi**, or **stretch**.
 

--- a/doc/man/man1/ncplayer.1.md
+++ b/doc/man/man1/ncplayer.1.md
@@ -87,10 +87,8 @@ fixed-width font with good coverage of the Unicode Block Drawing Characters.
 
 # BUGS
 
-Direct mode (**-k**) does not yet support multiframe media. It'll read them
-just fine, but only show the first frame. This might or might not change in
-the future. Direct mode is kinda fundamentally suboptimal for multiframe
-media. Until that time, **-k** is exclusive with **-d** and **-L**.
+Direct mode is kinda fundamentally suboptimal for multiframe media, and
+is not yet supported with **-L** nor **-d**.
 
 # SEE ALSO
 

--- a/doc/man/man1/notcurses-demo.1.md
+++ b/doc/man/man1/notcurses-demo.1.md
@@ -57,7 +57,7 @@ terminal, and will refuse to run in anything smaller than 80x24.
 
 **-d** ***delaymult***: Apply a non-negative rational multiplier to the standard delay of 1s.
 
-**-l** ***loglevel***: Log everything (log level 8) or nothing (log level 0) to stderr.
+**-l** ***loglevel***: Log between everything (loglevel 8) and nothing (loglevel 0) to stderr.
 
 **-f** ***renderfile***: Render each frame to ***renderfile*** in addition to the screen.
 

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1148,5 +1148,6 @@ int ncdirect_stream(ncdirect* n, const char* filename, ncstreamcb streamer,
     streamer(ncv, vopts, NULL, curry);
   }while(ncvisual_decode(ncv) == 0);
   ncvisual_destroy(ncv);
+  // FIXME needn't we free v also?
   return 0;
 }

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -487,7 +487,8 @@ int ncdirect_raster_frame(ncdirect* n, ncdirectv* ncdv, ncalign_e align){
 
 static ncdirectv*
 ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
-                       ncscale_e scale, int ymax, int xmax){
+                       ncscale_e scale, int ymax, int xmax,
+                       uint32_t transcolor){
   int dimy = ymax > 0 ? ymax : ncdirect_dim_y(n);
   int dimx = xmax > 0 ? xmax : ncdirect_dim_x(n);
 //fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d\n", ncv->data, ncv->rows, ncv->cols);
@@ -539,6 +540,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
     return NULL;
   }
   blitterargs bargs = {};
+  bargs.transcolor = transcolor;
   if(bset->geom == NCBLIT_PIXEL){
     bargs.u.pixel.celldimx = n->tcache.cellpixx;
     bargs.u.pixel.celldimy = n->tcache.cellpixy;
@@ -564,7 +566,7 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
   if(ncv == NULL){
     return NULL;
   }
-  ncdirectv* v = ncdirect_render_visual(n, ncv, blitfxn, scale, ymax, xmax);
+  ncdirectv* v = ncdirect_render_visual(n, ncv, blitfxn, scale, ymax, xmax, 0);
   ncvisual_destroy(ncv);
   return v;
 }
@@ -1137,7 +1139,9 @@ int ncdirect_stream(ncdirect* n, const char* filename, ncstreamcb streamer,
     if(x > 0){
       ncdirect_cursor_left(n, x);
     }
-    ncdirectv* v = ncdirect_render_visual(n, ncv, vopts->blitter, vopts->scaling, 0, 0);
+    ncdirectv* v = ncdirect_render_visual(n, ncv, vopts->blitter, vopts->scaling,
+                                          0, 0, (vopts->flags & NCVISUAL_OPTION_ADDALPHA) ?
+                                                 vopts->transcolor | 0x1000000ul : 0);
     if(v == NULL){
       ncvisual_destroy(ncv);
       return -1;

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1123,8 +1123,7 @@ int ncdirect_check_pixel_support(ncdirect* n){
 
 int ncdirect_stream(ncdirect* n, const char* filename, ncstreamcb streamer,
                     struct ncvisual_options* vopts, void* curry){
-  int y, x;
-  if(ncdirect_cursor_yx(n, &y, &x)){
+  if(ncdirect_cursor_push(n)){
     return -1;
   }
   ncvisual* ncv = ncvisual_from_file(filename);
@@ -1132,7 +1131,11 @@ int ncdirect_stream(ncdirect* n, const char* filename, ncstreamcb streamer,
     return -1;
   }
   do{
-    if(ncdirect_cursor_move_yx(n, y, x)){
+    if(ncdirect_cursor_pop(n)){
+      ncvisual_destroy(ncv);
+      return -1;
+    }
+    if(ncdirect_cursor_push(n)){
       ncvisual_destroy(ncv);
       return -1;
     }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -592,25 +592,25 @@ typedef struct notcurses {
 } notcurses;
 
 typedef struct {
-  int begy;             // upper left start within visual
+  int begy;            // upper left start within visual
   int begx;
-  int placey;           // placement within ncplane
+  int placey;          // placement within ncplane
   int placex;
-  uint32_t transcolor;  // if non-zero, treat the lower 24 bits as a transparent color
+  uint32_t transcolor; // if non-zero, treat the lower 24 bits as a transparent color
   union { // cell vs pixel-specific arguments
     struct {
-      int blendcolors;    // use CELL_ALPHA_BLEND
-    } cell;               // for cells
+      int blendcolors; // use CELL_ALPHA_BLEND
+    } cell;            // for cells
     struct {
-      int celldimx;       // horizontal pixels per cell
-      int celldimy;       // vertical pixels per cell
-      int colorregs;      // number of color registers
-      sprixel* spx;       // sprixel object
+      int celldimx;    // horizontal pixels per cell
+      int celldimy;    // vertical pixels per cell
+      int colorregs;   // number of color registers
+      sprixel* spx;    // sprixel object
       // in at least mlterm, emitting a sixel makes the cursor visible.
       // if the cursor is hidden, and sprixel_cursor_hack is set, this
       // is set to the civis capability.
       const char* cursor_hack;
-    } pixel;              // for pixels
+    } pixel;           // for pixels
   } u;
 } blitterargs;
 

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -560,7 +560,11 @@ ncplane* ncvisual_render_cells(notcurses* nc, ncvisual* ncv, const struct blitse
   lenx = (lenx / (double)ncv->cols) * ((double)dispcols);
 //fprintf(stderr, "blit: %dx%d:%d+%d of %d/%d stride %u %p\n", begy, begx, leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
   blitterargs bargs;
-  bargs.transcolor = transcolor;
+  if(flags & NCVISUAL_OPTION_ADDALPHA){
+    bargs.transcolor = transcolor | 0x1000000ul;
+  }else{
+    bargs.transcolor = 0;
+  }
   bargs.begy = begy;
   bargs.begx = begx;
   bargs.placey = placey;
@@ -669,7 +673,11 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
   }
 //fprintf(stderr, "pblit: %dx%d <- %dx%d of %d/%d stride %u @%dx%d %p %u\n", disprows, dispcols, begy, begx, ncv->rows, ncv->cols, ncv->rowstride, placey, placex, ncv->data, nc->tcache.cellpixx);
   blitterargs bargs;
-  bargs.transcolor = transcolor;
+  if(flags & NCVISUAL_OPTION_ADDALPHA){
+    bargs.transcolor = transcolor | 0x1000000ul;
+  }else{
+    bargs.transcolor = 0;
+  }
   bargs.begy = begy;
   bargs.begx = begx;
   bargs.placey = placey;

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -322,6 +322,7 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
       blitter = NCBLIT_DEFAULT;
     }
   }
+  dm.cursor_disable();
   for(auto i = 0 ; i < argc ; ++i){
     auto faken = dm.prep_image(argv[i], blitter, scalemode, -1,
                                dm.get_dim_x() - (lmargin + rmargin));
@@ -354,6 +355,7 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
       failed = true;
     }
   }
+  dm.cursor_enable();
   return failed ? -1 : 0;
 }
 

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -324,12 +324,6 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
   }
   dm.cursor_disable();
   for(auto i = 0 ; i < argc ; ++i){
-    auto faken = dm.prep_image(argv[i], blitter, scalemode, -1,
-                               dm.get_dim_x() - (lmargin + rmargin));
-    if(!faken){
-      failed = true;
-      break;
-    }
     // FIXME need to free faken
     // FIXME we want to honor the different left and right margins, but that
     // would require raster_image() knowing how far over we were starting for
@@ -341,11 +335,6 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
     }else{
       a = NCAlign::Center;
     }
-    int y, x;
-    dm.get_cursor_yx(&y, &x);
-    if(x){
-      std::cout << std::endl;
-    }
     struct ncvisual_options vopts{};
     vopts.blitter = blitter;
     vopts.scaling = scalemode;
@@ -353,6 +342,11 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
     vopts.flags = NCVISUAL_OPTION_HORALIGNED;
     if(dm.streamfile(argv[i], perframe_direct, &vopts, NULL)){
       failed = true;
+    }
+    int y, x;
+    dm.get_cursor_yx(&y, &x);
+    if(x){
+      std::cout << std::endl;
     }
   }
   dm.cursor_enable();

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -310,7 +310,7 @@ int perframe_direct(struct ncvisual* ncv, struct ncvisual_options* vopts,
 
 // argc/argv ought already be reduced to only the media arguments
 int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
-                       ncblitter_e blitter, int lmargin, int rmargin){
+                       ncblitter_e blitter, int lmargin){
   Direct dm{};
   if(!dm.canopen_images()){
     std::cerr << "Notcurses was compiled without multimedia support\n";
@@ -504,7 +504,7 @@ auto main(int argc, char** argv) -> int {
   // if -k was provided, we now use direct mode rather than simply not using the
   // alternate screen, so that output is inline with the shell.
   if(ncopts.flags & NCOPTION_NO_ALTERNATE_SCREEN){
-    r = direct_mode_player(argc - nonopt, argv + nonopt, scalemode, blitter, ncopts.margin_l, ncopts.margin_r);
+    r = direct_mode_player(argc - nonopt, argv + nonopt, scalemode, blitter, ncopts.margin_l);
   }else{
     r = rendered_mode_player(argc - nonopt, argv + nonopt, scalemode, blitter, ncopts,
                              quiet, loop, timescale, displaytime, transcolor);

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -323,18 +323,16 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
     }
   }
   for(auto i = 0 ; i < argc ; ++i){
-    /*
     auto faken = dm.prep_image(argv[i], blitter, scalemode, -1,
                                dm.get_dim_x() - (lmargin + rmargin));
     if(!faken){
       failed = true;
       break;
     }
-    */
+    // FIXME need to free faken
     // FIXME we want to honor the different left and right margins, but that
     // would require raster_image() knowing how far over we were starting for
     // multiline cellular blittings...
-    (void)rmargin;
     ncpp::NCAlign a;
     if(blitter == NCBLIT_PIXEL){
       printf("%*.*s", lmargin, lmargin, "");
@@ -342,12 +340,6 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
     }else{
       a = NCAlign::Center;
     }
-    /*
-    if(dm.raster_image(faken, a)){
-      failed = true;
-      break;
-    }
-    */
     int y, x;
     dm.get_cursor_yx(&y, &x);
     if(x){

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -26,7 +26,7 @@ void usage(std::ostream& o, const char* name, int exitcode){
   o << " -k: use direct mode (cannot be used with -L or -d)\n";
   o << " -L: loop frames\n";
   o << " -t seconds: delay t seconds after each file\n";
-  o << " -l loglevel: integer between 0 and 9, goes to stderr'\n";
+  o << " -l loglevel: integer between 0 and 8, goes to stderr'\n";
   o << " -s scaling: one of 'none', 'hires', 'scale', 'scalehi', or 'stretch'\n";
   o << " -b blitter: one of 'ascii', 'half', 'quad', 'sex', 'braille', or 'pixel'\n";
   o << " -m margins: margin, or 4 comma-separated margins\n";

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -310,7 +310,8 @@ int perframe_direct(struct ncvisual* ncv, struct ncvisual_options* vopts,
 
 // argc/argv ought already be reduced to only the media arguments
 int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
-                       ncblitter_e blitter, int lmargin){
+                       ncblitter_e blitter, int lmargin,
+                       unsigned transcolor){
   Direct dm{};
   if(!dm.canopen_images()){
     std::cerr << "Notcurses was compiled without multimedia support\n";
@@ -340,6 +341,10 @@ int direct_mode_player(int argc, char** argv, ncscale_e scalemode,
     vopts.scaling = scalemode;
     vopts.x = static_cast<int>(a);
     vopts.flags = NCVISUAL_OPTION_HORALIGNED;
+    if(transcolor){
+      vopts.flags |= NCVISUAL_OPTION_ADDALPHA;
+    }
+    vopts.transcolor = transcolor & 0xffffffull;
     if(dm.streamfile(argv[i], perframe_direct, &vopts, NULL)){
       failed = true;
     }
@@ -504,7 +509,8 @@ auto main(int argc, char** argv) -> int {
   // if -k was provided, we now use direct mode rather than simply not using the
   // alternate screen, so that output is inline with the shell.
   if(ncopts.flags & NCOPTION_NO_ALTERNATE_SCREEN){
-    r = direct_mode_player(argc - nonopt, argv + nonopt, scalemode, blitter, ncopts.margin_l);
+    r = direct_mode_player(argc - nonopt, argv + nonopt, scalemode, blitter,
+                           ncopts.margin_l, transcolor);
   }else{
     r = rendered_mode_player(argc - nonopt, argv + nonopt, scalemode, blitter, ncopts,
                              quiet, loop, timescale, displaytime, transcolor);


### PR DESCRIPTION
Adds support for multiframe media (videos) to direct mode as used by `-k`. Improves `ncdirect_stream()` by using cursor push/pop to avoid terminal interrogation. Disables the cursor around direct-mode play. Closes #1515.