### PR TITLE
Deepclean sixel on move

### DIFF
--- a/TERMINALS.md
+++ b/TERMINALS.md
@@ -19,6 +19,7 @@ relies on the font. Patches to correct/complete this table are very welcome!
 | --------------- | ------------------ | ----- | ------ | -----------------------           | ----- |
 | [Alacritty](https://github.com/alacritty/alacritty)       | ✅                 |  ✅   |❌      |`TERM=alacritty` `COLORTERM=24bit` | [Sixel support WIP](https://github.com/ayosec/alacritty/tree/graphics) |
 | [Contour](https://github.com/christianparpart/contour)    | ❌                 |  ✅   |?       |`TERM=contour-latest` ?            | Claims Sixel support             |
+| [ETerm](https://github.com/mej/Eterm) | | | | TERM="Eterm" | Doesn't reply to Send Device Attributes |
 | [FBterm](https://github.com/zhangyuanwei/fbterm)          | ❌                 |  ?    |?       |`TERM=fbterm`                      | 256 colors, no RGB color. |
 | [foot](https://codeberg.org/dnkl/foot)            | ✅                 |  ✅   |✅      |`TERM=foot`                        | Sixel support. |
 | [Gnome Terminal](https://gitlab.gnome.org/GNOME/gnome-terminal)  |                    |  ❌   |✅      |`TERM=gnome` `COLORTERM=24bit`     | `ccc` support *is* available when run with `vte-256color`. |

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -514,10 +514,16 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
     }
     if(scale == NCSCALE_SCALE || scale == NCSCALE_SCALE_HIRES){
       scale_visual(ncv, &disprows, &dispcols);
+      if(bset->geom == NCBLIT_PIXEL){
+        clamp_to_sixelmax(&n->tcache, &disprows, &dispcols);
+      }
     }
   }else{
     disprows = ncv->rows;
     dispcols = ncv->cols;
+    if(bset->geom == NCBLIT_PIXEL){
+      clamp_to_sixelmax(&n->tcache, &disprows, &dispcols);
+    }
   }
   leny = (leny / (double)ncv->rows) * ((double)disprows);
   lenx = (lenx / (double)ncv->cols) * ((double)dispcols);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -158,6 +158,7 @@ typedef struct sprixel {
   int y, x;
   int dimy, dimx;       // cell geometry
   int pixy, pixx;       // pixel geometry (might be smaller than cell geo)
+  int cellpxy, cellpxx; // cell-pixel geometry at time of creation
   // each tacache entry is one of 0 (standard opaque cell), 1 (cell with
   // some transparency), 2 (annihilated, excised)
   int parse_start;   // where to start parsing for cell wipes

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -163,6 +163,7 @@ typedef struct sprixel {
   int parse_start;   // where to start parsing for cell wipes
   int movedfromy;       // for SPRIXEL_MOVED, the starting absolute position,
   int movedfromx;       // so that we can damage old cells when redrawn
+  bool wipes_outstanding; // do we need execute wipes on move?
 } sprixel;
 
 // A plane is memory for some rectilinear virtual window, plus current cursor

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -635,7 +635,7 @@ int sixel_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
     for(int yy = s->movedfromy ; yy < s->movedfromy + s->dimy && yy < p->dimy ; ++yy){
       for(int xx = s->movedfromx ; xx < s->movedfromx + s->dimx && xx < p->dimx ; ++xx){
         struct crender *r = &p->crender[yy * p->dimx + xx];
-        if(!r->sprixel || sprixel_state(r->sprixel, yy, xx) == SPRIXCELL_OPAQUE){
+        if(!r->sprixel || sprixel_state(r->sprixel, yy, xx) != SPRIXCELL_OPAQUE){
           r->s.damaged = 1;
         }
       }

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -154,7 +154,7 @@ int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
 
 // precondition: s->invalidated is SPRIXEL_INVALIDATED or SPRIXEL_MOVED.
 int sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-//sprixel_debug(stderr, s);
+sprixel_debug(stderr, s);
   int r = n->tcache.pixel_draw(n, p, s, out);
   return r;
 }

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -109,6 +109,7 @@ sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx, int placey, int placex){
     ret->y = placey;
     ret->x = placex;
     ret->id = ++sprixelid_nonce;
+    ret->wipes_outstanding = false;
 //fprintf(stderr, "LOOKING AT %p (p->n = %p)\n", ret, ret->n);
     if(ncplane_pile(ret->n)){
       notcurses* nc = ncplane_notcurses(ret->n);

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -115,7 +115,12 @@ sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx, int placey, int placex){
       notcurses* nc = ncplane_notcurses(ret->n);
       ret->next = nc->sprixelcache;
       nc->sprixelcache = ret;
+      ret->cellpxy = nc->tcache.cellpixy;
+      ret->cellpxx = nc->tcache.cellpixx;
 //fprintf(stderr, "%p %p %p\n", nc->sprixelcache, ret, nc->sprixelcache->next);
+    }else{
+      ret->next = NULL;
+      ret->cellpxy = ret->cellpxx = -1;
     }
   }
   return ret;
@@ -155,7 +160,7 @@ int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
 
 // precondition: s->invalidated is SPRIXEL_INVALIDATED or SPRIXEL_MOVED.
 int sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-sprixel_debug(stderr, s);
+//sprixel_debug(stderr, s);
   int r = n->tcache.pixel_draw(n, p, s, out);
   return r;
 }

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -351,6 +351,7 @@ setup_sixel(tinfo* ti){
 // query for Sixel support
 static int
 query_sixel(tinfo* ti, int fd){
+  // Send Device Attributes (see decTerminalID resource)
   if(writen(fd, "\x1b[c", 3) != 3){
     return -1;
   }

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -633,6 +633,8 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
       clamp_to_sixelmax(&nc->tcache, &disprows, &dispcols);
       if(scaling == NCSCALE_SCALE || scaling == NCSCALE_SCALE_HIRES){
         scale_visual(ncv, &disprows, &dispcols); // can only shrink
+        // FIXME can't we keep this limited to one clamp-to-6 max?
+        clamp_to_sixelmax(&nc->tcache, &disprows, &dispcols);
       }
     }
     struct ncplane_options nopts = {

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -673,9 +673,10 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
         disprows -= placey * nc->tcache.cellpixy;
       }
     }
-  }
-  if(scaling == NCSCALE_SCALE || scaling == NCSCALE_SCALE_HIRES){
-    scale_visual(ncv, &disprows, &dispcols);
+    if(scaling == NCSCALE_SCALE || scaling == NCSCALE_SCALE_HIRES){
+      scale_visual(ncv, &disprows, &dispcols);
+      clamp_to_sixelmax(&nc->tcache, &disprows, &dispcols);
+    }
   }
   if(flags & NCVISUAL_OPTION_HORALIGNED){
     if(placex == NCALIGN_CENTER){


### PR DESCRIPTION
Normally, we don't bother to edit Sixels in-place upon annihilation, since you can just print the character over them and be done with it. If we move one, however, we need to cut the annihilated pixels out of the Sixel. Failure to do so was leading to flicker around the base of the orca's Segway in the `intro` demo. This was a bit of a struggle, but it seems to work beautifully (though a bit slower than I would care for -- we'll do something about that). Closes #1555.