### PR TITLE
Fix rotation under ffmpeg

### DIFF
--- a/src/demo/intro.c
+++ b/src/demo/intro.c
@@ -39,22 +39,28 @@ greatscott(struct notcurses* nc, int dimx){
   if(ncv == NULL){
     return NULL;
   }
-  int celldimy, celldimx;
-  ncplane_pixelgeom(notcurses_stdplane(nc), NULL, NULL, &celldimy, &celldimx, NULL, NULL);
-  if(ncvisual_resize(ncv, 18 * celldimy, celldimx * (dimx - 2))){
+  struct ncplane_options opts = {
+    .y = 2,
+    .x = NCALIGN_CENTER,
+    .rows = 18,
+    .cols = dimx - 2,
+    .flags = NCPLANE_OPTION_HORALIGNED,
+    .name = "gsct",
+  };
+  struct ncplane* n = ncplane_create(notcurses_stdplane(nc), &opts);
+  if(n == NULL){
     ncvisual_destroy(ncv);
     return NULL;
   }
   struct ncvisual_options vopts = {
-    .y = 2,
-    .x = NCALIGN_CENTER,
+    .n = n,
     .blitter = NCBLIT_PIXEL,
-    .scaling = NCSCALE_NONE,
-    .flags = NCVISUAL_OPTION_NODEGRADE | NCVISUAL_OPTION_HORALIGNED,
+    .scaling = NCSCALE_STRETCH,
+    .flags = NCVISUAL_OPTION_NODEGRADE,
   };
-  struct ncplane* n = ncvisual_render(nc, ncv, &vopts);
+  struct ncplane* ret = ncvisual_render(nc, ncv, &vopts);
   ncvisual_destroy(ncv);
-  return n;
+  return ret;
 }
 
 static struct ncplane*

--- a/src/lib/visual-details.h
+++ b/src/lib/visual-details.h
@@ -5,7 +5,6 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/src/lib/visual-details.h
+++ b/src/lib/visual-details.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -452,7 +452,6 @@ int ncvisual_rotate(ncvisual* ncv, double rads){
       if(deconvy >= 0 && deconvx >= 0 && deconvy < bby && deconvx < bbx){
         data[deconvy * bbx + deconvx] = ncv->data[y * (ncv->rowstride / 4) + x];
       }
- //     data[deconvy * (ncv->pixx) + deconvx] = ncv->data[y * (ncv->rowstride / 4) + x];
 //fprintf(stderr, "CW: %d/%d (%08x) -> %d/%d (stride: %d)\n", y, x, ncv->data[y * (ncv->rowstride / 4) + x], targy, targx, ncv->rowstride);
 //fprintf(stderr, "wrote %08x to %d (%d)\n", data[targy * ncv->pixy + targx], targy * ncv->pixy + targx, (targy * ncv->pixy + targx) * 4);
     }
@@ -461,6 +460,7 @@ int ncvisual_rotate(ncvisual* ncv, double rads){
   ncv->pixx = bbx;
   ncv->pixy = bby;
   ncv->rowstride = bbx * 4;
+  ncvisual_details_seed(ncv);
   return 0;
 }
 

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -558,7 +558,7 @@ void ffmpeg_details_destroy(ncvisual_details* deets){
   avcodec_close(deets->codecctx);
   avcodec_free_context(&deets->subtcodecctx);
   avcodec_free_context(&deets->codecctx);
-  av_frame_free(&deets->frame);
+  //av_frame_free(&deets->frame);
   //avcodec_parameters_free(&ncv->cparams);
   sws_freeContext(deets->swsctx);
   av_packet_free(&deets->packet);

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -558,7 +558,7 @@ void ffmpeg_details_destroy(ncvisual_details* deets){
   avcodec_close(deets->codecctx);
   avcodec_free_context(&deets->subtcodecctx);
   avcodec_free_context(&deets->codecctx);
-  //av_frame_free(&deets->frame);
+  av_frame_free(&deets->frame);
   //avcodec_parameters_free(&ncv->cparams);
   sws_freeContext(deets->swsctx);
   av_packet_free(&deets->packet);


### PR DESCRIPTION
Rotation using ffmpeg has apparently been broken since at least 2.0.0, quite some time ago, despite always being used at the end of the `normal` demo (I guess I've just always had low expectations?). Get it working again (as verified using `visual`, `rotate`, and the `normal` unit test); it already was using OpenImageIO. Eliminate the `oframe` of our ffmpeg `visual_details`, simplifying some logic.