### PR TITLE
add function ncvisual_inflate()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,12 @@ This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
 * 2.2.7 (not yet released)
-  * `cell_extended_gcluster()` has been deprecated in favor of the new
-    function `nccell_extended_gcluster()`, which the former now wraps.
-    It will be removed in ABI3. The same treatment has been applied to
-    `cell_load_egc32()`, `cell_load_char()`, `cellcmp()`, `cell_init()`,
-    `cell_extract()`, `cell_load()`, and `cell_prime()`.
+  * All remaining functions prefixed with `cell_` or `cells_` have been
+    deprecated in favor of versions prefixed with `nccell_` or `nccell_`,
+    respectively, which the former now wrap. The old versions will be
+    removed in ABI3.
+  * `ncvisual_inflate()` has been added to perform non-interpolative
+    enlarging. It is intended for use with pixel art.
 
 * 2.2.6 (2021-04-12)
   * `ncplane_rgba()` has been deprecated in favor of the new function

--- a/USAGE.md
+++ b/USAGE.md
@@ -3076,6 +3076,10 @@ int ncvisual_rotate(struct ncvisual* n, double rads);
 // transformation, unless the size is unchanged.
 int ncvisual_resize(struct ncvisual* n, int rows, int cols);
 
+// Inflate each pixel in the image to 'scale'x'scale' pixels. It is an error
+// if 'scale' is less than 1. The original color is retained.
+int ncvisual_inflate(struct ncvisual* n, int scale);
+
 // Polyfill at the specified location within the ncvisual 'n', using 'rgba'.
 int ncvisual_polyfill_yx(struct ncvisual* n, int y, int x, uint32_t rgba);
 

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -76,6 +76,8 @@ typedef int (*streamcb)(struct notcurses*, struct ncvisual*, void*);
 
 **int ncvisual_resize(struct ncvisual* ***n***, int ***rows***, int ***cols***);**
 
+**int ncvisual_inflate(struct ncvisual* ***n***, int ***scale***);**
+
 **int ncvisual_polyfill_yx(struct ncvisual* ***n***, int ***y***, int ***x***, uint32_t ***rgba***);**
 
 **int ncvisual_at_yx(const struct ncvisual* ***n***, int ***y***, int ***x***, uint32_t* ***pixel***);**
@@ -109,10 +111,14 @@ and codecs, but does not verify that the entire file is well-formed.
 per frame. **ncvisual_decode_loop** will return to the first frame,
 as if **ncvisual_decode** had never been called.
 
-Once the visual is loaded, it can be transformed using **ncvisual_rotate**
-and **ncvisual_resize**. These are persistent operations, unlike any scaling
-that takes place at render time. If a subtitle is associated with the frame,
-it can be acquired with **ncvisual_subtitle**.
+Once the visual is loaded, it can be transformed using **ncvisual_rotate**,
+**ncvisual_resize**, and **ncvisual_inflate**. These are persistent operations,
+unlike any scaling that takes place at render time. If a subtitle is associated
+with the frame, it can be acquired with **ncvisual_subtitle**.
+**ncvisual_resize** uses the media layer's best scheme to enlarge or shrink the
+original data, typically involving some interpolation. **ncvisual_inflate**
+maps each pixel to ***scale***x***scale*** pixels square, retaining the
+original color; it is an error if ***scale*** is less than one.
 
 **ncvisual_from_rgba** and **ncvisual_from_bgra** both require a number of
 **rows**, a number of image columns **cols**, and a virtual row length of

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2735,9 +2735,14 @@ API int ncvisual_decode_loop(struct ncvisual* nc)
 API int ncvisual_rotate(struct ncvisual* n, double rads)
   __attribute__ ((nonnull (1)));
 
-// Resize the visual so that it is 'rows' X 'columns'. This is a lossy
-// transformation, unless the size is unchanged.
+// Resize the visual so that it is 'rows' X 'columns', using the best scheme
+// available. This is a lossy transformation, unless the size is unchanged.
 API int ncvisual_resize(struct ncvisual* n, int rows, int cols)
+  __attribute__ ((nonnull (1)));
+
+// Inflate each pixel in the image to 'scale'x'scale' pixels. It is an error
+// if 'scale' is less than 1. The original color is retained.
+API int ncvisual_inflate(struct ncvisual* n, int scale)
   __attribute__ ((nonnull (1)));
 
 // Polyfill at the specified location within the ncvisual 'n', using 'rgba'.

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -101,7 +101,7 @@ ncvisual_blitset_geom(const notcurses* nc, const ncvisual* n,
   *lenx = vopts ? vopts->lenx : 0;
   *leny = vopts ? vopts->leny : 0;
 //fprintf(stderr, "blit %dx%d+%dx%d %p\n", begy, begx, *leny, *lenx, ncv->data);
-  if(begy < 0 || begx < 0 || *lenx < -1 || *leny < -1){
+  if(begy < 0 || begx < 0 || *lenx <= -1 || *leny <= -1){
     logerror(nc, "Invalid geometry for visual %d %d %d %d\n", begy, begx, *leny, *lenx);
     return -1;
   }
@@ -172,7 +172,13 @@ ncvisual_blitset_geom(const notcurses* nc, const ncvisual* n,
   }
   if(vopts && vopts->flags & NCVISUAL_OPTION_HORALIGNED){
     if(vopts->x < NCALIGN_UNALIGNED || vopts->x > NCALIGN_RIGHT){
-      logerror(nc, "Bad x value %d for horizontal alignment\n", vopts->x);
+      logerror(nc, "Bad x %d for horizontal alignment\n", vopts->x);
+      return -1;
+    }
+  }
+  if(vopts && vopts->flags & NCVISUAL_OPTION_VERALIGNED){
+    if(vopts->y < NCALIGN_UNALIGNED || vopts->y > NCALIGN_RIGHT){
+      logerror(nc, "Bad y %d for vertical alignment\n", vopts->y);
       return -1;
     }
   }

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -1,4 +1,5 @@
 #include "main.h"
+#include "visual-details.h"
 #include <vector>
 
 TEST_CASE("Visual") {
@@ -32,6 +33,33 @@ TEST_CASE("Visual") {
     CHECK(0 == notcurses_render(nc_));
     ncvisual_destroy(ncv);
     ncplane_destroy(n);
+  }
+
+  SUBCASE("InflateBitmap") {
+    const uint32_t pixels[4] = { htole(0xffff0000), htole(0xff00ff00), htole(0xff0000ff), htole(0xffffffff) };
+    auto ncv = ncvisual_from_rgba(pixels, 2, 8, 2);
+    REQUIRE(ncv);
+    CHECK(0 == ncvisual_inflate(ncv, 3));
+    CHECK(0 == notcurses_render(nc_));
+    CHECK(6 == ncv->rows);
+    CHECK(6 == ncv->cols);
+    for(int y = 0 ; y < 3 ; ++y){
+      for(int x = 0 ; x < 3 ; ++x){
+        CHECK(pixels[0] == ncv->data[y * ncv->cols + x]);
+      }
+      for(int x = 3 ; x < 6 ; ++x){
+        CHECK(pixels[1] == ncv->data[y * ncv->cols + x]);
+      }
+    }
+    for(int y = 3 ; y < 6 ; ++y){
+      for(int x = 0 ; x < 3 ; ++x){
+        CHECK(pixels[2] == ncv->data[y * ncv->cols + x]);
+      }
+      for(int x = 3 ; x < 6 ; ++x){
+        CHECK(pixels[3] == ncv->data[y * ncv->cols + x]);
+      }
+    }
+    ncvisual_destroy(ncv);
   }
 
   SUBCASE("LoadRGBAFromMemory") {


### PR DESCRIPTION
Add new function `ncvisual_inflate()`, which scales each pixel by an integer square, and uses that pixel's color throughout--no interpolation. @joseluis requested this for pixel art. Add documentation to `USAGE.md` and `notcurses_visual(3)`, and entry to `NEWS.md`. Add unit test. Closes #1548.