### PR TITLE
Fully general noninterpolative inflate/deflate

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1610,7 +1610,6 @@ rgba_blitter(const struct tinfo* tcache, const struct ncvisual_options* opts) {
 static inline uint32_t*
 resize_bitmap(const uint32_t* bmap, int srows, int scols, size_t sstride,
               int drows, int dcols, size_t dstride){
-fprintf(stderr, "sstride: %zu dstride: %zu\n", sstride, dstride);
   if(sstride < scols * sizeof(*bmap)){
     return NULL;
   }
@@ -1624,14 +1623,13 @@ fprintf(stderr, "sstride: %zu dstride: %zu\n", sstride, dstride);
   }
   float xrat = (float)dcols / scols;
   float yrat = (float)drows / srows;
-fprintf(stderr, "xrat: %f yrat: %f\n", xrat, yrat);
   int dy = 0;
   for(int y = 0 ; y < srows ; ++y){
-    float ytarg = y * yrat;
+    float ytarg = (y + 1) * yrat;
     while(ytarg > dy){
       int dx = 0;
       for(int x = 0 ; x < scols ; ++x){
-        float xtarg = x * xrat;
+        float xtarg = (x + 1) * xrat;
         while(xtarg > dx){
           ret[dy * dstride / sizeof(*ret) + dx] = bmap[y * sstride / sizeof(*ret) + x];
           ++dx;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1637,8 +1637,8 @@ fprintf(stderr, "xrat: %f yrat: %f\n", xrat, yrat);
           ++dx;
         }
       }
+      ++dy;
     }
-    ++dy;
   }
   return ret;
 }

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -589,7 +589,6 @@ ncvisual* ncvisual_from_bgra(const void* bgra, int rows, int rowstride, int cols
 int ncvisual_resize(ncvisual* nc, int rows, int cols){
   if(!visual_implementation){
     size_t dstride = pad_for_image(cols * 4);
-fprintf(stderr, "DSTRIDE: %zu\n", dstride);
     uint32_t* r = resize_bitmap(nc->data, nc->pixy, nc->pixx, nc->rowstride,
                                 rows, cols, dstride);
     if(r == NULL){

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -1078,29 +1078,6 @@ char* ncvisual_subtitle(const ncvisual* ncv){
   return visual_implementation->visual_subtitle(ncv);
 }
 
-// Inflate each pixel of 'bmap' to 'scale'x'scale' pixels square, using the
-// same color as the original pixel.
-// FIXME replace with resize_bitmap()
-static inline void*
-inflate_bitmap(const uint32_t* bmap, int scale, int rows, int stride, int cols){
-  size_t size = rows * cols * scale * scale * sizeof(*bmap);
-  uint32_t* ret = malloc(size);
-  if(ret){
-    for(int y = 0 ; y < rows ; ++y){
-      const uint32_t* src = bmap + y * (stride / sizeof(*bmap));
-      for(int yi = 0 ; yi < scale ; ++yi){
-        uint32_t* dst = ret + (y * scale + yi) * cols * scale;
-        for(int x = 0 ; x < cols ; ++x){
-          for(int xi = 0 ; xi < scale ; ++xi){
-            dst[x * scale + xi] = src[x];
-          }
-        }
-      }
-    }
-  }
-  return ret;
-}
-
 int ncvisual_inflate(ncvisual* n, int scale){
   if(scale <= 0){
     return -1;

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -1091,7 +1091,7 @@ int ncvisual_inflate(ncvisual* n, int scale){
   ncvisual_set_data(n, inflaton, true);
   n->pixy *= scale;
   n->pixx *= scale;
-  n->rowstride = 4 * n->pixx;
+  n->rowstride = dstride;
   ncvisual_details_seed(n);
   return 0;
 }

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -1063,8 +1063,48 @@ int ncvisual_resize(ncvisual* nc, int rows, int cols){
   return 0;
 }
 
+// naive resize of |bmap| from |srows|x|scols| -> |drows|x|dcols|, suitable for
+// pixel art. we either select at a constant interval (for shrinking) or duplicate
+// at a constant ratio (for inflation). in the absence of a multimedia engine, this
+// is the only kind of resizing we support.
+static inline uint32_t*
+resize_bitmap(const uint32_t* bmap, int srows, int scols, size_t sstride,
+              int drows, int dcols, size_t dstride){
+  if(sstride < scols * sizeof(*bmap)){
+    return NULL;
+  }
+  if(dstride < dcols * sizeof(*bmap)){
+    return NULL;
+  }
+  size_t size = drows * dstride;
+  uint32_t* ret = malloc(size);
+  if(ret == NULL){
+    return NULL;
+  }
+  float xrat = (float)dcols / scols;
+  float yrat = (float)drows / srows;
+fprintf(stderr, "xrat: %f yrat: %f\n", xrat, yrat);
+  int dy = 0;
+  for(int y = 0 ; y < srows ; ++y){
+    float ytarg = y * yrat;
+    while(ytarg > dy){
+      int dx = 0;
+      for(int x = 0 ; x < scols ; ++x){
+        float xtarg = x * xrat;
+        while(xtarg > dx){
+          ret[dy * dstride / sizeof(*ret) + dx] = bmap[y * sstride / sizeof(*ret) + x];
+          ++dx;
+        }
+      }
+    }
+    ++dy;
+  }
+  return ret;
+}
+
 // Inflate each pixel of 'bmap' to 'scale'x'scale' pixels square, using the
 // same color as the original pixel.
+// FIXME replace with resize_bitmap()
 static inline void*
 inflate_bitmap(const uint32_t* bmap, int scale, int rows, int stride, int cols){
   size_t size = rows * cols * scale * scale * sizeof(*bmap);

--- a/src/media/none.cpp
+++ b/src/media/none.cpp
@@ -35,7 +35,18 @@ int none_resize(ncvisual* nc, int rows, int cols){
   if(nc->pixy == rows && nc->pixx == cols){
     return 0;
   }
-  return -1;
+  size_t dstride = cols * 4;
+fprintf(stderr, "DSTRIDE: %zu\n", dstride);
+  uint32_t* r = resize_bitmap(nc->data, nc->pixy, nc->pixx, nc->rowstride,
+                              rows, cols, dstride);
+  if(r == NULL){
+    return -1;
+  }
+  ncvisual_set_data(nc, r, true);
+  nc->rowstride = dstride;
+  nc->pixy = rows;
+  nc->pixx = cols;
+  return 0;
 }
 
 int none_blit(struct ncvisual* ncv, int rows, int cols,

--- a/src/media/none.cpp
+++ b/src/media/none.cpp
@@ -36,7 +36,6 @@ int none_resize(ncvisual* nc, int rows, int cols){
     return 0;
   }
   size_t dstride = cols * 4;
-fprintf(stderr, "DSTRIDE: %zu\n", dstride);
   uint32_t* r = resize_bitmap(nc->data, nc->pixy, nc->pixx, nc->rowstride,
                               rows, cols, dstride);
   if(r == NULL){

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -105,18 +105,18 @@ TEST_CASE("Visual") {
     CHECK(6 == ncv->pixx);
     for(int y = 0 ; y < 3 ; ++y){
       for(int x = 0 ; x < 3 ; ++x){
-        CHECK(pixels[0] == ncv->data[y * ncv->pixx + x]);
+        CHECK(pixels[0] == ncv->data[y * ncv->rowstride / 4 + x]);
       }
       for(int x = 3 ; x < 6 ; ++x){
-        CHECK(pixels[1] == ncv->data[y * ncv->pixx + x]);
+        CHECK(pixels[1] == ncv->data[y * ncv->rowstride / 4 + x]);
       }
     }
     for(int y = 3 ; y < 6 ; ++y){
       for(int x = 0 ; x < 3 ; ++x){
-        CHECK(pixels[2] == ncv->data[y * ncv->pixx + x]);
+        CHECK(pixels[2] == ncv->data[y * ncv->rowstride / 4 + x]);
       }
       for(int x = 3 ; x < 6 ; ++x){
-        CHECK(pixels[3] == ncv->data[y * ncv->pixx + x]);
+        CHECK(pixels[3] == ncv->data[y * ncv->rowstride / 4 + x]);
       }
     }
     REQUIRE(newn);


### PR DESCRIPTION
For `NCSCALE_INFLATE`, we need free-geometry noninterpolative resizing. This will also provide a resize method when compiled without a multimedia engine, or when linked to only `libnotcurses-core`. Closes #1705.