### PR TITLE
Don't take ownership of signal atomic if we're not registering signal handlers

### DIFF
--- a/src/lib/signal.c
+++ b/src/lib/signal.c
@@ -67,7 +67,7 @@ int drop_signals(void* nc){
   }
   pthread_mutex_unlock(&lock);
   if(ret){
-    fprintf(stderr, "Couldn't drop signals with %p (had %p)\n", nc, expected);
+    fprintf(stderr, "Signals weren't registered for %p (had %p)\n", nc, expected);
   }
   return ret;
 }
@@ -105,10 +105,13 @@ int setup_signals(void* vnc, bool no_quit_sigs, bool no_winch_sig,
   notcurses* nc = vnc;
   void* expected = NULL;
   struct sigaction sa;
-  // we expect NULL (nothing registered), and want to register nc
-  if(!atomic_compare_exchange_strong(&signal_nc, &expected, nc)){
-    loginfo(nc, "%p is already registered for signals (provided %p)\n", expected, nc);
-    return -1;
+  // don't register ourselves if we don't intend to set up signal handlers
+  if(!no_winch_sig || !no_quit_sigs){
+    // we expect NULL (nothing registered), and want to register nc
+    if(!atomic_compare_exchange_strong(&signal_nc, &expected, nc)){
+      loginfo(nc, "%p is already registered for signals (provided %p)\n", expected, nc);
+      return -1;
+    }
   }
   if(!no_winch_sig){
     memset(&sa, 0, sizeof(sa));


### PR DESCRIPTION
Addresses the issues raised in #1666, where someone wants to use an ncdirect concurrently with a rendering-mode notcurses...or at least allows them to be addressed. Before, even if specifying no signal handlers via options, any context took the signal atomic.