### PR TITLE
Sixel: properly set P2=1 on reloaded visuals with cached wipes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ rearrangements of Notcurses.
     static linking on systems with libtinfo embedded into libncurses.
   * Added `ncblit_rgb_loose()` and `ncblit_rgb_packed()` helpers for blitting
     32bpp RGBx and 24bpp RGB.
+  * Added `ncplane_erase_region()` to initialize all `nccell`s within a
+    region of a plane.
 
 * 2.2.10 (2021-05-05)
   * Added `NCVISUAL_OPTION_CHILDPLANE` to interpret the `n` field of

--- a/USAGE.md
+++ b/USAGE.md
@@ -820,6 +820,14 @@ int ncplane_mergedown_simple(const ncplane* restrict src, ncplane* restrict dst)
 // with this ncplane are invalidated, and must not be used after the call,
 // excluding the base cell. The cursor is homed.
 void ncplane_erase(struct ncplane* n);
+
+// Erase every cell in the region starting at {ystart, xstart} and having size
+// {ylen, xlen}. It is an error if any of ystart, xstart, ylen, or xlen is
+// negative. A value of 0 may be provided for ylen and/or xlen, meaning to
+// erase everything along that dimension. It is an error if ystart + ylen
+// or xstart + xlen is not in the plane.
+int ncplane_erase_region(struct ncplane* n, int ystart, int xstart,
+                         int ylen, int xlen);
 ```
 
 All planes, including the standard plane, are created with scrolling disabled.

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -192,6 +192,8 @@ typedef struct ncplane_options {
 
 **void ncplane_erase(struct ncplane* ***n***);**
 
+**int ncplane_erase_region(struct ncplane* ***n***, int ***ystart***, int ***xstart***, int ***ylen***, int ***xlen***);**
+
 **bool ncplane_set_scrolling(struct ncplane* ***n***, bool ***scrollp***);**
 
 **int ncplane_rotate_cw(struct ncplane* ***n***);**
@@ -286,6 +288,9 @@ might see changes. It is an error to merge a plane onto itself.
 
 **ncplane_erase** zeroes out every cell of the plane, dumps the egcpool, and
 homes the cursor. The base cell is preserved, as are the active attributes.
+**ncplane_erase_region** does the same for a subregion of the plane. For the
+latter, supply 0 for ***ylen*** and/or ***xlen*** to erase through that
+dimension, starting at the specified point.
 
 When a plane is resized (whether by **ncplane_resize**, **SIGWINCH**, or any
 other mechanism), a depth-first recursion is performed on its children.
@@ -396,6 +401,9 @@ destroyed. The caller should release this **nccell** with **nccell_release**.
 
 **ncplane_as_rgba** returns a heap-allocated array of **uint32_t** values,
 each representing a single RGBA pixel, or **NULL** on failure.
+
+**ncplane_erase_region** returns -1 if any of its parameters are negative, or
+if they specify any area beyond the plane.
 
 Functions returning **int** return 0 on success, and non-zero on error.
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1982,6 +1982,15 @@ API int ncplane_mergedown(struct ncplane* RESTRICT src,
 // The cursor is homed. The plane's active attributes are unaffected.
 API void ncplane_erase(struct ncplane* n);
 
+// Erase every cell in the region starting at {ystart, xstart} and having size
+// {ylen, xlen}. It is an error if any of ystart, xstart, ylen, or xlen is
+// negative. A value of 0 may be provided for ylen and/or xlen, meaning to
+// erase everything along that dimension. It is an error if ystart + ylen
+// or xstart + xlen is not in the plane.
+API int ncplane_erase_region(struct ncplane* n, int ystart, int xstart,
+                             int ylen, int xlen)
+  __attribute__ ((nonnull (1)));
+
 // Extract 24 bits of foreground RGB from 'cl', shifted to LSBs.
 static inline uint32_t
 nccell_fg_rgb(const nccell* cl){

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -993,7 +993,7 @@ sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
 // precondition: s->invalidated is SPRIXEL_INVALIDATED or SPRIXEL_MOVED.
 static inline int
 sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-//sprixel_debug(stderr, s);
+sprixel_debug(stderr, s);
   return n->tcache.pixel_draw(p, s, out);
 }
 

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -993,7 +993,7 @@ sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
 // precondition: s->invalidated is SPRIXEL_INVALIDATED or SPRIXEL_MOVED.
 static inline int
 sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-sprixel_debug(stderr, s);
+//sprixel_debug(stderr, s);
   return n->tcache.pixel_draw(p, s, out);
 }
 

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -336,13 +336,13 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
 }
 
 int kitty_wipe(sprixel* s, int ycell, int xcell){
-//fprintf(stderr, "WIPING %d/%d\n", ycell, xcell);
+fprintf(stderr, "WIPING %d/%d\n", ycell, xcell);
   if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
-//fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
+fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 0; // already annihilated, needn't draw glyph in kitty
   }
   uint8_t* auxvec = sprixel_auxiliary_vector(s);
-//fprintf(stderr, "NEW WIPE %d %d/%d\n", s->id, ycell, xcell);
+fprintf(stderr, "NEW WIPE %d %d/%d\n", s->id, ycell, xcell);
   const int totalpixels = s->pixy * s->pixx;
   const int xpixels = s->cellpxx;
   const int ypixels = s->cellpxy;
@@ -586,15 +586,18 @@ int kitty_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
           sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy - stdn->absy,
                                               xx - s->movedfromx + s->n->absx - stdn->absx);
           if(state == SPRIXCELL_OPAQUE_KITTY){
+fprintf(stderr, "DAMAGED 1\n");
             r->s.damaged = 1;
           }else if(s->invalidated == SPRIXEL_MOVED){
             // ideally, we wouldn't damage our annihilated sprixcells, but if
             // we're being annihilated only during this cycle, we need to go
             // ahead and damage it.
+fprintf(stderr, "DAMAGED 2\n");
             r->s.damaged = 1;
           }
         }else{
-          r->s.damaged = 1;
+fprintf(stderr, "DAMAGED 3\n");
+          //r->s.damaged = 1;
         }
       }
     }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -336,13 +336,8 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
 }
 
 int kitty_wipe(sprixel* s, int ycell, int xcell){
-fprintf(stderr, "WIPING %d/%d\n", ycell, xcell);
-  if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
-fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
-    return 0; // already annihilated, needn't draw glyph in kitty
-  }
+//fprintf(stderr, "NEW WIPE %d %d/%d\n", s->id, ycell, xcell);
   uint8_t* auxvec = sprixel_auxiliary_vector(s);
-fprintf(stderr, "NEW WIPE %d %d/%d\n", s->id, ycell, xcell);
   const int totalpixels = s->pixy * s->pixx;
   const int xpixels = s->cellpxx;
   const int ypixels = s->cellpxy;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -586,17 +586,17 @@ int kitty_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
           sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy - stdn->absy,
                                               xx - s->movedfromx + s->n->absx - stdn->absx);
           if(state == SPRIXCELL_OPAQUE_KITTY){
-fprintf(stderr, "DAMAGED 1\n");
+//fprintf(stderr, "DAMAGED 1\n");
             r->s.damaged = 1;
           }else if(s->invalidated == SPRIXEL_MOVED){
             // ideally, we wouldn't damage our annihilated sprixcells, but if
             // we're being annihilated only during this cycle, we need to go
             // ahead and damage it.
-fprintf(stderr, "DAMAGED 2\n");
+//fprintf(stderr, "DAMAGED 2\n");
             r->s.damaged = 1;
           }
         }else{
-fprintf(stderr, "DAMAGED 3\n");
+//fprintf(stderr, "DAMAGED 3\n");
           //r->s.damaged = 1;
         }
       }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2030,6 +2030,39 @@ void ncplane_erase(ncplane* n){
   n->y = n->x = 0;
 }
 
+int ncplane_erase_region(ncplane* n, int ystart, int xstart, int ylen, int xlen){
+  const notcurses* nc = ncplane_notcurses_const(n);
+  if(ylen < 0 || xlen < 0){
+    logerror(nc, "Won't erase section of negative length (%d, %d)\n", ylen, xlen);
+    return -1;
+  }
+  if(ystart < 0 || xstart < 0){
+    logerror(nc, "Illegal start of erase (%d, %d)\n", ystart, xstart);
+    return -1;
+  }
+  if(ystart >= ncplane_dim_y(n) || ystart + ylen > ncplane_dim_y(n)){
+    logerror(nc, "Illegal y spec for erase (%d, %d)\n", ystart, ylen);
+    return -1;
+  }
+  if(ylen == 0){
+    ylen = ncplane_dim_y(n) - ystart;
+  }
+  if(xstart >= ncplane_dim_x(n) || xstart + xlen > ncplane_dim_x(n)){
+    logerror(nc, "Illegal x spec for erase (%d, %d)\n", xstart, xlen);
+    return -1;
+  }
+  if(xlen == 0){
+    xlen = ncplane_dim_x(n) - ystart;
+  }
+  for(int y = ystart ; y < ystart + ylen ; ++y){
+    for(int x = xstart ; x < xstart + xlen ; ++x){
+      nccell_release(n, &n->fb[nfbcellidx(n, y, x)]);
+      nccell_init(&n->fb[nfbcellidx(n, y, x)]);
+    }
+  }
+  return 0;
+}
+
 ncplane* notcurses_top(notcurses* n){
   return ncplane_pile(n->stdplane)->top;
 }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -174,7 +174,7 @@ paint_sprixel(ncplane* p, struct crender* rvec, int starty, int startx,
         // if sprite_wipe_cell() fails, we presumably do not have the
         // ability to wipe, and must reprint the character
         if(sprite_wipe(nc, p->sprite, y, x)){
-fprintf(stderr, "damaging due to wipe [%s] %d/%d\n", nccell_extended_gcluster(crender->p, &crender->c), absy, absx);
+//fprintf(stderr, "damaging due to wipe [%s] %d/%d\n", nccell_extended_gcluster(crender->p, &crender->c), absy, absx);
           crender->s.damaged = 1;
         }
         crender->s.p_beats_sprixel = 1;
@@ -441,17 +441,16 @@ postpaint_cell(nccell* lastframe, int dimx, struct crender* crender,
   nccell* targc = &crender->c;
   lock_in_highcontrast(targc, crender);
   nccell* prevcell = &lastframe[fbcellidx(y, dimx, *x)];
-if(y < 5 && *x < 5) fprintf(stderr, "taking a look at %d/%d %08x %08x [%u]\n", y, *x, prevcell->gcluster, crender->c.gcluster, crender->s.damaged);
   if(cellcmp_and_dupfar(pool, prevcell, crender->p, targc) > 0){
 //fprintf(stderr, "damaging due to cmp [%s] %d %d\n", nccell_extended_gcluster(crender->p, &crender->c), y, *x);
     if(crender->sprixel){
       sprixcell_e state = sprixel_state(crender->sprixel, y, *x);
       if(!crender->s.p_beats_sprixel && state != SPRIXCELL_OPAQUE_KITTY && state != SPRIXCELL_OPAQUE_SIXEL){
-fprintf(stderr, "damaged due to opaque\n");
+//fprintf(stderr, "damaged due to opaque\n");
         crender->s.damaged = 1;
       }
     }else{
-fprintf(stderr, "damaged due to opaque else %d %d\n", y, *x);
+//fprintf(stderr, "damaged due to opaque else %d %d\n", y, *x);
       crender->s.damaged = 1;
     }
     assert(!nccell_wide_right_p(targc));
@@ -923,7 +922,7 @@ clean_sprixels(notcurses* nc, ncpile* p, FILE* out){
   int ret = 0;
   while( (s = *parent) ){
     if(s->invalidated == SPRIXEL_HIDE){
-fprintf(stderr, "OUGHT HIDE %d [%dx%d] %p\n", s->id, s->dimy, s->dimx, s);
+//fprintf(stderr, "OUGHT HIDE %d [%dx%d] %p\n", s->id, s->dimy, s->dimx, s);
       if(sprite_destroy(nc, p, out, s) == 0){
         if( (*parent = s->next) ){
           s->next->prev = s->prev;
@@ -1010,7 +1009,7 @@ rasterize_core(notcurses* nc, const ncpile* p, FILE* out, unsigned phase){
           ++x;
         }
       }else if(phase != 0 || !rvec[damageidx].s.p_beats_sprixel){
-fprintf(stderr, "phase %u damaged at %d/%d\n", phase, innery, innerx);
+//fprintf(stderr, "phase %u damaged at %d/%d\n", phase, innery, innerx);
         // in the first text phase, we draw only those glyphs where the glyph
         // was not above a sprixel (and the cell is damaged). in the second
         // phase, we draw everything that remains damaged.
@@ -1085,7 +1084,7 @@ fprintf(stderr, "phase %u damaged at %d/%d\n", phase, innery, innerx);
           nc->rstate.bgdefelidable = false;
           nc->rstate.bgpalelidable = false;
         }
-fprintf(stderr, "RAST %08x [%s] to %d/%d cols: %u %016lx\n", srccell->gcluster, pool_extended_gcluster(&nc->pool, srccell), y, x, srccell->width, srccell->channels);
+//fprintf(stderr, "RAST %08x [%s] to %d/%d cols: %u %016lx\n", srccell->gcluster, pool_extended_gcluster(&nc->pool, srccell), y, x, srccell->width, srccell->channels);
         // this is used to invalidate the sprixel in the first text round,
         // which is only necessary for sixel, not kitty.
         if(rvec[damageidx].sprixel){
@@ -1106,8 +1105,6 @@ fprintf(stderr, "RAST %08x [%s] to %d/%d cols: %u %016lx\n", srccell->gcluster, 
           x += srccell->width - 1;
           nc->rstate.x += srccell->width - 1;
         }
-      }else{
-fprintf(stderr, "YEET phase %u damaged at %d/%d\n", phase, innery, innerx);
       }
 //fprintf(stderr, "damageidx: %ld\n", damageidx);
     }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -923,7 +923,7 @@ clean_sprixels(notcurses* nc, ncpile* p, FILE* out){
   int ret = 0;
   while( (s = *parent) ){
     if(s->invalidated == SPRIXEL_HIDE){
-//fprintf(stderr, "OUGHT HIDE %d [%dx%d] %p\n", s->id, s->dimy, s->dimx, s);
+fprintf(stderr, "OUGHT HIDE %d [%dx%d] %p\n", s->id, s->dimy, s->dimx, s);
       if(sprite_destroy(nc, p, out, s) == 0){
         if( (*parent = s->next) ){
           s->next->prev = s->prev;

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -262,7 +262,8 @@ extract_color_table(const uint32_t* data, int linesize, int cols,
         const uint32_t* rgb = (data + (linesize / 4 * sy) + visx);
         int txyidx = (sy / cdimy) * cols + (visx / cdimx);
         if(tam[txyidx].state == SPRIXCELL_ANNIHILATED || tam[txyidx].state == SPRIXCELL_ANNIHILATED_TRANS){
-fprintf(stderr, "TRANS SKIP %d %d %d %d (cell: %d %d)\n", visy, visx, sy, txyidx, sy / cdimy, visx / cdimx);
+//fprintf(stderr, "TRANS SKIP %d %d %d %d (cell: %d %d)\n", visy, visx, sy, txyidx, sy / cdimy, visx / cdimx);
+          stab->p2 = SIXEL_P2_TRANS; // even one forces P2=1
           continue;
         }
         if(rgba_trans_p(*rgb, bargs->transcolor)){
@@ -844,10 +845,6 @@ wipe_color(sixelmap* smap, int color, int sband, int eband,
 // using sixel. we just mark it as partially transparent, so that if it's
 // redrawn, it's redrawn using P2=1.
 int sixel_wipe(sprixel* s, int ycell, int xcell){
-  if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
-//fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
-    return 1; // already annihilated FIXME but 0 breaks things
-  }
 //fprintf(stderr, "WIPING %d/%d\n", ycell, xcell);
   uint8_t* auxvec = sprixel_auxiliary_vector(s);
   memset(auxvec + s->cellpxx * s->cellpxy, 0xff, s->cellpxx * s->cellpxy);

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -262,7 +262,7 @@ extract_color_table(const uint32_t* data, int linesize, int cols,
         const uint32_t* rgb = (data + (linesize / 4 * sy) + visx);
         int txyidx = (sy / cdimy) * cols + (visx / cdimx);
         if(tam[txyidx].state == SPRIXCELL_ANNIHILATED || tam[txyidx].state == SPRIXCELL_ANNIHILATED_TRANS){
-//fprintf(stderr, "TRANS SKIP %d %d %d %d (cell: %d %d)\n", visy, visx, sy, txyidx, sy / cdimy, visx / cdimx);
+fprintf(stderr, "TRANS SKIP %d %d %d %d (cell: %d %d)\n", visy, visx, sy, txyidx, sy / cdimy, visx / cdimx);
           continue;
         }
         if(rgba_trans_p(*rgb, bargs->transcolor)){
@@ -696,7 +696,7 @@ int sixel_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
     for(int xx = startx ; xx < startx + s->dimx && xx < p->dimx ; ++xx){
       struct crender *r = &p->crender[yy * p->dimx + xx];
       if(!r->sprixel){
-        r->s.damaged = 1;
+        //r->s.damaged = 1;
       }
     }
   }
@@ -846,7 +846,7 @@ wipe_color(sixelmap* smap, int color, int sband, int eband,
 int sixel_wipe(sprixel* s, int ycell, int xcell){
   if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
-    return 1; // already annihilated FIXME but 0 breaks things
+    return 0; // already annihilated FIXME but 0 breaks things
   }
 //fprintf(stderr, "WIPING %d/%d\n", ycell, xcell);
   uint8_t* auxvec = sprixel_auxiliary_vector(s);

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -696,7 +696,7 @@ int sixel_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
     for(int xx = startx ; xx < startx + s->dimx && xx < p->dimx ; ++xx){
       struct crender *r = &p->crender[yy * p->dimx + xx];
       if(!r->sprixel){
-        //r->s.damaged = 1;
+        r->s.damaged = 1;
       }
     }
   }
@@ -846,7 +846,7 @@ wipe_color(sixelmap* smap, int color, int sband, int eband,
 int sixel_wipe(sprixel* s, int ycell, int xcell){
   if(s->n->tam[s->dimx * ycell + xcell].state == SPRIXCELL_ANNIHILATED){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
-    return 0; // already annihilated FIXME but 0 breaks things
+    return 1; // already annihilated FIXME but 0 breaks things
   }
 //fprintf(stderr, "WIPING %d/%d\n", ycell, xcell);
   uint8_t* auxvec = sprixel_auxiliary_vector(s);

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -5,8 +5,8 @@
 static atomic_uint_fast32_t sprixelid_nonce;
 
 void sprixel_debug(FILE* out, const sprixel* s){
-  fprintf(out, "Sprixel %d (%p) %dx%d (%dx%d) @%d/%d state: %d\n",
-          s->id, s, s->dimy, s->dimx, s->pixy, s->pixx,
+  fprintf(out, "Sprixel %d (%p) %dB %dx%d (%dx%d) @%d/%d state: %d\n",
+          s->id, s, s->glyphlen, s->dimy, s->dimx, s->pixy, s->pixx,
           s->n ? s->n->absy : 0, s->n ? s->n->absx : 0,
           s->invalidated);
   if(s->n){

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -82,7 +82,6 @@ void sprixel_movefrom(sprixel* s, int y, int x){
 
 void sprixel_hide(sprixel* s){
   if(ncplane_pile(s->n) == NULL){ // ncdirect case; destroy now
-fprintf(stderr, "DESTROY IMMEDIATELY\n");
     sprixel_free(s);
     return;
   }
@@ -187,9 +186,9 @@ int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
     s->n->tam[idx].state = SPRIXCELL_ANNIHILATED_TRANS;
     return 1;
   }
-  if(s->n->tam[idx].state == SPRIXCELL_ANNIHILATED_TRANS){
-    // both handle this correctly; one day, we will also check for ANNIHILATED
-    // here, and return 0 (sixel currently must return 1) FIXME
+  if(s->n->tam[idx].state == SPRIXCELL_ANNIHILATED_TRANS ||
+      s->n->tam[idx].state == SPRIXCELL_ANNIHILATED){
+//fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 0;
   }
 //fprintf(stderr, "ANNIHILATING %p %d\n", s->n->tam, idx);

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -82,6 +82,7 @@ void sprixel_movefrom(sprixel* s, int y, int x){
 
 void sprixel_hide(sprixel* s){
   if(ncplane_pile(s->n) == NULL){ // ncdirect case; destroy now
+fprintf(stderr, "DESTROY IMMEDIATELY\n");
     sprixel_free(s);
     return;
   }

--- a/src/poc/textplay.c
+++ b/src/poc/textplay.c
@@ -108,7 +108,9 @@ textplay(struct notcurses* nc, struct ncplane* tplane, struct ncvisual* ncv){
     if(!ncv){
       clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, NULL);
     }else{
-      ncvisual_decode(ncv);
+      for(int i = 0 ; i < 3 ; ++i){
+        ncvisual_decode(ncv);
+      }
     }
   }
   ncplane_destroy(vopts.n);

--- a/src/poc/wipebitmap.c
+++ b/src/poc/wipebitmap.c
@@ -25,10 +25,10 @@ wipebitmap(struct notcurses* nc){
   if(n == NULL){
     return -1;
   }
-  ncvisual_destroy(ncv);
   ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see full square");
+  notcurses_debug(nc, stderr);
   notcurses_render(nc);
-  sleep(3);
+  sleep(2);
 
   ncplane_erase(notcurses_stdplane(nc));
   for(int y = 1 ; y < 5 ; ++y){
@@ -43,12 +43,13 @@ wipebitmap(struct notcurses* nc){
   ncplane_move_top(notcurses_stdplane(nc));
   ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see 16 *s");
   notcurses_render(nc);
-  sleep(3);
+  sleep(2);
 
   ncplane_erase(notcurses_stdplane(nc));
   ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see full square");
+  notcurses_debug(nc, stderr);
   notcurses_render(nc);
-  sleep(3);
+  sleep(2);
 
   ncplane_erase(notcurses_stdplane(nc));
   for(int y = 1 ; y < 5 ; ++y){
@@ -57,31 +58,66 @@ wipebitmap(struct notcurses* nc){
     }
   }
   ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see 16 spaces");
+  notcurses_debug(nc, stderr);
   notcurses_render(nc);
-  sleep(3);
+  sleep(2);
 
   ncplane_erase(notcurses_stdplane(nc));
   ncplane_destroy(n);
   ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see nothing");
+  notcurses_debug(nc, stderr);
   notcurses_render(nc);
-  sleep(3);
+  sleep(2);
 
   ncplane_erase(notcurses_stdplane(nc));
   for(int i = cellpxy ; i < 5 * cellpxy ; ++i){
     memset(pixels + (i * 6 * cellpxx + cellpxx), 0, cellpxx * 4 * sizeof(*pixels));
   }
-  ncv = ncvisual_from_rgba(pixels, 6 * cellpxy, 6 * cellpxx * 4, 6 * cellpxx);
-  if(ncv == NULL){
+  struct ncvisual* ncve = ncvisual_from_rgba(pixels, 6 * cellpxy, 6 * cellpxx * 4, 6 * cellpxx);
+  if(ncve == NULL){
     return -1;
   }
-  if((n = ncvisual_render(nc, ncv, &vopts)) == NULL){
+  if((n = ncvisual_render(nc, ncve, &vopts)) == NULL){
     return -1;
   }
   ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see empty square");
-  ncvisual_destroy(ncv);
+  notcurses_debug(nc, stderr);
   notcurses_render(nc);
+  sleep(2);
+  vopts.n = n;
+  ncplane_move_top(notcurses_stdplane(nc));
+
+  // now, actually wipe the middle with *s, and then ensure that a new render
+  // gets wiped out before being displayed
+  if(ncvisual_render(nc, ncv, &vopts) == NULL){
+    return -1;
+  }
+  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see full square");
+  notcurses_debug(nc, stderr);
+  notcurses_render(nc);
+  sleep(2);
+
+  for(int y = 1 ; y < 5 ; ++y){
+    for(int x = 1 ; x < 5 ; ++x){
+      ncplane_putchar_yx(notcurses_stdplane(nc), y, x, '*');
+    }
+  }
+  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see 16 *s");
+  notcurses_debug(nc, stderr);
+  notcurses_render(nc);
+  sleep(2);
+
+  if((n = ncvisual_render(nc, ncv, &vopts)) == NULL){
+    return -1;
+  }
+  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought *still* see 16 *s");
+  notcurses_debug(nc, stderr);
+  notcurses_render(nc);
+  sleep(2);
+
+  ncvisual_destroy(ncve);
+  ncvisual_destroy(ncv);
   ncplane_destroy(n);
-  sleep(3);
   return 0;
 }
 

--- a/src/poc/wipebitmap.c
+++ b/src/poc/wipebitmap.c
@@ -4,6 +4,7 @@
 static void
 emit(struct ncplane* n, const char* str){
   fprintf(stderr, "\n\n\n%s\n", str);
+  ncplane_erase_region(n, 6, 0, 0, 0);
   ncplane_putstr_yx(n, 6, 0, str);
 }
 

--- a/src/poc/wipebitmap.c
+++ b/src/poc/wipebitmap.c
@@ -1,6 +1,12 @@
 #include <unistd.h>
 #include <notcurses/notcurses.h>
 
+static void
+emit(struct ncplane* n, const char* str){
+  fprintf(stderr, "\n\n\n%s\n", str);
+  ncplane_putstr_yx(n, 6, 0, str);
+}
+
 // draw a bitmap of 6x6 cells with a cell left out
 static int
 wipebitmap(struct notcurses* nc){
@@ -25,7 +31,7 @@ wipebitmap(struct notcurses* nc){
   if(n == NULL){
     return -1;
   }
-  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see full square");
+  emit(notcurses_stdplane(nc), "Ought see full square");
   notcurses_debug(nc, stderr);
   notcurses_render(nc);
   sleep(2);
@@ -41,12 +47,12 @@ wipebitmap(struct notcurses* nc){
   ncchannels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
   ncplane_set_base(notcurses_stdplane(nc), "", 0, channels);
   ncplane_move_top(notcurses_stdplane(nc));
-  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see 16 *s");
+  emit(notcurses_stdplane(nc), "Ought see 16 *s");
   notcurses_render(nc);
   sleep(2);
 
   ncplane_erase(notcurses_stdplane(nc));
-  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see full square");
+  emit(notcurses_stdplane(nc), "Ought see full square");
   notcurses_debug(nc, stderr);
   notcurses_render(nc);
   sleep(2);
@@ -57,14 +63,14 @@ wipebitmap(struct notcurses* nc){
       ncplane_putchar_yx(notcurses_stdplane(nc), y, x, ' ');
     }
   }
-  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see 16 spaces");
+  emit(notcurses_stdplane(nc), "Ought see 16 spaces");
   notcurses_debug(nc, stderr);
   notcurses_render(nc);
   sleep(2);
 
   ncplane_erase(notcurses_stdplane(nc));
   ncplane_destroy(n);
-  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see nothing");
+  emit(notcurses_stdplane(nc), "Ought see nothing");
   notcurses_debug(nc, stderr);
   notcurses_render(nc);
   sleep(2);
@@ -80,7 +86,7 @@ wipebitmap(struct notcurses* nc){
   if((n = ncvisual_render(nc, ncve, &vopts)) == NULL){
     return -1;
   }
-  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see empty square");
+  emit(notcurses_stdplane(nc), "Ought see empty square");
   notcurses_debug(nc, stderr);
   notcurses_render(nc);
   sleep(2);
@@ -92,7 +98,7 @@ wipebitmap(struct notcurses* nc){
   if(ncvisual_render(nc, ncv, &vopts) == NULL){
     return -1;
   }
-  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see full square");
+  emit(notcurses_stdplane(nc), "Ought see full square");
   notcurses_debug(nc, stderr);
   notcurses_render(nc);
   sleep(2);
@@ -102,15 +108,33 @@ wipebitmap(struct notcurses* nc){
       ncplane_putchar_yx(notcurses_stdplane(nc), y, x, '*');
     }
   }
-  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought see 16 *s");
+  emit(notcurses_stdplane(nc), "Ought see 16 *s");
   notcurses_debug(nc, stderr);
   notcurses_render(nc);
   sleep(2);
 
-  if((n = ncvisual_render(nc, ncv, &vopts)) == NULL){
+  if(ncvisual_render(nc, ncv, &vopts) == NULL){
     return -1;
   }
-  ncplane_putstr_yx(notcurses_stdplane(nc), 6, 0, "Ought *still* see 16 *s");
+  emit(notcurses_stdplane(nc), "Ought *still* see 16 *s");
+  notcurses_debug(nc, stderr);
+  notcurses_render(nc);
+  sleep(2);
+
+  ncplane_move_yx(n, 0, 7);
+  emit(notcurses_stdplane(nc), "Full square on right");
+  notcurses_debug(nc, stderr);
+  notcurses_render(nc);
+  sleep(2);
+
+  ncplane_move_yx(n, 0, 0);
+  emit(notcurses_stdplane(nc), "Ought see 16 *s");
+  notcurses_debug(nc, stderr);
+  notcurses_render(nc);
+  sleep(2);
+
+  ncplane_move_yx(n, 0, 7);
+  emit(notcurses_stdplane(nc), "Full square on right");
   notcurses_debug(nc, stderr);
   notcurses_render(nc);
   sleep(2);


### PR DESCRIPTION
In Sixel, we need emit P2 with a value of 0 or 1. For our purposes, P2=1 means "there are transparent pixels in this sprixel; take care to preserve existing content" while P2=0 means "feel free to blow away everything in the region" (in this case, transparent pixels are colored with color 0). We were properly setting P2=1 when we found transparent pixels in a loaded visual, or when we wiped that visual. We were *not* setting it upon an `ncvisual` reload hitting a cached `SPRIXCELL_ANNIHILATED` or `SPRIXCELL_ANNIHILATED_TRANS`, however, despite resetting P2 to 0 at the beginning of all reloads. As a result, reloads with cached wipes would draw the wipes in. This was why we needed to return 1 from `sixel_wipe()` for cached wipes, leading to a great many unnecessary glyph invalidations, and to the flickering we saw in `yield` for the past month. We now properly set P2=1 upon hitting a cached wipe. Furthermore, the shared prelude in `sprite_wipe()` now checks for `SPRIXCELL_ANNIHILATED`, and returns 0 when seen (the check has been removed from `sixel_wipe()` and `kitty_wipe()`), eliminating several FIXMEs. Reduces output bytes in `intro` by 10%, and some others by a small amount. More importantly, eliminates the flicker in `yield`. Closes #1557. Boom, motherfuckers!