### PR TITLE
Honor leny/lenx in ncvisual_options, cap direct rendering at proper height

### DIFF
--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -355,8 +355,8 @@ API int ncdirect_render_image(struct ncdirect* n, const char* filename,
 // the result. The image may be arbitrarily many rows -- the output will scroll
 // -- but will only occupy the column of the cursor, and those to the right.
 // To actually write (and free) this, invoke ncdirect_raster_frame(). 'maxx'
-// and 'maxy', if greater than 0, are used for scaling; the terminal's geometry
-// is otherwise used.
+// and 'maxy' (cell geometry, *not* pixel), if greater than 0, are used for
+// scaling; the terminal's geometry is otherwise used.
 API ALLOC ncdirectv* ncdirect_render_frame(struct ncdirect* n, const char* filename,
                                            ncblitter_e blitter, ncscale_e scale,
                                            int maxy, int maxx)

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -336,7 +336,7 @@ typedef struct ncvgeom {
   int pixy, pixx;     // true pixel geometry of ncvisual data
   int cdimy, cdimx;   // terminal cell geometry when this was calculated
   int rpixy, rpixx;   // rendered pixel geometry
-  int rcelly, rcellx; // rendered cell geometry
+  int rcelly, rcellx; // rendered cell geometry FIXME not yet filled in
   int scaley, scalex; // pixels per filled cell
   // only defined for NCBLIT_PIXEL
   int maxpixely, maxpixelx;

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1261,6 +1261,7 @@ int ncdirectf_geom(ncdirect* n, ncdirectf* frame,
   geom->maxpixely = n->tcache.sixel_maxy;
   geom->maxpixelx = n->tcache.sixel_maxx;
   const struct blitset* bset;
+  geom->rcelly = geom->rcellx = -1; // FIXME
   int r = ncvisual_blitset_geom(NULL, &n->tcache, frame, &vopts,
                                 &geom->pixy, &geom->pixx,
                                 &geom->scaley, &geom->scalex,

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1203,6 +1203,7 @@ int ncdirect_stream(ncdirect* n, const char* filename, ncstreamcb streamer,
     if(x > 0){
       ncdirect_cursor_left(n, x);
     }
+    // FIXME what about vopts->beg{yx} and vopts->len{yx}?
     ncdirectv* v = ncdirect_render_visual(n, ncv, vopts->blitter, vopts->scaling,
                                           0, 0, (vopts->flags & NCVISUAL_OPTION_ADDALPHA) ?
                                                  vopts->transcolor | 0x1000000ul : 0);

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -557,6 +557,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
     }
     if(scale == NCSCALE_SCALE || scale == NCSCALE_SCALE_HIRES){
       scale_visual(ncv, &disprows, &dispcols);
+      outy = disprows;
       if(bset->geom == NCBLIT_PIXEL){
         clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy, scale);
       }
@@ -577,7 +578,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, ncblitter_e blitfxn,
     }
   }
 //fprintf(stderr, "max: %d/%d out: %d/%d\n", ymax, xmax, outy, dispcols);
-//fprintf(stderr, "render: %d/%d stride %u %p\n", ncv->pixy, ncv->pixx, ncv->pixytride, ncv->data);
+//fprintf(stderr, "render: %d/%d stride %u %p\n", ncv->pixy, ncv->pixx, ncv->rowstride, ncv->data);
   ncplane_options nopts = {
     .y = 0,
     .x = 0,

--- a/src/lib/tabbed.c
+++ b/src/lib/tabbed.c
@@ -217,7 +217,7 @@ nctab* nctabbed_add(nctabbed* nt, nctab* after, nctab* before, tabcb cb,
     after = nt->selected;
   }
   if((t = malloc(sizeof(*t))) == NULL){
-    logerror(nc, "Couldn't alocate nctab")
+    logerror(nc, "Couldn't allocate nctab")
     return NULL;
   }
   if((t->name = strdup(name)) == NULL){

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -575,7 +575,7 @@ ncvisual* ncvisual_from_bgra(const void* bgra, int rows, int rowstride, int cols
 // ncv->pixx define the source geometry in pixels.
 ncplane* ncvisual_render_cells(notcurses* nc, ncvisual* ncv, const struct blitset* bset,
                                int placey, int placex, int begy, int begx,
-                               ncplane* n, ncscale_e scaling,
+                               int leny, int lenx, ncplane* n, ncscale_e scaling,
                                uint64_t flags, uint32_t transcolor){
   int disprows, dispcols;
   ncplane* createdn = NULL;
@@ -737,8 +737,8 @@ make_sprixel_plane(notcurses* nc, ncplane* parent, ncvisual* ncv,
 // output width is always equal to the scaled width; it has no distinct name.
 ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blitset* bset,
                                 int placey, int placex, int begy, int begx,
-                                ncplane* n, ncscale_e scaling, uint64_t flags,
-                                uint32_t transcolor){
+                                int leny, int lenx, ncplane* n, ncscale_e scaling,
+                                uint64_t flags, uint32_t transcolor){
   ncplane* stdn = notcurses_stdplane(nc);
   if(n == stdn){
     logerror(nc, "Won't blit bitmaps to the standard plane\n");
@@ -884,9 +884,11 @@ ncplane* ncvisual_render(notcurses* nc, ncvisual* ncv, const struct ncvisual_opt
   }
   if(bset->geom != NCBLIT_PIXEL){
     n = ncvisual_render_cells(nc, ncv, bset, placey, placex, begy, begx,
-                              n, scaling, vopts ? vopts->flags : 0, transcolor);
+                              leny, leny, n, scaling,
+                              vopts ? vopts->flags : 0, transcolor);
   }else{
-    n = ncvisual_render_pixels(nc, ncv, bset, placey, placex, begy, begx, n, scaling,
+    n = ncvisual_render_pixels(nc, ncv, bset, placey, placex, begy, begx,
+                               leny, lenx, n, scaling,
                                vopts ? vopts->flags : 0, transcolor);
   }
   return n;

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -585,8 +585,8 @@ ncplane* ncvisual_render_cells(notcurses* nc, ncvisual* ncv, const struct blitse
       n = notcurses_stdplane(nc);
     }
     if(scaling == NCSCALE_NONE || scaling == NCSCALE_NONE_HIRES){
-      dispcols = ncv->pixx;
-      disprows = ncv->pixy;
+      dispcols = lenx;
+      disprows = leny;
     }else{
       ncplane_dim_yx(n, &disprows, &dispcols);
       dispcols *= encoding_x_scale(&nc->tcache, bset);
@@ -622,8 +622,8 @@ ncplane* ncvisual_render_cells(notcurses* nc, ncvisual* ncv, const struct blitse
     placex = 0;
   }else{
     if(scaling == NCSCALE_NONE || scaling == NCSCALE_NONE_HIRES){
-      dispcols = ncv->pixx;
-      disprows = ncv->pixy;
+      dispcols = lenx;
+      disprows = leny;
     }else{
       ncplane_dim_yx(n, &disprows, &dispcols);
       dispcols *= encoding_x_scale(&nc->tcache, bset);
@@ -884,7 +884,7 @@ ncplane* ncvisual_render(notcurses* nc, ncvisual* ncv, const struct ncvisual_opt
   }
   if(bset->geom != NCBLIT_PIXEL){
     n = ncvisual_render_cells(nc, ncv, bset, placey, placex, begy, begx,
-                              leny, leny, n, scaling,
+                              leny, lenx, n, scaling,
                               vopts ? vopts->flags : 0, transcolor);
   }else{
     n = ncvisual_render_pixels(nc, ncv, bset, placey, placex, begy, begx,

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -654,6 +654,8 @@ ncplane* ncvisual_render_cells(notcurses* nc, ncvisual* ncv, const struct blitse
   }
   bargs.begy = begy;
   bargs.begx = begx;
+  bargs.leny = leny;
+  bargs.lenx = lenx;
   bargs.u.cell.placey = placey;
   bargs.u.cell.placex = placex;
   bargs.u.cell.blendcolors = flags & NCVISUAL_OPTION_BLEND;
@@ -772,8 +774,8 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
       disppixx -= absplacex * nc->tcache.cellpixx;
       disppixy -= absplacey * nc->tcache.cellpixy;
     }else{
-      disppixx = ncv->pixx;
-      disppixy = ncv->pixy;
+      disppixx = lenx;
+      disppixy = leny;
     }
     if(scaling == NCSCALE_SCALE || scaling == NCSCALE_SCALE_HIRES){
       clamp_to_sixelmax(&nc->tcache, &disppixy, &disppixx, &outy, scaling);
@@ -795,6 +797,8 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
   }
   bargs.begy = begy;
   bargs.begx = begx;
+  bargs.leny = leny;
+  bargs.lenx = lenx;
   bargs.u.pixel.celldimx = nc->tcache.cellpixx;
   bargs.u.pixel.celldimy = nc->tcache.cellpixy;
   bargs.u.pixel.colorregs = nc->tcache.color_registers;

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -468,9 +468,11 @@ int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
 //fprintf(stderr, "Couldn't allocate output frame for scaled frame\n");
       return -1;
     }
-    //fprintf(stderr, "WHN NCV: %d/%d\n", inframe->width, inframe->height);
+//fprintf(stderr, "WHN NCV: %d/%d bargslen: %d/%d\n", inframe->width, inframe->height, bargs->leny, bargs->lenx);
+    const int srclenx = bargs->lenx ? bargs->lenx : inframe->width;
+    const int srcleny = bargs->leny ? bargs->leny : inframe->height;
     ncv->details->swsctx = sws_getCachedContext(ncv->details->swsctx,
-                                                inframe->width, inframe->height,
+                                                srclenx, srcleny,
                                                 inframe->format,
                                                 cols, rows, targformat,
                                                 SWS_LANCZOS, NULL, NULL, NULL);
@@ -492,7 +494,7 @@ int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
     }
 //fprintf(stderr, "INFRAME DAA: %p SDATA: %p FDATA: %p\n", inframe->data[0], sframe->data[0], ncv->details->frame->data[0]);
     int height = sws_scale(ncv->details->swsctx, (const uint8_t* const*)inframe->data,
-                           inframe->linesize, 0, inframe->height, sframe->data,
+                           inframe->linesize, 0, srcleny, sframe->data,
                            sframe->linesize);
     if(height < 0){
 //fprintf(stderr, "Error applying scaling (%d X %d)\n", inframe->height, inframe->width);

--- a/src/media/oiio.cpp
+++ b/src/media/oiio.cpp
@@ -158,6 +158,7 @@ int oiio_blit(struct ncvisual* ncv, int rows, int cols,
     OIIO::ImageSpec sp{};
     sp.width = cols;
     sp.height = rows;
+    // FIXME need to honor leny/lenx and begy/begx
     ibuf->reset(sp, OIIO::InitializePixels::Yes);
     OIIO::ROI roi(0, cols, 0, rows, 0, 1, 0, 4);
     if(!OIIO::ImageBufAlgo::resize(*ibuf, *ncv->details->ibuf, "", 0, roi)){

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -42,6 +42,7 @@ TEST_CASE("Bitmaps") {
     auto s = n->sprite;
     REQUIRE(nullptr != s);
     ncvisual_destroy(ncv);
+    CHECK(0 == ncplane_destroy(n));
   }
 
   SUBCASE("SprixelMaximize") {

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -35,6 +35,30 @@ TEST_CASE("Visual") {
     CHECK(0 == ncplane_destroy(n));
   }
 
+  // check that leny/lenx properly limit the output
+  SUBCASE("Partial") {
+    auto y = 10;
+    auto x = 10;
+    std::vector<uint32_t> v(x * y, htole(0xe61c28ff));
+    auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
+    REQUIRE(nullptr != ncv);
+    struct ncvisual_options vopts = {
+      .n = nullptr,
+      .scaling = NCSCALE_NONE,
+      .y = 0, .x = 0,
+      .begy = 0, .begx = 0,
+      .leny = 5, .lenx = 8,
+      .blitter = NCBLIT_1x1,
+      .flags = 0, .transcolor = 0,
+    };
+    auto n = ncvisual_render(nc_, ncv, &vopts);
+    REQUIRE(nullptr != n);
+    CHECK(5 == ncplane_dim_y(n));
+    CHECK(8 == ncplane_dim_x(n));
+    ncvisual_destroy(ncv);
+    CHECK(0 == ncplane_destroy(n));
+  }
+
   SUBCASE("InflateBitmap") {
     const uint32_t pixels[4] = { htole(0xffff00ff), htole(0xff00ffff), htole(0xff0000ff), htole(0xffffffff) };
     auto ncv = ncvisual_from_rgba(pixels, 2, 8, 2);

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Visual") {
     CHECK(0 == ncplane_destroy(n));
   }
 
-  // check that leny/lenx properly limit the output
+  // check that leny/lenx properly limit the output, new plane
   SUBCASE("Partial") {
     auto y = 10;
     auto x = 10;
@@ -55,6 +55,32 @@ TEST_CASE("Visual") {
     REQUIRE(nullptr != n);
     CHECK(5 == ncplane_dim_y(n));
     CHECK(8 == ncplane_dim_x(n));
+    ncvisual_destroy(ncv);
+    CHECK(0 == ncplane_destroy(n));
+  }
+
+  // partial limit via len, offset via y/x, new plane
+  SUBCASE("PartialOffset") {
+    auto y = 10;
+    auto x = 10;
+    std::vector<uint32_t> v(x * y, htole(0xe61c28ff));
+    auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
+    REQUIRE(nullptr != ncv);
+    struct ncvisual_options vopts = {
+      .n = nullptr,
+      .scaling = NCSCALE_NONE,
+      .y = 2, .x = 4,
+      .begy = 0, .begx = 0,
+      .leny = 5, .lenx = 8,
+      .blitter = NCBLIT_1x1,
+      .flags = 0, .transcolor = 0,
+    };
+    auto n = ncvisual_render(nc_, ncv, &vopts);
+    REQUIRE(nullptr != n);
+    CHECK(5 == ncplane_dim_y(n));
+    CHECK(8 == ncplane_dim_x(n));
+    CHECK(2 == ncplane_y(n));
+    CHECK(4 == ncplane_x(n));
     ncvisual_destroy(ncv);
     CHECK(0 == ncplane_destroy(n));
   }

--- a/tools/debrelease.sh
+++ b/tools/debrelease.sh
@@ -3,15 +3,20 @@
 set -e
 
 # export DISTRIBUTION to use something other than unstable (or whatever was
-# last used in debian/changelog). see dch(1).
+# last used in debian/changelog). see dch(1). can use a DEBVERSION exported
+# in the process's environment.
 usage() { echo "usage: `basename $0` version" ; }
 
 [ $# -eq 1 ] || { usage >&2 ; exit 1 ; }
 
 VERSION="$1"
 
+if [ -z "$DEBVERSION" ] ; then
+  DEBVERSION=1
+fi
+
 rm -fv debian/files
-dch -v $VERSION+dfsg.1-1
+dch -v $VERSION+dfsg.1-$DEBVERSION
 if [ -n "$DISTRIBUTION" ] ; then
   dch -r --distribution "$DISTRIBUTION"
 else


### PR DESCRIPTION
During 2.2.x late development, I disabled support for `leny`/`lenx` in `ncvisual_options`, as it was buggy. Enable it once more, and get it working. Add several unit tests, which initially did not pass, but now do. Closes #1611. In direct mode, update `outy` following a scaling operation, so that glyph-based rendering uses the proper number of output rows. Closes #1673.