### PR TITLE
Enforce a single context across both direct and rendered mode #1694

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,10 @@ rearrangements of Notcurses.
   * Sadly, `ncplane_contents()` no longer accepts a `const ncplane*`, since it
     might write temporaries to the plane's EGCpool during operation.
   * Added `ncdirect_styles()`, to retrieve the current styling.
+  * In previous versions of Notcurses, a rendered-mode context
+    (`struct notcurses`) and a direct-mode context (`struct ncdirect`) could
+    be open at the same time. This was never intended, and is no longer
+    possible.
 
 * 2.3.1 (2021-05-18)
   * Sprixels no longer interact with their associated plane's framebuffer. This

--- a/doc/man/man3/notcurses.3.md
+++ b/doc/man/man3/notcurses.3.md
@@ -49,6 +49,9 @@ functionality. This subset is intended to be interleaved with user-generated
 output, and is limited to coloring and styling. Direct mode is documented in
 **notcurses_direct(3)**.
 
+Only one context can be active in a process at a time, whether direct mode
+(**struct ncdirect**) or rendered mode (**struct notcurses**).
+
 ## Output
 
 All output is performed on **struct ncplane**s (see [Ncplanes][] below). Output

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -129,7 +129,8 @@ styling. On success, a pointer to a valid **struct ncdirect** is returned.
 should be called to reset the terminal and free up resources. **ncdirect_init**
 places the terminal into "cbreak" (also known as "rare") mode, disabling
 line-buffering and echo of input. **ncdirect_stop** restores the terminal state
-as it was when the corresponding **ncdirect_init** call was made.
+as it was when the corresponding **ncdirect_init** call was made. A process
+can have only one context active at once.
 
 The following flags are defined:
 

--- a/doc/man/man3/notcurses_init.3.md
+++ b/doc/man/man3/notcurses_init.3.md
@@ -57,9 +57,8 @@ typedef struct notcurses_options {
 **notcurses_init** prepares the terminal for cursor-addressable (multiline)
 mode. The **FILE** provided as ***fp*** must be writable and attached to a
 terminal, or **NULL**. If it is **NULL**, **/dev/tty** will be opened. The
-**struct notcurses_option** passed as ***opts*** controls behavior. Only one
-instance should be associated with a given terminal at a time, though it is no
-problem to have multiple instances in a given process.
+**struct notcurses_option** passed as ***opts*** controls behavior. A process
+can have only one Notcurses context active at a time.
 
 On success, a pointer to a valid **struct notcurses** is returned. **NULL** is
 returned on failure. Before the process exits, **notcurses_stop(3)** should be

--- a/src/lib/signal.c
+++ b/src/lib/signal.c
@@ -102,6 +102,9 @@ fatal_handler(int signo, siginfo_t* siginfo, void* v){
   }
 }
 
+// this both sets up our signal handlers (unless that behavior has been
+// inhibited), and ensures that only one notcurses/ncdirect context is active
+// at any given time.
 int setup_signals(void* vnc, bool no_quit_sigs, bool no_winch_sig,
                   int(*handler)(void*)){
   notcurses* nc = vnc;

--- a/src/lib/signal.c
+++ b/src/lib/signal.c
@@ -111,12 +111,10 @@ int setup_signals(void* vnc, bool no_quit_sigs, bool no_winch_sig,
   void* expected = NULL;
   struct sigaction sa;
   // don't register ourselves if we don't intend to set up signal handlers
-  if(!no_winch_sig || !no_quit_sigs){
-    // we expect NULL (nothing registered), and want to register nc
-    if(!atomic_compare_exchange_strong(&signal_nc, &expected, nc)){
-      loginfo(nc, "%p is already registered for signals (provided %p)\n", expected, nc);
-      return -1;
-    }
+  // we expect NULL (nothing registered), and want to register nc
+  if(!atomic_compare_exchange_strong(&signal_nc, &expected, nc)){
+    loginfo(nc, "%p is already registered for signals (provided %p)\n", expected, nc);
+    return -1;
   }
   if(!no_winch_sig){
     memset(&sa, 0, sizeof(sa));


### PR DESCRIPTION
Even if we're not registering ourselves for any signals, only allow one instance of either rendered- or direct-mode at a time within a process. Enforce this by always attempting to take the atomic `signal_nc`. This will be annoying for `notcurses-tester`, since all the unit tests following one which bombed out with `REQUIRE` or a signal will fail, but we have `--abort-after=1` in our `CMakeLists.txt` now, so [shrug]. Closes #1694.