### PR TITLE
Invalidate sprixel following a rebuild

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1012,6 +1012,7 @@ sprite_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
     free(auxvec);
     s->n->tam[s->dimx * ycell + xcell].auxvector = NULL;
   }
+  s->invalidated = SPRIXEL_INVALIDATED;
   return ret;
 }
 

--- a/src/poc/wipebitmap.c
+++ b/src/poc/wipebitmap.c
@@ -26,9 +26,11 @@ wipebitmap(struct notcurses* nc){
     return -1;
   }
   ncvisual_destroy(ncv);
+  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see full square");
   notcurses_render(nc);
   sleep(3);
 
+  ncplane_erase(notcurses_stdplane(nc));
   for(int y = 1 ; y < 5 ; ++y){
     for(int x = 1 ; x < 5 ; ++x){
       ncplane_putchar_yx(notcurses_stdplane(nc), y, x, '*');
@@ -39,24 +41,43 @@ wipebitmap(struct notcurses* nc){
   ncchannels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
   ncplane_set_base(notcurses_stdplane(nc), "", 0, channels);
   ncplane_move_top(notcurses_stdplane(nc));
+  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see 16 *s");
   notcurses_render(nc);
   sleep(3);
 
   ncplane_erase(notcurses_stdplane(nc));
+  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see full square");
   notcurses_render(nc);
   sleep(3);
 
-  for(int i = cellpxy ; i < cellpxy + cellpxy ; ++i){
-    memset(pixels + (i * cellpxx), 0, sizeof(cellpxx) * 6 * sizeof(*pixels));
+  ncplane_erase(notcurses_stdplane(nc));
+  for(int y = 1 ; y < 5 ; ++y){
+    for(int x = 1 ; x < 5 ; ++x){
+      ncplane_putchar_yx(notcurses_stdplane(nc), y, x, ' ');
+    }
+  }
+  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see 16 spaces");
+  notcurses_render(nc);
+  sleep(3);
+
+  ncplane_erase(notcurses_stdplane(nc));
+  ncplane_destroy(n);
+  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see nothing");
+  notcurses_render(nc);
+  sleep(3);
+
+  ncplane_erase(notcurses_stdplane(nc));
+  for(int i = cellpxy ; i < 5 * cellpxy ; ++i){
+    memset(pixels + (i * 6 * cellpxx + cellpxx), 0, cellpxx * 4 * sizeof(*pixels));
   }
   ncv = ncvisual_from_rgba(pixels, 6 * cellpxy, 6 * cellpxx * 4, 6 * cellpxx);
   if(ncv == NULL){
     return -1;
   }
-  vopts.n = n;
-  if(ncvisual_render(nc, ncv, &vopts) == NULL){
+  if((n = ncvisual_render(nc, ncv, &vopts)) == NULL){
     return -1;
   }
+  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see empty square");
   ncvisual_destroy(ncv);
   notcurses_render(nc);
   ncplane_destroy(n);


### PR DESCRIPTION
The `wipebitmap` PoC made plain that we weren't invalidating sprixels following a rebuild. As a result, the rebuild wouldn't be visible. Fix that up.