### PR TITLE
Unify tpreserved/ncinputlayer across direct and rendered modes

### DIFF
--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -20,6 +20,9 @@ void sigwinch_handler(int signo){
 }
 
 int cbreak_mode(int ttyfd, const struct termios* tpreserved){
+  if(n->ttyfd < 0){
+    return 0;
+  }
   // assume it's not a true terminal (e.g. we might be redirected to a file)
   struct termios modtermios;
   memcpy(&modtermios, tpreserved, sizeof(modtermios));

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -405,7 +405,6 @@ typedef struct ncdirect {
   tinfo tcache;              // terminfo cache
   uint64_t channels;         // current channels
   uint16_t stylemask;        // current styles
-  struct termios tpreserved; // terminal state upon entry
   // some terminals (e.g. kmscon) return cursor coordinates inverted from the
   // typical order. we detect it the first time ncdirect_cursor_yx() is called.
   bool detected_cursor_inversion; // have we performed inversion testing?
@@ -487,7 +486,6 @@ typedef struct notcurses {
   int ttyfd;      // file descriptor for controlling tty
   FILE* renderfp; // debugging FILE* to which renderings are written
   tinfo tcache;   // terminfo cache
-  struct termios tpreserved; // terminal state upon entry
   pthread_mutex_t pilelock; // guards pile list, locks resize in render
   bool suppress_banner; // from notcurses_options
 
@@ -591,8 +589,8 @@ void init_lang(notcurses* nc); // nc may be NULL, only used for logging
 // initialized. set |utf8| if we've verified UTF8 output encoding.
 // set |noaltscreen| to inhibit alternate screen detection. |fd| ought
 // be connected to a terminal device, or -1 if no terminal is available.
-int interrogate_terminfo(tinfo* ti, int fd, const char* termname,
-                         unsigned utf8, unsigned noaltscreen);
+int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
+                         unsigned noaltscreen, unsigned nocbreak);
 int term_supported_styles(const tinfo* ti);
 int reset_term_attributes(const tinfo* ti, FILE* fp);
 

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -186,9 +186,11 @@ int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
                          unsigned noaltscreen, unsigned nocbreak){
   memset(ti, 0, sizeof(*ti));
   ti->utf8 = utf8;
-  if(tcgetattr(fd, &ti->tpreserved)){
-    fprintf(stderr, "Couldn't preserve terminal state for %d (%s)\n", fd, strerror(errno));
-    return -1;
+  if(fd >= 0){
+    if(tcgetattr(fd, &ti->tpreserved)){
+      fprintf(stderr, "Couldn't preserve terminal state for %d (%s)\n", fd, strerror(errno));
+      return -1;
+    }
   }
   if(ncinputlayer_init(&ti->input, stdin)){
     return -1;

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -118,6 +118,7 @@ typedef struct tinfo {
   int (*pixel_shutdown)(int fd);  // called during context shutdown
   int (*pixel_clear_all)(int fd); // called during startup, kitty only
   int sprixel_scale_height; // sprixel must be a multiple of this many rows
+  struct termios tpreserved; // terminal state upon entry
   ncinputlayer input;       // input layer
   bool bitmap_supported;    // do we support bitmaps (post pixel_query_done)?
   bool pixel_query_done;    // have we yet performed pixel query?


### PR DESCRIPTION
Both `ncdirect` and `notcurses` structs contained `termios` and `ncinputlayer` members. Move these instead to the common `tinfo` struct, and unify their initialization. Related to #1525.