### PR TITLE
recognize ‘\E[?6;4c’ as supporting sixel images

### DIFF
--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -506,6 +506,9 @@ query_sixel(tinfo* ti, int fd){
           }
           state = WANT_C4;
         }else if(in == 'c'){
+          if(in4){
+            setup_sixel_bitmaps(ti);
+          }
           state = DONE;
         }else if(in == '6'){
           state = WANT_VT102_C;


### PR DESCRIPTION
This isn’t a DA response ever used by real hardware of course; I’ll understand if you don’t want it to.