### PR TITLE
[WIP] macOS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ include(GNUInstallDirs)
 include(CMakeDependentOption)
 include(FeatureSummary)
 
+if(APPLE)
+  set(QRCODEGEN_OPTION_DEFAULT OFF)
+else()
+  set(QRCODEGEN_OPTION_DEFAULT ON)
+endif()
+
 ###################### USER-SELECTABLE OPTIONS ###########################
 # BUILD_TESTING is defined by CTest
 option(DFSG_BUILD "DFSG build (no non-free media/code)" OFF)
@@ -76,6 +82,51 @@ add_compile_options(-Wall -Wextra -W -Wshadow -Wformat -Wno-nonnull-compare
 message(STATUS "Requested multimedia engine: ${USE_MULTIMEDIA}")
 message(STATUS "Requested build mode: ${CMAKE_BUILD_TYPE}")
 
+if(APPLE)
+  macro(_get_brew_prefix BREW_RECIPE_NAME VAR)
+    execute_process(
+      COMMAND "${BREW}" --prefix ${BREW_RECIPE_NAME}
+      OUTPUT_VARIABLE MAC_${VAR}_PREFIX
+      RESULT_VARIABLE MAC_${VAR}_RESULT
+    )
+
+    string(STRIP "${MAC_${VAR}_PREFIX}" MAC_${VAR}_PREFIX)
+  endmacro()
+
+  # ncurses version shipped with the latest macOS SDK is a fossilware version of 5.7 (A.D. 2008)
+  # We need 6.1, we need to take it from brew (for instance) and we need to be
+  # sneaky since the newer versions must not disrupt the fossilware installed with
+  # the SDK
+
+  # We support homebrew (https://brew.sh/) for now since I don't use anything else
+  find_program(BREW brew REQUIRED)
+
+  # We set up the environment so that pkg-config below can find ncurses
+  _get_brew_prefix(ncurses NCURSES)
+  if(NOT MAC_NCURSES_RESULT EQUAL 0)
+     message(FATAL_ERROR "Notcurses require ncurses >= 6.1 to be installed with homebrew: brew install ncurses")
+  endif()
+  set(ENV{PKG_CONFIG_PATH} "${MAC_NCURSES_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+
+  # We set up the environment so that pkg-config below can find readline
+  _get_brew_prefix(readline READLINE)
+  if(NOT MAC_READLINE_RESULT EQUAL 0)
+    message(FATAL_ERROR "Notcurses require readline >= 8.0 to be installed with homebrew: brew install readline")
+  endif()
+  set(ENV{PKG_CONFIG_PATH} "${MAC_READLINE_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+
+  # We set up the environment so that libunistring can be found
+  _get_brew_prefix(libunistring UNISTRING)
+  if(NOT MAC_UNISTRING_RESULT EQUAL 0)
+     message(FATAL_ERROR "Notcurses require libunistring to be installed with homebrew: brew install libunistring")
+  endif()
+  set(LIBUNISTRING_LIBRARY_DIRS "${MAC_UNISTRING_PREFIX}/lib")
+  set(LIBUNISTRING_INCLUDE_DIRS "${MAC_UNISTRING_PREFIX}/include")
+  set(CMAKE_REQUIRED_INCLUDES "${LIBUNISTRING_INCLUDE_DIRS}")
+
+  set(MACOS_COMPAT_SRC src/lib/macos-compat.c)
+endif()
+
 find_package(PkgConfig REQUIRED)
 # don't use REQUIRED with subsequent find_package() operations; we use
 # feature_summary + set_package_properties to fail in one fell swoop.
@@ -128,7 +179,7 @@ if(NOT "${HAVE_QRCODEGEN_H}")
 endif()
 set_property(GLOBAL APPEND PROPERTY PACKAGES_FOUND qrcodegen)
 endif()
-if (NOT MSYS)
+if (NOT APPLE AND NOT MSYS)
   find_library(LIBM m)
   find_library(LIBRT rt)
 endif()
@@ -140,7 +191,7 @@ file(GLOB COMPATSRC CONFIGURE_DEPENDS src/compat/compat.c)
 ############################################################################
 # libnotcurses-core (core shared library, core static library)
 file(GLOB NCCORESRCS CONFIGURE_DEPENDS src/lib/*.c src/lib/*.cpp)
-add_library(notcurses-core SHARED ${NCCORESRCS} ${COMPATSRC})
+add_library(notcurses-core SHARED ${NCCORESRCS} ${COMPATSRC} ${MACOS_COMPAT_SRC})
 if(${USE_STATIC})
 add_library(notcurses-core-static STATIC ${NCCORESRCS})
 else()
@@ -219,7 +270,7 @@ endif()
 ############################################################################
 # libnotcurses (multimedia shared library+static library)
 file(GLOB NCSRCS CONFIGURE_DEPENDS src/media/*.c src/media/*.cpp)
-add_library(notcurses SHARED ${NCSRCS} ${COMPATSRC})
+add_library(notcurses SHARED ${NCSRCS} ${COMPATSRC} ${MACOS_COMPAT_SRC})
 if(${USE_STATIC})
 add_library(notcurses-static STATIC ${NCSRCS})
 else()
@@ -365,6 +416,7 @@ set(NCPP_INCLUDE_DIRS
   include
     "${PROJECT_BINARY_DIR}/include"
     "${TERMINFO_INCLUDE_DIRS}"
+    "${READLINE_INCLUDE_DIRS}"
   )
 
 target_include_directories(notcurses++
@@ -442,7 +494,7 @@ if(USE_POC)
 file(GLOB POCSRCS CONFIGURE_DEPENDS src/poc/*.c)
 foreach(f ${POCSRCS})
   get_filename_component(fe "${f}" NAME_WE)
-  add_executable(${fe} ${f} ${COMPATSRC})
+  add_executable(${fe} ${f} ${COMPATSRC} ${MACOS_COMPAT_SRC})
   target_include_directories(${fe}
     PRIVATE include src "${TERMINFO_INCLUDE_DIRS}"
     "${PROJECT_BINARY_DIR}/include"
@@ -457,7 +509,7 @@ endforeach()
 file(GLOB POCPPSRCS CONFIGURE_DEPENDS src/pocpp/*.cpp)
 foreach(f ${POCPPSRCS})
   get_filename_component(fe "${f}" NAME_WE)
-  add_executable(${fe} ${f} ${COMPATSRC})
+  add_executable(${fe} ${f} ${COMPATSRC} ${MACOS_COMPAT_SRC})
   target_include_directories(${fe}
     PRIVATE include src "${TERMINFO_INCLUDE_DIRS}"
     "${PROJECT_BINARY_DIR}/include"
@@ -474,7 +526,7 @@ endif()
 ############################################################################
 # notcurses-demo
 file(GLOB DEMOSRCS CONFIGURE_DEPENDS src/demo/*.c)
-add_executable(notcurses-demo ${DEMOSRCS} ${COMPATSRC})
+add_executable(notcurses-demo ${DEMOSRCS} ${COMPATSRC} ${MACOS_COMPAT_SRC})
 target_compile_definitions(notcurses-demo
   PRIVATE
     _GNU_SOURCE
@@ -584,7 +636,7 @@ tarGET_Link_libraries(ncls
 ############################################################################
 # ncplayer
 file(GLOB PLAYERSRCS CONFIGURE_DEPENDS src/player/*.cpp)
-add_executable(ncplayer ${PLAYERSRCS} ${COMPATSRC})
+add_executable(ncplayer ${PLAYERSRCS} ${COMPATSRC} ${MACOS_COMPAT_SRC})
 target_include_directories(ncplayer
   PRIVATE
     include
@@ -611,6 +663,7 @@ target_include_directories(notcurses-tester
     src
     "${CMAKE_REQUIRED_INCLUDES}"
     "${PROJECT_BINARY_DIR}/include"
+    "${TERMINFO_INCLUDE_DIRS}"
     src/lib
 )
 target_link_libraries(notcurses-tester
@@ -618,7 +671,15 @@ target_link_libraries(notcurses-tester
     notcurses++
     "${unistring}"
     "${TERMINFO_LIBRARIES}"
+    doctest::doctest
 )
+if(APPLE)
+  target_link_directories(notcurses-tester
+    PRIVATE
+      "${TERMINFO_LIBRARY_DIRS}"
+      "${READLINE_LIBRARY_DIRS}"
+  )
+endif()
 add_test(
   NAME notcurses-tester
   COMMAND notcurses-tester -p ${CMAKE_CURRENT_SOURCE_DIR}/data --abort-after=1

--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ may well be possible to use still older versions. Let me know of any successes!
 * (OPTIONAL) (rust bindings): rust 1.47.0+, [bindgen](https://crates.io/crates/bindgen) 0.55.1+, pkg-config 0.3.18+, cty 0.2.1+
 * (runtime) Linux 5.3+, FreeBSD 11+, or DragonFly BSD 5.9+
 
+### macOS prerequisites
+
+Currently, Notcurses supports only Homebrew (https://brew.sh) for installation
+of extra packages not available in the macOS SDK.  Names below represent
+the Homebrew recipe name, to be installed with `brew install $NAME`.
+
+* doctest
+* ffmpeg
+* pandoc
+* pkg-config
+* libunistring
+* readline
+
 [Here's more information](INSTALL.md) on building and installation.
 
 ## Included tools

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2,7 +2,15 @@
 #define NOTCURSES_NOTCURSES
 
 #include <time.h>
+#if !defined(__APPLE__)
+// Apple clang supports C11, but it does not have uchar.h
 #include <uchar.h>
+#else
+#ifndef __cplusplus
+#include <stdint.h>
+typedef uint32_t char32_t;
+#endif // __cplusplus
+#endif
 #include <ctype.h>
 #include <wchar.h>
 #include <stdio.h>
@@ -18,6 +26,9 @@
 #if defined(__linux__) || defined(__gnu_hurd__)
 #include <byteswap.h>
 #define htole(x) (__bswap_32(htonl(x)))
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#define htole(x) OSSwapHostToLittleInt32((x))
 #else
 #include <sys/endian.h>
 #define htole(x) (bswap32(htonl(x)))

--- a/src/compat/compat.c
+++ b/src/compat/compat.c
@@ -3,7 +3,7 @@
 #include <time.h>
 #include <stdint.h>
 #include "compat/compat.h"
-#if !defined(__DragonFly_version) || __DragonFly_version < 500907
+#if !defined(__APPLE__) && (!defined(__DragonFly_version) || __DragonFly_version < 500907)
 // clock_nanosleep is unavailable on DragonFly BSD and Mac OS X
 int clock_nanosleep(clockid_t clockid, int flags, const struct timespec *request,
                     struct timespec *remain){

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -24,9 +24,11 @@ ns_to_timespec(uint64_t ns, struct timespec* ts){
 // compatibility wrappers for code available only on certain operating systems.
 // this file is not installed, but only consumed during compilation. if we're
 // on an operating system which implements a given function, it won't be built.
+#ifndef __APPLE__
 int clock_nanosleep(clockid_t clockid, int flags,
                     const struct timespec *request,
                     struct timespec *remain);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/demo/demo.h
+++ b/src/demo/demo.h
@@ -11,6 +11,9 @@
 #include <version.h>
 #include "compat/compat.h"
 
+#if defined(__APPLE__)
+#include "../lib/macos-compat.h"
+#endif
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/demo/outro.c
+++ b/src/demo/outro.c
@@ -1,5 +1,6 @@
 #include <pthread.h>
 #include "demo.h"
+#include "../lib/macos-compat.h"
 
 static int y;
 static int targy;

--- a/src/lib/fd.c
+++ b/src/lib/fd.c
@@ -392,6 +392,8 @@ ncsubproc* ncsubproc_createvpe(ncplane* n, const ncsubproc_options* opts,
   if(ret->pid == 0){
 #ifdef __linux__
     execvpe(bin, arg, env);
+#elif defined(__APPLE__)
+    execve(bin, arg, env);
 #else
     exect(bin, arg, env);
 #endif

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -10,6 +10,7 @@ extern "C" {
 
 #include <poll.h>
 #include <term.h>
+#include <ncurses.h>
 #include <time.h>
 #include <poll.h>
 #include <stdio.h>
@@ -33,6 +34,10 @@ extern "C" {
 
 #define API __attribute__((visibility("default")))
 #define ALLOC __attribute__((malloc)) __attribute__((warn_unused_result))
+
+#if defined(__APPLE__)
+#include "macos-compat.h"
+#endif
 
 struct sixelmap;
 struct ncvisual_details;
@@ -1198,6 +1203,10 @@ term_emit(const char* seq, FILE* out, bool flush){
   }
   return flush ? ncflush(out) : 0;
 }
+
+#if defined(__APPLE__)
+char* tiparm(const char *cm, ...);
+#endif
 
 static inline int
 term_bg_palindex(const notcurses* nc, FILE* out, unsigned pal){

--- a/src/lib/macos-compat.c
+++ b/src/lib/macos-compat.c
@@ -1,0 +1,100 @@
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "macos-compat.h"
+
+// Time code based on: https://github.com/ChisholmKyle/PosixMachTiming/tree/master/src
+static inline void time_diff (const struct timespec* in, struct timespec* out)
+{
+  out->tv_sec = in->tv_sec - out->tv_sec;
+  out->tv_nsec = in->tv_nsec - out->tv_nsec;
+
+  if (out->tv_sec < 0) {
+    out->tv_sec = 0;
+    out->tv_nsec = 0;
+    return;
+  }
+
+  if (out->tv_nsec > 0) {
+    return;
+  }
+
+  if (out->tv_sec == 0) {
+    out->tv_sec = 0;
+    out->tv_nsec = 0;
+  } else {
+    out->tv_sec = out->tv_sec - 1;
+    out->tv_nsec = out->tv_nsec + 1000000000;
+  }
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+int clock_nanosleep (int clockid, int flags, const struct timespec *request, struct timespec *remain)
+{
+  struct timespec delta;
+  int rv = clock_gettime (CLOCK_MONOTONIC, &delta);
+  if (rv == 0) {
+    time_diff (request, &delta);
+    rv = nanosleep (&delta, NULL);
+  }
+
+  return rv;
+}
+#pragma clang diagnostic pop
+
+static inline int set_fd_flags (int fd, int flags)
+{
+  if ((flags & O_CLOEXEC) == O_CLOEXEC) {
+    int ret = fcntl (fd, F_SETFD, FD_CLOEXEC);
+    if (ret != 0) {
+      return ret;
+    }
+  }
+
+  if ((flags & O_NONBLOCK) == O_NONBLOCK) {
+    return fcntl (fd, F_SETFL, O_NONBLOCK);
+  }
+
+  return 0;
+}
+
+int pipe2 (int pipefd[2], int flags)
+{
+  int ret = pipe (pipefd);
+  if (ret != 0) {
+    return ret;
+  }
+
+  ret = set_fd_flags (pipefd[0], flags);
+  if (ret != 0) {
+    return ret;
+  }
+
+  return set_fd_flags (pipefd[1], flags);
+}
+
+static pthread_mutex_t ppoll_lock;
+
+int ppoll (struct pollfd *fds, nfds_t nfds, const struct timespec *tmo_p, const sigset_t *sigmask)
+{
+  pthread_mutex_lock (&ppoll_lock);
+
+  sigset_t origmask;
+  int timeout = (tmo_p == NULL) ? -1 : (tmo_p->tv_sec * 1000 + tmo_p->tv_nsec / 1000000);
+  pthread_sigmask (SIG_SETMASK, sigmask, &origmask);
+  int ret= poll (fds, nfds, timeout);
+  pthread_sigmask (SIG_SETMASK, &origmask, NULL);
+
+  pthread_mutex_unlock (&ppoll_lock);
+
+  return ret;
+}
+
+void macos_init ()
+{
+  pthread_mutex_init (&ppoll_lock, NULL);
+}

--- a/src/lib/macos-compat.h
+++ b/src/lib/macos-compat.h
@@ -1,0 +1,24 @@
+#if !defined(NOTCURSES_MACOS_COMPAT_H)
+#define NOTCURSES_MACOS_COMPAT_H
+
+#include <poll.h>
+
+#if !defined(TIMER_ABSTIME)
+// Value doesn't matter, mac builds don't use it anyway
+#define TIMER_ABSTIME 0
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+int clock_nanosleep (int clockid, int flags, const struct timespec *request, struct timespec *remain);
+int pipe2 (int pipefd[2], int flags);
+int ppoll (struct pollfd *fds, nfds_t nfds, const struct timespec *tmo_p, const sigset_t *sigmask);
+void macos_init ();
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // NOTCURSES_MACOS_COMPAT_H

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1017,6 +1017,9 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   if(outfp == NULL){
     outfp = stdout;
   }
+#if defined(__APPLE__)
+  macos_init ();
+#endif
   notcurses_options defaultopts = { };
   if(!opts){
     opts = &defaultopts;

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -12,6 +12,7 @@
 #include <ncpp/Visual.hh>
 #include <ncpp/NotCurses.hh>
 #include "compat/compat.h"
+#include "../lib/macos-compat.h"
 
 using namespace ncpp;
 

--- a/src/poc/blitters.c
+++ b/src/poc/blitters.c
@@ -4,6 +4,10 @@
 #include <notcurses/notcurses.h>
 #include "compat/compat.h"
 
+#if defined(__APPLE__)
+#include "../lib/macos-compat.h"
+#endif
+
 int main(int argc, char** argv){
   if(setlocale(LC_ALL, "") == NULL){
     fprintf(stderr, "Couldn't set locale based off LANG\n");

--- a/src/poc/rotate.c
+++ b/src/poc/rotate.c
@@ -7,6 +7,10 @@
 #include <notcurses/notcurses.h>
 #include "compat/compat.h"
 
+#if defined(__APPLE__)
+#include "../lib/macos-compat.h"
+#endif
+
 int main(int argc, char** argv){
   struct timespec ts = {
     .tv_sec = 0,

--- a/src/poc/statepixel.c
+++ b/src/poc/statepixel.c
@@ -1,6 +1,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <notcurses/notcurses.h>
+#include "../lib/macos-compat.h"
 
 // drag plane |t| across plane |n| at cell row |y|
 static int

--- a/src/poc/textplay.c
+++ b/src/poc/textplay.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <notcurses/notcurses.h>
+#include "../lib/macos-compat.h"
 
 #define GIG 1000000000ull
 static const uint32_t LOWCOLOR = 0x004080;


### PR DESCRIPTION
This is my attempt to catch up @grendello's fork's `macos` branch with this repo's current `master`, cf. PR #1280.

Note: I'm not a C programmer (will learn as I go) and only in the last year+ have been getting familiar with "systems" programming, Makefiles, cmake, etc., after spending many years working with langs/envs such as Node.js, Clojure, etc. In other words, my changes in this draft PR don't represent a deep analysis or contribution, I mainly just fiddled with @grendello's modifications until I got them working again.

With these changes in place and a fresh clone (and on this PR branch), the following works on macOS (I'm using 10.15), as long as the necessaries have been installed with `brew`:
```
$ mkdir build && cd build
$ cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MULTIMEDIA=ffmpeg ..
$ make
```

After building, I've tried running `build/notcurses-demo` in iTerm2 (`TERM=xterm-256color`), Alacritty (`TERM=alacritty`), and Kitty (`TERM=xterm-kitty`) on macOS (`COLORTERM=truecolor`):
```
$ build/notcurses-demo -p ./data
```

In all cases the demo doesn't run all the way through, always ends like this:
```
...
14│ animate│ 28.43ms│     11│ 123.13Ki│  386.9│ 7│ 1│71│ 482.62║FAILED
15│    reel│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
16│whiteout│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
17│uniblock│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
18│    view│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
19│   luigi│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
20│ sliders│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
21│ fallin'│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
22│  jungle│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
23│  qrcode│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
24│     zoo│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
25│   outro│   0.00s│      0│     0.00│    0.0│ 0│ 0│ 0│   0.00║SKIPPED
══╧════════╧════════╪═══════╪═════════╪═══════╧══╧══╧══╧═══════╝
...
Error running demo.
Is "./data" the correct data path? Supply it with -p.
```

Always reported as not available: `sexblitter`.
Reported as not available in iTerm2 and Alacritty: `quadblitter`, `sexblitter`, `pixelblitter`.

I'm not sure why it doesn't think `./data` is the correct data path for some parts of the demo. Note that I didn't install with `make install`, preferring to run from build and data in the repo.

The framerate is low-ish in iTerm2 and better in Alacritty, the visual quality is about the same in either. In Kitty the visual quality is much better but the framerate is abysmal (about 1 to 2 fps) during the intro with the spinning 3D text and also when the world map is being colored red.

I've tried compiling with the default compiler, i.e. clang that ships with Xcode. I've also tried with compilers installed via brew:
```
export CC=/usr/local/opt/gcc/bin/gcc-11
export CXX=/usr/local/opt/gcc/bin/g++-11
```
```
export CC=/usr/local/opt/llvm/bin/clang-12
export CXX=/usr/local/opt/llvm/bin/clang-12
```
I didn't notice any differences from the results described above.

Here's the tail end of the results of running `./notcurses-tester -p ../data` in Kitty:
```
                                                             ncdirect_core_init:737:Passed unsupported flags 0xffffffffffffffff
Signals weren't registered for 0x7f860a00c000 (had 0x0)
===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/egcpool.cpp:5:
TEST CASE:  EGCpool
  AddAndRemove

/Users/michael/repos/forks/notcurses/src/tests/egcpool.cpp:51: ERROR: CHECK( 1 == nccell_width(n_, &c) ) is NOT correct!
  values: CHECK( 1 == 0 )

/Users/michael/repos/forks/notcurses/src/tests/egcpool.cpp:52: FATAL ERROR: REQUIRE( 0 <= egcpool_stash(&pool_, wstr, ulen) ) is NOT correct!
  values: REQUIRE( 0 <= -1 )

get_tty_fd:490:Returning TTY fd 4
setup_signals:114:0x7f860a011600 is already registered for signals (provided 0x7f860a024000)
===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/Exceptions.cpp:7:
TEST CASE:  Exceptions
  ResetStats

/Users/michael/repos/forks/notcurses/src/tests/Exceptions.cpp:7: ERROR: test case THREW exception: exception thrown in subcase - will translate later when the whole test case has been exited (cannot translate while there is an active exception)

===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/Exceptions.cpp:7:
TEST CASE:  Exceptions

DEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):
  ResetStats

/Users/michael/repos/forks/notcurses/src/tests/Exceptions.cpp:7: ERROR: test case THREW exception: unknown exception

get_tty_fd:490:Returning TTY fd 13
setup_signals:114:0x7f860a011600 is already registered for signals (provided 0x7f860a024000)
===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/Ncpp.cpp:7:
DESCRIPTION: Basic C++ wrapper tests
TEST CASE:  Ncpp
  ConstructNotCurses

/Users/michael/repos/forks/notcurses/src/tests/Ncpp.cpp:7: ERROR: test case THREW exception: exception thrown in subcase - will translate later when the whole test case has been exited (cannot translate while there is an active exception)

===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/Ncpp.cpp:7:
DESCRIPTION: Basic C++ wrapper tests
TEST CASE:  Ncpp

DEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):
  ConstructNotCurses

/Users/michael/repos/forks/notcurses/src/tests/Ncpp.cpp:7: ERROR: test case THREW exception: unknown exception

===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/sixel.cpp:140:
TEST CASE:  Sixels

/Users/michael/repos/forks/notcurses/src/tests/sixel.cpp:142: FATAL ERROR: REQUIRE( nullptr != nc_ ) is NOT correct!
  values: REQUIRE( NULL != NULL )

===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/version.cpp:3:
TEST CASE:  Version

/Users/michael/repos/forks/notcurses/src/tests/version.cpp:5: FATAL ERROR: REQUIRE( nullptr != nc_ ) is NOT correct!
  values: REQUIRE( NULL != NULL )

===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/visual.cpp:5:
TEST CASE:  Visual

/Users/michael/repos/forks/notcurses/src/tests/visual.cpp:7: FATAL ERROR: REQUIRE( nullptr != nc_ ) is NOT correct!
  values: REQUIRE( NULL != NULL )

===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/wide.cpp:10:
TEST CASE:  Wide

/Users/michael/repos/forks/notcurses/src/tests/wide.cpp:12: FATAL ERROR: REQUIRE( nullptr != nc_ ) is NOT correct!
  values: REQUIRE( NULL != NULL )

===============================================================================
/Users/michael/repos/forks/notcurses/src/tests/zaxis.cpp:5:
TEST CASE:  ZAxis

/Users/michael/repos/forks/notcurses/src/tests/zaxis.cpp:7: FATAL ERROR: REQUIRE( nullptr != nc_ ) is NOT correct!
  values: REQUIRE( NULL != NULL )

===============================================================================
[doctest] test cases:    47 |    38 passed |  9 failed | 1 skipped
[doctest] assertions: 13658 | 13646 passed | 12 failed |
[doctest] Status: FAILURE!
```

---

Notcurses seems like a great project, truly inspiring! In the near-ish future I hope to contribute a [Nim](https://nim-lang.org/) language wrapper, as it happens that my current employment has me learning and programming in Nim on a daily basis. I'd like to write a killer TUI app as an alternative/complement to [status-desktop](https://github.com/status-im/status-desktop) (I also work on that project) and at present am experimenting with a Nim wrapper around ncurses. I think it would be a lot more interesting and exciting to implement that TUI app with notcurses! 🚀 

In addition to working with notcurses on macOS, I'll see how far I can get compiling it in an MSYS2 context and running the demo in Alacritty, etc. on MS Windows.