### PR TITLE
kitty: calculate damage out properly #1618

### DIFF
--- a/src/demo/intro.c
+++ b/src/demo/intro.c
@@ -118,8 +118,8 @@ int intro(struct notcurses* nc){
   ncchannel_set_rgb8(&ccll, 0xff, 0, 0);
   ncchannel_set_rgb8(&cclr, 0, 0, 0xff);
   // we use full block rather+fg than space+bg to conflict less with the menu
-  ncplane_home(ncp);
-  if(ncplane_highgradient_sized(ncp, ccul, ccur, ccll, cclr, rows, cols) <= 0){
+  ncplane_cursor_move_yx(ncp, 2, 1);
+  if(ncplane_highgradient_sized(ncp, ccul, ccur, ccll, cclr, rows - 3, cols - 2) <= 0){
     return -1;
   }
   nccell c = CELL_TRIVIAL_INITIALIZER;


### PR DESCRIPTION
Properly invalidates kitty sprixel following a fresh wipe, closing #1618. Does away with unnecessary damage, speeding up multiframe media display with kitty. Well, emitting many fewer bytes, anyway--it looks like kitty optimizes away hidden glyph writes very well, as the timings change almost not at all. actually, it looks like glyphs are just dwarfed by the bitmaps, ho humm.

with:

```
[schwarzgerat](0) $ time ./ncplayer -bpixel -q -t0 ../data/samoa.avi 

real	0m22.466s
user	0m9.118s
sys	0m6.048s
[schwarzgerat](0) $ 

             runtime│ frames│output(B)│    FPS│%r│%a│%w│TheoFPS║
══╤════════╤════════╪═══════╪═════════╪═══════╪══╪══╪══╪═══════╣
 1│   intro│   4.16s│    533│  19.90Mi│  128.1│ 3│ 0│ 5│  1.39K║
 2│    xray│  11.77s│    486│ 893.49Mi│   41.3│ 0│ 0│87│  46.66║
 3│   eagle│   3.28s│    346│  17.82Mi│  105.6│ 2│ 0│ 4│  1.39K║
 4│     zoo│  13.46s│   1527│   1.63Mi│  113.5│ 2│ 0│ 0│  2.50K║
 5│  chunli│   5.44s│    477│   1.78Mi│   87.6│ 2│ 0│ 0│  2.16K║
 6│   yield│   9.70s│    262│ 519.70Mi│   27.0│ 0│ 0│50│  52.95║
 7│   trans│  11.39s│  15211│   2.23Mi│ 1335.1│18│ 6│ 4│  4.57K║
 8│  normal│   6.36s│    674│  11.45Mi│  106.0│ 2│ 0│ 2│  1.74K║
 9│ highcon│   2.00s│   6002│ 579.48Ki│ 2999.0│39│17│ 8│  4.56K║
10│  dragon│   2.33s│    198│ 120.52Ki│   85.0│ 1│ 0│ 0│  2.71K║
11│mojibake│  12.29s│   1437│  11.82Mi│  116.9│ 2│ 1│ 2│  1.95K║
12│     box│   3.21s│    101│   7.78Mi│   31.5│ 0│ 0│ 3│ 757.09║
13│  keller│  12.28s│    959│  11.59Mi│   78.1│ 2│ 0│ 1│  1.89K║
14│    grid│   3.02s│    768│ 158.96Mi│  254.3│ 3│ 0│82│ 290.75║
15│ animate│   5.00s│   3335│   2.95Mi│  667.6│10│ 3│ 2│  4.02K║
16│    reel│   5.00s│    404│ 443.09Ki│   80.7│ 2│ 0│ 0│  2.19K║
17│whiteout│   5.00s│  11051│   9.42Mi│ 2208.0│30│10│ 9│  4.38K║
18│uniblock│  14.10s│   1190│1012.23Ki│   84.4│ 2│ 0│ 0│  2.50K║
19│    view│  15.42s│   1712│ 246.54Mi│  111.0│ 1│ 0│12│ 758.44║
20│   luigi│   1.83s│    366│   2.03Mi│  200.3│ 4│ 1│ 2│  2.65K║
21│ sliders│   6.19s│    859│ 717.88Ki│  138.7│ 3│ 1│ 0│  2.85K║
22│ fallin'│   7.05s│   5787│   3.75Mi│  821.0│14│ 4│ 3│  3.71K║
23│  jungle│   5.00s│    600│ 256.95Ki│  120.0│ 2│ 1│ 0│  2.60K║
24│  qrcode│ 24.78µs│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
25│   outro│  10.22s│    829│  41.56Mi│   81.1│ 2│ 0│ 3│  1.10K║
══╧════════╧════════╪═══════╪═════════╪═══════╧══╧══╧══╧═══════╝
             175.50s│  55114│   1.92Gi│
```

without:

```
[schwarzgerat](0) $ time ./ncplayer -bpixel -q -t0 ../data/samoa.avi 

real	0m22.501s
user	0m9.119s
sys	0m6.135s
[schwarzgerat](0) $ 
             runtime│ frames│output(B)│    FPS│%r│%a│%w│TheoFPS║
══╤════════╤════════╪═══════╪═════════╪═══════╪══╪══╪══╪═══════╣
 1│   intro│   4.16s│    533│  20.01Mi│  128.1│ 2│ 0│ 4│  1.47K║
 2│    xray│  11.87s│    486│ 894.61Mi│   40.9│ 0│ 0│86│  46.56║
 3│   eagle│   3.29s│    346│  17.82Mi│  105.1│ 2│ 0│ 5│  1.22K║
 4│     zoo│  13.46s│   1526│   1.63Mi│  113.4│ 3│ 0│ 0│  2.29K║
 5│  chunli│   5.43s│    477│   1.78Mi│   87.8│ 2│ 0│ 0│  2.29K║
 6│   yield│   9.02s│    248│ 481.14Mi│   27.5│ 0│ 0│49│  54.38║
 7│   trans│  11.35s│  15245│   3.07Mi│ 1343.6│18│ 6│ 3│  4.65K║
 8│  normal│   6.36s│    674│  11.44Mi│  106.0│ 2│ 0│ 2│  1.70K║
 9│ highcon│   2.00s│   6032│ 579.90Ki│ 3014.0│39│18│ 7│  4.59K║
10│  dragon│   2.33s│    198│ 122.08Ki│   85.1│ 1│ 0│ 0│  2.85K║
11│mojibake│  12.29s│   1437│  11.82Mi│  117.0│ 2│ 1│ 1│  2.05K║
12│     box│   3.20s│    101│   7.78Mi│   31.5│ 0│ 0│ 3│ 794.19║
13│  keller│  12.32s│    960│  11.59Mi│   77.9│ 2│ 0│ 1│  1.84K║
14│    grid│   2.91s│    768│ 158.95Mi│  263.8│ 4│ 0│81│ 305.12║
15│ animate│   5.00s│   3335│   2.95Mi│  667.6│12│ 4│ 3│  3.21K║
16│    reel│   5.00s│    402│ 319.52Ki│   80.3│ 2│ 0│ 0│  2.27K║
17│whiteout│   5.01s│  11245│   9.20Mi│ 2246.5│30│10│ 8│  4.53K║
18│uniblock│  14.10s│   1190│ 994.15Ki│   84.4│ 2│ 0│ 0│  2.48K║
19│    view│  15.42s│   1623│ 251.80Mi│  105.3│ 1│ 0│13│ 647.24║
20│   luigi│   1.85s│    366│   2.03Mi│  197.5│ 5│ 1│ 2│  2.17K║
21│ sliders│   6.20s│    856│ 715.27Ki│  138.2│ 3│ 1│ 0│  2.79K║
22│ fallin'│   7.58s│   5774│   3.75Mi│  761.8│17│ 5│ 3│  2.93K║
23│  jungle│   5.00s│    600│ 255.84Ki│  120.0│ 2│ 1│ 0│  2.81K║
24│  qrcode│ 21.21µs│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
25│   outro│  10.23s│    826│  41.55Mi│   80.7│ 3│ 0│ 4│  1.01K║
══╧════════╧════════╪═══════╪═════════╪═══════╧══╧══╧══╧═══════╝
             175.38s│  55248│   1.89Gi│
```