### PR TITLE
Kitty: restore bitmaps when no longer occluded

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -147,7 +147,7 @@ typedef enum {
 // reconstruction of annihilated cells, valid only for SPRIXCELL_ANNIHILATED.
 typedef struct tament {
   sprixcell_e state;
-  uint8_t auxvector; // palette entries for sixel, alphas for kitty
+  uint8_t* auxvector; // palette entries for sixel, alphas for kitty
 } tament;
 
 // a sprixel represents a bitmap, using whatever local protocol is available.
@@ -959,6 +959,9 @@ sprixel* sprixel_by_id(const ncpile* n, uint32_t id);
 void sprixel_invalidate(sprixel* s, int y, int x);
 void sprixel_movefrom(sprixel* s, int y, int x);
 
+// create an auxiliary vector suitable for a sprixcell, and zero it out
+uint8_t* sprixel_auxiliary_vector(const sprixel* s);
+
 int sixel_blit(ncplane* nc, int linesize, const void* data,
                int leny, int lenx, const blitterargs* bargs);
 
@@ -991,7 +994,7 @@ sprixel_debug(FILE* out, const sprixel* s){
 // precondition: s->invalidated is SPRIXEL_INVALIDATED or SPRIXEL_MOVED.
 static inline int
 sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-sprixel_debug(stderr, s);
+//sprixel_debug(stderr, s);
   return n->tcache.pixel_draw(n, p, s, out);
 }
 

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -450,6 +450,8 @@ typedef struct tinfo {
   // means leaving out the pixels (and likely resizes the string). for kitty,
   // this means dialing down their alpha to 0 (in equivalent space).
   int (*pixel_cell_wipe)(const struct notcurses* nc, sprixel* s, int y, int x);
+  // perform the inverse of pixel_cell_wipe, restoring an annihilated sprixcell.
+  int (*pixel_rebuild)(const struct notcurses* nc, sprixel* s, int y, int x);
   int (*pixel_remove)(int id, FILE* out); // kitty only, issue actual delete command
   int (*pixel_init)(int fd);     // called when support is detected
   int (*pixel_draw)(const struct notcurses* n, const struct ncpile* p, sprixel* s, FILE* out);
@@ -922,7 +924,9 @@ int sixel_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell);
 // nulls out a cell from a kitty bitmap via changing the alpha value
 // throughout to 0. the same trick doesn't work on sixel, but there we
 // can just print directly over the bitmap.
-int kitty_wipe(const notcurses* nc, sprixel* s, int y, int x);
+int kitty_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell);
+int sixel_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell);
+int kitty_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell);
 
 void sprixel_free(sprixel* s);
 void sprixel_hide(sprixel* s);
@@ -958,6 +962,11 @@ int kitty_blit(ncplane* nc, int linesize, const void* data,
 static inline int
 sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
   return nc->tcache.pixel_destroy(nc, p, out, s);
+}
+
+static inline int
+sprite_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
+  return nc->tcache.pixel_rebuild(nc, s, ycell, xcell);
 }
 
 static inline void

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -970,10 +970,28 @@ sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
   return nc->tcache.pixel_destroy(nc, p, out, s);
 }
 
+__attribute__ ((unused)) static inline void
+sprixel_debug(FILE* out, const sprixel* s){
+  fprintf(out, "Sprixel %d (%p) %dx%d (%dx%d) @%d/%d state: %d\n",
+          s->id, s, s->dimy, s->dimx, s->pixy, s->pixx,
+          s->n ? s->n->absy : 0, s->n ? s->n->absx : 0,
+          s->invalidated);
+  if(s->n){
+    int idx = 0;
+    for(int y = 0 ; y < s->dimy ; ++y){
+      for(int x = 0 ; x < s->dimx ; ++x){
+        fprintf(out, "%d", s->n->tam[idx].state);
+        ++idx;
+      }
+      fprintf(out, "\n");
+    }
+  }
+}
+
 // precondition: s->invalidated is SPRIXEL_INVALIDATED or SPRIXEL_MOVED.
 static inline int
 sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-//sprixel_debug(stderr, s);
+sprixel_debug(stderr, s);
   return n->tcache.pixel_draw(n, p, s, out);
 }
 

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -289,6 +289,7 @@ int kitty_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 0; // already annihilated, needn't draw glyph in kitty
   }
+  uint8_t* auxvec = sprixel_auxiliary_vector(s);
 //fprintf(stderr, "NEW WIPE %d %d/%d\n", s->id, ycell, xcell);
   const int totalpixels = s->pixy * s->pixx;
   const int xpixels = nc->tcache.cellpixx;
@@ -343,6 +344,7 @@ int kitty_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
         if(--targy == 0){
           // FIXME make sure state is MIXED if we had any transparency
           s->n->tam[s->dimx * ycell + xcell].state = state;
+          s->n->tam[s->dimx * ycell + xcell].auxvector = auxvec;
           return 0;
         }
         thisrow = targx;
@@ -361,6 +363,7 @@ int kitty_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
     }
     ++c;
   }
+  free(auxvec);
   return -1;
 }
 

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -217,7 +217,7 @@ kitty_restore(char* triplet, int skip, int max, int pleft, const uint8_t* auxvec
     if(max > 1){
       a = auxvec[1];
       triplet[0x9] = b64subs[(b64idx(triplet[0x9]) & 0x30) | ((a & 0xf0) >> 4)];
-      triplet[0xA] = b64subs[((a & 0xf) << 2) | (b64idx(triplet[0xA]) & 0xf)];
+      triplet[0xA] = b64subs[((a & 0xf) << 2) | (b64idx(triplet[0xA]) & 0x3)];
     }
     if(max == 3){
       a = auxvec[2];
@@ -227,7 +227,7 @@ kitty_restore(char* triplet, int skip, int max, int pleft, const uint8_t* auxvec
   }else if(skip == 1){
     int a = auxvec[0];
     triplet[0x9] = b64subs[(b64idx(triplet[0x9]) & 0x30) | ((a & 0xf0) >> 4)];
-    triplet[0xA] = b64subs[((a & 0xf) << 2) | (b64idx(triplet[0xA]) & 0xf)];
+    triplet[0xA] = b64subs[((a & 0xf) << 2) | (b64idx(triplet[0xA]) & 0x3)];
     if(max == 2){
       a = auxvec[1];
       triplet[0xE] = b64subs[((a & 0xc0) >> 6) | (b64idx(triplet[0xE]) & 0x3c)];

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -38,9 +38,9 @@ b64idx(char b64){
   if(b64 >= 'A' && b64 <= 'Z'){
     return b64 - 'A';
   }else if(b64 >= 'a' && b64 <= 'z'){
-    return b64 - 'a';
+    return b64 - 'a' + 26;
   }else if(b64 >= '0' && b64 <= '9'){
-    return b64 - '0';
+    return b64 - '0' + 52;
   }else if(b64 == '+'){
     return 62;
   }else{

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -153,6 +153,14 @@ kitty_null(char* triplet, int skip, int max, int pleft){
 }
 
 #define RGBA_MAXLEN 768 // 768 base64-encoded pixels in 4096 bytes
+int kitty_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
+  (void)nc;
+  (void)s;
+  (void)ycell;
+  (void)xcell;
+  return 0;
+}
+
 int kitty_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
   if(s->n->tacache[s->dimx * ycell + xcell] == SPRIXCELL_ANNIHILATED){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -269,7 +269,14 @@ void free_plane(ncplane* p){
     if(p->sprite){
       sprixel_hide(p->sprite);
     }
-    free(p->tam);
+    if(p->tam){
+      for(int y = 0 ; y < p->leny ; ++y){
+        for(int x = 0 ; x < p->lenx ; ++x){
+          free(p->tam[y * p->lenx + x].auxvector);
+        }
+      }
+      free(p->tam);
+    }
     egcpool_dump(&p->pool);
     free(p->name);
     free(p->fb);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -269,7 +269,7 @@ void free_plane(ncplane* p){
     if(p->sprite){
       sprixel_hide(p->sprite);
     }
-    free(p->tacache);
+    free(p->tam);
     egcpool_dump(&p->pool);
     free(p->name);
     free(p->fb);
@@ -381,7 +381,7 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
   p->name = strdup(nopts->name ? nopts->name : "");
   p->halign = NCALIGN_UNALIGNED;
   p->valign = NCALIGN_UNALIGNED;
-  p->tacache = NULL;
+  p->tam = NULL;
   if(!n){ // new root/standard plane
     p->absy = nopts->y;
     p->absx = nopts->x;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -171,13 +171,14 @@ paint_sprixel(ncplane* p, struct crender* rvec, int starty, int startx,
           crender->s.damaged = 1;
         }
         crender->s.p_beats_sprixel = 1;
-      }else if(!crender->p){
+      }else if(!crender->p && !crender->s.bgblends){
         // if we are a bitmap, and above a cell that has changed (and
         // will thus be printed), we'll need redraw the sprixel.
         if(crender->sprixel == NULL){
           crender->sprixel = s;
         }
         if(sprixel_state(s, absy, absx) == SPRIXCELL_ANNIHILATED){
+fprintf(stderr, "REBUILDING AT %d/%d\n", y, x);
           sprite_rebuild(nc, s, y, x);
         }
       }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -178,7 +178,7 @@ paint_sprixel(ncplane* p, struct crender* rvec, int starty, int startx,
           crender->sprixel = s;
         }
         if(sprixel_state(s, absy, absx) == SPRIXCELL_ANNIHILATED){
-fprintf(stderr, "REBUILDING AT %d/%d\n", y, x);
+//fprintf(stderr, "REBUILDING AT %d/%d\n", y, x);
           sprite_rebuild(nc, s, y, x);
         }
       }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -178,8 +178,7 @@ paint_sprixel(ncplane* p, struct crender* rvec, int starty, int startx,
           crender->sprixel = s;
         }
         if(sprixel_state(s, absy, absx) == SPRIXCELL_ANNIHILATED){
-          // FIXME rebuild!
-fprintf(stderr, "annihilation UNDONE at %d/%d\n", y, x);
+          sprite_rebuild(nc, s, y, x);
         }
       }
     }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -177,6 +177,10 @@ paint_sprixel(ncplane* p, struct crender* rvec, int starty, int startx,
         if(crender->sprixel == NULL){
           crender->sprixel = s;
         }
+        if(sprixel_state(s, absy, absx) == SPRIXCELL_ANNIHILATED){
+          // FIXME rebuild!
+fprintf(stderr, "annihilation UNDONE at %d/%d\n", y, x);
+        }
       }
     }
   }

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -746,8 +746,7 @@ int sixel_init(int fd){
   return tty_emit("\e[?80;8452h", fd);
 }
 
-int sixel_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
-  (void)nc;
+int sixel_rebuild(sprixel* s, int ycell, int xcell){
   (void)s;
   (void)ycell;
   (void)xcell;

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -746,6 +746,14 @@ int sixel_init(int fd){
   return tty_emit("\e[?80;8452h", fd);
 }
 
+int sixel_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
+  (void)nc;
+  (void)s;
+  (void)ycell;
+  (void)xcell;
+  return 0;
+}
+
 // we return -1 because we're not doing a proper wipe -- that's not possible
 // using sixel. we just mark it as partially transparent, so that if it's
 // redrawn, it's redrawn using P2=1.

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -153,3 +153,10 @@ int sprite_init(const notcurses* nc){
   }
   return nc->tcache.pixel_init(nc->ttyfd);
 }
+
+uint8_t* sprixel_auxiliary_vector(const sprixel* s){
+  int pixels = s->cellpxy * s->cellpxx;
+  uint8_t* ret = malloc(sizeof(*ret) * pixels);
+  memset(ret, 0, sizeof(*ret) * pixels);
+  return ret;
+}

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -4,6 +4,36 @@
 // FIXME needs be atomic
 static uint32_t sprixelid_nonce;
 
+void sprixel_debug(FILE* out, const sprixel* s){
+  fprintf(out, "Sprixel %d (%p) %dx%d (%dx%d) @%d/%d state: %d\n",
+          s->id, s, s->dimy, s->dimx, s->pixy, s->pixx,
+          s->n ? s->n->absy : 0, s->n ? s->n->absx : 0,
+          s->invalidated);
+  if(s->n){
+    int idx = 0;
+    for(int y = 0 ; y < s->dimy ; ++y){
+      for(int x = 0 ; x < s->dimx ; ++x){
+        fprintf(out, "%d", s->n->tam[idx].state);
+        ++idx;
+      }
+      fprintf(out, "\n");
+    }
+    idx = 0;
+    for(int y = 0 ; y < s->dimy ; ++y){
+      for(int x = 0 ; x < s->dimx ; ++x){
+        if(s->n->tam[idx].state == SPRIXCELL_ANNIHILATED){
+          fprintf(out, "%03d] ", idx);
+          for(int p = 0 ; p < s->cellpxx * s->cellpxy ; ++p){
+            fprintf(out, "%02x ", s->n->tam[idx].auxvector[idx]);
+          }
+          fprintf(out, "\n");
+        }
+        ++idx;
+      }
+    }
+  }
+}
+
 // doesn't splice us out of any lists, just frees
 void sprixel_free(sprixel* s){
   if(s){

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -14,7 +14,7 @@ sprixel_debug(FILE* out, const sprixel* s){
     int idx = 0;
     for(int y = 0 ; y < s->dimy ; ++y){
       for(int x = 0 ; x < s->dimx ; ++x){
-        fprintf(out, "%d", s->n->tacache[idx]);
+        fprintf(out, "%d", s->n->tam[idx].state);
         ++idx;
       }
       fprintf(out, "\n");
@@ -85,9 +85,9 @@ void sprixel_invalidate(sprixel* s, int y, int x){
   if(s->invalidated != SPRIXEL_HIDE && s->n){
     int localy = y - s->n->absy;
     int localx = x - s->n->absx;
-//fprintf(stderr, "INVALIDATING AT %d/%d (%d/%d) TAM: %d\n", y, x, localy, localx, s->n->tacache[localy * s->dimx + localx]);
-    if(s->n->tacache[localy * s->dimx + localx] != SPRIXCELL_TRANSPARENT &&
-       s->n->tacache[localy * s->dimx + localx] != SPRIXCELL_ANNIHILATED){
+//fprintf(stderr, "INVALIDATING AT %d/%d (%d/%d) TAM: %d\n", y, x, localy, localx, s->n->tam[localy * s->dimx + localx].state);
+    if(s->n->tam[localy * s->dimx + localx].state != SPRIXCELL_TRANSPARENT &&
+       s->n->tam[localy * s->dimx + localx].state != SPRIXCELL_ANNIHILATED){
       s->invalidated = SPRIXEL_INVALIDATED;
     }
   }
@@ -156,19 +156,12 @@ int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
   if(s->invalidated == SPRIXEL_HIDE){ // no need to do work if we're killing it
     return 0;
   }
-//fprintf(stderr, "ANNIHILATED %p %d\n", s->n->tacache, s->dimx * ycell + xcell);
+//fprintf(stderr, "ANNIHILATED %p %d\n", s->n->tam, s->dimx * ycell + xcell);
   int r = nc->tcache.pixel_cell_wipe(nc, s, ycell, xcell);
 //fprintf(stderr, "WIPED %d %d/%d ret=%d\n", s->id, ycell, xcell, r);
   // mark the cell as annihilated whether we actually scrubbed it or not,
   // so that we use this fact should we move to another frame
-  s->n->tacache[s->dimx * ycell + xcell] = SPRIXCELL_ANNIHILATED;
-  return r;
-}
-
-// precondition: s->invalidated is SPRIXEL_INVALIDATED or SPRIXEL_MOVED.
-int sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-//sprixel_debug(stderr, s);
-  int r = n->tcache.pixel_draw(n, p, s, out);
+  s->n->tam[s->dimx * ycell + xcell].state = SPRIXCELL_ANNIHILATED;
   return r;
 }
 

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -4,24 +4,6 @@
 // FIXME needs be atomic
 static uint32_t sprixelid_nonce;
 
-__attribute__ ((unused)) static inline void
-sprixel_debug(FILE* out, const sprixel* s){
-  fprintf(out, "Sprixel %d (%p) %dx%d (%dx%d) @%d/%d state: %d\n",
-          s->id, s, s->dimy, s->dimx, s->pixy, s->pixx,
-          s->n ? s->n->absy : 0, s->n ? s->n->absx : 0,
-          s->invalidated);
-  if(s->n){
-    int idx = 0;
-    for(int y = 0 ; y < s->dimy ; ++y){
-      for(int x = 0 ; x < s->dimx ; ++x){
-        fprintf(out, "%d", s->n->tam[idx].state);
-        ++idx;
-      }
-      fprintf(out, "\n");
-    }
-  }
-}
-
 // doesn't splice us out of any lists, just frees
 void sprixel_free(sprixel* s){
   if(s){

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -15,6 +15,7 @@ setup_sixel_bitmaps(tinfo* ti){
   ti->pixel_destroy = sixel_destroy;
   ti->pixel_cell_wipe = sixel_wipe;
   ti->pixel_shutdown = sixel_shutdown;
+  ti->pixel_rebuild = sixel_rebuild;
   ti->sprixel_height_factor = 6;
 }
 
@@ -27,6 +28,7 @@ setup_kitty_bitmaps(tinfo* ti){
   ti->pixel_draw = kitty_draw;
   ti->pixel_shutdown = kitty_shutdown;
   ti->sprixel_height_factor = 1;
+  ti->pixel_rebuild = kitty_rebuild;
   set_pixel_blitter(kitty_blit);
 }
 

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -419,13 +419,13 @@ TEST_CASE("Bitmaps") {
     REQUIRE(s);
     CHECK(s->dimy == dimy);
     CHECK(s->dimx == dimx);
-    const auto tam = n->tacache;
+    const auto tam = n->tam;
     for(int i = 0 ; i < s->dimy * s->dimx ; ++i){
       int py = (i / dimx) * nc_->tcache.cellpixy;
       int px = (i % dimx) * nc_->tcache.cellpixx;
       // cells with a transparent pixel ought be SPRIXCELL_MIXED;
       // cells without one ought be SPRIXCELL_OPAQUE.
-      sprixcell_e state = tam[(i / dimx) + (i % dimx)];
+      sprixcell_e state = tam[(i / dimx) + (i % dimx)].state;
       if(i % 2){
         if(state == SPRIXCELL_MIXED_SIXEL){
           state = SPRIXCELL_MIXED_KITTY;

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -50,7 +50,6 @@ TEST_CASE("Visual") {
     };
     auto newn = ncvisual_render(nc_, ncv, &vopts);
     CHECK(0 == notcurses_render(nc_));
-sleep(2);
     CHECK(0 == ncvisual_inflate(ncv, 3));
     CHECK(6 == ncv->rows);
     CHECK(6 == ncv->cols);
@@ -79,7 +78,6 @@ sleep(2);
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncplane_destroy(newn));
     CHECK(0 == ncplane_destroy(enewn));
-sleep(2);
     ncvisual_destroy(ncv);
   }
 


### PR DESCRIPTION
When a sprixcell is no longer covered, it transitions from `SPRIXCELL_ANNIHILATED` back to some other state. When this happens, we need restore the sprixcell from the auxiliary vector in the corresponding TAM entry. Do so for Kitty, special-casing the O(1) transformation to `SPRIXCELL_TRANSPARENT`.