### PR TITLE
Don't run cursor tests unless on a TTY

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1293,9 +1293,6 @@ void nclog(const char* fmt, ...);
 
 bool is_linux_console(const notcurses* nc, unsigned no_font_changes);
 
-// get a file descriptor for the controlling tty device, -1 on error
-int get_controlling_tty(FILE* fp);
-
 // logging
 #define logerror(nc, fmt, ...) do{ \
   if(nc){ if((nc)->loglevel >= NCLOGLEVEL_ERROR){ \

--- a/src/lib/signal.c
+++ b/src/lib/signal.c
@@ -69,7 +69,9 @@ int drop_signals(void* nc){
   if(ret){
     fprintf(stderr, "Signals weren't registered for %p (had %p)\n", nc, expected);
   }
-  return ret;
+  // we might not have established any handlers in setup_signals(); always
+  // return 0 here, for now...
+  return 0;
 }
 
 static void

--- a/src/poc/cursor.c
+++ b/src/poc/cursor.c
@@ -1,0 +1,21 @@
+#include <notcurses/direct.h>
+
+int main(void){
+  struct ncdirect* n = ncdirect_core_init(NULL, stdout, 0);
+  if(n == NULL){
+    return EXIT_FAILURE;
+  }
+  int y, x;
+  if(ncdirect_cursor_yx(n, &y, &x)){
+    goto err;
+  }
+  int dimx = ncdirect_dim_x(n);
+  int dimy = ncdirect_dim_y(n);
+  printf("Cursor: column %d/%d row %d/%d\n", x, dimx, y, dimy);
+  ncdirect_stop(n);
+  return EXIT_SUCCESS;
+
+err:
+  ncdirect_stop(n);
+  return EXIT_FAILURE;
+}

--- a/src/poc/direct.c
+++ b/src/poc/direct.c
@@ -45,12 +45,6 @@ int main(void){
     y += 2; // we just went down two lines
     while(y > 3){
       ret = -1;
-      const int up = y >= 3 ? 3 : y;
-      if(ncdirect_cursor_up(n, up)){
-        break;
-      }
-      fflush(stdout);
-      y -= up;
       int newy;
       if(ncdirect_cursor_yx(n, &newy, NULL)){
         break;
@@ -61,6 +55,12 @@ int main(void){
       }
       printf("\n\tRead cursor position: y: %d x: %d\n", newy, x);
       y += 2;
+      const int up = 3;
+      if(ncdirect_cursor_up(n, up)){
+        break;
+      }
+      fflush(stdout);
+      y -= up;
       ret = 0;
     }
   }else{

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -105,7 +105,7 @@ TEST_CASE("DirectMode") {
   }
 
   SUBCASE("CursorPostGlyphRender") {
-    if(is_test_tty(stdout)){
+    if(is_test_tty()){
       auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
       REQUIRE(nullptr != dirf);
       auto ncdv = ncdirectf_render(nc_, dirf, NCBLIT_1x1, NCSCALE_NONE, 0, 0);
@@ -124,7 +124,7 @@ TEST_CASE("DirectMode") {
   }
 
   SUBCASE("CursorPostSprixel") {
-    if(is_test_tty(stdout)){
+    if(is_test_tty()){
       if(ncdirect_check_pixel_support(nc_) > 0){
         auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
         REQUIRE(nullptr != dirf);

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -105,27 +105,10 @@ TEST_CASE("DirectMode") {
   }
 
   SUBCASE("CursorPostGlyphRender") {
-    auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
-    REQUIRE(nullptr != dirf);
-    auto ncdv = ncdirectf_render(nc_, dirf, NCBLIT_1x1, NCSCALE_NONE, 0, 0);
-    CHECK(nullptr != ncdv);
-    CHECK(0 == ncdirect_raster_frame(nc_, ncdv, NCALIGN_LEFT));
-    ncdirectf_free(dirf);
-    int y, x;
-    int dimy = ncdirect_dim_y(nc_);
-    int dimx = ncdirect_dim_x(nc_);
-    CHECK(0 == ncdirect_cursor_yx(nc_, &y, &x));
-    CHECK(0 <= y);
-    CHECK(dimy > y);
-    CHECK(0 <= x);
-    CHECK(dimx > x);
-  }
-
-  SUBCASE("CursorPostSprixel") {
-    if(ncdirect_check_pixel_support(nc_) > 0){
+    if(is_test_tty(stdout)){
       auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
       REQUIRE(nullptr != dirf);
-      auto ncdv = ncdirectf_render(nc_, dirf, NCBLIT_PIXEL, NCSCALE_NONE, 0, 0);
+      auto ncdv = ncdirectf_render(nc_, dirf, NCBLIT_1x1, NCSCALE_NONE, 0, 0);
       CHECK(nullptr != ncdv);
       CHECK(0 == ncdirect_raster_frame(nc_, ncdv, NCALIGN_LEFT));
       ncdirectf_free(dirf);
@@ -137,6 +120,27 @@ TEST_CASE("DirectMode") {
       CHECK(dimy > y);
       CHECK(0 <= x);
       CHECK(dimx > x);
+    }
+  }
+
+  SUBCASE("CursorPostSprixel") {
+    if(is_test_tty(stdout)){
+      if(ncdirect_check_pixel_support(nc_) > 0){
+        auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
+        REQUIRE(nullptr != dirf);
+        auto ncdv = ncdirectf_render(nc_, dirf, NCBLIT_PIXEL, NCSCALE_NONE, 0, 0);
+        CHECK(nullptr != ncdv);
+        CHECK(0 == ncdirect_raster_frame(nc_, ncdv, NCALIGN_LEFT));
+        ncdirectf_free(dirf);
+        int y, x;
+        int dimy = ncdirect_dim_y(nc_);
+        int dimx = ncdirect_dim_x(nc_);
+        CHECK(0 == ncdirect_cursor_yx(nc_, &y, &x));
+        CHECK(0 <= y);
+        CHECK(dimy > y);
+        CHECK(0 <= x);
+        CHECK(dimx > x);
+      }
     }
   }
 #endif

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -31,6 +31,16 @@ auto find_data(const char* datum) -> char* {
   return strdup(p.c_str());
 }
 
+auto is_test_tty(FILE* fp) -> bool {
+  int fd = fileno(fp);
+  if(fd >= 0){
+    if(isatty(fd)){
+      return true;
+    }
+  }
+  return false;
+}
+
 static void
 handle_opts(const char** argv){
   bool inarg = false;

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -31,14 +31,13 @@ auto find_data(const char* datum) -> char* {
   return strdup(p.c_str());
 }
 
-auto is_test_tty(FILE* fp) -> bool {
-  int fd = fileno(fp);
-  if(fd >= 0){
-    if(isatty(fd)){
-      return true;
-    }
+auto is_test_tty() -> bool {
+  int fd = open("/dev/tty", O_RDWR);
+  if(fd < 0){
+    return false;
   }
-  return false;
+  close(fd);
+  return true;
 }
 
 static void

--- a/src/tests/main.h
+++ b/src/tests/main.h
@@ -10,7 +10,7 @@
 #include <ncpp/_exceptions.hh>
 #include "internal.h"
 
-auto is_test_tty(FILE* fp) -> bool;
+auto is_test_tty() -> bool;
 auto find_data(const char* datum) -> char*;
 auto testing_notcurses() -> struct notcurses*;
 auto ncreel_validate(const ncreel* n) -> bool;

--- a/src/tests/main.h
+++ b/src/tests/main.h
@@ -10,6 +10,7 @@
 #include <ncpp/_exceptions.hh>
 #include "internal.h"
 
+auto is_test_tty(FILE* fp) -> bool;
 auto find_data(const char* datum) -> char*;
 auto testing_notcurses() -> struct notcurses*;
 auto ncreel_validate(const ncreel* n) -> bool;


### PR DESCRIPTION
I added some cursor tests to investigate an issue @dknl reported, but they were dying in CI, because there's no TTY connected to react to cursor movement commands. Gate them with new `notcurses-tester` function `is_test_tty()`.

though...why were we able to get the cursor location at all? we had it not *reacting* to our cursor moves, but we knew that because it reported the same cursor location twice. what the hell was responding? is the issue here that we're not writing the cursor moves to the correct place (i.e. where we're writing the cursor lookup)? don't merge this until investigating...

Closes #1668.