### PR TITLE
Threaded xray

### DIFF
--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -342,6 +342,10 @@ the standard pile. This ought become a reality soon.
 Sprixels interact poorly with multiple planes, and such usage is discouraged.
 This situation might improve in the future.
 
+Multiple threads may not currently call **ncvisual_render** concurrently
+using the same **ncvisual**, even if targeting distinct **ncplane**s. This
+will likely change in the future.
+
 # SEE ALSO
 
 **notcurses(3)**,

--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -411,12 +411,11 @@ struct ncplane* hud_create(struct notcurses* nc){
   }
   int dimx, dimy;
   notcurses_term_dim_yx(nc, &dimy, &dimx);
-  int yoffset = dimy - HUD_ROWS;
   struct ncplane_options nopts = {
-    .y = yoffset,
+    .y = 2,
     // we want it to start tucked right up underneath the title of the FPS
     // graph. graph is min(FPSGRAPH_MAX_COLS, dimx) wide, centered, and we want 6 in.
-    .x = (dimx - (dimx > FPSGRAPH_MAX_COLS ? FPSGRAPH_MAX_COLS : dimx)) / 2 + 6,
+    .x = dimx - 2 - HUD_COLS,
     .rows = HUD_ROWS,
     .cols = HUD_COLS,
     .userptr = NULL,

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -182,6 +182,7 @@ int xray_demo(struct notcurses* nc){
   marsh.ncv = ncv;
   marsh.next_frame = 0;
   marsh.last_frame_rendered = -1;
+  marsh.lplane = NULL;
   if(pthread_create(&tid1, NULL, xray_thread, NULL)){
     ncvisual_destroy(ncv);
     ncplane_destroy(slider);
@@ -195,6 +196,7 @@ int xray_demo(struct notcurses* nc){
   }
   // FIXME need wake them more reliably
   int ret = pthread_join(tid1, NULL) | pthread_join(tid2, NULL);
+  ncplane_destroy(marsh.lplane);
   ncvisual_destroy(ncv);
   ncplane_destroy(slider);
   return ret;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2255,13 +2255,14 @@ int ncplane_resize_maximize(ncplane* n){
 }
 
 int ncplane_resize_realign(ncplane* n){
+  const notcurses* nc = ncplane_notcurses_const(n);
   const ncplane* parent = ncplane_parent_const(n);
   if(parent == n){
-    logerror(ncplane_notcurses(n), "Can't realign a root plane");
+    logerror(nc, "Can't realign a root plane\n");
     return 0;
   }
   if(n->halign == NCALIGN_UNALIGNED && n->valign == NCALIGN_UNALIGNED){
-    logerror(ncplane_notcurses(n), "Passed a non-aligned plane");
+    logerror(nc, "Passed a non-aligned plane\n");
     return -1;
   }
   int xpos = ncplane_x(n);
@@ -2282,10 +2283,13 @@ int ncplane_resize_realign(ncplane* n){
 // reparents any children to the parent of 'n', or makes them root planes if
 // 'n' is a root plane.
 ncplane* ncplane_reparent(ncplane* n, ncplane* newparent){
-  if(n == ncplane_notcurses(n)->stdplane){
+  const notcurses* nc = ncplane_notcurses_const(n);
+  if(n == nc->stdplane){
+    logerror(nc, "Won't reparent standard plane\n");
     return NULL; // can't reparent standard plane
   }
   if(n->boundto == newparent){
+    loginfo(nc, "Won't reparent plane to itself\n");
     return n;
   }
 //notcurses_debug(ncplane_notcurses(n), stderr);

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -1,8 +1,8 @@
 #include "internal.h"
 #include "visual-details.h"
+#include <stdatomic.h>
 
-// FIXME needs be atomic
-static uint32_t sprixelid_nonce;
+static atomic_uint_fast32_t sprixelid_nonce;
 
 void sprixel_debug(FILE* out, const sprixel* s){
   fprintf(out, "Sprixel %d (%p) %dx%d (%dx%d) @%d/%d state: %d\n",


### PR DESCRIPTION
Use two threads in `xray` so one can render while one rasterizes. Gets W% up to ~98 and saves 20--30% of runtime. Move sprixels between piles along with planes. Closes #1607. Closes #1608.