### PR TITLE
autogenerate cffi from notcurses.h

### DIFF
--- a/cffi/src/notcurses/build_notcurses.py
+++ b/cffi/src/notcurses/build_notcurses.py
@@ -1,3 +1,4 @@
+import re
 from cffi import FFI
 ffibuild = FFI()
 
@@ -10,449 +11,60 @@ ffibuild.set_source(
     libraries=["notcurses"],
 )
 
-ffibuild.cdef("""
-typedef struct ncinput {
-  char32_t id;     // Unicode codepoint
-  int y;           // Y cell coordinate of event, -1 for undefined
-  int x;           // X cell coordinate of event, -1 for undefined
-  bool alt;        // Was Alt held during the event?
-  bool shift;      // Was Shift held during the event?
-  bool ctrl;       // Was Ctrl held during the event?
-  uint64_t seqnum; // Monotonically increasing input event counter
-} ncinput;
-// sigset_t differs from system to system, annoying
-// char32_t notcurses_getc(struct notcurses* n, const struct timespec* ts, sigset_t* sigmask, ncinput* ni);
-int notcurses_inputready_fd(struct notcurses* n);
-typedef struct cell {
-  uint32_t gcluster;          // 4B → 4B
-  uint8_t gcluster_backstop;  // 1B → 5B (8 bits of zero)
-  uint8_t width;              // 1B → 6B (8 bits, width)
-  uint16_t stylemask;         // 2B → 8B (16 bits of NCSTYLE_* attributes)
-  uint64_t channels;          // + 8b == 16b
-} cell;
-typedef enum {
-  NCLOGLEVEL_SILENT,  // default. print nothing once fullscreen service begins
-  NCLOGLEVEL_PANIC,   // print diagnostics immediately related to crashing
-  NCLOGLEVEL_FATAL,   // we're hanging around, but we've had a horrible fault
-  NCLOGLEVEL_ERROR,   // we can't keep doin' this, but we can do other things
-  NCLOGLEVEL_WARNING, // you probably don't want what's happening to happen
-  NCLOGLEVEL_INFO,    // "standard information"
-  NCLOGLEVEL_VERBOSE, // "detailed information"
-  NCLOGLEVEL_DEBUG,   // this is honestly a bit much
-  NCLOGLEVEL_TRACE,   // there's probably a better way to do what you want
-} ncloglevel_e;
-typedef struct notcurses_options {
-  const char* termtype;
-  FILE* renderfp;
-  ncloglevel_e loglevel;
-  int margin_t, margin_r, margin_b, margin_l;
-  uint64_t flags;
-} notcurses_options;
-struct notcurses* notcurses_init(const notcurses_options*, FILE*);
-void notcurses_version_components(int* major, int* minor, int* patch, int* tweak);
-int notcurses_lex_margins(const char* op, notcurses_options* opts);
-int notcurses_stop(struct notcurses*);
-int notcurses_render(struct notcurses* nc);
-int ncpile_render(struct ncplane* n);
-int ncpile_rasterize(struct ncplane* n);
-int notcurses_render_to_buffer(struct notcurses* nc, char** buf, size_t* buflen);
-int notcurses_render_to_file(struct notcurses* nc, FILE* fp);
-struct ncplane* notcurses_stdplane(struct notcurses*);
-const struct ncplane* notcurses_stdplane_const(const struct notcurses* nc);
-void ncplane_set_channels(struct ncplane* n, uint64_t channels);
-uint64_t ncplane_set_fchannel(struct ncplane* n, uint32_t channel);
-uint64_t ncplane_set_bchannel(struct ncplane* n, uint32_t channel);
-int ncplane_set_base_cell(struct ncplane* ncp, const cell* c);
-int ncplane_set_base(struct ncplane* ncp, const char* egc, uint32_t styles, uint64_t channels);
-int ncplane_base(struct ncplane* ncp, cell* c);
-struct ncplane* notcurses_top(struct notcurses* n);
-struct ncplane* notcurses_bottom(struct notcurses* n);
-void notcurses_drop_planes(struct notcurses* nc);
-int notcurses_refresh(struct notcurses* n, int* restrict y, int* restrict x);
-struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparent);
-typedef enum {
-  NCALIGN_LEFT,
-  NCALIGN_CENTER,
-  NCALIGN_RIGHT,
-} ncalign_e;
-typedef struct ncplane_options {
-  int y;            // vertical placement relative to parent plane
-  int x;            // horizontal placement relative to parent plane
-  int rows;         // number of rows, must be positive
-  int cols;         // number of columns, must be positive
-  void* userptr;    // user curry, may be NULL
-  const char* name; // name (used only for debugging), may be NULL
-  int (*resizecb)(struct ncplane*); // callback when parent is resized
-  uint64_t flags;   // closure over NCPLANE_OPTION_*
-} ncplane_options;
-struct ncplane* ncplane_create(struct ncplane* n, const ncplane_options* nopts);
-unsigned notcurses_supported_styles(const struct notcurses* nc);
-unsigned notcurses_palette_size(const struct notcurses* nc);
-bool notcurses_cantruecolor(const struct notcurses* nc);
-bool notcurses_canfade(const struct notcurses* nc);
-bool notcurses_canchangecolor(const struct notcurses* nc);
-bool notcurses_canopen_images(const struct notcurses* nc);
-bool notcurses_canopen_videos(const struct notcurses* nc);
-bool notcurses_canutf8(const struct notcurses* nc);
-int notcurses_mouse_enable(struct notcurses* n);
-int notcurses_mouse_disable(struct notcurses* n);
-int ncplane_destroy(struct ncplane* ncp);
-int ncplane_mergedown(struct ncplane* src, struct ncplane* dst, int begsrcy, int begsrcx, int leny, int lenx, int dsty, int dstx);
-int ncplane_mergedown_simple(struct ncplane* restrict src, struct ncplane* restrict dst);
-void ncplane_erase(struct ncplane* n);
-int ncplane_cursor_move_yx(struct ncplane* n, int y, int x);
-void ncplane_cursor_yx(struct ncplane* n, int* y, int* x);
-int ncplane_move_yx(struct ncplane* n, int y, int x);
-void ncplane_yx(struct ncplane* n, int* y, int* x);
-int ncplane_y(const struct ncplane* n);
-int ncplane_x(const struct ncplane* n);
-void ncplane_dim_yx(const struct ncplane* n, int* rows, int* cols);
-int ncplane_putc_yx(struct ncplane* n, int y, int x, const cell* c);
-void ncplane_move_top(struct ncplane* n);
-void ncplane_move_bottom(struct ncplane* n);
-int ncplane_move_below(struct ncplane* restrict n, struct ncplane* restrict below);
-int ncplane_move_above(struct ncplane* restrict n, struct ncplane* restrict above);
-struct ncplane* ncplane_below(struct ncplane* n);
-struct ncplane* ncplane_above(struct ncplane* n);
-char* notcurses_at_yx(struct notcurses* nc, int yoff, int xoff, uint16_t* stylemask, uint64_t* channels);
-char* ncplane_at_cursor(struct ncplane* n, uint16_t* stylemask, uint64_t* channels);
-char* ncplane_at_yx(const struct ncplane* n, int y, int x, uint16_t* stylemask, uint64_t* channels);
-typedef enum {
-  NCBLIT_1x1,
-  NCBLIT_2x1,
-  NCBLIT_2x2,
-  NCBLIT_3x2,
-  NCBLIT_4x1,
-  NCBLIT_BRAILLE,
-  NCBLIT_8x1,
-  NCBLIT_PIXEL,
-} ncblitter_e;
-const char* notcurses_str_blitter(ncblitter_e blitter);
-int notcurses_lex_blitter(const char* op, ncblitter_e* blitter);
-uint32_t* ncplane_as_rgba(const struct ncplane* nc, ncblitter_e blit, int begy, int begx, int leny, int lenx, int* pxdimy, int* pxdimx);
-char* ncplane_contents(const struct ncplane* nc, int begy, int begx, int leny, int lenx);
-void* ncplane_set_userptr(struct ncplane* n, void* opaque);
-void* ncplane_userptr(struct ncplane* n);
-int ncplane_resize(struct ncplane* n, int keepy, int keepx, int keepleny, int keeplenx, int yoff, int xoff, int ylen, int xlen);
-uint64_t ncplane_channels(const struct ncplane* n);
-int ncplane_set_fg_rgb8(struct ncplane* n, int r, int g, int b);
-int ncplane_set_bg_rgb8(struct ncplane* n, int r, int g, int b);
-void ncplane_set_fg_rgb8_clipped(struct ncplane* n, int r, int g, int b);
-void ncplane_set_bg_rgb8_clipped(struct ncplane* n, int r, int g, int b);
-int ncplane_set_fg_rgb(struct ncplane* n, unsigned channel);
-int ncplane_set_bg_rgb(struct ncplane* n, unsigned channel);
-void ncplane_set_fg_default(struct ncplane* n);
-void ncplane_set_bg_default(struct ncplane* n);
-int ncplane_set_fg_alpha(struct ncplane* n, unsigned alpha);
-int ncplane_set_bg_alpha(struct ncplane* n, unsigned alpha);
-int ncplane_set_fg_palindex(struct ncplane* n, int idx);
-int ncplane_set_bg_palindex(struct ncplane* n, int idx);
-unsigned ncplane_styles(const struct ncplane* n);
-void ncplane_set_styles(struct ncplane* n, unsigned stylebits);
-void ncplane_on_styles(struct ncplane* n, unsigned stylebits);
-void ncplane_off_styles(struct ncplane* n, unsigned stylebits);
-typedef struct ncstats {
-  uint64_t renders;
-  uint64_t failed_renders;
-  uint64_t render_bytes;
-  int64_t render_max_bytes;
-  int64_t render_min_bytes;
-  uint64_t render_ns;
-  int64_t render_max_ns;
-  int64_t render_min_ns;
-  uint64_t cellelisions;
-  uint64_t cellemissions;
-  uint64_t fbbytes;
-  uint64_t fgelisions;
-  uint64_t fgemissions;
-  uint64_t bgelisions;
-  uint64_t bgemissions;
-  uint64_t defaultelisions;
-  uint64_t defaultemissions;
-  uint64_t refreshes;
-} ncstats;
-ncstats* notcurses_stats_alloc(struct notcurses* nc);
-void notcurses_stats(struct notcurses* nc, ncstats* stats);
-void notcurses_stats_reset(struct notcurses* nc, ncstats* stats);
-int ncplane_hline_interp(struct ncplane* n, const cell* c, int len, uint64_t c1, uint64_t c2);
-int ncplane_vline_interp(struct ncplane* n, const cell* c, int len, uint64_t c1, uint64_t c2);
-int ncplane_box(struct ncplane* n, const cell* ul, const cell* ur, const cell* ll, const cell* lr, const cell* hline, const cell* vline, int ystop, int xstop, unsigned ctlword);
-typedef int (*fadecb)(struct notcurses* nc, struct ncplane* ncp, const struct timespec* ts, void* curry);
-int ncplane_fadeout(struct ncplane* n, const struct timespec* ts, fadecb fader, void* curry);
-int ncplane_fadein(struct ncplane* n, const struct timespec* ts, fadecb fader, void* curry);
-int ncplane_pulse(struct ncplane* n, const struct timespec* ts, fadecb fader, void* curry);
-int ncplane_putegc_yx(struct ncplane* n, int y, int x, const char* gclust, int* sbytes);
-int ncplane_putstr_aligned(struct ncplane* n, int y, ncalign_e align, const char* s);
-int ncplane_putstr_stained(struct ncplane* n, const char* s);
-int ncplane_putwstr_stained(struct ncplane* n, const wchar_t* gclustarr);
-struct ncplane* ncplane_dup(const struct ncplane* n, void* opaque);
-int nccell_load(struct ncplane* n, cell* c, const char* gcluster);
-int nccell_duplicate(struct ncplane* n, cell* targ, const cell* c);
-void nccell_release(struct ncplane* n, cell* c);
-const char* nccell_extended_gcluster(const struct ncplane* n, const cell* c);
-typedef struct ncpalette {
-  // We store the RGB values as a regular ol' channel
-  uint32_t chans[256];
-} ncpalette;
-ncpalette* ncpalette_new(struct notcurses* nc);
-int ncpalette_use(struct notcurses* nc, const ncpalette* p);
-void ncpalette_free(ncpalette* p);
-typedef enum {
-  NCSCALE_NONE,
-  NCSCALE_SCALE,
-  NCSCALE_STRETCH,
-} ncscale_e;
-int notcurses_lex_scalemode(const char* op, ncscale_e* scalemode);
-const char* notcurses_str_scalemode(ncscale_e scalemode);
-struct ncvisual* ncvisual_from_file(const char* file);
-struct ncvisual* ncvisual_from_rgba(const void* rgba, int rows, int rowstride, int cols);
-struct ncvisual* ncvisual_from_bgra(const void* rgba, int rows, int rowstride, int cols);
-struct ncvisual* ncvisual_from_plane(const struct ncplane* n, ncblitter_e blit, int begy, int begx, int leny, int lenx);
-int ncvisual_blitter_geom(const struct notcurses* nc, const struct ncvisual* n, const struct ncvisual_options* vopts, int* y, int* x, int* toy, int* tox, ncblitter_e* blitter);
-void ncvisual_destroy(struct ncvisual* ncv);
-int ncvisual_decode(struct ncvisual* nc);
-int ncvisual_decode_loop(struct ncvisual* nc);
-int ncvisual_rotate(struct ncvisual* n, double rads);
-int ncvisual_resize(struct ncvisual* n, int rows, int cols);
-int ncvisual_polyfill_yx(struct ncvisual* n, int y, int x, uint32_t rgba);
-struct ncplane* ncvisual_render(struct notcurses* nc, struct ncvisual* ncv, const struct ncvisual_options* vopts);
-char* ncvisual_subtitle(const struct ncvisual* ncv);
-int ncvisual_at_yx(const struct ncvisual* n, int y, int x, uint32_t* pixel);
-int ncvisual_set_yx(const struct ncvisual* n, int y, int x, uint32_t pixel);
-typedef int (*streamcb)(struct ncvisual*, struct ncvisual_options*, const struct timespec*, void*);
-int ncvisual_stream(struct notcurses* nc, struct ncvisual* ncv, float timescale, streamcb streamer, const struct ncvisual_options* vopts, void* curry);
-struct ncvisual_options {
-  struct ncplane* n;
-  ncscale_e scaling;
-  int y, x;
-  int begy, begx;
-  int leny, lenx;
-  ncblitter_e blitter;
-  uint64_t flags;
-};
-int ncblit_bgrx(const void* data, int linesize, const struct ncvisual_options *vopts);
-int ncblit_rgba(const void* data, int linesize, const struct ncvisual_options *vopts);
-struct ncselector_item {
-  char* option;
-  char* desc;
-  size_t opcolumns;   // filled in by library
-  size_t desccolumns; // filled in by library
-};
-typedef struct ncselector_options {
-  char* title; // title may be NULL, inhibiting riser, saving two rows.
-  char* secondary; // secondary may be NULL
-  char* footer; // footer may be NULL
-  struct ncselector_item* items; // initial items and descriptions
-  // default item (selected at start), must be < itemcount unless itemcount
-  // is 0, in which case 'defidx' must also be 0
-  unsigned defidx;
-  // maximum number of options to display at once, 0 to use all available space
-  unsigned maxdisplay;
-  // exhaustive styling options
-  uint64_t opchannels;   // option channels
-  uint64_t descchannels; // description channels
-  uint64_t titlechannels;// title channels
-  uint64_t footchannels; // secondary and footer channels
-  uint64_t boxchannels;  // border channels
-  uint64_t flags;        // bitmap over NCSELECTOR_OPTIONS_*
-} ncselector_options;
-struct ncselector* ncselector_create(struct ncplane* n, const ncselector_options* opts);
-int ncselector_additem(struct ncselector* n, const struct ncselector_item* item);
-int ncselector_delitem(struct ncselector* n, const char* item);
-const char* ncselector_selected(const struct ncselector* n);
-struct ncplane* ncselector_plane(struct ncselector* n);
-const char* ncselector_previtem(struct ncselector* n);
-const char* ncselector_nextitem(struct ncselector* n);
-bool ncselector_offer_input(struct ncselector* n, const struct ncinput* nc);
-void ncselector_destroy(struct ncselector* n, char** item);
-struct ncmselector_item {
-  char* option;
-  char* desc;
-  bool selected;
-};
-typedef struct ncmultiselector_options {
-  char* title; // title may be NULL, inhibiting riser, saving two rows.
-  char* secondary; // secondary may be NULL
-  char* footer; // footer may be NULL
-  struct ncmselector_item* items; // initial items, descriptions, and statuses
-  // maximum number of options to display at once, 0 to use all available space
-  unsigned maxdisplay;
-  // exhaustive styling options
-  uint64_t opchannels;   // option channels
-  uint64_t descchannels; // description channels
-  uint64_t titlechannels;// title channels
-  uint64_t footchannels; // secondary and footer channels
-  uint64_t boxchannels;  // border channels
-  uint64_t flags;        // bitmap over NCSELECTOR_OPTIONS_*
-} ncmultiselector_options;
-struct ncmultiselector* ncmultiselector_create(struct ncplane* n, const ncmultiselector_options* opts);
-int ncmultiselector_selected(struct ncmultiselector* n, bool* selected, unsigned count);
-struct ncplane* ncmultiselector_plane(struct ncmultiselector* n);
-bool ncmultiselector_offer_input(struct ncmultiselector* n, const struct ncinput* nc);
-void ncmultiselector_destroy(struct ncmultiselector* n);
-struct ncmenu_item {
-  char* desc;           // utf-8 menu item, NULL for horizontal separator
-  ncinput shortcut;     // shortcut, all should be distinct
-};
-struct ncmenu_section {
-  char* name;             // utf-8 c string
-  int itemcount;
-  struct ncmenu_item* items;
-  ncinput shortcut;       // shortcut, will be underlined if present in name
-};
-typedef struct ncmenu_options {
-  struct ncmenu_section* sections; // array of 'sectioncount' menu_sections
-  int sectioncount;         // must be positive
-  uint64_t headerchannels;  // styling for header
-  uint64_t sectionchannels; // styling for sections
-  unsigned flags;           // bitfield over NCMENU_OPTION_*
-} ncmenu_options;
-struct ncmenu* ncmenu_create(struct ncplane* n, const ncmenu_options* opts);
-int ncmenu_unroll(struct ncmenu* n, int sectionidx);
-int ncmenu_rollup(struct ncmenu* n);
-int ncmenu_nextsection(struct ncmenu* n);
-int ncmenu_prevsection(struct ncmenu* n);
-int ncmenu_nextitem(struct ncmenu* n);
-int ncmenu_previtem(struct ncmenu* n);
-int ncmenu_item_set_status(struct ncmenu* n, const char* section, const char* item, bool enabled);
-const char* ncmenu_selected(const struct ncmenu* n, struct ncinput* ni);
-bool ncmenu_offer_input(struct ncmenu* n, const struct ncinput* nc);
-int ncmenu_destroy(struct ncmenu* n);
-const char* ncmetric(uintmax_t val, unsigned decimal, char* buf, int omitdec, unsigned mult, int uprefix);
-typedef struct ncreel_options {
-  unsigned bordermask;
-  uint64_t borderchan;
-  unsigned tabletmask;
-  uint64_t tabletchan;
-  uint64_t focusedchan;
-  unsigned flags;      // bitfield over NCREEL_OPTION_*
-} ncreel_options;
-struct ncreel* ncreel_create(struct ncplane* nc, const ncreel_options* popts);
-struct ncplane* ncreel_plane(struct ncreel* pr);
-typedef int (*tabletcb)(struct nctablet* t, bool cliptop);
-struct nctablet* ncreel_add(struct ncreel* pr, struct nctablet* after, struct nctablet* before, tabletcb cb, void* opaque);
-int ncreel_tabletcount(const struct ncreel* pr);
-int ncreel_del(struct ncreel* pr, struct nctablet* t);
-int ncreel_redraw(struct ncreel* pr);
-struct nctablet* ncreel_focused(struct ncreel* pr);
-struct nctablet* ncreel_next(struct ncreel* pr);
-struct nctablet* ncreel_prev(struct ncreel* pr);
-void ncreel_destroy(struct ncreel* pr);
-void* nctablet_userptr(struct nctablet* t);
-struct ncplane* nctablet_plane(struct nctablet* t);
-int ncplane_polyfill_yx(struct ncplane* n, int y, int x, const cell* c);
-int ncplane_gradient(struct ncplane* n, const char* egc, uint32_t styles, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ystop, int xstop);
-int ncplane_highgradient(struct ncplane* n, uint32_t ul, uint32_t ur, uint32_t ll, uint32_t lr, int ystop, int xstop);
-int ncplane_highgradient_sized(struct ncplane* n, uint32_t ul, uint32_t ur, uint32_t ll, uint32_t lr, int ylen, int xlen);
-int ncplane_putchar_stained(struct ncplane* n, char c);
-int ncplane_putegc_stained(struct ncplane* n, const char* gclust, int* sbytes);
-int ncplane_putwegc_stained(struct ncplane* n, const wchar_t* gclust, int* sbytes);
-int ncplane_format(struct ncplane* n, int ystop, int xstop, uint32_t styles);
-int ncplane_stain(struct ncplane* n, int ystop, int xstop, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr);
-int ncplane_rotate_cw(struct ncplane* n);
-int ncplane_rotate_ccw(struct ncplane* n);
-void ncplane_translate(const struct ncplane* src, const struct ncplane* dst, int* y, int* x);
-bool ncplane_translate_abs(const struct ncplane* n, int* y, int* x);
-typedef struct ncplot_options {
-  uint64_t maxchannels;
-  uint64_t minchannels;
-  uint16_t legendstyle;
-  ncblitter_e gridtype;
-  uint64_t rangex;
-  unsigned flags;
-  const char* title;
-  uint64_t flags;        // bitmap over NCPLOT_OPTIONS_*
-} ncplot_options;
-struct ncuplot* ncuplot_create(struct ncplane* n, const ncplot_options* opts, uint64_t miny, uint64_t maxy);
-struct ncdplot* ncdplot_create(struct ncplane* n, const ncplot_options* opts, double miny, double maxy);
-struct ncplane* ncuplot_plane(struct ncuplot* n);
-struct ncplane* ncdplot_plane(struct ncdplot* n);
-int ncuplot_add_sample(struct ncuplot* n, uint64_t x, uint64_t y);
-int ncdplot_add_sample(struct ncdplot* n, uint64_t x, double y);
-int ncuplot_set_sample(struct ncuplot* n, uint64_t x, uint64_t y);
-int ncdplot_set_sample(struct ncdplot* n, uint64_t x, double y);
-int ncuplot_sample(const struct ncuplot* n, uint64_t x, uint64_t* y);
-int ncdplot_sample(const struct ncdplot* n, uint64_t x, double* y);
-void ncuplot_destroy(struct ncuplot* n);
-void ncdplot_destroy(struct ncdplot* n);
-bool ncplane_set_scrolling(struct ncplane* n, bool scrollp);
-typedef struct ncfdplane_options {
-  void* curry; // parameter provided to callbacks
-  bool follow; // keep reading after hitting end? (think tail -f)
-  uint64_t flags;        // bitmap over NCPLOT_OPTIONS_*
-} ncfdplane_options;
-typedef int(ncfdplane_callback)(struct ncfdplane* n, const void* buf, size_t s, void* curry);
-typedef int(ncfdplane_done_cb)(struct ncfdplane* n, int fderrno, void* curry);
-struct ncfdplane* ncfdplane_create(struct ncplane* n, const ncfdplane_options* opts, int fd, ncfdplane_callback cbfxn, ncfdplane_done_cb donecbfxn);
-struct ncplane* ncfdplane_plane(struct ncfdplane* n);
-int ncfdplane_destroy(struct ncfdplane* n);
-typedef struct ncsubproc_options {
-  void* curry;
-  uint64_t restart_period;  // restart this many seconds after an exit (watch)
-  uint64_t flags;        // bitmap over NCPLOT_OPTIONS_*
-} ncsubproc_options;
-struct ncsubproc* ncsubproc_createv(struct ncplane* n, const ncsubproc_options* opts, const char* bin, char* const arg[], ncfdplane_callback cbfxn, ncfdplane_done_cb donecbfxn);
-struct ncsubproc* ncsubproc_createvp(struct ncplane* n, const ncsubproc_options* opts, const char* bin, char* const arg[], ncfdplane_callback cbfxn, ncfdplane_done_cb donecbfxn);
-struct ncsubproc* ncsubproc_createvpe(struct ncplane* n, const ncsubproc_options* opts, const char* bin, char* const arg[], char* const env[], ncfdplane_callback cbfxn, ncfdplane_done_cb donecbfxn);
-struct ncplane* ncsubproc_plane(struct ncsubproc* n);
-int ncsubproc_destroy(struct ncsubproc* n);
-typedef struct ncreader_options {
-  uint64_t tchannels; // channels used for input
-  uint32_t tattrword; // attributes used for input
-  unsigned flags;     // bitfield over NCREADER_OPTION_*
-} ncreader_options;
-struct ncreader* ncreader_create(struct ncplane* n, const ncreader_options* opts);
-int ncreader_clear(struct ncreader* n);
-struct ncplane* ncreader_plane(struct ncreader* n);
-bool ncreader_offer_input(struct ncreader* n, const struct ncinput* ni);
-char* ncreader_contents(const struct ncreader* n);
-void ncreader_destroy(struct ncreader* n, char** contents);
-int ncplane_puttext(struct ncplane* n, int y, ncalign_e align, const char* text, size_t* bytes);
-int ncplane_putnstr_yx(struct ncplane* n, int y, int x, size_t s, const char* gclusters);
-int ncplane_putnstr_aligned(struct ncplane* n, int y, ncalign_e align, size_t s, const char* gclustarr);
-int ncplane_qrcode(struct ncplane* n, int* ymax, int* xmax, const void* data, size_t len);
-struct ncdirect* ncdirect_init(const char* termtype, FILE* fp, uint64_t flags);
-int ncdirect_set_bg_rgb8(struct ncdirect* n, unsigned r, unsigned g, unsigned b);
-int ncdirect_set_fg_rgb8(struct ncdirect* n, unsigned r, unsigned g, unsigned b);
-unsigned ncdirect_palette_size(const struct ncdirect* nc);
-int ncdirect_putstr(struct ncdirect* nc, uint64_t channels, const char* utf8);
-int ncdirect_printf_aligned(struct ncdirect* n, int y, ncalign_e align, const char* fmt, ...);
-int ncdirect_set_fg_rgb(struct ncdirect* n, unsigned rgb);
-int ncdirect_set_bg_rgb(struct ncdirect* n, unsigned rgb);
-int ncdirect_set_styles(struct ncdirect* n, unsigned stylebits);
-int ncdirect_on_styles(struct ncdirect* n, unsigned stylebits);
-int ncdirect_off_styles(struct ncdirect* n, unsigned stylebits);
-int ncdirect_clear(struct ncdirect* n);
-int ncdirect_stop(struct ncdirect* n);
-int ncdirect_dim_x(const struct ncdirect* nc);
-int ncdirect_dim_y(const struct ncdirect* nc);
-int ncdirect_cursor_move_yx(struct ncdirect* n, int y, int x);
-int ncdirect_cursor_enable(struct ncdirect* nc);
-int ncdirect_cursor_disable(struct ncdirect* nc);
-int ncdirect_cursor_up(struct ncdirect* nc, int num);
-int ncdirect_cursor_left(struct ncdirect* nc, int num);
-int ncdirect_cursor_right(struct ncdirect* nc, int num);
-int ncdirect_cursor_down(struct ncdirect* nc, int num);
-int ncdirect_flush(const struct ncdirect* nc);
-int ncdirect_hline_interp(struct ncdirect* n, const char* egc, int len, uint64_t h1, uint64_t h2);
-int ncdirect_vline_interp(struct ncdirect* n, const char* egc, int len, uint64_t h1, uint64_t h2);
-int ncdirect_box(struct ncdirect* n, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, const wchar_t* wchars, int ylen, int xlen, unsigned ctlword);
-int ncdirect_rounded_box(struct ncdirect* n, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ylen, int xlen, unsigned ctlword);
-int ncdirect_double_box(struct ncdirect* n, uint64_t ul, uint64_t ur, uint64_t ll, uint64_t lr, int ylen, int xlen, unsigned ctlword);
-bool ncdirect_canopen_images(const struct ncdirect* n);
-bool ncdirect_canutf8(const struct ncdirect* n);
-int ncdirect_render_image(struct ncdirect* n, const char* filename, ncalign_e align, ncblitter_e blitter, ncscale_e scale);
-struct ncplane* ncplane_parent(struct ncplane* n);
-const struct ncplane* ncplane_parent_const(const struct ncplane* n);
-int notcurses_cursor_enable(struct notcurses* nc, int y, int x);
-int notcurses_cursor_disable(struct notcurses* nc);
-int ncreader_move_left(struct ncreader* n);
-int ncreader_move_right(struct ncreader* n);
-int ncreader_move_up(struct ncreader* n);
-int ncreader_move_down(struct ncreader* n);
-int ncreader_write_egc(struct ncreader* n, const char* egc);
-int ncstrwidth(const char* text);
-""")
+with open('../include/notcurses/notcurses.h') as fp:
+    lines = fp.read().splitlines()
+    # remove initial #includes and #ifdefs
+    first = next(i for i, line in enumerate(lines) if 'notcurses_version' in line)
+    del lines[:first]
+    # remove corresponding #endifs
+    last = next(i for i, line in enumerate(lines) if '#undef' in line)
+    del lines[last:]
+
+# same with direct.h
+with open('../include/notcurses/direct.h') as fp:
+    direct_lines = fp.read().splitlines()
+    first = next(i for i, line in enumerate(direct_lines) if 'typedef struct ncplane' in line)
+    del direct_lines[:first]
+    defs = next(i for i, line in enumerate(direct_lines) if '#define API' in line)
+    del direct_lines[defs:defs+2]
+    last = next(i for i, line in enumerate(direct_lines) if '#undef' in line)
+    del direct_lines[last:]
+
+# and also nckeys.key
+with open('../include/notcurses/nckeys.h') as fp:
+    nckeys_lines = fp.read().splitlines()
+    first = next(i for i, line in enumerate(nckeys_lines) if '#define NCKEY_' in line)
+    del nckeys_lines[:first]
+    last = next(i for i, line in enumerate(nckeys_lines) if '#ifdef' in line)
+    del nckeys_lines[last:]
+
+# turn static function defs into declarations, remove deprecation declarations
+lines = '\n'.join(lines + direct_lines + nckeys_lines)
+lines = re.sub(r'(?m)(^static (.*[^;]\n)+.*)\(\(deprecated\)\);', r'', lines)
+lines = re.sub(r'(?m)(^(ALLOC |__attribute__ .*)?static (.*[^{]\n)+.*)\{$(?s:.*?^\}$)', r'\1;', lines)
+
+# fix missing struct definitions
+# it doesn't actually matter what these are typedef'd to
+lines = 'typedef int sigset_t;\ntypedef int va_list;' + lines
+
+# remove various compiler/preprocessor hints that cffi doesn't understand
+lines = re.sub(r'\b(API|RESTRICT|ALLOC|static) ', '', lines)
+lines = lines.replace('__attribute__ ((unused))', '')
+lines = re.sub(r'__attribute(__)? \(\(.*\)\)', '', lines)
+
+# fix up #define constants
+# TODO: parse macro functions / struct initializers into C or python functions
+def define(m):
+    if re.match(r'\s*(0x)?[a-fA-F0-9](u(ll)?)?', m[2]):
+        return m[0]
+    elif '{' not in m[2]:
+        return m[1] + ' ...'
+    return ''
+lines = re.sub(r'(?m)^(#define [^ (]+) ((.*\\$\n)*.*$)', define, lines)
+lines = re.sub(r'(?m)^(#define [^)\n]+\)) (.*\\$\n)*.*$', r'', lines)
+
+# override=True so that the multiple definitions/declarations don't error out
+ffibuild.cdef(lines, override=True)
 
 if __name__ == "__main__":
     ffibuild.compile(verbose=True)

--- a/cffi/src/notcurses/notcurses.py
+++ b/cffi/src/notcurses/notcurses.py
@@ -5,29 +5,6 @@ import locale
 import _cffi_backend
 from _notcurses import lib, ffi
 
-NCCHANNEL_ALPHA_MASK = 0x30000000
-CELL_ALPHA_HIGHCONTRAST = 0x30000000
-CELL_ALPHA_TRANSPARENT = 0x20000000
-CELL_ALPHA_BLEND = 0x10000000
-CELL_ALPHA_OPAQUE = 0x00000000
-NCOPTION_INHIBIT_SETLOCALE = 0x0001
-NCOPTION_NO_WINCH_SIGHANDLER = 0x0004
-NCOPTION_NO_QUIT_SIGHANDLERS = 0x0008
-NCOPTION_SUPPRESS_BANNERS = 0x0020
-NCOPTION_NO_ALTERNATE_SCREEN = 0x0040
-NCOPTION_NO_FONT_CHANGES = 0x0080
-CELL_WIDEASIAN_MASK = 0x8000000000000000
-CELL_NOBACKGROUND_MASK = 0x0400000000000000
-CELL_BGDEFAULT_MASK = 0x0000000040000000
-CELL_FGDEFAULT_MASK = (CELL_BGDEFAULT_MASK << 32)
-CELL_BG_RGB_MASK = 0x0000000000ffffff
-CELL_FG_RGB_MASK = (CELL_BG_RGB_MASK << 32)
-CELL_BG_PALETTE = 0x0000000008000000
-NCPALETTESIZE = 256
-CELL_FG_PALETTE = (CELL_BG_PALETTE << 32)
-CELL_BG_ALPHA_MASK = NCCHANNEL_ALPHA_MASK
-CELL_FG_ALPHA_MASK = (CELL_BG_ALPHA_MASK << 32)
-
 def channel_r(channel):
     return (channel & 0xff0000) >> 16;
 
@@ -43,7 +20,7 @@ def channel_rgb8(channel):
 def channel_set_rgb8(channel, r, g, b):
     checkRGB(r, g, b)
     c = (r << 16) | (g << 8) | b
-    return (channel & ~CELL_BG_RGB_MASK) | CELL_BGDEFAULT_MASK | c
+    return (channel & ~lib.CELL_BG_RGB_MASK) | lib.CELL_BGDEFAULT_MASK | c
 
 def channels_fchannel(channels):
     return channels & 0xffffffff00000000
@@ -154,7 +131,7 @@ class Ncplane:
 class Notcurses:
     def __init__(self):
         opts = ffi.new("notcurses_options *")
-        opts.flags = NCOPTION_NO_ALTERNATE_SCREEN
+        opts.flags = lib.NCOPTION_NO_ALTERNATE_SCREEN
         self.nc = lib.notcurses_init(opts, sys.stdout)
         if not self.nc:
             raise NotcursesError("Error initializing notcurses")


### PR DESCRIPTION
Fixes #1636.

Autogenerates cffi bindings for python.
It's a little fragile since it's not _really_ parsing the `notcurses.h` header,
just using a lot of regex since that was the easiest to get up and going.

I can also try using `pycparser` instead to actually parse out the definitions/declarations in `notcurses.h`
for something more robust, I can take a crack at that later.

I tested this against the v2.2.10 release/tag, but I had to comment out the declaration of `nctree_goto` since the
corresponding definition doesn't exist (causing the cffi compilation to fail).
