### PR TITLE
Properly allocate image in ffmpeg_resize()

### DIFF
--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Bitmaps") {
     CHECK(nc_->tcache.bitmap_supported);
   }
 
-  SUBCASE("SprixelResize") {
+  SUBCASE("SprixelMinimize") {
     auto y = 10;
     auto x = 10;
     std::vector<uint32_t> v(x * y, htole(0xe61c28ff));
@@ -44,6 +44,34 @@ TEST_CASE("Bitmaps") {
     auto s = n->sprite;
     REQUIRE(nullptr != s);
     ncvisual_destroy(ncv);
+  }
+
+  SUBCASE("SprixelMaximize") {
+    auto y = 10;
+    auto x = 10;
+    std::vector<uint32_t> v(x * y, htole(0xe61c28ff));
+    auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
+    REQUIRE(nullptr != ncv);
+    struct ncvisual_options vopts = {
+      .n = n_,
+      .scaling = NCSCALE_NONE,
+      .y = 0, .x = 0,
+      .begy = 0, .begx = 0,
+      .leny = 0, .lenx = 0,
+      .blitter = NCBLIT_PIXEL,
+      .flags = NCVISUAL_OPTION_NODEGRADE,
+      .transcolor = 0,
+    };
+    int maxy, maxx;
+    ncplane_pixelgeom(n_, nullptr, nullptr, nullptr, nullptr, &maxy, &maxx);
+    CHECK(0 == ncvisual_resize(ncv, maxy, maxx));
+    auto n = ncvisual_render(nc_, ncv, &vopts);
+    REQUIRE(n_ == n);
+    auto s = n->sprite;
+    REQUIRE(nullptr != s);
+    CHECK(0 == notcurses_render(nc_));
+    ncvisual_destroy(ncv);
+    ncplane_erase(n);
   }
 
   // a sprixel requires a plane large enough to hold it

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -5,8 +5,6 @@
 TEST_CASE("Bitmaps") {
   auto nc_ = testing_notcurses();
   REQUIRE(nullptr != nc_);
-  ncplane* ncp_ = notcurses_stdplane(nc_);
-  REQUIRE(ncp_);
   auto n_ = notcurses_stdplane(nc_);
   REQUIRE(n_);
 

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -50,8 +50,10 @@ TEST_CASE("Bitmaps") {
     std::vector<uint32_t> v(x * y, htole(0xe61c28ff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
+    auto nn = ncplane_dup(n_, nullptr);
+    REQUIRE(nullptr != nn);
     struct ncvisual_options vopts = {
-      .n = n_,
+      .n = nn,
       .scaling = NCSCALE_NONE,
       .y = 0, .x = 0,
       .begy = 0, .begx = 0,
@@ -64,12 +66,12 @@ TEST_CASE("Bitmaps") {
     ncplane_pixelgeom(n_, nullptr, nullptr, nullptr, nullptr, &maxy, &maxx);
     CHECK(0 == ncvisual_resize(ncv, maxy, maxx));
     auto n = ncvisual_render(nc_, ncv, &vopts);
-    REQUIRE(n_ == n);
+    REQUIRE(nn == n);
     auto s = n->sprite;
     REQUIRE(nullptr != s);
     CHECK(0 == notcurses_render(nc_));
     ncvisual_destroy(ncv);
-    ncplane_erase(n);
+    CHECK(0 == ncplane_destroy(nn));
   }
 
   // a sprixel requires a plane large enough to hold it

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -40,7 +40,7 @@ handle_opts(const char** argv){
       inarg = false;
     }else if(strcmp(*argv, "-p") == 0){
       inarg = true;
-    }else if(strcmp(*argv, "-l") == 0){
+    }else if(strncmp(*argv, "-l", 2) == 0){ // just require -l
       loglevel = NCLOGLEVEL_TRACE;
     }
     ++argv;


### PR DESCRIPTION
In `ffmpeg_resize()`, we were only allocating a frame, not an image. This meant we reused the old memory. That worked well enough when shrinking the image, but simply will not do for enlarging. Add a unit test for positive `ncvisual_resize()`, and use `av_image_alloc()` in `ffmpeg_resize()`. Closes #1658.