### PR TITLE
Enforce directmode image rendering length caps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,11 @@ rearrangements of Notcurses.
   * Fixed bad bug in `ncvisual_resize()` when growing an image. This isn't
     relevant to enlarging an `ncvisual` via scaling, but only when persistently
     growing one with `ncvisual_resize()`.
+  * Direct mode image rendering now honors the `maxy` and `maxx` parameters,
+    which specify the maximum number of cell rows and columns, respectively,
+    to use for the render. They were previously ignored, contrary to
+    documentation. It is now an error to pass a negative number for either of
+    these values. Use 0 to specify "as much space as is necessary".
   * Added `ncdirectf_from_file()`, `ncdirectf_geom()`, and `ncdirectf_render()`,
     with the net result that you can now (efficiently) get media geometry in
     direct mode. If you don't care about media geometry, you can keep using

--- a/USAGE.md
+++ b/USAGE.md
@@ -467,7 +467,7 @@ int ncdirect_render_image(struct ncdirect* nc, const char* filename,
 // -- but will only occupy the column of the cursor, and those to the right.
 // To actually write (and free) this, invoke ncdirect_raster_frame(). 'maxx'
 // and 'maxy', if greater than 0, are used for scaling; the terminal's geometry
-// is otherwise used.
+// is otherwise used. It is an error to pass a negative 'maxy' or 'maxx'.
 ncdirectv* ncdirect_render_frame(struct ncdirect* n, const char* filename,
                                  ncblitter_e blitter, ncscale_e scale,
                                  int maxy, int maxx);

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -179,6 +179,10 @@ must be supplied to **ncdirect_init**.
 before **NCBLIT_PIXEL** can be used to render images; see
 **notcurses_visual(3)** for more details.
 
+When rendering an image, ***maxy*** and ***maxx*** specify a maximum number
+of (cell) rows and columns to use, respectively. Passing 0 means "use as much
+space as is necessary". It is an error to pass a negative number for either.
+
 # RETURN VALUES
 
 **ncdirect_init** returns **NULL** on failure. Otherwise, the return value

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -618,6 +618,8 @@ typedef struct blitterargs {
   // consumed there, and blitters ought always work with the scaled output.
   int begy;            // upper left start within visual
   int begx;
+  int leny;            // number of source pixels to use
+  int lenx;
   uint32_t transcolor; // if non-zero, treat the lower 24 bits as a transparent color
   union { // cell vs pixel-specific arguments
     struct {

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -147,7 +147,7 @@ void ncls_thread(const lsContext* ctx) {
       work.pop();
       pthread_mutex_unlock(&mtx);
       auto s = j.dir / j.p;
-      auto faken = ctx->nc.prep_image(s.c_str(), ctx->blitter, ctx->scaling, -1, -1);
+      auto faken = ctx->nc.prep_image(s.c_str(), ctx->blitter, ctx->scaling, 0, 0);
       pthread_mutex_lock(&outmtx);
       std::cout << j.p << '\n';
       if(faken){

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -95,6 +95,9 @@ int main(void){
                            NCBLIT_DEFAULT, NCSCALE_NONE)){
     goto err;
   }
+  if(partial_image(n, "../data/warmech.bmp")){
+    goto err;
+  }
   if(ncdirect_stop(n)){
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
Enforce `maxx` and `maxy` parameters in direct mode when rendering images. Update documentation to reflect this, and also that -1 is now an error (just pass 0 to indicate don't-care). Extend `vizdirect` PoC to exercise this functionality -- looks good. Update `ncls` to properly invoke image render.