### PR TITLE
Ensure sixels are always multiples of 6 pixels tall

### DIFF
--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -511,7 +511,7 @@ postinit_checks(struct notcurses* nc, struct ncplane* n){
   if(ncplane_cursor_move_yx(n, ncplane_dim_y(n) - 1, 0)){
     return -1;
   }
-  ncplane_set_fg_rgb(n, 0xdddddd);
+  ncplane_set_fg_rgb(n, 0x888888);
   ncplane_set_styles(n, NCSTYLE_NONE);
   ncplane_putstr(n, " Enabling mouse...");
   notcurses_render(nc);
@@ -521,7 +521,7 @@ postinit_checks(struct notcurses* nc, struct ncplane* n){
   ncplane_set_fg_rgb(n, 0x22cc22);
   ncplane_set_styles(n, NCSTYLE_ITALIC);
   ncplane_putstr(n, "done.");
-  ncplane_set_fg_rgb(n, 0xdddddd);
+  ncplane_set_fg_rgb(n, 0x888888);
   ncplane_set_styles(n, NCSTYLE_NONE);
   ncplane_putstr(n, " Checking for bitmap support...");
   notcurses_render(nc);

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -489,9 +489,9 @@ static ncdirectv*
 ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
                        ncscale_e scale, int ymax, int xmax,
                        uint32_t transcolor){
-  int dimy = ymax > 0 ? ymax : ncdirect_dim_y(n);
+  int dimy = ymax > 0 ? ymax : (ncdirect_dim_y(n) - 1);
   int dimx = xmax > 0 ? xmax : ncdirect_dim_x(n);
-//fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d\n", ncv->data, ncv->pixy, ncv->pixx);
+//fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d outsize: %d/%d\n", ncv->data, ncv->pixy, ncv->pixx, dimy, dimx);
 //fprintf(stderr, "render %d/%d to scaling: %d\n", ncv->pixy, ncv->pixx, scale);
   const struct blitset* bset = rgba_blitter_low(&n->tcache, scale, true, blitfxn);
   if(!bset){
@@ -505,7 +505,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
       outy = disprows;
     }else{
       dispcols = dimx * n->tcache.cellpixx;
-      disprows = (dimy - 1) * n->tcache.cellpixy;
+      disprows = dimy * n->tcache.cellpixy;
       clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy);
     }
     if(scale == NCSCALE_SCALE || scale == NCSCALE_SCALE_HIRES){

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -492,12 +492,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
   int dimy = ymax > 0 ? ymax : ncdirect_dim_y(n);
   int dimx = xmax > 0 ? xmax : ncdirect_dim_x(n);
 //fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d\n", ncv->data, ncv->pixy, ncv->pixx);
-  int leny = ncv->pixy; // we allow it to freely scroll
-  int lenx = ncv->pixx;
-  if(leny == 0 || lenx == 0){
-    return NULL;
-  }
-//fprintf(stderr, "render %d/%d to %d+%d scaling: %d\n", ncv->pixy, ncv->pixx, leny, lenx, scale);
+//fprintf(stderr, "render %d/%d to scaling: %d\n", ncv->pixy, ncv->pixx, scale);
   const struct blitset* bset = rgba_blitter_low(&n->tcache, scale, true, blitfxn);
   if(!bset){
     return NULL;
@@ -528,9 +523,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
       outy = disprows;
     }
   }
-  leny = (leny / (double)ncv->pixy) * ((double)disprows);
-  lenx = (lenx / (double)ncv->pixx) * ((double)dispcols);
-//fprintf(stderr, "render: %d+%d of %d/%d stride %u %p\n", leny, lenx, ncv->pixy, ncv->pixx, ncv->pixytride, ncv->data);
+//fprintf(stderr, "render: %d/%d stride %u %p\n", ncv->pixy, ncv->pixx, ncv->pixytride, ncv->data);
   ncplane_options nopts = {
     .y = 0,
     .x = 0,
@@ -561,7 +554,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
     }
     ncdv->sprite = bargs.u.pixel.spx;
   }
-  if(ncvisual_blit(ncv, disprows, dispcols, ncdv, bset, leny, lenx, &bargs)){
+  if(ncvisual_blit(ncv, disprows, dispcols, ncdv, bset, &bargs)){
     free_plane(ncdv);
     return NULL;
   }

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -491,7 +491,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
                        uint32_t transcolor){
   int dimy = ymax > 0 ? ymax : (ncdirect_dim_y(n) - 1);
   int dimx = xmax > 0 ? xmax : ncdirect_dim_x(n);
-//fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d outsize: %d/%d\n", ncv->data, ncv->pixy, ncv->pixx, dimy, dimx);
+//fprintf(stderr, "OUR DATA: %p rows/cols: %d/%d outsize: %d/%d %d\n", ncv->data, ncv->pixy, ncv->pixx, dimy, dimx, ymax);
 //fprintf(stderr, "render %d/%d to scaling: %d\n", ncv->pixy, ncv->pixx, scale);
   const struct blitset* bset = rgba_blitter_low(&n->tcache, scale, true, blitfxn);
   if(!bset){
@@ -506,21 +506,27 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
     }else{
       dispcols = dimx * n->tcache.cellpixx;
       disprows = dimy * n->tcache.cellpixy;
-      clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy);
+      clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy, scale);
     }
     if(scale == NCSCALE_SCALE || scale == NCSCALE_SCALE_HIRES){
       scale_visual(ncv, &disprows, &dispcols);
       if(bset->geom == NCBLIT_PIXEL){
-        clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy);
+        clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy, scale);
       }
     }
   }else{
     disprows = ncv->pixy;
     dispcols = ncv->pixx;
     if(bset->geom == NCBLIT_PIXEL){
-      clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy);
+      clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy, scale);
     }else{
       outy = disprows;
+    }
+  }
+  if(bset->geom == NCBLIT_PIXEL){
+    while((outy + n->tcache.cellpixy - 1) / n->tcache.cellpixy > dimy){
+      outy -= n->tcache.sprixel_scale_height;
+      disprows = outy;
     }
   }
 //fprintf(stderr, "render: %d/%d stride %u %p\n", ncv->pixy, ncv->pixx, ncv->pixytride, ncv->data);

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -502,7 +502,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
   if(!bset){
     return NULL;
   }
-  int disprows, dispcols;
+  int disprows, dispcols, outy;
   if(scale != NCSCALE_NONE && scale != NCSCALE_NONE_HIRES){
     if(bset->geom != NCBLIT_PIXEL){
       dispcols = dimx * encoding_x_scale(&n->tcache, bset);
@@ -510,19 +510,19 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
     }else{
       dispcols = dimx * n->tcache.cellpixx;
       disprows = (dimy - 1) * n->tcache.cellpixy;
-      clamp_to_sixelmax(&n->tcache, &disprows, &dispcols);
+      clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy);
     }
     if(scale == NCSCALE_SCALE || scale == NCSCALE_SCALE_HIRES){
       scale_visual(ncv, &disprows, &dispcols);
       if(bset->geom == NCBLIT_PIXEL){
-        clamp_to_sixelmax(&n->tcache, &disprows, &dispcols);
+        clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy);
       }
     }
   }else{
     disprows = ncv->pixy;
     dispcols = ncv->pixx;
     if(bset->geom == NCBLIT_PIXEL){
-      clamp_to_sixelmax(&n->tcache, &disprows, &dispcols);
+      clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy);
     }
   }
   leny = (leny / (double)ncv->pixy) * ((double)disprows);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1022,14 +1022,22 @@ sprite_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
 // geometry is derived from scaled geometry and output requirements (that Sixel
 // must be a multiple of six pixels tall). output width is always equal to
 // scaled width. all are pixels.
+// happy fact: common reported values for maximum sixel height are 256, 1024,
+// and 4096...not a single goddamn one of which is divisible by six. augh.
 static inline void
-clamp_to_sixelmax(const tinfo* t, int* y, int* x, int* outy){
+clamp_to_sixelmax(const tinfo* t, int* y, int* x, int* outy, ncscale_e scaling){
   if(t->sixel_maxy && *y > t->sixel_maxy){
     *y = t->sixel_maxy;
   }
   *outy = *y;
   if(*outy % t->sprixel_scale_height){
     *outy += t->sprixel_scale_height - (*outy % t->sprixel_scale_height);
+    while(*outy > t->sixel_maxy){
+      *outy -= t->sprixel_scale_height;
+    }
+    if(scaling == NCSCALE_STRETCH || *y > *outy){
+      *y = *outy;
+    }
   }
   if(t->sixel_maxx && *x > t->sixel_maxx){
     *x = t->sixel_maxx;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -617,6 +617,8 @@ typedef struct notcurses {
 } notcurses;
 
 typedef struct blitterargs {
+  // FIXME begy/begx are really only of interest to scaling; they ought be
+  // consumed there, and blitters ought always work with the scaled output.
   int begy;            // upper left start within visual
   int begx;
   uint32_t transcolor; // if non-zero, treat the lower 24 bits as a transparent color
@@ -639,14 +641,17 @@ typedef struct blitterargs {
   } u;
 } blitterargs;
 
+// scaledy and scaledx are output geometry from scaling; data is output data
+// from scaling. we might actually need more pixels due to framing concerns,
+// in which case just assume transparent input pixels where needed.
 typedef int (*ncblitter)(struct ncplane* n, int linesize, const void* data,
-                         int leny, int lenx, const blitterargs* bargs);
+                         int scaledy, int scaledx, const blitterargs* bargs);
 
-// a system for rendering RGBA pixels as text glyphs
+// a system for rendering RGBA pixels as text glyphs or sixel/kitty bitmaps
 struct blitset {
   ncblitter_e geom;
-  int width;
-  int height;
+  int width;        // number of input pixels per output cell, width
+  int height;       // number of input pixels per output cell, height
   // the EGCs which form the various levels of a given plotset. if the geometry
   // is wide, things are arranged with the rightmost side increasing most
   // quickly, i.e. it can be indexed as height arrays of 1 + height glyphs. i.e.

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1265,7 +1265,7 @@ ALLOC char* ncplane_vprintf_prep(const char* format, va_list ap);
 // change the internals of the ncvisual. Uses oframe.
 int ncvisual_blit(struct ncvisual* ncv, int rows, int cols,
                   ncplane* n, const struct blitset* bset,
-                  int leny, int lenx, const blitterargs* bargs);
+                  const blitterargs* bargs);
 
 void nclog(const char* fmt, ...);
 
@@ -1694,8 +1694,7 @@ typedef struct ncvisual_implementation {
   int (*visual_init)(int loglevel);
   void (*visual_printbanner)(const struct notcurses* nc);
   int (*visual_blit)(struct ncvisual* ncv, int rows, int cols, ncplane* n,
-                     const struct blitset* bset,
-                     int leny, int lenx, const blitterargs* barg);
+                     const struct blitset* bset, const blitterargs* barg);
   struct ncvisual* (*visual_create)(void);
   struct ncvisual* (*visual_from_file)(const char* fname);
   // ncv constructors other than ncvisual_from_file() need to set up the

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1038,7 +1038,8 @@ clamp_to_sixelmax(const tinfo* t, int* y, int* x, int* outy){
 
 // any sprixcell which does not cover the entirety of the underlying cell
 // cannot be SPRIXCELL_OPAQUE. this postprocesses the TAM, flipping any
-// such sprixcells to SPRIXCELL_MIXED.
+// such sprixcells to SPRIXCELL_MIXED. |leny| and |lenx| are output geometry
+// in pixels. |cdimy| and |cdimx| are output coverage in cells.
 static inline void
 scrub_tam_boundaries(tament* tam, int leny, int lenx, int cdimy, int cdimx){
   // any sprixcells which don't cover the full cell underneath them cannot
@@ -1470,7 +1471,8 @@ egc_rtl(const char* egc, int* bytes){
 
 // a sprixel occupies the entirety of its associated plane. each cell contains
 // a reference to the context-wide sprixel cache. this ought be an entirely
-// new, purpose-specific plane.
+// new, purpose-specific plane. |leny| and |lenx| are output geometry in pixels.
+// |cols| and |rows| are output coverage in cells.
 static inline int
 plane_blit_sixel(sprixel* spx, char* s, int bytes, int rows, int cols,
                  int leny, int lenx, int parse_start, tament* tam){
@@ -1479,9 +1481,8 @@ plane_blit_sixel(sprixel* spx, char* s, int bytes, int rows, int cols,
   }
   ncplane* n = spx->n;
   uint32_t gcluster = htole(0x02000000ul) + htole(spx->id);
-  // FIXME rows/cols ought never exceed the size, right?. why need we check?
-  for(int y = 0 ; y < rows && y < ncplane_dim_y(n) ; ++y){
-    for(int x = 0 ; x < cols && x < ncplane_dim_x(n) ; ++x){
+  for(int y = 0 ; y < rows ; ++y){
+    for(int x = 0 ; x < cols ; ++x){
       nccell* c = ncplane_cell_ref_yx(n, y, x);
       memcpy(&c->gcluster, &gcluster, sizeof(gcluster));
       c->width = cols;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1017,15 +1017,19 @@ sprite_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
   return ret;
 }
 
+// |y| and |x| are scaled geometry on input, and clamped scaled geometry on
+// output. |outy| is output geometry on output, and unused on input. output
+// geometry is derived from scaled geometry and output requirements (that Sixel
+// must be a multiple of six pixels tall). output width is always equal to
+// scaled width. all are pixels.
 static inline void
-clamp_to_sixelmax(const tinfo* t, int* y, int* x){
+clamp_to_sixelmax(const tinfo* t, int* y, int* x, int* outy){
   if(t->sixel_maxy && *y > t->sixel_maxy){
     *y = t->sixel_maxy;
   }
-  if(*y % t->sprixel_scale_height){
-    // FIXME take it up and use transparent rows, rather than clipping FIXME
-    //*y += t->sprixel_scale_height - (*y % t->sprixel_scale_height);
-    *y -= *y % t->sprixel_scale_height;
+  *outy = *y;
+  if(*outy % t->sprixel_scale_height){
+    *outy += t->sprixel_scale_height - (*outy % t->sprixel_scale_height);
   }
   if(t->sixel_maxx && *x > t->sixel_maxx){
     *x = t->sixel_maxx;

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -519,16 +519,16 @@ write_sixel_payload(FILE* fp, int lenx, const sixelmap* map,
 
 // emit the sixel in its entirety, plus escapes to start and end pixel mode.
 // only called the first time we encode; after that, the palette remains
-// constant, and is simply copied. fclose()s |fp| on success. |leny| and |lenx|
-// are scaled output geometry; |outy| is output geometry.
+// constant, and is simply copied. fclose()s |fp| on success. |outx| and |outy|
+// are output geometry.
 static int
-write_sixel(FILE* fp, int leny, int lenx, int outy, const sixeltable* stab,
+write_sixel(FILE* fp, int outy, int outx, const sixeltable* stab,
             int* parse_start, const char* cursor_hack, sixel_p2_e p2){
-  *parse_start = write_sixel_header(fp, outy, lenx, stab, p2);
+  *parse_start = write_sixel_header(fp, outy, outx, stab, p2);
   if(*parse_start < 0){
     return -1;
   }
-  if(write_sixel_payload(fp, lenx, stab->map, cursor_hack) < 0){
+  if(write_sixel_payload(fp, outx, stab->map, cursor_hack) < 0){
     return -1;
   }
   if(fclose(fp) == EOF){
@@ -596,7 +596,7 @@ sixel_blit_inner(int leny, int lenx, const sixeltable* stab, int rows, int cols,
     outy += 6 - (leny % 6);
   }
   // calls fclose() on success
-  if(write_sixel(fp, leny, lenx, outy, stab, &parse_start,
+  if(write_sixel(fp, outy, lenx, stab, &parse_start,
                  bargs->u.pixel.cursor_hack, stab->p2)){
     fclose(fp);
     free(buf);

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -147,12 +147,19 @@ sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx){
 }
 
 // |pixy| and |pixx| are the output pixel geometry (i.e. |pixy| must be a
-// multiple of 6 for sixel). takes ownership of 's' on success.
+// multiple of 6 for sixel). output coverage ought already have been loaded.
+// takes ownership of 's' on success. frees any existing glyph.
 int sprixel_load(sprixel* spx, char* s, int bytes, int pixy, int pixx,
                  int parse_start){
   assert(spx->n);
-  assert((pixy + s->cellpxy - 1) / s->cellpxy == s->dimy);
-  assert((pixx + s->cellpxx - 1) / s->cellpxx == s->dimx);
+  if(spx->cellpxy > 0){ // don't explode on ncdirect case
+    if((pixy + spx->cellpxy - 1) / spx->cellpxy != spx->dimy){
+      return -1;
+    }
+    if((pixx + spx->cellpxx - 1) / spx->cellpxx != spx->dimx){
+      return -1;
+    }
+  }
   free(spx->glyph);
   spx->glyph = s;
   spx->glyphlen = bytes;

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -146,11 +146,13 @@ sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx){
   return ret;
 }
 
-// 'y' and 'x' are the cell geometry, not the pixel geometry. takes
-// ownership of 's' on success. pixel geometry ought include any Sixel excess.
+// |pixy| and |pixx| are the output pixel geometry (i.e. |pixy| must be a
+// multiple of 6 for sixel). takes ownership of 's' on success.
 int sprixel_load(sprixel* spx, char* s, int bytes, int pixy, int pixx,
                  int parse_start){
   assert(spx->n);
+  assert((pixy + s->cellpxy - 1) / s->cellpxy == s->dimy);
+  assert((pixx + s->cellpxx - 1) / s->cellpxx == s->dimx);
   free(spx->glyph);
   spx->glyph = s;
   spx->glyphlen = bytes;

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -625,15 +625,15 @@ make_sprixel_plane(notcurses* nc, ncvisual* ncv, ncscale_e scaling,
     --*disppixy; // most terminals will scroll if we blit to the last row
     *disppixx *= nc->tcache.cellpixx;
     *disppixy *= nc->tcache.cellpixy;
-    clamp_to_sixelmax(&nc->tcache, disppixy, disppixx, outy);
+    clamp_to_sixelmax(&nc->tcache, disppixy, disppixx, outy, scaling);
     if(scaling == NCSCALE_SCALE || scaling == NCSCALE_SCALE_HIRES){
       scale_visual(ncv, disppixy, disppixx); // can only shrink
-      clamp_to_sixelmax(&nc->tcache, disppixy, disppixx, outy);
+      clamp_to_sixelmax(&nc->tcache, disppixy, disppixx, outy, scaling);
     }
   }else{
     *disppixx = ncv->pixx;
     *disppixy = ncv->pixy;
-    clamp_to_sixelmax(&nc->tcache, disppixy, disppixx, outy);
+    clamp_to_sixelmax(&nc->tcache, disppixy, disppixx, outy, scaling);
   }
   struct ncplane_options nopts = {
     .y = *placey,
@@ -698,7 +698,7 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
       ncplane_dim_yx(n, &disppixy, &disppixx);
       disppixx *= nc->tcache.cellpixx;
       disppixy *= nc->tcache.cellpixy;
-      clamp_to_sixelmax(&nc->tcache, &disppixy, &disppixx, &outy);
+      clamp_to_sixelmax(&nc->tcache, &disppixy, &disppixx, &outy, scaling);
       int absplacex = 0, absplacey = 0;
       if(!(flags & NCVISUAL_OPTION_HORALIGNED)){
         absplacex = placex;
@@ -713,14 +713,14 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
       disppixy = ncv->pixy;
     }
     if(scaling == NCSCALE_SCALE || scaling == NCSCALE_SCALE_HIRES){
-      clamp_to_sixelmax(&nc->tcache, &disppixy, &disppixx, &outy);
+      clamp_to_sixelmax(&nc->tcache, &disppixy, &disppixx, &outy, scaling);
       scale_visual(ncv, &disppixy, &disppixx);
     }
-    clamp_to_sixelmax(&nc->tcache, &disppixy, &disppixx, &outy);
+    clamp_to_sixelmax(&nc->tcache, &disppixy, &disppixx, &outy, scaling);
     // FIXME use a closed form
     while((outy + nc->tcache.cellpixy - 1) / nc->tcache.cellpixy > ncplane_dim_y(n)){
-      --disppixy;
-      clamp_to_sixelmax(&nc->tcache, &disppixy, &disppixx, &outy);
+      outy -= nc->tcache.sprixel_scale_height;
+      disppixy = outy;
     }
   }
 //fprintf(stderr, "pblit: %dx%d <- %dx%d of %d/%d stride %u @%dx%d %p %u\n", disppixy, disppixx, begy, begx, ncv->pixy, ncv->pixx, ncv->rowstride, placey, placex, ncv->data, nc->tcache.cellpixx);

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -693,9 +693,8 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
   ncplane* createdn = NULL;
 //fprintf(stderr, "INPUT N: %p rows: %d cols: %d 0x%016lx\n", n ? n : NULL, disppixy, disppixx, flags);
   if(n == NULL){ // create plane
-    createdn = make_sprixel_plane(nc, ncv, scaling, &disppixy, &disppixx,
-                                  flags, &outy, &placey, &placex);
-    if(createdn == NULL){
+    if((createdn = make_sprixel_plane(nc, ncv, scaling, &disppixy, &disppixx,
+                                      flags, &outy, &placey, &placex)) == NULL){
       return NULL;
     }
     n = createdn;

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -457,10 +457,8 @@ int ffmpeg_decode_loop(ncvisual* ncv){
 }
 
 // rows/cols: scaled output geometry (pixels)
-// leny/lenx: selected input region (pixels)
 int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
-                const struct blitset* bset,
-                int leny, int lenx, const blitterargs* bargs){
+                const struct blitset* bset, const blitterargs* bargs){
   const AVFrame* inframe = ncv->details->oframe ? ncv->details->oframe : ncv->details->frame;
 //fprintf(stderr, "inframe: %p oframe: %p frame: %p\n", inframe, ncv->details->oframe, ncv->details->frame);
   void* data = NULL;
@@ -469,7 +467,7 @@ int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
   const int targformat = AV_PIX_FMT_RGBA;
 //fprintf(stderr, "got format: %d want format: %d\n", inframe->format, targformat);
   if(inframe && (cols != inframe->width || rows != inframe->height || inframe->format != targformat)){
-//fprintf(stderr, "resize+render: %d/%d->%d/%d (%d/%d)\n", inframe->height, inframe->width, rows, cols, leny, lenx);
+//fprintf(stderr, "resize+render: %d/%d->%d/%d\n", inframe->height, inframe->width, rows, cols);
     sframe = av_frame_alloc();
     if(sframe == NULL){
 //fprintf(stderr, "Couldn't allocate output frame for scaled frame\n");
@@ -512,8 +510,8 @@ int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
     stride = ncv->rowstride;
     data = ncv->data;
   }
-//fprintf(stderr, "rows/cols: %d/%d %d/%d\n", rows, cols, leny, lenx);
-  if(rgba_blit_dispatch(n, bset, stride, data, leny, lenx, bargs) < 0){
+//fprintf(stderr, "rows/cols: %d/%d\n", rows, cols);
+  if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, bargs) < 0){
 //fprintf(stderr, "rgba dispatch failed!\n");
     if(sframe){
       av_freep(sframe->data);

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -456,6 +456,8 @@ int ffmpeg_decode_loop(ncvisual* ncv){
   return r;
 }
 
+// rows/cols: scaled output geometry (pixels)
+// leny/lenx: selected input region (pixels)
 int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
                 const struct blitset* bset,
                 int leny, int lenx, const blitterargs* bargs){

--- a/src/media/none.cpp
+++ b/src/media/none.cpp
@@ -40,11 +40,9 @@ int none_resize(ncvisual* nc, int rows, int cols){
 
 int none_blit(struct ncvisual* ncv, int rows, int cols,
               ncplane* n, const struct blitset* bset,
-              int leny, int lenx, const blitterargs* bargs){
-  (void)rows;
-  (void)cols;
+              const blitterargs* bargs){
   if(rgba_blit_dispatch(n, bset, ncv->rowstride, ncv->data,
-                        leny, lenx, bargs) >= 0){
+                        rows, cols, bargs) >= 0){
     return 0;
   }
   return -1;

--- a/src/media/oiio.cpp
+++ b/src/media/oiio.cpp
@@ -149,7 +149,7 @@ int oiio_resize(ncvisual* nc, int rows, int cols) {
 
 int oiio_blit(struct ncvisual* ncv, int rows, int cols,
               ncplane* n, const struct blitset* bset,
-              int leny, int lenx, const blitterargs* bargs) {
+              const blitterargs* bargs) {
 //fprintf(stderr, "%d/%d -> %d/%d on the resize\n", ncv->pixy, ncv->pixx, rows, cols);
   void* data = nullptr;
   int stride = 0;
@@ -170,7 +170,7 @@ int oiio_blit(struct ncvisual* ncv, int rows, int cols,
     data = ncv->data;
     stride = ncv->rowstride;
   }
-  return oiio_blit_dispatch(n, bset, stride, data, leny, lenx, bargs);
+  return oiio_blit_dispatch(n, bset, stride, data, rows, cols, bargs);
 }
 
 // FIXME before we can enable this, we need build an OIIO::APPBUFFER-style

--- a/src/media/oiio.h
+++ b/src/media/oiio.h
@@ -21,7 +21,7 @@ ncvisual* oiio_create(void);
 void oiio_destroy(ncvisual* ncv);
 int oiio_blit_dispatch(struct ncplane* nc, const struct blitset* bset,
                        int linesize, const void* data,
-                       int leny, int lenx, const blitterargs* bargs);
+                       const blitterargs* bargs);
 
 #ifdef __cplusplus
 }

--- a/src/media/oiio.h
+++ b/src/media/oiio.h
@@ -13,7 +13,7 @@ void oiio_printbanner(const struct notcurses* nc);
 void oiio_details_seed(struct ncvisual* ncv);
 int oiio_blit(ncvisual* ncv, int rows, int cols,
               struct ncplane* n, const struct blitset* bset,
-              int leny, int lenx, const blitterargs* bargs);
+              const blitterargs* bargs);
 ncvisual* oiio_from_file(const char* filename);
 int oiio_decode_loop(ncvisual* ncv);
 int oiio_resize(ncvisual* nc, int rows, int cols);
@@ -21,7 +21,7 @@ ncvisual* oiio_create(void);
 void oiio_destroy(ncvisual* ncv);
 int oiio_blit_dispatch(struct ncplane* nc, const struct blitset* bset,
                        int linesize, const void* data,
-                       const blitterargs* bargs);
+                       int leny, int lenx, const blitterargs* bargs);
 
 #ifdef __cplusplus
 }

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Bitmaps") {
       .flags = NCVISUAL_OPTION_NODEGRADE,
       .transcolor = 0,
     };
-    CHECK(0 == ncvisual_resize(ncv, 6, 1)); // FIXME get down to (1, 1)
+    CHECK(0 == ncvisual_resize(ncv, 1, 1));
     auto n = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != n);
     auto s = n->sprite;

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -252,7 +252,16 @@ TEST_CASE("Bitmaps") {
     vopts.scaling = NCSCALE_NONE;
     auto infn = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(infn);
-    CHECK(4 == ncplane_dim_y(infn));
+    if(nc_->tcache.sprixel_scale_height == 6){
+      if(4 * nc_->tcache.cellpixy % 6){
+        CHECK(5 == ncplane_dim_y(infn));
+      }else{
+        CHECK(4 == ncplane_dim_y(infn));
+      }
+    }else{
+      CHECK(nc_->tcache.sprixel_scale_height == 1);
+      CHECK(4 == ncplane_dim_y(infn));
+    }
     CHECK(4 == ncplane_dim_x(infn));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_resize(ncv, 8, 8));


### PR DESCRIPTION
Prior to this, when input bitmaps weren't a multiple of 6 pixels tall, we cut them down to the nearest smaller multiple of 6, implying (among other things) that we couldn't handle images less than 6 pixels tall under Sixel. We now properly go to the nearest larger multiple of 6, filling in with virtual transparent rows. I've added documentation to `HACKING.md` about the six(?) different geometries one deals with rendering an image. Eliminated some unnecessary checks in `plane_blit_sixel()`. The `BitmapResize` unit test now goes for (1, 1) rather than (6, 1), hopefully fixing an issue of @joseluis 's, or at least getting closer. Flesh out a lot of comments. Purge `leny`/`lenx` arguments from `ncvisual_blit()` until we're using them properly.