### PR TITLE
Restore wiped cells when no longer obscured

### DIFF
--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2526,6 +2526,29 @@ API struct ncplane* ncvisual_render(struct notcurses* nc, struct ncvisual* ncv,
                                     const struct ncvisual_options* vopts)
   __attribute__ ((nonnull (2)));
 
+__attribute__ ((nonnull (1, 2, 3))) static inline struct ncplane*
+ncvisualplane_create(struct ncplane* n, const struct ncplane_options* opts,
+                     struct ncvisual* ncv, struct ncvisual_options* vopts){
+  if(vopts && vopts->n){ // the whole point is to create a new plane
+    return NULL;
+  }
+  struct ncplane* newn = ncplane_create(n, opts);
+  if(newn){
+    struct ncvisual_options v;
+    if(!vopts){
+      vopts = &v;
+      memset(vopts, 0, sizeof(*vopts));
+    }
+    vopts->n = newn;
+    if(ncvisual_render(ncplane_notcurses(n), ncv, vopts) == NULL){
+      ncplane_destroy(newn);
+      vopts->n = NULL;
+      return NULL;
+    }
+  }
+  return newn;
+}
+
 // If a subtitle ought be displayed at this time, return a heap-allocated copy
 // of the UTF8 text.
 API ALLOC char* ncvisual_subtitle(const struct ncvisual* ncv)

--- a/src/demo/intro.c
+++ b/src/demo/intro.c
@@ -93,7 +93,7 @@ orcaride(struct notcurses* nc, struct ncplane* on){
   ncplane_dim_yx(notcurses_stdplane(nc), NULL, &dimx);
   ncplane_yx(on, &oy, &ox);
   ncplane_dim_yx(on, &odimy, &odimx);
-  ox -= 3;
+  ox -= 14;
   if(ox < 1){
     ox = 1;
   }

--- a/src/demo/intro.c
+++ b/src/demo/intro.c
@@ -88,12 +88,12 @@ orcashow(struct notcurses* nc, int dimy, int dimx){
 }
 
 static int
-orcaride(struct notcurses* nc, struct ncplane* on){
+orcaride(struct notcurses* nc, struct ncplane* on, int iterations){
   int odimy, odimx, oy, ox, dimx;
   ncplane_dim_yx(notcurses_stdplane(nc), NULL, &dimx);
   ncplane_yx(on, &oy, &ox);
   ncplane_dim_yx(on, &odimy, &odimx);
-  ox -= 14;
+  ox -= ncplane_dim_x(notcurses_stdplane(nc)) / iterations;
   if(ox < 1){
     ox = 1;
   }
@@ -225,6 +225,7 @@ int intro(struct notcurses* nc){
   struct timespec now;
   clock_gettime(CLOCK_MONOTONIC, &now);
   // there ought be 20 iterations
+  const int expected_iter = 20;
   uint64_t deadline = timespec_to_ns(&now) + timespec_to_ns(&demodelay) * 2;
   struct timespec iter;
   timespec_div(&demodelay, 10, &iter);
@@ -242,9 +243,9 @@ int intro(struct notcurses* nc){
         on = orcashow(nc, rows, cols);
       }
     }else{
-      orcaride(nc, on);
+      orcaride(nc, on, expected_iter);
     }
-  }while(timespec_to_ns(&now) < deadline || flipmode < 20);
+  }while(timespec_to_ns(&now) < deadline || flipmode < expected_iter);
   ncplane_destroy(on);
   struct ncplane* gscott = NULL;
   if(notcurses_check_pixel_support(nc) && notcurses_canopen_images(nc)){

--- a/src/demo/keller.c
+++ b/src/demo/keller.c
@@ -16,6 +16,7 @@ visualize(struct notcurses* nc, struct ncvisual* ncv){
   struct ncplane* stdn = notcurses_stdplane(nc);
   ncplane_set_fg_rgb(stdn, 0xffffff);
   ncplane_set_bg_rgb(stdn, 0);
+  ncplane_set_styles(stdn, NCSTYLE_BOLD);
   uint64_t channels = 0;
   ncchannels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
   ncchannels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
@@ -43,7 +44,9 @@ visualize(struct notcurses* nc, struct ncvisual* ncv){
     }
 //fprintf(stderr, "X: %d truex: %d scalex: %d\n", vopts.x, truex, scalex);
     if(!n){
+      ncplane_on_styles(stdn, NCSTYLE_ITALIC);
       ncplane_printf_aligned(stdn, ncplane_dim_y(stdn) / 2 - 1, NCALIGN_CENTER, "not available");
+      ncplane_off_styles(stdn, NCSTYLE_ITALIC);
     }
     const char* name = notcurses_str_blitter(bs[i]);
     ncplane_printf_aligned(stdn, ncplane_dim_y(stdn) / 2 - 3, NCALIGN_CENTER, "%sblitter", name);

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -491,13 +491,13 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
                        uint32_t transcolor){
   int dimy = ymax > 0 ? ymax : ncdirect_dim_y(n);
   int dimx = xmax > 0 ? xmax : ncdirect_dim_x(n);
-//fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d\n", ncv->data, ncv->rows, ncv->cols);
-  int leny = ncv->rows; // we allow it to freely scroll
-  int lenx = ncv->cols;
+//fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d\n", ncv->data, ncv->pixy, ncv->pixx);
+  int leny = ncv->pixy; // we allow it to freely scroll
+  int lenx = ncv->pixx;
   if(leny == 0 || lenx == 0){
     return NULL;
   }
-//fprintf(stderr, "render %d/%d to %d+%d scaling: %d\n", ncv->rows, ncv->cols, leny, lenx, scale);
+//fprintf(stderr, "render %d/%d to %d+%d scaling: %d\n", ncv->pixy, ncv->pixx, leny, lenx, scale);
   const struct blitset* bset = rgba_blitter_low(&n->tcache, scale, true, blitfxn);
   if(!bset){
     return NULL;
@@ -519,15 +519,15 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
       }
     }
   }else{
-    disprows = ncv->rows;
-    dispcols = ncv->cols;
+    disprows = ncv->pixy;
+    dispcols = ncv->pixx;
     if(bset->geom == NCBLIT_PIXEL){
       clamp_to_sixelmax(&n->tcache, &disprows, &dispcols);
     }
   }
-  leny = (leny / (double)ncv->rows) * ((double)disprows);
-  lenx = (lenx / (double)ncv->cols) * ((double)dispcols);
-//fprintf(stderr, "render: %d+%d of %d/%d stride %u %p\n", leny, lenx, ncv->rows, ncv->cols, ncv->rowstride, ncv->data);
+  leny = (leny / (double)ncv->pixy) * ((double)disprows);
+  lenx = (lenx / (double)ncv->pixx) * ((double)dispcols);
+//fprintf(stderr, "render: %d+%d of %d/%d stride %u %p\n", leny, lenx, ncv->pixy, ncv->pixx, ncv->pixytride, ncv->data);
   ncplane_options nopts = {
     .y = 0,
     .x = 0,

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1052,7 +1052,7 @@ sprixel_state(const sprixel* s, int y, int x){
   const ncplane* stdn = notcurses_stdplane_const(ncplane_notcurses_const(s->n));
   int localy = y - (s->n->absy - stdn->absy);
   int localx = x - (s->n->absx - stdn->absx);
-//fprintf(stderr, "TAM %d at %d/%d (%d/%d)\n", s->n->tacache[localy * s->dimx + localx], localy, localx, y, x);
+//fprintf(stderr, "TAM %d at %d/%d (%d/%d)\n", s->n->tam[localy * s->dimx + localx].state, localy, localx, y, x);
   assert(localy >= 0);
   assert(localy < s->dimy);
   assert(localx >= 0);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -617,7 +617,7 @@ typedef struct notcurses {
   unsigned stdio_blocking_save; // was stdio blocking at entry? restore on stop.
 } notcurses;
 
-typedef struct {
+typedef struct blitterargs {
   int begy;            // upper left start within visual
   int begx;
   int placey;          // placement within ncplane
@@ -1002,6 +1002,7 @@ sprite_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
     s->n->tam[s->dimx * ycell + xcell].state = SPRIXCELL_TRANSPARENT;
   }else if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
     uint8_t* auxvec = s->n->tam[s->dimx * ycell + xcell].auxvector;
+    assert(auxvec);
     // sets the new state itself
     ret = nc->tcache.pixel_rebuild(s, ycell, xcell, auxvec);
   }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -970,7 +970,7 @@ sprixel* sprixel_by_id(const ncpile* n, uint32_t id);
 void sprixel_invalidate(sprixel* s, int y, int x);
 void sprixel_movefrom(sprixel* s, int y, int x);
 void sprixel_debug(FILE* out, const sprixel* s);
-void free_sixelmap(struct sixelmap *s);
+void sixelmap_free(struct sixelmap *s);
 
 // create an auxiliary vector suitable for a sprixcell, and zero it out
 uint8_t* sprixel_auxiliary_vector(const sprixel* s);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -460,8 +460,8 @@ typedef struct tinfo {
   // wipe out a cell's worth of pixels from within a sprixel. for sixel, this
   // means leaving out the pixels (and likely resizes the string). for kitty,
   // this means dialing down their alpha to 0 (in equivalent space).
-  int (*pixel_cell_wipe)(const struct notcurses* nc, sprixel* s, int y, int x);
-  // perform the inverse of pixel_cell_wipe, restoring an annihilated sprixcell.
+  int (*pixel_wipe)(sprixel* s, int y, int x);
+  // perform the inverse of pixel_wipe, restoring an annihilated sprixcell.
   int (*pixel_rebuild)(sprixel* s, int y, int x, const uint8_t* auxvec);
   int (*pixel_remove)(int id, FILE* out); // kitty only, issue actual delete command
   int (*pixel_init)(int fd);     // called when support is detected
@@ -934,11 +934,11 @@ plane_debug(const ncplane* n, bool details){
 
 // cell coordinates *within the sprixel*, not absolute
 int sprite_wipe(const notcurses* nc, sprixel* s, int y, int x);
-int sixel_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell);
+int sixel_wipe(sprixel* s, int ycell, int xcell);
 // nulls out a cell from a kitty bitmap via changing the alpha value
 // throughout to 0. the same trick doesn't work on sixel, but there we
 // can just print directly over the bitmap.
-int kitty_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell);
+int kitty_wipe(sprixel* s, int ycell, int xcell);
 int sixel_rebuild(sprixel* s, int ycell, int xcell, const uint8_t* auxvec);
 int kitty_rebuild(sprixel* s, int ycell, int xcell, const uint8_t* auxvec);
 
@@ -1059,12 +1059,6 @@ sprixel_state(const sprixel* s, int y, int x){
   assert(localx >= 0);
   assert(localx < s->dimx);
   return s->n->tam[localy * s->dimx + localx].state;
-}
-
-// is sprixel backend kitty (only valid after calling setup_kitty_bitmaps())?
-// FIXME kill this off, and use different states instead
-static inline bool sprixel_kitty_p(const tinfo* t){
-  return t->pixel_shutdown == kitty_shutdown;
 }
 
 static inline void

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1001,15 +1001,15 @@ sprite_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
   int ret = 0;
   // special case the transition back to SPRIXCELL_TRANSPARENT; this can be
   // done in O(1), since the actual glyph needn't change.
+  uint8_t* auxvec = s->n->tam[s->dimx * ycell + xcell].auxvector;
+  assert(auxvec);
   if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED_TRANS){
     s->n->tam[s->dimx * ycell + xcell].state = SPRIXCELL_TRANSPARENT;
   }else if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
-    uint8_t* auxvec = s->n->tam[s->dimx * ycell + xcell].auxvector;
-    assert(auxvec);
     // sets the new state itself
     ret = nc->tcache.pixel_rebuild(s, ycell, xcell, auxvec);
-    free(auxvec);
   }
+  free(auxvec);
   s->n->tam[s->dimx * ycell + xcell].auxvector = NULL;
   return ret;
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -469,7 +469,7 @@ typedef struct tinfo {
   int (*pixel_rebuild)(sprixel* s, int y, int x, uint8_t* auxvec);
   int (*pixel_remove)(int id, FILE* out); // kitty only, issue actual delete command
   int (*pixel_init)(int fd);     // called when support is detected
-  int (*pixel_draw)(const struct notcurses* n, const struct ncpile* p, sprixel* s, FILE* out);
+  int (*pixel_draw)(const struct ncpile* p, sprixel* s, FILE* out);
   int (*pixel_shutdown)(int fd); // called during context shutdown
   bool bitmap_supported;    // do we support bitmaps (post pixel_query_done)?
   bool sprixel_cursor_hack; // do sprixels reset the cursor? (mlterm)
@@ -949,8 +949,8 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 void sprixel_free(sprixel* s);
 void sprixel_hide(sprixel* s);
 
-int kitty_draw(const notcurses* n, const ncpile *p, sprixel* s, FILE* out);
-int sixel_draw(const notcurses* n, const ncpile *p, sprixel* s, FILE* out);
+int kitty_draw(const ncpile *p, sprixel* s, FILE* out);
+int sixel_draw(const ncpile *p, sprixel* s, FILE* out);
 // dimy and dimx are cell geometry, not pixel.
 sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx, int placey, int placex);
 sprixel* sprixel_recycle(ncplane* n);
@@ -990,7 +990,7 @@ sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
 static inline int
 sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
 //sprixel_debug(stderr, s);
-  return n->tcache.pixel_draw(n, p, s, out);
+  return n->tcache.pixel_draw(p, s, out);
 }
 
 static inline int

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -571,8 +571,6 @@ int kitty_remove(int id, FILE* out){
 // removes the kitty bitmap graphic identified by s->id, and damages those
 // cells which weren't SPRIXCEL_OPAQUE
 int kitty_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
-  (void)p;
-  (void)nc;
   if(kitty_remove(s->id, out)){
     return -1;
   }
@@ -601,8 +599,7 @@ int kitty_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
   return 0;
 }
 
-int kitty_draw(const notcurses* nc, const ncpile* p, sprixel* s, FILE* out){
-  (void)nc;
+int kitty_draw(const ncpile* p, sprixel* s, FILE* out){
   (void)p;
   int ret = 0;
   if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -264,7 +264,7 @@ kitty_restore(char* triplet, int skip, int max, int pleft,
 #define RGBA_MAXLEN 768 // 768 base64-encoded pixels in 4096 bytes
 // restore an annihilated sprixcell by copying the alpha values from the
 // auxiliary vector back into the actual data. we then free the auxvector.
-int kitty_rebuild(sprixel* s, int ycell, int xcell, const uint8_t* auxvec){
+int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
   const int totalpixels = s->pixy * s->pixx;
   const int xpixels = s->cellpxx;
   const int ypixels = s->cellpxy;
@@ -314,6 +314,7 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, const uint8_t* auxvec){
 //fprintf(stderr, "CLEARED ROW, TARGY: %d\n", targy - 1);
         if(--targy == 0){
           s->n->tam[s->dimx * ycell + xcell].state = state;
+          free(auxvec);
           return 0;
         }
         thisrow = targx;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -335,7 +335,7 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, const uint8_t* auxvec){
   return -1;
 }
 
-int kitty_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
+int kitty_wipe(sprixel* s, int ycell, int xcell){
   if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 0; // already annihilated, needn't draw glyph in kitty
@@ -343,8 +343,8 @@ int kitty_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
   uint8_t* auxvec = sprixel_auxiliary_vector(s);
 //fprintf(stderr, "NEW WIPE %d %d/%d\n", s->id, ycell, xcell);
   const int totalpixels = s->pixy * s->pixx;
-  const int xpixels = nc->tcache.cellpixx;
-  const int ypixels = nc->tcache.cellpixy;
+  const int xpixels = s->cellpxx;
+  const int ypixels = s->cellpxy;
   // if the cell is on the right or bottom borders, it might only be partially
   // filled by actual graphic data, and we need to cap our target area.
   int targx = xpixels;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -205,7 +205,7 @@ kitty_null(char* triplet, int skip, int max, int pleft, uint8_t* auxvec){
 static inline int
 kitty_restore(char* triplet, int skip, int max, int pleft,
               const uint8_t* auxvec, sprixcell_e* state){
-//fprintf(stderr, "SKIP/MAX/PLEFT %d/%d/%d\n", skip, max, pleft);
+//fprintf(stderr, "SKIP/MAX/PLEFT %d/%d/%d auxvec %p\n", skip, max, pleft, auxvec);
   if(pleft > 3){
     pleft = 3;
   }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -314,7 +314,6 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
 //fprintf(stderr, "CLEARED ROW, TARGY: %d\n", targy - 1);
         if(--targy == 0){
           s->n->tam[s->dimx * ycell + xcell].state = state;
-          free(auxvec);
           return 0;
         }
         thisrow = targx;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -269,6 +269,14 @@ void free_plane(ncplane* p){
     if(p->sprite){
       sprixel_hide(p->sprite);
     }
+    if(p->tam){
+      for(int y = 0 ; y < p->leny ; ++y){
+        for(int x = 0 ; x < p->lenx ; ++x){
+          free(p->tam[y * p->lenx + x].auxvector);
+          p->tam[y * p->lenx + x].auxvector = NULL;
+        }
+      }
+    }
     free(p->tam);
     egcpool_dump(&p->pool);
     free(p->name);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1966,12 +1966,14 @@ int ncplane_move_yx(ncplane* n, int y, int x){
   int dy, dx; // amount moved
   dy = (n->boundto->absy + y) - n->absy;
   dx = (n->boundto->absx + x) - n->absx;
-  if(n->sprite){
-    sprixel_movefrom(n->sprite, n->absy, n->absx);
+  if(dy || dx){ // don't want to trigger sprixel_movefrom() if unneeded
+    if(n->sprite){
+      sprixel_movefrom(n->sprite, n->absy, n->absx);
+    }
+    n->absx += dx;
+    n->absy += dy;
+    move_bound_planes(n->blist, dy, dx);
   }
-  n->absx += dx;
-  n->absy += dy;
-  move_bound_planes(n->blist, dy, dx);
   return 0;
 }
 

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -179,7 +179,8 @@ paint_sprixel(ncplane* p, struct crender* rvec, int starty, int startx,
         if(crender->sprixel == NULL){
           crender->sprixel = s;
         }
-        if(sprixel_state(s, absy, absx) == SPRIXCELL_ANNIHILATED){
+        sprixcell_e state = sprixel_state(s, absy, absx);
+        if(state == SPRIXCELL_ANNIHILATED || state == SPRIXCELL_ANNIHILATED_TRANS){
 //fprintf(stderr, "REBUILDING AT %d/%d\n", y, x);
           sprite_rebuild(nc, s, y, x);
         }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -169,7 +169,7 @@ paint_sprixel(ncplane* p, struct crender* rvec, int starty, int startx,
         // if sprite_wipe_cell() fails, we presumably do not have the
         // ability to wipe, and must reprint the character
         if(sprite_wipe(nc, p->sprite, y, x)){
-    //fprintf(stderr, "damaging due to wipe [%s] %d/%d\n", nccell_extended_gcluster(crender->p, &crender->c), y, x);
+//fprintf(stderr, "damaging due to wipe [%s] %d/%d\n", nccell_extended_gcluster(crender->p, &crender->c), y, x);
           crender->s.damaged = 1;
         }
         crender->s.p_beats_sprixel = 1;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -941,8 +941,8 @@ clean_sprixels(notcurses* nc, ncpile* p, FILE* out){
           return -1;
         }
         nc->rstate.hardcursorpos = true;
-        parent = &s->next;
       }
+      parent = &s->next;
       ++nc->stats.sprixelemissions;
     }else{
       ++nc->stats.sprixelelisions;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -149,6 +149,7 @@ paint_sprixel(ncplane* p, struct crender* rvec, int starty, int startx,
   sprixel* s = p->sprite;
   int dimy = s->dimy;
   int dimx = s->dimx;
+//fprintf(stderr, "STARTY: %d DIMY: %d dim(p): %d/%d dim(s): %d/%d\n", starty, dimy, ncplane_dim_y(p), ncplane_dim_x(p), s->dimy, s->dimx);
   for(int y = starty ; y < dimy ; ++y){
     const int absy = y + offy;
     // once we've passed the physical screen's bottom, we're done

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -216,7 +216,7 @@ paint(ncplane* p, struct crender* rvec, int dstleny, int dstlenx,
   ncplane_dim_yx(p, &dimy, &dimx);
   offy = p->absy - dstabsy;
   offx = p->absx - dstabsx;
-//fprintf(stderr, "PLANE %p %d %d %d %d %d %d\n", p, dimy, dimx, offy, offx, dstleny, dstlenx);
+//fprintf(stderr, "PLANE %p %d %d %d %d %d %d %p\n", p, dimy, dimx, offy, offx, dstleny, dstlenx, p->sprite);
   // skip content above or to the left of the physical screen
   int starty, startx;
   if(offy < 0){
@@ -437,6 +437,7 @@ postpaint_cell(nccell* lastframe, int dimx, struct crender* crender,
   nccell* targc = &crender->c;
   lock_in_highcontrast(targc, crender);
   nccell* prevcell = &lastframe[fbcellidx(y, dimx, *x)];
+//fprintf(stderr, "taking a look at %d/%d %08x\n", y, *x, crender->c.gcluster);
   if(cellcmp_and_dupfar(pool, prevcell, crender->p, targc) > 0){
 //fprintf(stderr, "damaging due to cmp [%s] %d %d\n", nccell_extended_gcluster(crender->p, &crender->c), y, *x);
     if(crender->sprixel){

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -546,6 +546,7 @@ deepclean_output(FILE* fp, const sprixel* s, int y, int *x, int rle,
     unsigned char mask = 0;
     for(int yi = y ; yi < y + 6 ; ++yi){
       const int tidx = (yi / s->cellpxy) * s->dimx + (xi / s->cellpxx);
+      // FIXME need to make auxvec here
       const bool nihil = (s->n->tam[tidx].state == SPRIXCELL_ANNIHILATED) ||
                          (s->n->tam[tidx].state == SPRIXCELL_ANNIHILATED_TRANS);
       if(!nihil){
@@ -713,8 +714,8 @@ err:
 
 int sixel_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
   (void)n;
-  // if we've wiped any cells, we need actually wipe them out now, or else
-  // we'll get flicker when we move to the new location
+  // if we've wiped or rebuilt any cells, effect those changes now, or else
+  // we'll get flicker when we move to the new location.
   if(s->wipes_outstanding){
     if(sixel_deepclean(s)){
       return -1;
@@ -747,8 +748,9 @@ int sixel_init(int fd){
   return tty_emit("\e[?80;8452h", fd);
 }
 
-int sixel_rebuild(sprixel* s, int ycell, int xcell, const uint8_t* auxvec){
-  (void)s;
+// only called for cells in SPRIXCELL_ANNIHILATED
+int sixel_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
+  s->wipes_outstanding = true;
   (void)ycell;
   (void)xcell;
   (void)auxvec;

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -562,6 +562,8 @@ sixel_blit_inner(int leny, int lenx, const sixeltable* stab, int rows, int cols,
     free(buf);
     return -1;
   }
+  sixelmap_trim(stab->map);
+  bargs->u.pixel.spx->smap = stab->map;
   return 1;
 }
 

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -170,7 +170,7 @@ extract_color_table(const uint32_t* data, int linesize, int cols,
       for(int sy = visy ; sy < (begy + leny) && sy < visy + 6 ; ++sy){ // offset within sprixel
         const uint32_t* rgb = (data + (linesize / 4 * sy) + visx);
         int txyidx = (sy / cdimy) * cols + (visx / cdimx);
-        if(tam[txyidx].state == SPRIXCELL_ANNIHILATED){
+        if(tam[txyidx].state == SPRIXCELL_ANNIHILATED || tam[txyidx].state == SPRIXCELL_ANNIHILATED_TRANS){
 //fprintf(stderr, "TRANS SKIP %d %d %d %d (cell: %d %d)\n", visy, visx, sy, txyidx, sy / cdimy, visx / cdimx);
           continue;
         }
@@ -546,7 +546,8 @@ deepclean_output(FILE* fp, const sprixel* s, int y, int *x, int rle,
     unsigned char mask = 0;
     for(int yi = y ; yi < y + 6 ; ++yi){
       const int tidx = (yi / s->cellpxy) * s->dimx + (xi / s->cellpxx);
-      const bool nihil = (s->n->tam[tidx].state == SPRIXCELL_ANNIHILATED);
+      const bool nihil = (s->n->tam[tidx].state == SPRIXCELL_ANNIHILATED) ||
+                         (s->n->tam[tidx].state == SPRIXCELL_ANNIHILATED_TRANS);
       if(!nihil){
         mask |= (1u << (yi - y));
       }
@@ -746,10 +747,11 @@ int sixel_init(int fd){
   return tty_emit("\e[?80;8452h", fd);
 }
 
-int sixel_rebuild(sprixel* s, int ycell, int xcell){
+int sixel_rebuild(sprixel* s, int ycell, int xcell, const uint8_t* auxvec){
   (void)s;
   (void)ycell;
   (void)xcell;
+  (void)auxvec;
   return 0;
 }
 
@@ -758,7 +760,8 @@ int sixel_rebuild(sprixel* s, int ycell, int xcell){
 // redrawn, it's redrawn using P2=1.
 int sixel_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
   (void)nc;
-  if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
+  if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED ||
+     s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED_TRANS){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 1; // already annihilated FIXME but 0 breaks things
   }

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -758,8 +758,7 @@ int sixel_rebuild(sprixel* s, int ycell, int xcell, const uint8_t* auxvec){
 // we return -1 because we're not doing a proper wipe -- that's not possible
 // using sixel. we just mark it as partially transparent, so that if it's
 // redrawn, it's redrawn using P2=1.
-int sixel_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
-  (void)nc;
+int sixel_wipe(sprixel* s, int ycell, int xcell){
   if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 1; // already annihilated FIXME but 0 breaks things

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -813,6 +813,7 @@ extract_palette(const sprixel* spx, sixeltable* stable){
 // is redrawn, and annihilated sprixcells still require a glyph to be emitted.
 static int
 sixel_update(const notcurses* n, sprixel* s){
+  /* FIXME
   int sixelcount = s->pixx * (s->pixy + 5) / 6;
   sixeltable stable = {
     .colorregs = n->tcache.color_registers,
@@ -830,6 +831,7 @@ sixel_update(const notcurses* n, sprixel* s){
     return -1;
   }
   free(stable.table);
+  */
   return 0;
 }
 

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -813,7 +813,6 @@ extract_palette(const sprixel* spx, sixeltable* stable){
 // is redrawn, and annihilated sprixcells still require a glyph to be emitted.
 static int
 sixel_update(const notcurses* n, sprixel* s){
-  /* FIXME
   int sixelcount = s->pixx * (s->pixy + 5) / 6;
   sixeltable stable = {
     .colorregs = n->tcache.color_registers,
@@ -831,7 +830,6 @@ sixel_update(const notcurses* n, sprixel* s){
     return -1;
   }
   free(stable.table);
-  */
   return 0;
 }
 

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -746,7 +746,7 @@ wipe_color(sixelmap* smap, int color, int sband, int eband,
       }
 //fprintf(stderr, "s/e: %d/%d mask: %02x\n", starty, endy, mask);
     }
-    for(int x = startx ; x < endx ; ++x){
+    for(int x = startx ; x <= endx ; ++x){
       const int xoff = boff + x;
 //fprintf(stderr, "band: %d color: %d idx: %d\n", b, color, color * smap->sixelcount + xoff);
 //fprintf(stderr, "color: %d idx: %d data: %02x\n", color, color * smap->sixelcount + xoff, smap->data[color * smap->sixelcount + xoff]);

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -548,7 +548,7 @@ sixel_reblit(sprixel* s, tament* tam){
   if(fp == NULL){
     return -1;
   }
-  if(fwrite(s->glyph, s->parse_start, 1, fp) != (size_t)s->parse_start){
+  if(fwrite(s->glyph, s->parse_start, 1, fp) != 1){
     fclose(fp);
     free(buf);
     return -1;

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -760,8 +760,7 @@ int sixel_rebuild(sprixel* s, int ycell, int xcell, const uint8_t* auxvec){
 // redrawn, it's redrawn using P2=1.
 int sixel_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
   (void)nc;
-  if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED ||
-     s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED_TRANS){
+  if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 1; // already annihilated FIXME but 0 breaks things
   }

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -105,7 +105,8 @@ void sprixel_invalidate(sprixel* s, int y, int x){
     int localx = x - s->n->absx;
 //fprintf(stderr, "INVALIDATING AT %d/%d (%d/%d) TAM: %d\n", y, x, localy, localx, s->n->tam[localy * s->dimx + localx].state);
     if(s->n->tam[localy * s->dimx + localx].state != SPRIXCELL_TRANSPARENT &&
-       s->n->tam[localy * s->dimx + localx].state != SPRIXCELL_ANNIHILATED){
+       s->n->tam[localy * s->dimx + localx].state != SPRIXCELL_ANNIHILATED &&
+       s->n->tam[localy * s->dimx + localx].state != SPRIXCELL_ANNIHILATED_TRANS){
       s->invalidated = SPRIXEL_INVALIDATED;
     }
   }
@@ -173,6 +174,10 @@ int sprixel_load(sprixel* spx, char* s, int bytes, int placey, int placex,
 int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
   if(s->invalidated == SPRIXEL_HIDE){ // no need to do work if we're killing it
     return 0;
+  }
+  if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_TRANSPARENT){
+    s->n->tam[s->dimx * ycell + xcell].state = SPRIXCELL_ANNIHILATED_TRANS;
+    return 1;
   }
 //fprintf(stderr, "ANNIHILATED %p %d\n", s->n->tam, s->dimx * ycell + xcell);
   int r = nc->tcache.pixel_cell_wipe(nc, s, ycell, xcell);

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -40,6 +40,7 @@ void sprixel_free(sprixel* s){
     if(s->n){
       s->n->sprite = NULL;
     }
+    free_sixelmap(s->smap);
     free(s->glyph);
     free(s);
   }
@@ -131,7 +132,6 @@ sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx, int placey, int placex){
     ret->y = placey;
     ret->x = placex;
     ret->id = ++sprixelid_nonce;
-    ret->wipes_outstanding = false;
 //fprintf(stderr, "LOOKING AT %p (p->n = %p)\n", ret, ret->n);
     if(ncplane_pile(ret->n)){
       ncpile* np = ncplane_pile(ret->n);

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -48,7 +48,7 @@ void sprixel_free(sprixel* s){
 sprixel* sprixel_recycle(ncplane* n){
   assert(n->sprite);
   const notcurses* nc = ncplane_notcurses_const(n);
-  if(sprixel_kitty_p(&nc->tcache)){
+  if(nc->tcache.pixel_shutdown == kitty_shutdown){
     sprixel* hides = n->sprite;
     int dimy = hides->dimy;
     int dimx = hides->dimx;
@@ -185,7 +185,7 @@ int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
     return 0;
   }
 //fprintf(stderr, "ANNIHILATING %p %d\n", s->n->tam, s->dimx * ycell + xcell);
-  int r = nc->tcache.pixel_cell_wipe(nc, s, ycell, xcell);
+  int r = nc->tcache.pixel_wipe(s, ycell, xcell);
 //fprintf(stderr, "WIPED %d %d/%d ret=%d\n", s->id, ycell, xcell, r);
   // mark the cell as annihilated whether we actually scrubbed it or not,
   // so that we use this fact should we move to another frame

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -179,7 +179,12 @@ int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
     s->n->tam[s->dimx * ycell + xcell].state = SPRIXCELL_ANNIHILATED_TRANS;
     return 1;
   }
-//fprintf(stderr, "ANNIHILATED %p %d\n", s->n->tam, s->dimx * ycell + xcell);
+  if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED_TRANS){
+    // both handle this correctly; one day, we will also check for ANNIHILATED
+    // here, and return 0 (sixel currently must return 1) FIXME
+    return 0;
+  }
+//fprintf(stderr, "ANNIHILATING %p %d\n", s->n->tam, s->dimx * ycell + xcell);
   int r = nc->tcache.pixel_cell_wipe(nc, s, ycell, xcell);
 //fprintf(stderr, "WIPED %d %d/%d ret=%d\n", s->id, ycell, xcell, r);
   // mark the cell as annihilated whether we actually scrubbed it or not,

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -22,11 +22,15 @@ void sprixel_debug(FILE* out, const sprixel* s){
     for(int y = 0 ; y < s->dimy ; ++y){
       for(int x = 0 ; x < s->dimx ; ++x){
         if(s->n->tam[idx].state == SPRIXCELL_ANNIHILATED){
-          fprintf(out, "%03d] ", idx);
-          for(int p = 0 ; p < s->cellpxx * s->cellpxy ; ++p){
-            fprintf(out, "%02x ", s->n->tam[idx].auxvector[idx]);
+          if(s->n->tam[idx].auxvector){
+            fprintf(out, "%03d] ", idx);
+            for(int p = 0 ; p < s->cellpxx * s->cellpxy ; ++p){
+              fprintf(out, "%02x ", s->n->tam[idx].auxvector[idx]);
+            }
+            fprintf(out, "\n");
+          }else{
+            fprintf(out, "%03d] missing!\n", idx);
           }
-          fprintf(out, "\n");
         }
         ++idx;
       }
@@ -147,7 +151,7 @@ sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx, int placey, int placex){
 }
 
 // 'y' and 'x' are the cell geometry, not the pixel geometry. takes
-// ownership of 's' on success.
+// ownership of 's' on success. pixel geometry ought include any Sixel excess.
 int sprixel_load(sprixel* spx, char* s, int bytes, int placey, int placex,
                  int pixy, int pixx, int parse_start){
   assert(spx->n);
@@ -196,7 +200,9 @@ int sprite_init(const notcurses* nc){
 
 uint8_t* sprixel_auxiliary_vector(const sprixel* s){
   int pixels = s->cellpxy * s->cellpxx;
-  uint8_t* ret = malloc(sizeof(*ret) * pixels);
+  // for now we just do two bytes per pixel. we ought squeeze the transparency
+  // vector down to a bit per pixel, rather than a byte FIXME.
+  uint8_t* ret = malloc(sizeof(*ret) * pixels * 2);
   memset(ret, 0, sizeof(*ret) * pixels);
   return ret;
 }

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -40,7 +40,7 @@ void sprixel_free(sprixel* s){
     if(s->n){
       s->n->sprite = NULL;
     }
-    free_sixelmap(s->smap);
+    sixelmap_free(s->smap);
     free(s->glyph);
     free(s);
   }

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -86,12 +86,6 @@ void sprixel_hide(sprixel* s){
     s->movedfromy = ncplane_abs_y(s->n);
     s->movedfromx = ncplane_abs_x(s->n);
     if(s->n){
-      for(int y = 0 ; y < s->dimy ; ++y){
-        for(int x = 0 ; x < s->dimx ; ++x){
-          free(s->n->tam[y * s->dimx + x].auxvector);
-          s->n->tam[y * s->dimx + x].auxvector = NULL;
-        }
-      }
       s->n->sprite = NULL;
       s->n = NULL;
     }

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -13,7 +13,7 @@ setup_sixel_bitmaps(tinfo* ti){
   ti->sixel_maxy = 4096;
   ti->pixel_remove = NULL;
   ti->pixel_destroy = sixel_destroy;
-  ti->pixel_cell_wipe = sixel_wipe;
+  ti->pixel_wipe = sixel_wipe;
   ti->pixel_shutdown = sixel_shutdown;
   ti->pixel_rebuild = sixel_rebuild;
   ti->sprixel_height_factor = 6;
@@ -21,7 +21,7 @@ setup_sixel_bitmaps(tinfo* ti){
 
 static inline void
 setup_kitty_bitmaps(tinfo* ti){
-  ti->pixel_cell_wipe = kitty_wipe;
+  ti->pixel_wipe = kitty_wipe;
   ti->pixel_destroy = kitty_destroy;
   ti->pixel_init = kitty_init;
   ti->pixel_remove = kitty_remove;

--- a/src/lib/terminfo.c
+++ b/src/lib/terminfo.c
@@ -16,7 +16,7 @@ setup_sixel_bitmaps(tinfo* ti){
   ti->pixel_wipe = sixel_wipe;
   ti->pixel_shutdown = sixel_shutdown;
   ti->pixel_rebuild = sixel_rebuild;
-  ti->sprixel_height_factor = 6;
+  ti->sprixel_scale_height = 6;
 }
 
 static inline void
@@ -27,7 +27,7 @@ setup_kitty_bitmaps(tinfo* ti){
   ti->pixel_remove = kitty_remove;
   ti->pixel_draw = kitty_draw;
   ti->pixel_shutdown = kitty_shutdown;
-  ti->sprixel_height_factor = 1;
+  ti->sprixel_scale_height = 1;
   ti->pixel_rebuild = kitty_rebuild;
   set_pixel_blitter(kitty_blit);
 }

--- a/src/lib/visual-details.h
+++ b/src/lib/visual-details.h
@@ -21,7 +21,7 @@ struct ncvisual_details;
 typedef struct ncvisual {
   struct ncvisual_details* details;// implementation-specific details
   uint32_t* data; // (scaled) RGBA image data, rowstride bytes per row
-  int cols, rows; // pixel geometry, *not* cell geometry
+  int pixx, pixy; // pixel geometry, *not* cell geometry
   // lines are sometimes padded. this many true bytes per row in data.
   int rowstride;
   bool owndata; // we own data iff owndata == true
@@ -39,12 +39,12 @@ ncvisual_set_data(ncvisual* ncv, void* data, bool owned){
 // shrink one dimension to retrieve the original aspect ratio
 static inline void
 scale_visual(const ncvisual* ncv, int* disprows, int* dispcols){
-  float xratio = (float)(*dispcols) / ncv->cols;
-  if(xratio * ncv->rows > *disprows){
-    xratio = (float)(*disprows) / ncv->rows;
+  float xratio = (float)(*dispcols) / ncv->pixx;
+  if(xratio * ncv->pixy > *disprows){
+    xratio = (float)(*disprows) / ncv->pixy;
   }
-  *disprows = xratio * (ncv->rows);
-  *dispcols = xratio * (ncv->cols);
+  *disprows = xratio * (ncv->pixy);
+  *dispcols = xratio * (ncv->pixx);
 }
 
 #ifdef __cplusplus

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -152,6 +152,7 @@ ncvisual_blitset_geom(const notcurses* nc, const ncvisual* n,
       }
       // FIXME clamp to sprixel limits
       if(vopts->scaling == NCSCALE_NONE || vopts->scaling == NCSCALE_NONE_HIRES){
+        /*
         int rows = (*leny + nc->tcache.cellpixy - 1) / nc->tcache.cellpixy;
         if(rows > ncplane_dim_y(vopts->n)){
           logerror(nc, "Sprixel too tall %d for plane %d\n", *leny, ncplane_dim_y(vopts->n) * nc->tcache.cellpixy);
@@ -162,6 +163,7 @@ ncvisual_blitset_geom(const notcurses* nc, const ncvisual* n,
           logerror(nc, "Sprixel too wide %d for plane %d\n", *lenx, ncplane_dim_x(vopts->n) * nc->tcache.cellpixx);
           return -1;
         }
+        */
       }
     }
   }

--- a/src/media/none.cpp
+++ b/src/media/none.cpp
@@ -32,7 +32,7 @@ int none_resize(ncvisual* nc, int rows, int cols){
   // we'd need to verify that it's RGBA as well, except that if we've got no
   // multimedia engine, we've only got memory-assembled ncvisuals, which are
   // RGBA-native. so we ought be good, but this is undeniably sloppy...
-  if(nc->rows == rows && nc->cols == cols){
+  if(nc->pixy == rows && nc->pixx == cols){
     return 0;
   }
   return -1;

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -449,7 +449,7 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
       }
     }while(loop && r == 0);
     if(r < 0){ // positive is intentional abort
-      std::cerr << "Error decoding " << argv[i] << std::endl;
+      std::cerr << "Error while playing " << argv[i] << std::endl;
       return -1;
     }
   }

--- a/src/poc/statepixel.c
+++ b/src/poc/statepixel.c
@@ -1,0 +1,106 @@
+#include <time.h>
+#include <stdio.h>
+#include <notcurses/notcurses.h>
+
+// drag plane |t| across plane |n| at cell row |y|
+static int
+across_row(struct notcurses* nc, int y, struct ncplane* n, struct ncplane* t,
+           const struct timespec* ds){
+  for(int x = 0 ; x < ncplane_dim_x(n) ; ++x){
+    if(ncplane_move_yx(t, y, x)){
+      return -1;
+    }
+    if(notcurses_render(nc)){
+      return -1;
+    }
+    clock_nanosleep(CLOCK_MONOTONIC, 0, ds, NULL);
+  }
+  return 0;
+}
+
+static int
+handle(struct notcurses* nc, const char* fn){
+  struct ncvisual* ncv = ncvisual_from_file(fn);
+  struct timespec ds = { .tv_sec = 0, .tv_nsec = 25000000, };
+  if(!ncv){
+    return -1;
+  }
+  // render by itself
+  struct ncvisual_options vopts = {
+    .blitter = NCBLIT_PIXEL,
+    .flags = NCVISUAL_OPTION_NODEGRADE,
+  };
+  struct ncplane* n = ncvisual_render(nc, ncv, &vopts);
+  if(n == NULL){
+    ncvisual_destroy(ncv);
+    return -1;
+  }
+  notcurses_render(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ds, NULL);
+  // render a single cell atop it
+  struct ncplane_options opts = {
+    .rows = 1,
+    .cols = 1,
+  };
+  struct ncplane* t = ncplane_create(n, &opts);
+  if(!t){
+    ncplane_destroy(n);
+    ncvisual_destroy(ncv);
+    return -1;
+  }
+  uint64_t channels = CHANNELS_RGB_INITIALIZER(0xff, 0xff, 0xff, 0xff, 0xff, 0xff);
+  ncplane_set_base(t, " ", 0, channels);
+  notcurses_render(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ds, NULL);
+  // move said cell through the sprixel
+  for(int y = 0 ; y < ncplane_dim_y(n) - 1 ; ++y){
+    if(across_row(nc, y, n, t, &ds)){
+      ncplane_destroy(n);
+      ncvisual_destroy(ncv);
+    }
+  }
+  // now make it big and throw it over the bottom
+  if(ncplane_resize_simple(t, 6, ncplane_dim_x(n))){
+    ncplane_destroy(n);
+    ncvisual_destroy(ncv);
+    return -1;
+  }
+  if(ncplane_move_yx(t, ncplane_dim_y(n) - ncplane_dim_y(t), 0)){
+    ncplane_destroy(n);
+    ncvisual_destroy(ncv);
+    return -1;
+  }
+  notcurses_render(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ds, NULL);
+  // now restore the sprixel entirely
+  ncplane_destroy(t);
+  notcurses_render(nc);
+  clock_nanosleep(CLOCK_MONOTONIC, 0, &ds, NULL);
+  ncplane_destroy(n);
+  ncvisual_destroy(ncv);
+  return 0;
+}
+
+int main(int argc, char **argv){
+  if(argc < 2){
+    fprintf(stderr, "need image arguments\n");
+    return EXIT_FAILURE;
+  }
+  char** a = argv + 1;
+  struct notcurses_options opts = { };
+  struct notcurses* nc = notcurses_init(&opts, NULL);
+  if(notcurses_check_pixel_support(nc) <= 0){
+    notcurses_stop(nc);
+    fprintf(stderr, "this program requires pixel graphics support\n");
+    return EXIT_FAILURE;
+  }
+  do{
+    if(handle(nc, *a)){
+      notcurses_stop(nc);
+      fprintf(stderr, "Error working with %s\n", *a);
+      return EXIT_FAILURE;
+    }
+  }while(*++a);
+  notcurses_stop(nc);
+  return EXIT_SUCCESS;
+}

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Bitmaps") {
       .flags = NCVISUAL_OPTION_NODEGRADE,
       .transcolor = 0,
     };
-    CHECK(0 == ncvisual_resize(ncv, 6, 1)); // FIXME get down to 1, 1 (sixel needs handle)
+    CHECK(0 == ncvisual_resize(ncv, 6, 1)); // FIXME get down to (1, 1)
     auto n = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != n);
     auto s = n->sprite;
@@ -224,8 +224,8 @@ TEST_CASE("Bitmaps") {
     REQUIRE(nullptr != n);
     auto s = n->sprite;
     REQUIRE(nullptr != s);
-    CHECK(nc_->tcache.cellpixy == ncv->rows);
-    CHECK(nc_->tcache.cellpixx == ncv->cols);
+    CHECK(nc_->tcache.cellpixy == ncv->pixy);
+    CHECK(nc_->tcache.cellpixx == ncv->pixx);
     CHECK(0 == notcurses_render(nc_));
     struct ncplane_options nopts = {
       .y = 1,
@@ -244,8 +244,8 @@ TEST_CASE("Bitmaps") {
     CHECK(vopts.n == ncvisual_render(nc_, ncv, &vopts));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_inflate(ncv, 4));
-    CHECK(4 * nc_->tcache.cellpixy == ncv->rows);
-    CHECK(4 * nc_->tcache.cellpixx == ncv->cols);
+    CHECK(4 * nc_->tcache.cellpixy == ncv->pixy);
+    CHECK(4 * nc_->tcache.cellpixx == ncv->pixx);
     vopts.y = 1;
     vopts.x = 6;
     vopts.n = nullptr;
@@ -256,8 +256,8 @@ TEST_CASE("Bitmaps") {
     CHECK(4 == ncplane_dim_x(infn));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_resize(ncv, 8, 8));
-    CHECK(ncv->rows == 8);
-    CHECK(ncv->cols == 8);
+    CHECK(ncv->pixy == 8);
+    CHECK(ncv->pixx == 8);
     vopts.x = 11;
     auto resizen = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(resizen);

--- a/src/tests/sixel.cpp
+++ b/src/tests/sixel.cpp
@@ -169,7 +169,7 @@ TEST_CASE("Sixels") {
       for(int x = 0 ; x < newn->sprite->pixx ; ++x){
 //fprintf(stderr, "%03d/%03d NCV: %08x RGB: %08x\n", y, x, ncv->data[y * newn->sprite->pixx + x], rgb[y * newn->sprite->pixx + x]);
         // FIXME
-        CHECK(ncv->data[y * newn->sprite->pixx + x] == rgb[y * newn->sprite->pixx + x]);
+        //CHECK(ncv->data[y * newn->sprite->pixx + x] == rgb[y * newn->sprite->pixx + x]);
       }
     }
     ncvisual_destroy(ncv);

--- a/src/tests/sixel.cpp
+++ b/src/tests/sixel.cpp
@@ -169,7 +169,7 @@ TEST_CASE("Sixels") {
       for(int x = 0 ; x < newn->sprite->pixx ; ++x){
 //fprintf(stderr, "%03d/%03d NCV: %08x RGB: %08x\n", y, x, ncv->data[y * newn->sprite->pixx + x], rgb[y * newn->sprite->pixx + x]);
         // FIXME
-        //CHECK(ncv->data[y * newn->sprite->pixx + x] == rgb[y * newn->sprite->pixx + x]);
+        CHECK(ncv->data[y * newn->sprite->pixx + x] == rgb[y * newn->sprite->pixx + x]);
       }
     }
     ncvisual_destroy(ncv);

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -51,22 +51,22 @@ TEST_CASE("Visual") {
     auto newn = ncvisual_render(nc_, ncv, &vopts);
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_inflate(ncv, 3));
-    CHECK(6 == ncv->rows);
-    CHECK(6 == ncv->cols);
+    CHECK(6 == ncv->pixy);
+    CHECK(6 == ncv->pixx);
     for(int y = 0 ; y < 3 ; ++y){
       for(int x = 0 ; x < 3 ; ++x){
-        CHECK(pixels[0] == ncv->data[y * ncv->cols + x]);
+        CHECK(pixels[0] == ncv->data[y * ncv->pixx + x]);
       }
       for(int x = 3 ; x < 6 ; ++x){
-        CHECK(pixels[1] == ncv->data[y * ncv->cols + x]);
+        CHECK(pixels[1] == ncv->data[y * ncv->pixx + x]);
       }
     }
     for(int y = 3 ; y < 6 ; ++y){
       for(int x = 0 ; x < 3 ; ++x){
-        CHECK(pixels[2] == ncv->data[y * ncv->cols + x]);
+        CHECK(pixels[2] == ncv->data[y * ncv->pixx + x]);
       }
       for(int x = 3 ; x < 6 ; ++x){
-        CHECK(pixels[3] == ncv->data[y * ncv->cols + x]);
+        CHECK(pixels[3] == ncv->data[y * ncv->pixx + x]);
       }
     }
     REQUIRE(newn);


### PR DESCRIPTION
When we print a glyph over a bitmap, we "wipe" the cell's worth of pixels out of the bitmap, so that they are all transparent. This is necessary to print the glyph at all over a kitty bitmap, and necessary to eliminate flicker when loading a new frame into a sixel. When the cell is no longer obscured, we need restore it in the bitmap. To do so, we keep an "auxiliary vector" in the TAM on a per-cell basis. This `auxvec` is non-`NULL` iff we are `ANNIHILATED` or `ANNIHILATED_TRANS`. In Kitty, we store the alpha values, at a byte per pixel (the RGB values are left untouched, and we just take the alpha values to 0 for a wipe). In Sixel, we store the palette index and the transparency status, at nine bits per pixel assuming 256 color registers. Add new rebuild functions which play this auxiliary vector back into the bitmap, and then free the vector. These have been hammered on pretty hard in testing.

For now, there's some flicker introduced by this work (see the `intro` demo especially). I'll attend to that before 2.3.0. This has to go in, though. It's also not yet as performant as I would like, which will be addressed. Finally, we ought be rebuilding the auxiliary vectors when we load a new frame into a sprixel. This is not yet being done; it has been punted to #1605. This means we might get old data when we rebuild (for now). It's safe, just incorrect.