### PR TITLE
ncdirect pixel geom access

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,14 @@ rearrangements of Notcurses.
   * 8bpc RGB is unconditionally enabled if the terminal emulator is determined
     to be Kitty, Alacritty, or foot; there is no longer any need to export
     `COLORTERM` on these terminals.
-  * Add `NCSCALE_INFLATE`.
+  * Fixed bad bug in `ncvisual_resize()` when growing an image. This isn't
+    relevant to enlarging an `ncvisual` via scaling, but only when persistently
+    growing one with `ncvisual_resize()`.
+  * Added `ncdirectf_from_file()`, `ncdirectf_geom()`, and `ncdirectf_render()`,
+    with the net result that you can now (efficiently) get media geometry in
+    direct mode. If you don't care about media geometry, you can keep using
+    `ncdirect_render_frame()` and/or `ncdirect_render_image()`, and Godspeed.
+    Oh yes, and `ncdirectf_free()`. Rien n'est simple, mais tout est facile....
 
 * 2.3.0 (2021-05-09) **"Triumph"**
   * No user-visible changes.

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -112,7 +112,7 @@ typedef struct ncvgeom {
 
 **void ncdirectf_free(struct ncdirectf* ***frame***);**
 
-**ncdirectv* ncdirectf_render(struct ncdirect* ***n***, const struct ncdirectf* ***frame***, ncblitter_e ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***);**
+**ncdirectv* ncdirectf_render(struct ncdirect* ***n***, struct ncdirectf* ***frame***, ncblitter_e ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***);**
 
 **int ncdirectf_geom(struct ncdirect* ***n***, struct ncdirectf* ***frame***, ncblitter_e* ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***, ncvgeom* ***geom***);**
 

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -84,15 +84,38 @@ notcurses_direct - minimal notcurses instances for styling text
 
 **int ncdirect_double_box(struct ncdirect* ***n***, uint64_t ***ul***, uint64_t ***ur***, uint64_t ***ll***, uint64_t ***lr***, int ***ylen***, int ***xlen***, unsigned ***ctlword***);**
 
-**int ncdirect_render_image(struct ncdirect* ***n***, const char* ***filename***, ncblitter_e ***blitter***, ncscale_e ***scale***);**
-
 **ncdirectv* ncdirect_render_frame(struct ncdirect* ***n***, const char* ***filename***, ncblitter_e ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***);**
+
+**char* ncdirect_readline(struct ncdirect* ***n***, const char* ***prompt***);**
+
+```c
+typedef struct ncvgeom {
+  int pixy, pixx;     // true pixel geometry of ncvisual data
+  int cdimy, cdimx;   // terminal cell geometry when this was calculated
+  int rpixy, rpixx;   // rendered pixel geometry
+  int rcelly, rcellx; // rendered cell geometry
+  int scaley, scalex; // pixels per filled cell
+  // only defined for NCBLIT_PIXEL
+  int maxpixely, maxpixelx;
+} ncvgeom;
+```
+
+**int ncdirect_render_image(struct ncdirect* ***n***, const char* ***filename***, ncblitter_e ***blitter***, ncscale_e ***scale***);**
 
 **int ncdirect_raster_frame(struct ncdirect* ***n***, ncdirectv* ***ncdv***, ncalign_e ***align***);**
 
 **int ncdirect_stream(struct ncdirect* ***n***, const char* ***filename***, ncstreamcb ***streamer***, struct ncvisual_options* ***vopts***, void* ***curry***);**
 
-**char* ncdirect_readline(struct ncdirect* ***n***, const char* ***prompt***);**
+**int ncdirect_raster_frame(struct ncdirect* ***n***, ncdirectv* ***ncdv***, ncalign_e ***align***);**
+
+**struct ncdirectf* ncdirectf_from_file(struct ncdirect* ***n***, const char* ***filename***);***
+
+**void ncdirectf_free(struct ncdirectf* ***frame***);**
+
+**ncdirectv* ncdirectf_render(struct ncdirect* ***n***, const struct ncdirectf* ***frame***, ncblitter_e ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***);**
+
+**int ncdirectf_geom(struct ncdirect* ***n***, struct ncdirectf* ***frame***, ncblitter_e* ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***, ncvgeom* ***geom***);**
+
 
 # DESCRIPTION
 

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -315,8 +315,8 @@ ncdirect_getc_blocking(struct ncdirect* n, ncinput* ni){
 // Release 'nc' and any associated resources. 0 on success, non-0 on failure.
 API int ncdirect_stop(struct ncdirect* nc);
 
-struct ncdirectf;
 typedef struct ncplane ncdirectv;
+typedef struct ncvisual ncdirectf;
 
 // FIXME this ought be used in the rendered mode API as well; it's currently
 // only used by direct mode. describes all geometries of an ncvisual--both those
@@ -371,22 +371,22 @@ API int ncdirect_raster_frame(struct ncdirect* n, ncdirectv* ncdv, ncalign_e ali
 // to get its geometry via ncdirect_geom_frame(), or to use the same file with
 // ncdirect_render_loaded_frame() multiple times). You must destroy the result
 // with ncdirectf_free();
-API ALLOC struct ncdirectf* ncdirectf_from_file(struct ncdirect* n, const char* filename)
+API ALLOC ncdirectf* ncdirectf_from_file(struct ncdirect* n, const char* filename)
   __attribute__ ((nonnull (1, 2)));
 
 // Free a ncdirectf returned from ncdirectf_from_file().
-API void ncdirectf_free(struct ncdirectf* frame);
+API void ncdirectf_free(ncdirectf* frame);
 
 // Same as ncdirect_render_frame(), except 'frame' must already have been
 // loaded. A loaded frame may be rendered in different ways before it is
 // destroyed.
-API ALLOC ncdirectv* ncdirectf_render(struct ncdirect* n, const struct ncdirectf* frame,
+API ALLOC ncdirectv* ncdirectf_render(struct ncdirect* n, ncdirectf* frame,
                                       ncblitter_e blitter, ncscale_e scale,
                                       int maxy, int maxx)
   __attribute__ ((nonnull (1, 2)));
 
 // Having loaded the frame 'frame', get the geometry of a potential render.
-API int ncdirectf_geom(struct ncdirect* n, struct ncdirectf* frame,
+API int ncdirectf_geom(struct ncdirect* n, ncdirectf* frame,
                        ncblitter_e* blitter, ncscale_e scale,
                        int maxy, int maxx, ncvgeom* geom)
   __attribute__ ((nonnull (1, 2)));

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -7,6 +7,7 @@
 extern "C" {
 #endif
 
+struct ncdirectf;
 typedef struct ncplane ncdirectv;
 
 #define API __attribute__((visibility("default")))
@@ -48,13 +49,16 @@ API ALLOC struct ncdirect* ncdirect_core_init(const char* termtype, FILE* fp, ui
 // Readline the first time it's called. For input to be echoed to the terminal,
 // it is necessary that NCDIRECT_OPTION_INHIBIT_CBREAK be provided to
 // ncdirect_init(). Returns NULL on error.
+__attribute__ ((nonnull (1)))
 API ALLOC char* ncdirect_readline(struct ncdirect* nc, const char* prompt);
 
 // Direct mode. This API can be used to colorize and stylize output generated
 // outside of notcurses, without ever calling notcurses_render(). These should
 // not be intermixed with standard Notcurses rendering.
-API int ncdirect_set_fg_rgb(struct ncdirect* nc, unsigned rgb);
-API int ncdirect_set_bg_rgb(struct ncdirect* nc, unsigned rgb);
+API int ncdirect_set_fg_rgb(struct ncdirect* nc, unsigned rgb)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_set_bg_rgb(struct ncdirect* nc, unsigned rgb)
+  __attribute__ ((nonnull (1)));
 
 static inline int ncdirect_fg_rgb(struct ncdirect* nc, unsigned rgb)
   __attribute__ ((deprecated));
@@ -72,8 +76,10 @@ ncdirect_bg_rgb(struct ncdirect* nc, unsigned rgb){
   return ncdirect_set_bg_rgb(nc, rgb);
 }
 
-API int ncdirect_set_fg_palindex(struct ncdirect* nc, int pidx);
-API int ncdirect_set_bg_palindex(struct ncdirect* nc, int pidx);
+API int ncdirect_set_fg_palindex(struct ncdirect* nc, int pidx)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_set_bg_palindex(struct ncdirect* nc, int pidx)
+  __attribute__ ((nonnull (1)));
 
 static inline int ncdirect_fg_palindex(struct ncdirect* nc, int pidx)
   __attribute__ ((deprecated));
@@ -94,21 +100,24 @@ ncdirect_bg_palindex(struct ncdirect* nc, int pidx){
 // Returns the number of simultaneous colors claimed to be supported, or 1 if
 // there is no color support. Note that several terminal emulators advertise
 // more colors than they actually support, downsampling internally.
-API unsigned ncdirect_palette_size(const struct ncdirect* nc);
+API unsigned ncdirect_palette_size(const struct ncdirect* nc)
+  __attribute__ ((nonnull (1)));
 
 // Output the string |utf8| according to the channels |channels|. Note that
 // ncdirect_putstr() does not explicitly flush output buffers, so it will not
 // necessarily be immediately visible.
-API int ncdirect_putstr(struct ncdirect* nc, uint64_t channels, const char* utf8);
+API int ncdirect_putstr(struct ncdirect* nc, uint64_t channels, const char* utf8)
+  __attribute__ ((nonnull (1, 3)));
 
 // Formatted printing (plus alignment relative to the terminal). Returns the
 // number of columns printed on success.
 API int ncdirect_printf_aligned(struct ncdirect* n, int y, ncalign_e align,
                                 const char* fmt, ...)
-  __attribute__ ((format (printf, 4, 5)));
+  __attribute__ ((nonnull (1, 4))) __attribute__ ((format (printf, 4, 5)));
 
 // Force a flush. Returns 0 on success, -1 on failure.
-API int ncdirect_flush(const struct ncdirect* nc);
+API int ncdirect_flush(const struct ncdirect* nc)
+  __attribute__ ((nonnull (1)));
 
 static inline int
 ncdirect_set_bg_rgb8(struct ncdirect* nc, unsigned r, unsigned g, unsigned b){
@@ -144,8 +153,10 @@ ncdirect_bg_rgb8(struct ncdirect* nc, unsigned r, unsigned g, unsigned b){
   return ncdirect_set_bg_rgb8(nc, r, g, b);
 }
 
-API int ncdirect_set_fg_default(struct ncdirect* nc);
-API int ncdirect_set_bg_default(struct ncdirect* nc);
+API int ncdirect_set_fg_default(struct ncdirect* nc)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_set_bg_default(struct ncdirect* nc)
+  __attribute__ ((nonnull (1)));
 
 static inline int ncdirect_fg_default(struct ncdirect* nc)
   __attribute__ ((deprecated));
@@ -164,13 +175,18 @@ ncdirect_bg_default(struct ncdirect* nc){
 }
 
 // Get the current number of columns/rows.
-API int ncdirect_dim_x(const struct ncdirect* nc);
-API int ncdirect_dim_y(const struct ncdirect* nc);
+API int ncdirect_dim_x(const struct ncdirect* nc)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_dim_y(const struct ncdirect* nc)
+  __attribute__ ((nonnull (1)));
 
 // ncplane_styles_*() analogues
-API int ncdirect_set_styles(struct ncdirect* n, unsigned stylebits);
-API int ncdirect_on_styles(struct ncdirect* n, unsigned stylebits);
-API int ncdirect_off_styles(struct ncdirect* n, unsigned stylebits);
+API int ncdirect_set_styles(struct ncdirect* n, unsigned stylebits)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_on_styles(struct ncdirect* n, unsigned stylebits)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_off_styles(struct ncdirect* n, unsigned stylebits)
+  __attribute__ ((nonnull (1)));
 
 // Deprecated forms of above.
 API int ncdirect_styles_set(struct ncdirect* n, unsigned stylebits)
@@ -181,23 +197,34 @@ API int ncdirect_styles_off(struct ncdirect* n, unsigned stylebits)
   __attribute__ ((deprecated));
 
 // Move the cursor in direct mode. -1 to retain current location on that axis.
-API int ncdirect_cursor_move_yx(struct ncdirect* n, int y, int x);
-API int ncdirect_cursor_enable(struct ncdirect* nc);
-API int ncdirect_cursor_disable(struct ncdirect* nc);
-API int ncdirect_cursor_up(struct ncdirect* nc, int num);
-API int ncdirect_cursor_left(struct ncdirect* nc, int num);
-API int ncdirect_cursor_right(struct ncdirect* nc, int num);
-API int ncdirect_cursor_down(struct ncdirect* nc, int num);
+API int ncdirect_cursor_move_yx(struct ncdirect* n, int y, int x)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_cursor_enable(struct ncdirect* nc)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_cursor_disable(struct ncdirect* nc)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_cursor_up(struct ncdirect* nc, int num)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_cursor_left(struct ncdirect* nc, int num)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_cursor_right(struct ncdirect* nc, int num)
+  __attribute__ ((nonnull (1)));
+API int ncdirect_cursor_down(struct ncdirect* nc, int num)
+  __attribute__ ((nonnull (1)));
 
 // Get the cursor position, when supported. This requires writing to the
 // terminal, and then reading from it. If the terminal doesn't reply, or
 // doesn't reply in a way we understand, the results might be deleterious.
-API int ncdirect_cursor_yx(struct ncdirect* n, int* y, int* x);
+API int ncdirect_cursor_yx(struct ncdirect* n, int* y, int* x)
+  __attribute__ ((nonnull (1)));
 
 // Push or pop the cursor location to the terminal's stack. The depth of this
 // stack, and indeed its existence, is terminal-dependent.
-API int ncdirect_cursor_push(struct ncdirect* n);
-API int ncdirect_cursor_pop(struct ncdirect* n);
+API int ncdirect_cursor_push(struct ncdirect* n)
+  __attribute__ ((nonnull (1)));
+
+API int ncdirect_cursor_pop(struct ncdirect* n)
+  __attribute__ ((nonnull (1)));
 
 // Display an image using the specified blitter and scaling. The image may
 // be arbitrarily many rows -- the output will scroll -- but will only occupy
@@ -205,21 +232,26 @@ API int ncdirect_cursor_pop(struct ncdirect* n);
 // can be split by using ncdirect_render_frame() and ncdirect_raster_frame().
 API int ncdirect_render_image(struct ncdirect* n, const char* filename,
                               ncalign_e align, ncblitter_e blitter,
-                              ncscale_e scale);
+                              ncscale_e scale)
+  __attribute__ ((nonnull (1, 2)));
 
 // Clear the screen.
-API int ncdirect_clear(struct ncdirect* nc);
+API int ncdirect_clear(struct ncdirect* nc)
+  __attribute__ ((nonnull (1)));
 
 // Can we load images? This requires being built against FFmpeg/OIIO.
-API bool ncdirect_canopen_images(const struct ncdirect* n);
+API bool ncdirect_canopen_images(const struct ncdirect* n)
+  __attribute__ ((nonnull (1)));
 
 // Is our encoding UTF-8? Requires LANG being set to a UTF8 locale.
-API bool ncdirect_canutf8(const struct ncdirect* n);
+API bool ncdirect_canutf8(const struct ncdirect* n)
+  __attribute__ ((nonnull (1)));
 
 // This function must successfully return before NCBLIT_PIXEL is available.
 // Returns -1 on error, 0 for no support, or 1 if pixel output is supported.
 // Must not be called concurrently with either input or rasterization.
-API int ncdirect_check_pixel_support(struct ncdirect* n);
+API int ncdirect_check_pixel_support(struct ncdirect* n)
+  __attribute__ ((nonnull (1)));
 
 // Draw horizontal/vertical lines using the specified channels, interpolating
 // between them as we go. The EGC may not use more than one column. For a
@@ -227,9 +259,12 @@ API int ncdirect_check_pixel_support(struct ncdirect* n);
 // offset. For a vertical line, it may be as long as you'd like; the screen
 // will scroll as necessary. All lines start at the current cursor position.
 API int ncdirect_hline_interp(struct ncdirect* n, const char* egc, int len,
-                              uint64_t h1, uint64_t h2);
+                              uint64_t h1, uint64_t h2)
+  __attribute__ ((nonnull (1)));
+
 API int ncdirect_vline_interp(struct ncdirect* n, const char* egc, int len,
-                              uint64_t h1, uint64_t h2);
+                              uint64_t h1, uint64_t h2)
+  __attribute__ ((nonnull (1)));
 
 // Draw a box with its upper-left corner at the current cursor position, having
 // dimensions |ylen|x|xlen|. See ncplane_box() for more information. The
@@ -237,17 +272,20 @@ API int ncdirect_vline_interp(struct ncdirect* n, const char* egc, int len,
 // array of 6 wide characters: UL, UR, LL, LR, HL, VL.
 API int ncdirect_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                      uint64_t ll, uint64_t lr, const wchar_t* wchars,
-                     int ylen, int xlen, unsigned ctlword);
+                     int ylen, int xlen, unsigned ctlword)
+  __attribute__ ((nonnull (1)));
 
 // ncdirect_box() with the rounded box-drawing characters
 API int ncdirect_rounded_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                              uint64_t ll, uint64_t lr,
-                             int ylen, int xlen, unsigned ctlword);
+                             int ylen, int xlen, unsigned ctlword)
+  __attribute__ ((nonnull (1)));
 
 // ncdirect_box() with the double box-drawing characters
 API int ncdirect_double_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                             uint64_t ll, uint64_t lr,
-                            int ylen, int xlen, unsigned ctlword);
+                            int ylen, int xlen, unsigned ctlword)
+  __attribute__ ((nonnull (1)));
 
 // See ppoll(2) for more detail. Provide a NULL 'ts' to block at length, a 'ts'
 // of 0 for non-blocking operation, and otherwise a timespec to bound blocking.
@@ -257,13 +295,15 @@ API int ncdirect_double_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
 // 'sigmask' may be NULL. Returns 0 on a timeout. If an event is processed, the
 // return value is the 'id' field from that event. 'ni' may be NULL.
 API char32_t ncdirect_getc(struct ncdirect* n, const struct timespec* ts,
-                           sigset_t* sigmask, ncinput* ni);
+                           sigset_t* sigmask, ncinput* ni)
+  __attribute__ ((nonnull (1)));
 
 // Get a file descriptor suitable for input event poll()ing. When this
 // descriptor becomes available, you can call ncdirect_getc_nblock(),
 // and input ought be ready. This file descriptor is *not* necessarily
 // the file descriptor associated with stdin (but it might be!).
-API int ncdirect_inputready_fd(struct ncdirect* n);
+API int ncdirect_inputready_fd(struct ncdirect* n)
+  __attribute__ ((nonnull (1)));
 
 // 'ni' may be NULL if the caller is uninterested in event details. If no event
 // is ready, returns 0.
@@ -295,13 +335,19 @@ API int ncdirect_stop(struct ncdirect* nc);
 // is otherwise used.
 API ALLOC ncdirectv* ncdirect_render_frame(struct ncdirect* n, const char* filename,
                                            ncblitter_e blitter, ncscale_e scale,
-                                           int maxy, int maxx);
+                                           int maxy, int maxx)
+  __attribute__ ((nonnull (1, 2)));
 
 // Takes the result of ncdirect_render_frame() and writes it to the output.
-API int ncdirect_raster_frame(struct ncdirect* n, ncdirectv* ncdv, ncalign_e align);
+API int ncdirect_raster_frame(struct ncdirect* n, ncdirectv* ncdv, ncalign_e align)
+  __attribute__ ((nonnull (1, 2)));
+
+API ALLOC struct ncdirectf* ncdirect_load_frame(struct ncdirect* n, const char* filename)
+  __attribute__ ((nonnull (1, 2)));
 
 API int ncdirect_stream(struct ncdirect* n, const char* filename, ncstreamcb streamer,
-                        struct ncvisual_options* vopts, void* curry);
+                        struct ncvisual_options* vopts, void* curry)
+  __attribute__ ((nonnull (1, 2)));
 
 #undef ALLOC
 #undef API

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1225,7 +1225,8 @@ int ncdirectf_geom(ncdirect* n, ncdirectf* frame,
   geom->maxpixely = n->tcache.sixel_maxy;
   geom->maxpixelx = n->tcache.sixel_maxx;
   const struct blitset* bset;
-  int r = ncvisual_blitset_geom(NULL, frame, &vopts, &geom->pixy, &geom->pixx,
+  int r = ncvisual_blitset_geom(NULL, &n->tcache, frame, &vopts,
+                                &geom->pixy, &geom->pixx,
                                 &geom->scaley, &geom->scalex,
                                 &geom->rpixy, &geom->rpixx, &bset);
   if(r == 0 && blitter){

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1214,4 +1214,22 @@ ncdirectv* ncdirectf_render(ncdirect* n, ncdirectf* frame,
 int ncdirectf_geom(ncdirect* n, ncdirectf* frame,
                    ncblitter_e* blitter, ncscale_e scale,
                    int maxy, int maxx, ncvgeom* geom){
+  struct ncvisual_options vopts = {
+    .blitter = blitter ? *blitter : NCBLIT_DEFAULT,
+    .scaling = scale,
+    .leny = maxy,
+    .lenx = maxx,
+  };
+  geom->cdimy = n->tcache.cellpixy;
+  geom->cdimx = n->tcache.cellpixx;
+  geom->maxpixely = n->tcache.sixel_maxy;
+  geom->maxpixelx = n->tcache.sixel_maxx;
+  const struct blitset* bset;
+  int r = ncvisual_blitset_geom(NULL, frame, &vopts, &geom->pixy, &geom->pixx,
+                                &geom->scaley, &geom->scalex,
+                                &geom->rpixy, &geom->rpixx, &bset);
+  if(r == 0 && blitter){
+    *blitter = bset->geom;
+  }
+  return r;
 }

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -590,11 +590,11 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
 ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
                                  ncblitter_e blitfxn, ncscale_e scale,
                                  int ymax, int xmax){
-  struct ncvisual* ncv = ncvisual_from_file(file);
+  ncdirectf* ncv = ncdirectf_from_file(n, file);
   if(ncv == NULL){
     return NULL;
   }
-  ncdirectv* v = ncdirect_render_visual(n, ncv, blitfxn, scale, ymax, xmax, 0);
+  ncdirectv* v = ncdirectf_render(n, ncv, blitfxn, scale, ymax, xmax);
   ncvisual_destroy(ncv);
   return v;
 }
@@ -1194,4 +1194,24 @@ int ncdirect_stream(ncdirect* n, const char* filename, ncstreamcb streamer,
   }while(ncvisual_decode(ncv) == 0);
   ncvisual_destroy(ncv);
   return 0;
+}
+
+ncdirectf* ncdirectf_from_file(ncdirect* n __attribute__ ((unused)),
+                               const char* filename){
+  return ncvisual_from_file(filename);
+}
+
+void ncdirectf_free(ncdirectf* frame){
+  ncvisual_destroy(frame);
+}
+
+ncdirectv* ncdirectf_render(ncdirect* n, ncdirectf* frame,
+                            ncblitter_e blitter, ncscale_e scale,
+                            int maxy, int maxx){
+  return ncdirect_render_visual(n, frame, blitter, scale, maxy, maxx, 0);
+}
+
+int ncdirectf_geom(ncdirect* n, ncdirectf* frame,
+                   ncblitter_e* blitter, ncscale_e scale,
+                   int maxy, int maxx, ncvgeom* geom){
 }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -661,7 +661,8 @@ struct blitset {
 
 #include "blitset.h"
 
-int ncvisual_blitset_geom(const notcurses* nc, const struct ncvisual* n,
+int ncvisual_blitset_geom(const notcurses* nc, const tinfo* tcache,
+                          const struct ncvisual* n,
                           const struct ncvisual_options* vopts,
                           int* y, int* x, int* scaley, int* scalex,
                           int* leny, int* lenx, const struct blitset** blitter);
@@ -1695,10 +1696,10 @@ rgba_blitter_low(const tinfo* tcache, ncscale_e scale, bool maydegrade,
 // RGBA visuals all use NCBLIT_2x1 by default (or NCBLIT_1x1 if not in
 // UTF-8 mode), but an alternative can be specified.
 static inline const struct blitset*
-rgba_blitter(const struct notcurses* nc, const struct ncvisual_options* opts) {
+rgba_blitter(const struct tinfo* tcache, const struct ncvisual_options* opts) {
   const bool maydegrade = !(opts && (opts->flags & NCVISUAL_OPTION_NODEGRADE));
   const ncscale_e scale = opts ? opts->scaling : NCSCALE_NONE;
-  return rgba_blitter_low(&nc->tcache, scale, maydegrade, opts ? opts->blitter : NCBLIT_DEFAULT);
+  return rgba_blitter_low(tcache, scale, maydegrade, opts ? opts->blitter : NCBLIT_DEFAULT);
 }
 
 typedef struct ncvisual_implementation {

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -661,6 +661,11 @@ struct blitset {
 
 #include "blitset.h"
 
+int ncvisual_blitset_geom(const notcurses* nc, const struct ncvisual* n,
+                          const struct ncvisual_options* vopts,
+                          int* y, int* x, int* scaley, int* scalex,
+                          int* leny, int* lenx, const struct blitset** blitter);
+
 static inline int
 ncfputs(const char* ext, FILE* out){
   int r;

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -78,11 +78,10 @@ ncvisual_origin(const struct ncvisual_options* vopts, int* restrict begy, int* r
 // FIXME we ought also do the output calculations here (how many rows x cols,
 //   given the input plane vopts->n and scaling vopts->scaling)--but do not
 //   perform any actual scaling, nor create any planes!
-static int
-ncvisual_blitset_geom(const notcurses* nc, const ncvisual* n,
-                      const struct ncvisual_options* vopts,
-                      int* y, int* x, int* scaley, int* scalex,
-                      int* leny, int* lenx, const struct blitset** blitter){
+int ncvisual_blitset_geom(const notcurses* nc, const ncvisual* n,
+                          const struct ncvisual_options* vopts,
+                          int* y, int* x, int* scaley, int* scalex,
+                          int* leny, int* lenx, const struct blitset** blitter){
   int fakeleny, fakelenx;
   if(leny == NULL){
     leny = &fakeleny;

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -69,6 +69,19 @@ TEST_CASE("DirectMode") {
       CHECK(0 == ncdirect_render_image(nc_, find_data("worldmap.png"), NCALIGN_RIGHT, NCBLIT_PIXEL, NCSCALE_SCALE));
     }
   }
+
+  SUBCASE("ImageGeom") {
+    auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
+    REQUIRE(nullptr != dirf);
+    ncblitter_e blitter = NCBLIT_DEFAULT;
+    ncvgeom geom;
+    CHECK(0 == ncdirectf_geom(nc_, dirf, &blitter, NCSCALE_NONE, 0, 0, &geom));
+    CHECK(475 == geom.pixy);
+    CHECK(860 == geom.pixx);
+    // FIXME
+    ncdirectf_free(dirf);
+  }
+
 #endif
 
   CHECK(0 == ncdirect_stop(nc_));

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -78,7 +78,7 @@ TEST_CASE("DirectMode") {
     CHECK(0 == ncdirectf_geom(nc_, dirf, &blitter, NCSCALE_NONE, 0, 0, &geom));
     CHECK(475 == geom.pixy);
     CHECK(860 == geom.pixx);
-    // FIXME
+    CHECK(NCBLIT_DEFAULT != blitter);
     ncdirectf_free(dirf);
   }
 


### PR DESCRIPTION
Adds `ncdirectf_{from_file, geom, render, free}()`, and some small unit testing. Closes #1659.