### PR TITLE
Add NCVISUAL_OPTION_CHILDPLANE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 2.2.10 (not yet released)
+  * Added `NCVISUAL_OPTION_CHILDPLANE` to interpret the `n` field of
+    `ncvisual_options` as a parent plane.
+
 * 2.2.9 (2021-05-03)
   * Added two new stats, `sprixelemissions` and `sprixelelisions`.
   * Added `notcurses_canhalfblock()` and `notcurses_canquadrant()`.

--- a/USAGE.md
+++ b/USAGE.md
@@ -3149,6 +3149,8 @@ const char* notcurses_str_blitter(ncblitter_e blitter);
 #define NCVISUAL_OPTION_BLEND      0x0002ull // use CELL_ALPHA_BLEND with visual
 #define NCVISUAL_OPTION_HORALIGNED 0x0004ull // x is an alignment, not absolute
 #define NCVISUAL_OPTION_VERALIGNED 0x0008ull // y is an alignment, not absolute
+#define NCVISUAL_OPTION_ADDALPHA   0x0010ull // transcolor is transparent
+#define NCVISUAL_OPTION_CHILDPLANE 0x0020ull // new plane is child of n
 
 struct ncvisual_options {
   // if no ncplane is provided, one will be created using the exact size
@@ -3176,6 +3178,7 @@ struct ncvisual_options {
   // chosen for NCBLIT_DEFAULT.
   ncblitter_e blitter; // glyph set to use (maps input to output cells)
   uint64_t flags; // bitmask over NCVISUAL_OPTION_*
+  uint32_t transcolor; // used only if NCVISUAL_OPTION_ADDALPHA is set
 };
 
 typedef enum {

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2424,11 +2424,13 @@ API ALLOC struct ncvisual* ncvisual_from_plane(const struct ncplane* n,
 #define NCVISUAL_OPTION_HORALIGNED 0x0004ull // x is an alignment, not absolute
 #define NCVISUAL_OPTION_VERALIGNED 0x0008ull // y is an alignment, not absolute
 #define NCVISUAL_OPTION_ADDALPHA   0x0010ull // transcolor is in effect
+#define NCVISUAL_OPTION_CHILDPLANE 0x0020ull // interpret n as parent
 
 struct ncvisual_options {
   // if no ncplane is provided, one will be created using the exact size
   // necessary to render the source with perfect fidelity (this might be
-  // smaller or larger than the rendering area).
+  // smaller or larger than the rendering area). if NCVISUAL_OPTION_CHILDPLANE
+  // is provided, this must be non-NULL, and will be interpreted as the parent.
   struct ncplane* n;
   // the scaling is ignored if no ncplane is provided (it ought be NCSCALE_NONE
   // in this case). otherwise, the source is stretched/scaled relative to the

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -36,91 +36,6 @@ int ncdirect_putstr(ncdirect* nc, uint64_t channels, const char* utf8){
   return fprintf(nc->ttyfp, "%s", utf8);
 }
 
-int ncdirect_cursor_up(ncdirect* nc, int num){
-  if(num < 0){
-    return -1;
-  }
-  if(!nc->tcache.cuu){
-    return -1;
-  }
-  return term_emit(tiparm(nc->tcache.cuu, num), nc->ttyfp, false);
-}
-
-int ncdirect_cursor_left(ncdirect* nc, int num){
-  if(num < 0){
-    return -1;
-  }
-  if(!nc->tcache.cub){
-    return -1;
-  }
-  return term_emit(tiparm(nc->tcache.cub, num), nc->ttyfp, false);
-}
-
-int ncdirect_cursor_right(ncdirect* nc, int num){
-  if(num < 0){
-    return -1;
-  }
-  if(!nc->tcache.cuf){ // FIXME fall back to cuf1
-    return -1;
-  }
-  return term_emit(tiparm(nc->tcache.cuf, num), nc->ttyfp, false);
-}
-
-int ncdirect_cursor_down(ncdirect* nc, int num){
-  if(num < 0){
-    return -1;
-  }
-  if(!nc->tcache.cud){
-    return -1;
-  }
-  return term_emit(tiparm(nc->tcache.cud, num), nc->ttyfp, false);
-}
-
-int ncdirect_clear(ncdirect* nc){
-  if(!nc->tcache.clearscr){
-    return -1; // FIXME scroll output off the screen
-  }
-  return term_emit(nc->tcache.clearscr, nc->ttyfp, true);
-}
-
-int ncdirect_dim_x(const ncdirect* nc){
-  int x;
-  if(nc->ctermfd >= 0){
-    if(update_term_dimensions(nc->ctermfd, NULL, &x, NULL) == 0){
-      return x;
-    }
-  }else{
-    return 80; // lol
-  }
-  return -1;
-}
-
-int ncdirect_dim_y(const ncdirect* nc){
-  int y;
-  if(nc->ctermfd >= 0){
-    if(update_term_dimensions(nc->ctermfd, &y, NULL, NULL) == 0){
-      return y;
-    }
-  }else{
-    return 24; // lol
-  }
-  return -1;
-}
-
-int ncdirect_cursor_enable(ncdirect* nc){
-  if(!nc->tcache.cnorm){
-    return -1;
-  }
-  return term_emit(nc->tcache.cnorm, nc->ttyfp, true);
-}
-
-int ncdirect_cursor_disable(ncdirect* nc){
-  if(!nc->tcache.civis){
-    return -1;
-  }
-  return term_emit(nc->tcache.civis, nc->ttyfp, true);
-}
-
 static int
 cursor_yx_get(int ttyfd, int* y, int* x){
   if(writen(ttyfd, "\033[6n", 4) != 4){
@@ -183,6 +98,105 @@ cursor_yx_get(int ttyfd, int* y, int* x){
     *x = column;
   }
   return 0;
+}
+
+int ncdirect_cursor_up(ncdirect* nc, int num){
+  if(num < 0){
+    return -1;
+  }
+  if(num == 0){
+    return 0;
+  }
+  if(!nc->tcache.cuu){
+    return -1;
+  }
+  return term_emit(tiparm(nc->tcache.cuu, num), nc->ttyfp, false);
+}
+
+int ncdirect_cursor_left(ncdirect* nc, int num){
+  if(num < 0){
+    return -1;
+  }
+  if(num == 0){
+    return 0;
+  }
+  if(!nc->tcache.cub){
+    return -1;
+  }
+  return term_emit(tiparm(nc->tcache.cub, num), nc->ttyfp, false);
+}
+
+int ncdirect_cursor_right(ncdirect* nc, int num){
+  if(num < 0){
+    return -1;
+  }
+  if(num == 0){
+    return 0;
+  }
+  if(!nc->tcache.cuf){ // FIXME fall back to cuf1
+    return -1;
+  }
+  return term_emit(tiparm(nc->tcache.cuf, num), nc->ttyfp, false);
+}
+
+// if we're on the last line, we need some scrolling action.
+int ncdirect_cursor_down(ncdirect* nc, int num){
+
+  if(num < 0){
+    return -1;
+  }
+  if(num == 0){
+    return 0;
+  }
+  if(!nc->tcache.cud){
+    return -1;
+  }
+  return term_emit(tiparm(nc->tcache.cud, num), nc->ttyfp, false);
+}
+
+int ncdirect_clear(ncdirect* nc){
+  if(!nc->tcache.clearscr){
+    return -1; // FIXME scroll output off the screen
+  }
+  return term_emit(nc->tcache.clearscr, nc->ttyfp, true);
+}
+
+int ncdirect_dim_x(const ncdirect* nc){
+  int x;
+  if(nc->ctermfd >= 0){
+    if(update_term_dimensions(nc->ctermfd, NULL, &x, NULL) == 0){
+      return x;
+    }
+  }else{
+    return 80; // lol
+  }
+  return -1;
+}
+
+int ncdirect_dim_y(const ncdirect* nc){
+  int y;
+  if(nc->ctermfd >= 0){
+    if(update_term_dimensions(nc->ctermfd, &y, NULL, NULL) == 0){
+      return y;
+    }
+  }else{
+    return 24; // lol
+  }
+  return -1;
+}
+
+int ncdirect_cursor_enable(ncdirect* nc){
+  if(!nc->tcache.cnorm){
+    return -1;
+  }
+  return term_emit(nc->tcache.cnorm, nc->ttyfp, true);
+}
+
+int ncdirect_cursor_disable(ncdirect* nc){
+  if(!nc->tcache.civis){
+    return -1;
+  }
+  return term_emit(nc->tcache.civis, nc->ttyfp, true);
 }
 
 // if we're lacking hpa/vpa, *and* -1 is passed for one of x/y, *and* we've

--- a/src/poc/dirlines.c
+++ b/src/poc/dirlines.c
@@ -13,6 +13,7 @@ int main(void){
     ncchannels_set_fg_rgb8(&c1, 0x0, 0x10 * i, 0xff);
     ncchannels_set_fg_rgb8(&c2, 0x10 * i, 0x0, 0x0);
     if(ncdirect_hline_interp(n, "-", i, c1, c2) < i){
+      ncdirect_stop(n);
       return EXIT_FAILURE;
     }
     ncdirect_set_fg_default(n);
@@ -24,12 +25,14 @@ int main(void){
     ncchannels_set_fg_rgb8(&c1, 0x0, 0x10 * i, 0xff);
     ncchannels_set_fg_rgb8(&c2, 0x10 * i, 0x0, 0x0);
     if(ncdirect_vline_interp(n, "|", i, c1, c2) < i){
+      ncdirect_stop(n);
       return EXIT_FAILURE;
     }
     ncdirect_set_fg_default(n);
     ncdirect_set_bg_default(n);
     if(i < 14){
       if(ncdirect_cursor_up(n, i)){
+        ncdirect_stop(n);
         return EXIT_FAILURE;
       }
     }
@@ -42,10 +45,12 @@ int main(void){
   ncchannels_set_fg_rgb8(&ll, 0x0, 0x0, 0xff);
   ncchannels_set_fg_rgb8(&lr, 0xff, 0x0, 0x0);
   if(ncdirect_rounded_box(n, ul, ur, ll, lr, 10, 10, 0) < 0){
+    ncdirect_stop(n);
     return EXIT_FAILURE;
   }
   ncdirect_cursor_up(n, 9);
   if(ncdirect_double_box(n, ul, ur, ll, lr, 10, 20, 0) < 0){
+    ncdirect_stop(n);
     return EXIT_FAILURE;
   }
   if(ncdirect_stop(n)){

--- a/src/poc/dirlines.c
+++ b/src/poc/dirlines.c
@@ -53,6 +53,7 @@ int main(void){
     ncdirect_stop(n);
     return EXIT_FAILURE;
   }
+  printf("\n");
   if(ncdirect_stop(n)){
     return EXIT_FAILURE;
   }

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -302,7 +302,7 @@ TEST_CASE("Bitmaps") {
       .x = NCALIGN_CENTER,
       .begy = 0, .begx = 0,
       .leny = 0, .lenx = 0,
-      .blitter = NCBLIT_1x1,
+      .blitter = NCBLIT_PIXEL,
       .flags = NCVISUAL_OPTION_CHILDPLANE |
                NCVISUAL_OPTION_HORALIGNED |
                NCVISUAL_OPTION_VERALIGNED,
@@ -344,7 +344,7 @@ TEST_CASE("Bitmaps") {
       .x = NCALIGN_CENTER,
       .begy = 0, .begx = 0,
       .leny = 0, .lenx = 0,
-      .blitter = NCBLIT_1x1,
+      .blitter = NCBLIT_PIXEL,
       .flags = NCVISUAL_OPTION_CHILDPLANE |
                NCVISUAL_OPTION_HORALIGNED |
                NCVISUAL_OPTION_VERALIGNED,

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -507,13 +507,94 @@ TEST_CASE("Visual") {
     }
   }
 
+  // test NCVISUAL_OPTIONS_CHILDPLANE + stretch + (null) alignment
+  SUBCASE("ImageChildScaling") {
+    struct ncplane_options opts = {
+      .y = 0, .x = 0,
+      .rows = 5, .cols = 5,
+      .userptr = nullptr,
+      .name = "parent",
+      .resizecb = nullptr,
+      .flags = 0,
+      .margin_b = 0,
+      .margin_r = 0,
+    };
+    auto parent = ncplane_create(n_, &opts);
+    REQUIRE(parent);
+    struct ncvisual_options vopts = {
+      .n = parent,
+      .scaling = NCSCALE_STRETCH,
+      .y = NCALIGN_CENTER,
+      .x = NCALIGN_CENTER,
+      .begy = 0, .begx = 0,
+      .leny = 0, .lenx = 0,
+      .blitter = NCBLIT_1x1,
+      .flags = NCVISUAL_OPTION_CHILDPLANE |
+               NCVISUAL_OPTION_HORALIGNED |
+               NCVISUAL_OPTION_VERALIGNED,
+      .transcolor = 0,
+    };
+    const uint32_t pixels[1] = { htole(0xffffffff) };
+    auto ncv = ncvisual_from_rgba(pixels, 1, 4, 1);
+    REQUIRE(ncv);
+    auto child = ncvisual_render(nc_, ncv, &vopts);
+    REQUIRE(child);
+    CHECK(5 == ncplane_dim_y(child));
+    CHECK(5 == ncplane_dim_x(child));
+    CHECK(0 == ncplane_y(child));
+    CHECK(0 == ncplane_x(child));
+    ncvisual_destroy(ncv);
+    CHECK(0 == ncplane_destroy(parent));
+    CHECK(0 == ncplane_destroy(child));
+  }
+
+  SUBCASE("ImageChildAlignment") {
+    struct ncplane_options opts = {
+      .y = 0, .x = 0,
+      .rows = 5, .cols = 5,
+      .userptr = nullptr,
+      .name = "parent",
+      .resizecb = nullptr,
+      .flags = 0,
+      .margin_b = 0,
+      .margin_r = 0,
+    };
+    auto parent = ncplane_create(n_, &opts);
+    REQUIRE(parent);
+    struct ncvisual_options vopts = {
+      .n = parent,
+      .scaling = NCSCALE_NONE,
+      .y = NCALIGN_CENTER,
+      .x = NCALIGN_CENTER,
+      .begy = 0, .begx = 0,
+      .leny = 0, .lenx = 0,
+      .blitter = NCBLIT_1x1,
+      .flags = NCVISUAL_OPTION_CHILDPLANE |
+               NCVISUAL_OPTION_HORALIGNED |
+               NCVISUAL_OPTION_VERALIGNED,
+      .transcolor = 0,
+    };
+    const uint32_t pixels[1] = { htole(0xffffffff) };
+    auto ncv = ncvisual_from_rgba(pixels, 1, 4, 1);
+    REQUIRE(ncv);
+    auto child = ncvisual_render(nc_, ncv, &vopts);
+    REQUIRE(child);
+    CHECK(1 == ncplane_dim_y(child));
+    CHECK(1 == ncplane_dim_x(child));
+    CHECK(2 == ncplane_y(child));
+    CHECK(2 == ncplane_x(child));
+    ncvisual_destroy(ncv);
+    CHECK(0 == ncplane_destroy(parent));
+    CHECK(0 == ncplane_destroy(child));
+  }
+
 #ifndef NOTCURSES_USE_MULTIMEDIA
-  SUBCASE("VisualDisabled"){
+  SUBCASE("VisualDisabled") {
     CHECK(!notcurses_canopen_images(nc_));
     CHECK(!notcurses_canopen_videos(nc_));
   }
 #else
-  SUBCASE("ImagesEnabled"){
+  SUBCASE("ImagesEnabled") {
     CHECK(notcurses_canopen_images(nc_));
   }
 


### PR DESCRIPTION
Add documentation and `NEWS.md` entry for `NCVISUAL_OPTION_CHILDPLANE`. Update `ncvisual_blitset_geom()` to check that when `NCVISUAL_OPTION_CHILDPLANE` is provided, `n` is also set. Implement `NCVISUAL_OPTION_CHILDPLANE` on both cell and bitmap paths. Add unit test for both paths, one test using scaling, and one not. Closes #1603.