### PR TITLE
Force media loaded from file to RGBA

### DIFF
--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -137,10 +137,6 @@ int ffmpeg_decode(ncvisual* n){
   }
   bool have_frame = false;
   bool unref = false;
-  // FIXME what if this was set up with e.g. ncvisual_from_rgba()?
-  if(n->details->frame){
-    //av_freep(&n->details->frame->data[0]);
-  }
   do{
     do{
       if(n->details->packet_outstanding){


### PR DESCRIPTION
In the ffmpeg implementation, we load media from disk, and leave it in its native pixel format until we go to blit it. The `ncpixel` API expects RGBA, and all constructors from memory force conversions to RGBA. We now convert to RGBA following decode. Closes #1680.