### PR TITLE
Perform implicit scaling in ncvisual_blit() even without multimedia backend

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 2.3.3 (not yet released)
+  * `ncvisual_blit()` without a multimedia engine will now properly scale
+    the output according to the provided `ncvisual_options`.
+
 * 2.3.2 (2021-06-03)
   * Fixed a bug affecting certain scalings of `ncvisual` objects created from
     memory (e.g. `ncvisual_from_rgba()`).

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -42,7 +42,6 @@ const demoresult* demoresult_lookup(int idx){
   return &results[idx];
 }
 
-// FIXME change to unique_ptr
 char* find_data(const char* datum){
   char* path = malloc(strlen(datadir) + 1 + strlen(datum) + 1);
   strcpy(path, datadir);

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -41,9 +41,9 @@ rgba_trans_q(const unsigned char* p, uint32_t transcolor){
 // Retarded RGBA blitter (ASCII only).
 static inline int
 tria_blit_ascii(ncplane* nc, int linesize, const void* data,
-                int leny, int lenx, const blitterargs* bargs){
+                int leny, int lenx, const blitterargs* bargs,
+                int bpp){
 //fprintf(stderr, "ASCII %d X %d @ %d X %d (%p) place: %d X %d\n", leny, lenx, bargs->begy, bargs->begx, data, bargs->u.cell.placey, bargs->u.cell.placex);
-  const int bpp = 32;
   int dimy, dimx, x, y;
   int total = 0; // number of cells written
   ncplane_dim_yx(nc, &dimy, &dimx);
@@ -94,11 +94,10 @@ tria_blit_ascii(ncplane* nc, int linesize, const void* data,
 // RGBA half-block blitter. Best for most images/videos. Full fidelity
 // combined with 1:1 pixel aspect ratio.
 static inline int
-tria_blit(ncplane* nc, int linesize, const void* data,
-          int leny, int lenx, const blitterargs* bargs){
+tria_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
+          const blitterargs* bargs, int bpp){
 //fprintf(stderr, "HALF %d X %d @ %d X %d (%p) place: %d X %d\n", leny, lenx, bargs->begy, bargs->begx, data, bargs->u.cell.placey, bargs->u.cell.placex);
   uint32_t transcolor = bargs->transcolor;
-  const int bpp = 32;
   int dimy, dimx, x, y;
   int total = 0; // number of cells written
   ncplane_dim_yx(nc, &dimy, &dimx);
@@ -424,9 +423,8 @@ qtrans_check(nccell* c, unsigned blendcolors,
 // quadrant blitter. maps 2x2 to each cell. since we only have two colors at
 // our disposal (foreground and background), we lose some fidelity.
 static inline int
-quadrant_blit(ncplane* nc, int linesize, const void* data,
-              int leny, int lenx, const blitterargs* bargs){
-  const int bpp = 32;
+quadrant_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
+              const blitterargs* bargs, int bpp){
   int dimy, dimx, x, y;
   int total = 0; // number of cells written
   ncplane_dim_yx(nc, &dimy, &dimx);
@@ -653,9 +651,8 @@ sex_trans_check(cell* c, const uint32_t rgbas[6], unsigned blendcolors,
 // sextant blitter. maps 3x2 to each cell. since we only have two colors at
 // our disposal (foreground and background), we lose some fidelity.
 static inline int
-sextant_blit(ncplane* nc, int linesize, const void* data,
-             int leny, int lenx, const blitterargs* bargs){
-  const int bpp = 32;
+sextant_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
+             const blitterargs* bargs, int bpp){
   int dimy, dimx, x, y;
   int total = 0; // number of cells written
   ncplane_dim_yx(nc, &dimy, &dimx);
@@ -727,9 +724,8 @@ fold_rgb8(unsigned* restrict r, unsigned* restrict g, unsigned* restrict b,
 // visuals with only two colors in a given area, as it packs lots of
 // resolution. always transparent background.
 static inline int
-braille_blit(ncplane* nc, int linesize, const void* data,
-             int leny, int lenx, const blitterargs* bargs){
-  const int bpp = 32;
+braille_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
+             const blitterargs* bargs, int bpp){
   int dimy, dimx, x, y;
   int total = 0; // number of cells written
   ncplane_dim_yx(nc, &dimy, &dimx);
@@ -1065,7 +1061,7 @@ int ncblit_rgba(const void* data, int linesize, const struct ncvisual_options* v
       },
     },
   };
-  return bset->blit(nc, linesize, data, leny, lenx, &bargs);
+  return bset->blit(nc, linesize, data, leny, lenx, &bargs, 32);
 }
 
 ncblitter_e ncvisual_media_defblitter(const notcurses* nc, ncscale_e scale){

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1649,6 +1649,8 @@ resize_bitmap(const uint32_t* bmap, int srows, int scols, size_t sstride,
   return ret;
 }
 
+// implemented by a multimedia backend (ffmpeg or oiio), and installed
+// prior to calling notcurses_core_init() (by notcurses_init()).
 typedef struct ncvisual_implementation {
   int (*visual_init)(int loglevel);
   void (*visual_printbanner)(const struct notcurses* nc);
@@ -1665,6 +1667,14 @@ typedef struct ncvisual_implementation {
   int (*visual_stream)(notcurses* nc, struct ncvisual* ncv, float timescale,
                        ncstreamcb streamer, const struct ncvisual_options* vopts, void* curry);
   char* (*visual_subtitle)(const struct ncvisual* ncv);
+  // do a resize, without updating the ncvisual structure. if the target
+  // parameters are already matched, the existing data will be returned.
+  // otherwise, a scaled copy will be returned. they can be differentiated
+  // by comparing the result against ncv->data.
+  uint32_t* (*visual_resize_internal)(const struct ncvisual* ncv, int rows,
+                                      int* stride, int cols,
+                                      const struct blitterargs* bargs);
+  // do a persistent resize, changing the ncv itself
   int (*visual_resize)(struct ncvisual* ncv, int rows, int cols);
   void (*visual_destroy)(struct ncvisual* ncv);
   bool canopen_images;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -528,7 +528,8 @@ typedef struct blitterargs {
 // from scaling. we might actually need more pixels due to framing concerns,
 // in which case just assume transparent input pixels where needed.
 typedef int (*ncblitter)(struct ncplane* n, int linesize, const void* data,
-                         int scaledy, int scaledx, const blitterargs* bargs);
+                         int scaledy, int scaledx, const blitterargs* bargs,
+                         int bpp);
 
 // a system for rendering RGBA pixels as text glyphs or sixel/kitty bitmaps
 struct blitset {
@@ -819,7 +820,7 @@ ncplane_cell_ref_yx(const ncplane* n, int y, int x){
 static inline void
 cell_debug(const egcpool* p, const nccell* c){
   fprintf(stderr, "gcluster: %08x %s style: 0x%04x chan: 0x%016jx\n",
-				  c->gcluster, egcpool_extended_gcluster(p, c), c->stylemask, c->channels);
+          c->gcluster, egcpool_extended_gcluster(p, c), c->stylemask, c->channels);
 }
 
 static inline void
@@ -879,11 +880,11 @@ void sixelmap_free(struct sixelmap *s);
 // the transparency vector up into 1/8th as many bytes.
 uint8_t* sprixel_auxiliary_vector(const sprixel* s);
 
-int sixel_blit(ncplane* nc, int linesize, const void* data,
-               int leny, int lenx, const blitterargs* bargs);
+int sixel_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
+               const blitterargs* bargs, int bpp);
 
-int kitty_blit(ncplane* nc, int linesize, const void* data,
-               int leny, int lenx, const blitterargs* bargs);
+int kitty_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
+               const blitterargs* bargs, int bpp);
 
 static inline int
 sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
@@ -1581,8 +1582,9 @@ const struct blitset* lookup_blitset(const tinfo* tcache, ncblitter_e setid, boo
 static inline int
 rgba_blit_dispatch(ncplane* nc, const struct blitset* bset,
                    int linesize, const void* data,
-                   int leny, int lenx, const blitterargs* bargs){
-  return bset->blit(nc, linesize, data, leny, lenx, bargs);
+                   int leny, int lenx, const blitterargs* bargs,
+                   int bpp){
+  return bset->blit(nc, linesize, data, leny, lenx, bargs, bpp);
 }
 
 static inline const struct blitset*

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1667,13 +1667,6 @@ typedef struct ncvisual_implementation {
   int (*visual_stream)(notcurses* nc, struct ncvisual* ncv, float timescale,
                        ncstreamcb streamer, const struct ncvisual_options* vopts, void* curry);
   char* (*visual_subtitle)(const struct ncvisual* ncv);
-  // do a resize, without updating the ncvisual structure. if the target
-  // parameters are already matched, the existing data will be returned.
-  // otherwise, a scaled copy will be returned. they can be differentiated
-  // by comparing the result against ncv->data.
-  uint32_t* (*visual_resize_internal)(const struct ncvisual* ncv, int rows,
-                                      int* stride, int cols,
-                                      const struct blitterargs* bargs);
   // do a persistent resize, changing the ncv itself
   int (*visual_resize)(struct ncvisual* ncv, int rows, int cols);
   void (*visual_destroy)(struct ncvisual* ncv);

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -508,8 +508,8 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx,
 
 // Kitty graphics blitter. Kitty can take in up to 4KiB at a time of (optionally
 // deflate-compressed) 24bit RGB. Returns -1 on error, 1 on success.
-int kitty_blit(ncplane* n, int linesize, const void* data,
-               int leny, int lenx, const blitterargs* bargs){
+int kitty_blit(ncplane* n, int linesize, const void* data, int leny, int lenx,
+               const blitterargs* bargs, int bpp __attribute__ ((unused))){
   int cols = bargs->u.pixel.spx->dimx;
   int rows = bargs->u.pixel.spx->dimy;
   char* buf = NULL;

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -740,8 +740,8 @@ sixel_blit_inner(int leny, int lenx, sixeltable* stab,
 
 // |leny| and |lenx| are the scaled output geometry. we take |leny| up to the
 // nearest multiple of six greater than or equal to |leny|.
-int sixel_blit(ncplane* n, int linesize, const void* data,
-               int leny, int lenx, const blitterargs* bargs){
+int sixel_blit(ncplane* n, int linesize, const void* data, int leny, int lenx,
+               const blitterargs* bargs, int bpp __attribute__ ((unused))){
   int colorregs = bargs->u.pixel.colorregs;
   if(colorregs <= 0){
     return -1;

--- a/src/lib/visual-details.h
+++ b/src/lib/visual-details.h
@@ -30,6 +30,7 @@ typedef struct ncvisual {
 
 static inline void
 ncvisual_set_data(ncvisual* ncv, void* data, bool owned){
+//fprintf(stderr, "replacing %p with %p (%u -> %u)\n", ncv->data, data, ncv->owndata, owned);
   if(ncv->owndata){
     if(data != ncv->data){
       free(ncv->data);

--- a/src/lib/visual-details.h
+++ b/src/lib/visual-details.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -70,7 +70,7 @@ int ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
     if(data == NULL){
       return -1;
     }
-    if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, barg) >= 0){
+    if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, barg, 32) >= 0){
       ret = 0;
     }
     if(data != ncv->data){

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -64,8 +64,17 @@ int ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
       ret = 0;
     }
   }else{
-    if(rgba_blit_dispatch(n, bset, ncv->rowstride, ncv->data, rows, cols, barg) >= 0){
+    int stride = 4 * cols;
+    uint32_t* data = resize_bitmap(ncv->data, ncv->pixy, ncv->pixx,
+                                   ncv->rowstride, rows, cols, stride);
+    if(data == NULL){
+      return -1;
+    }
+    if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, barg) >= 0){
       ret = 0;
+    }
+    if(data != ncv->data){
+      free(data);
     }
   }
   return ret;

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -551,7 +551,7 @@ int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
   }
 //fprintf(stderr, "WHN NCV: %d/%d bargslen: %d/%d targ: %d/%d\n", inframe->width, inframe->height, bargs->leny, bargs->lenx, rows, cols);
   int ret = 0;
-  if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, bargs) < 0){
+  if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, bargs, 32) < 0){
 //fprintf(stderr, "rgba dispatch failed!\n");
     ret = -1;
   }

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -526,8 +526,9 @@ int ffmpeg_resize(ncvisual* n, int rows, int cols){
   n->rowstride = sframe->linesize[0];
   n->pixy = rows;
   n->pixx = cols;
-//fprintf(stderr, "SETTING UP RESIZE %p\n", n->data);
-  av_frame_unref(n->details->frame);
+  if(n->owndata){
+    av_frame_unref(n->details->frame);
+  }
   ncvisual_set_data(n, sframe->data[0], true);
   n->details->frame = sframe;
 //fprintf(stderr, "SIZE SCALED: %d %d (%u)\n", n->details->frame->height, n->details->frame->width, n->details->frame->linesize[0]);

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -631,6 +631,7 @@ static const ncvisual_implementation ffmpeg_impl = {
   .visual_decode_loop = ffmpeg_decode_loop,
   .visual_stream = ffmpeg_stream,
   .visual_subtitle = ffmpeg_subtitle,
+  .visual_resize_internal = ffmpeg_resize_internal,
   .visual_resize = ffmpeg_resize,
   .visual_destroy = ffmpeg_destroy,
   .canopen_images = true,

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -455,8 +455,13 @@ int ffmpeg_decode_loop(ncvisual* ncv){
   return r;
 }
 
-uint32_t* ffmpeg_resize_internal(const ncvisual* ncv, int rows, int* stride,
-                                 int cols, const blitterargs* bargs){
+// do a resize *without* updating the ncvisual structure. if the target
+// parameters are already matched, the existing data will be returned.
+// otherwise, a scaled copy will be returned. they can be differentiated by
+// comparing the result against ncv->data.
+static uint32_t*
+ffmpeg_resize_internal(const ncvisual* ncv, int rows, int* stride, int cols,
+                       const blitterargs* bargs){
   const AVFrame* inframe = ncv->details->frame;
 //print_frame_summary(NULL, inframe);
   const int targformat = AV_PIX_FMT_RGBA;
@@ -631,7 +636,6 @@ static const ncvisual_implementation ffmpeg_impl = {
   .visual_decode_loop = ffmpeg_decode_loop,
   .visual_stream = ffmpeg_stream,
   .visual_subtitle = ffmpeg_subtitle,
-  .visual_resize_internal = ffmpeg_resize_internal,
   .visual_resize = ffmpeg_resize,
   .visual_destroy = ffmpeg_destroy,
   .canopen_images = true,

--- a/src/media/none.c
+++ b/src/media/none.c
@@ -4,7 +4,7 @@
 #include "internal.h"
 #include "visual-details.h"
 
-const ncvisual_implementation* local_visual_implementation = nullptr;
+const ncvisual_implementation* local_visual_implementation = NULL;
 
 #endif
 #endif

--- a/src/media/oiio-indep.c
+++ b/src/media/oiio-indep.c
@@ -6,8 +6,9 @@
 
 int oiio_blit_dispatch(struct ncplane* nc, const struct blitset* bset,
                        int linesize, const void* data,
-                       int leny, int lenx, const blitterargs* bargs){
-  if(rgba_blit_dispatch(nc, bset, linesize, data, leny, lenx, bargs) < 0){
+                       int leny, int lenx, const blitterargs* bargs,
+                       int bpp){
+  if(rgba_blit_dispatch(nc, bset, linesize, data, leny, lenx, bargs, bpp) < 0){
     return -1;
   }
   return 0;

--- a/src/media/oiio.cpp
+++ b/src/media/oiio.cpp
@@ -31,6 +31,7 @@ auto oiio_details_seed(ncvisual* ncv) -> void {
   ncv->details->frame = std::make_unique<uint32_t[]>(pixels);
   OIIO::ImageSpec rgbaspec{ncv->pixx, ncv->pixy, 4, OIIO::TypeDesc(OIIO::TypeDesc::UINT8, 4)};
   ncv->details->ibuf = std::make_unique<OIIO::ImageBuf>(rgbaspec, ncv->data);
+//fprintf(stderr, "got pixel_stride: %ld %ld\n", ncv->details->ibuf->pixel_stride(), ncv->details->ibuf->scanline_stride());
 }
 
 auto oiio_create() -> ncvisual* {
@@ -148,7 +149,8 @@ int oiio_blit(struct ncvisual* ncv, int rows, int cols,
               const blitterargs* bargs) {
 //fprintf(stderr, "%d/%d -> %d/%d on the resize\n", ncv->pixy, ncv->pixx, rows, cols);
   void* data = nullptr;
-  int stride = 0;
+  int stride;
+  int pstride;
   auto ibuf = std::make_unique<OIIO::ImageBuf>();
   if(ncv->details->ibuf && (ncv->pixx != cols || ncv->pixy != rows)){ // scale it
     // FIXME need to honor leny/lenx and begy/begx
@@ -156,15 +158,17 @@ int oiio_blit(struct ncvisual* ncv, int rows, int cols,
     if(!OIIO::ImageBufAlgo::resize(*ibuf, *ncv->details->ibuf, "", 0, roi)){
       return -1;
     }
+    pstride = ibuf->pixel_stride();
     stride = ibuf->scanline_stride();
-//std::cerr << "output: " << ibuf->roi() << " stride: " << stride << std::endl;
     data = ibuf->localpixels();
 //fprintf(stderr, "HAVE SOME NEW DATA: %p\n", ibuf->localpixels());
   }else{
     data = ncv->data;
     stride = ncv->rowstride;
+    pstride = 4; // FIXME need pixel_stride() if loaded from oiio...
   }
-  return oiio_blit_dispatch(n, bset, stride, data, rows, cols, bargs, ibuf->pixel_stride() * CHAR_BIT);
+//std::cerr << "output: " << ibuf->roi() << " stride: " << stride << " pstride: " << pstride << std::endl;
+  return oiio_blit_dispatch(n, bset, stride, data, rows, cols, bargs, pstride * CHAR_BIT);
 }
 
 // FIXME before we can enable this, we need build an OIIO::APPBUFFER-style

--- a/src/media/oiio.h
+++ b/src/media/oiio.h
@@ -21,7 +21,8 @@ ncvisual* oiio_create(void);
 void oiio_destroy(ncvisual* ncv);
 int oiio_blit_dispatch(struct ncplane* nc, const struct blitset* bset,
                        int linesize, const void* data,
-                       int leny, int lenx, const blitterargs* bargs);
+                       int leny, int lenx, const blitterargs* bargs,
+                       int bpp);
 
 #ifdef __cplusplus
 }

--- a/src/tests/Ncpp.cpp
+++ b/src/tests/Ncpp.cpp
@@ -66,7 +66,7 @@ TEST_CASE("Ncpp"
     NotCurses nc{ nopts };
     if(nc.can_open_images()){
       {
-        Visual v = Visual(find_data("changes.jpg"));
+        Visual v = Visual(find_data("changes.jpg").get());
       }
     }
     CHECK(nc.stop());

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -217,7 +217,7 @@ TEST_CASE("Bitmaps") {
 
 #ifdef NOTCURSES_USE_MULTIMEDIA
   SUBCASE("PixelRender") {
-    auto ncv = ncvisual_from_file(find_data("worldmap.png"));
+    auto ncv = ncvisual_from_file(find_data("worldmap.png").get());
     REQUIRE(ncv);
     struct ncvisual_options vopts{};
     vopts.blitter = NCBLIT_PIXEL;
@@ -588,7 +588,7 @@ TEST_CASE("Bitmaps") {
     ncchannels_set_fg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
     ncchannels_set_bg_alpha(&channels, CELL_ALPHA_TRANSPARENT);
     CHECK(0 == ncplane_set_base(n_, "", 0, channels));
-    auto ncv = ncvisual_from_file(find_data("worldmap.png"));
+    auto ncv = ncvisual_from_file(find_data("worldmap.png").get());
     REQUIRE(ncv);
     struct ncvisual_options vopts{};
     vopts.blitter = NCBLIT_PIXEL;

--- a/src/tests/blit.cpp
+++ b/src/tests/blit.cpp
@@ -179,6 +179,7 @@ TEST_CASE("Blit") {
     };
     auto p = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != p);
+    CHECK(0 == notcurses_render(nc_));
     CHECK(1 == ncplane_dim_y(p));
     CHECK(2 == ncplane_dim_x(p));
     int pxdimy, pxdimx;

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -63,19 +63,19 @@ TEST_CASE("DirectMode") {
   }
 
   SUBCASE("LoadImage") {
-    CHECK(0 == ncdirect_render_image(nc_, find_data("changes.jpg"), NCALIGN_LEFT, NCBLIT_1x1, NCSCALE_STRETCH));
-    CHECK(0 == ncdirect_render_image(nc_, find_data("worldmap.png"), NCALIGN_RIGHT, NCBLIT_1x1, NCSCALE_SCALE));
+    CHECK(0 == ncdirect_render_image(nc_, find_data("changes.jpg").get(), NCALIGN_LEFT, NCBLIT_1x1, NCSCALE_STRETCH));
+    CHECK(0 == ncdirect_render_image(nc_, find_data("worldmap.png").get(), NCALIGN_RIGHT, NCBLIT_1x1, NCSCALE_SCALE));
   }
 
   SUBCASE("LoadSprixel") {
     if(ncdirect_check_pixel_support(nc_) > 0){
-      CHECK(0 == ncdirect_render_image(nc_, find_data("changes.jpg"), NCALIGN_LEFT, NCBLIT_PIXEL, NCSCALE_STRETCH));
-      CHECK(0 == ncdirect_render_image(nc_, find_data("worldmap.png"), NCALIGN_RIGHT, NCBLIT_PIXEL, NCSCALE_SCALE));
+      CHECK(0 == ncdirect_render_image(nc_, find_data("changes.jpg").get(), NCALIGN_LEFT, NCBLIT_PIXEL, NCSCALE_STRETCH));
+      CHECK(0 == ncdirect_render_image(nc_, find_data("worldmap.png").get(), NCALIGN_RIGHT, NCBLIT_PIXEL, NCSCALE_SCALE));
     }
   }
 
   SUBCASE("ImageGeom") {
-    auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
+    auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png").get());
     REQUIRE(nullptr != dirf);
     ncblitter_e blitter = NCBLIT_DEFAULT;
     ncvgeom geom;
@@ -91,7 +91,7 @@ TEST_CASE("DirectMode") {
 
   SUBCASE("SprixelGeom") {
     if(ncdirect_check_pixel_support(nc_) > 0){
-      auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
+      auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png").get());
       REQUIRE(nullptr != dirf);
       ncblitter_e blitter = NCBLIT_PIXEL;
       ncvgeom geom;
@@ -110,7 +110,7 @@ TEST_CASE("DirectMode") {
 
   SUBCASE("CursorPostGlyphRender") {
     if(is_test_tty()){
-      auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
+      auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png").get());
       REQUIRE(nullptr != dirf);
       auto ncdv = ncdirectf_render(nc_, dirf, NCBLIT_1x1, NCSCALE_NONE, 0, 0);
       CHECK(nullptr != ncdv);
@@ -130,7 +130,7 @@ TEST_CASE("DirectMode") {
   SUBCASE("CursorPostSprixel") {
     if(is_test_tty()){
       if(ncdirect_check_pixel_support(nc_) > 0){
-        auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png"));
+        auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png").get());
         REQUIRE(nullptr != dirf);
         auto ncdv = ncdirectf_render(nc_, dirf, NCBLIT_PIXEL, NCSCALE_NONE, 0, 0);
         CHECK(nullptr != ncdv);

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -25,10 +25,13 @@ auto testing_notcurses() -> struct notcurses* {
   return nc;
 }
 
-auto find_data(const char* datum) -> char* {
+template <typename T> using uniqptr = std::unique_ptr<T,free_deleter>;
+
+auto find_data(const char* datum) -> uniqptr<char> {
   std::filesystem::path p = datadir;
   p /= datum;
-  return strdup(p.c_str());
+  uniqptr<char> uptr(strdup(p.c_str()));
+  return uptr;
 }
 
 auto is_test_tty() -> bool {
@@ -66,12 +69,10 @@ check_data_dir(){
     return -1;
   }
   struct stat s;
-  if(stat(p, &s)){
-    std::cerr << "Couldn't open " << p << ". Supply directory with -p." << std::endl;
-    free(p);
+  if(stat(p.get(), &s)){
+    std::cerr << "Couldn't open " << p.get() << ". Supply directory with -p." << std::endl;
     return -1;
   }
-  free(p);
   return 0;
 }
 

--- a/src/tests/main.h
+++ b/src/tests/main.h
@@ -1,6 +1,7 @@
 #ifndef NOTCURSES_TEST_MAIN
 #define NOTCURSES_TEST_MAIN
 
+#include <memory>
 #include <unistd.h>
 #include "version.h"
 #include "builddef.h"
@@ -10,8 +11,15 @@
 #include <ncpp/_exceptions.hh>
 #include "internal.h"
 
+struct free_deleter{
+  template <typename T>
+  void operator()(T *p) const {
+    std::free(const_cast<std::remove_const_t<T>*>(p));
+  }
+};
+
 auto is_test_tty() -> bool;
-auto find_data(const char* datum) -> char*;
+auto find_data(const char* datum) -> std::unique_ptr<char, free_deleter>;
 auto testing_notcurses() -> struct notcurses*;
 auto ncreel_validate(const ncreel* n) -> bool;
 

--- a/src/tests/sixel.cpp
+++ b/src/tests/sixel.cpp
@@ -158,7 +158,7 @@ TEST_CASE("Sixels") {
 #ifdef NOTCURSES_USE_MULTIMEDIA
   SUBCASE("SixelRoundtrip") {
     CHECK(1 == ncplane_set_base(n_, "&", 0, 0));
-    auto ncv = ncvisual_from_file(find_data("worldmap.png"));
+    auto ncv = ncvisual_from_file(find_data("worldmap.png").get());
     REQUIRE(ncv);
     struct ncvisual_options vopts{};
     vopts.blitter = NCBLIT_PIXEL;
@@ -179,7 +179,7 @@ TEST_CASE("Sixels") {
 
   SUBCASE("SixelBlit") {
     CHECK(1 == ncplane_set_base(n_, "&", 0, 0));
-    auto ncv = ncvisual_from_file(find_data("natasha-blur.png"));
+    auto ncv = ncvisual_from_file(find_data("natasha-blur.png").get());
     REQUIRE(ncv);
     struct ncvisual_options vopts{};
     vopts.blitter = NCBLIT_PIXEL;

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -670,7 +670,7 @@ TEST_CASE("Visual") {
   SUBCASE("LoadImageCreatePlane") {
     int dimy, dimx;
     ncplane_dim_yx(ncp_, &dimy, &dimx);
-    auto ncv = ncvisual_from_file(find_data("changes.jpg"));
+    auto ncv = ncvisual_from_file(find_data("changes.jpg").get());
     REQUIRE(ncv);
     /*CHECK(dimy * 2 == frame->height);
     CHECK(dimx == frame->width); FIXME */
@@ -687,7 +687,7 @@ TEST_CASE("Visual") {
   SUBCASE("LoadImage") {
     int dimy, dimx;
     ncplane_dim_yx(ncp_, &dimy, &dimx);
-    auto ncv = ncvisual_from_file(find_data("changes.jpg"));
+    auto ncv = ncvisual_from_file(find_data("changes.jpg").get());
     REQUIRE(ncv);
     /*CHECK(dimy * 2 == frame->height);
     CHECK(dimx == frame->width); FIXME */
@@ -703,7 +703,7 @@ TEST_CASE("Visual") {
   SUBCASE("InflateImage") {
     int dimy, dimx;
     ncplane_dim_yx(ncp_, &dimy, &dimx);
-    auto ncv = ncvisual_from_file(find_data("changes.jpg"));
+    auto ncv = ncvisual_from_file(find_data("changes.jpg").get());
     REQUIRE(ncv);
     int odimy, odimx, ndimy, ndimx;
     struct ncvisual_options opts{};
@@ -723,7 +723,7 @@ TEST_CASE("Visual") {
   SUBCASE("PlaneDuplicate") {
     int dimy, dimx;
     ncplane_dim_yx(ncp_, &dimy, &dimx);
-    auto ncv = ncvisual_from_file(find_data("changes.jpg"));
+    auto ncv = ncvisual_from_file(find_data("changes.jpg").get());
     REQUIRE(ncv);
     /*CHECK(dimy * 2 == frame->height);
     CHECK(dimx == frame->width); FIXME */
@@ -749,7 +749,7 @@ TEST_CASE("Visual") {
     if(notcurses_canopen_videos(nc_)){
       int dimy, dimx;
       ncplane_dim_yx(ncp_, &dimy, &dimx);
-      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv"));
+      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv").get());
       REQUIRE(ncv);
       // FIXME can't we use use ncvisual_stream() here?
       for(;;){ // run at the highest speed we can
@@ -773,7 +773,7 @@ TEST_CASE("Visual") {
     if(notcurses_canopen_videos(nc_)){
       int dimy, dimx;
       ncplane_dim_yx(ncp_, &dimy, &dimx);
-      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv"));
+      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv").get());
       REQUIRE(ncv);
       for(;;){ // run at the highest speed we can
         int ret = ncvisual_decode(ncv);
@@ -797,7 +797,7 @@ TEST_CASE("Visual") {
     if(notcurses_canopen_videos(nc_)){
       int dimy, dimx;
       ncplane_dim_yx(ncp_, &dimy, &dimx);
-      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv"));
+      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv").get());
       REQUIRE(ncv);
       for(;;){ // run at the highest speed we can
         int ret = ncvisual_decode(ncv);
@@ -820,7 +820,7 @@ TEST_CASE("Visual") {
     if(notcurses_canopen_videos(nc_)){
       int dimy, dimx;
       ncplane_dim_yx(ncp_, &dimy, &dimx);
-      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv"));
+      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv").get());
       REQUIRE(ncv);
       for(;;){ // run at the highest speed we can
         int ret = ncvisual_decode(ncv);
@@ -843,7 +843,7 @@ TEST_CASE("Visual") {
     if(notcurses_canopen_videos(nc_)){
       int dimy, dimx;
       ncplane_dim_yx(ncp_, &dimy, &dimx);
-      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv"));
+      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv").get());
       REQUIRE(ncv);
       for(;;){ // run at the highest speed we can
         int ret = ncvisual_decode(ncv);
@@ -867,7 +867,7 @@ TEST_CASE("Visual") {
       if(notcurses_canopen_videos(nc_)){
         int dimy, dimx;
         ncplane_dim_yx(ncp_, &dimy, &dimx);
-        auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv"));
+        auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv").get());
         REQUIRE(ncv);
         struct ncplane* n = NULL;
         for(;;){ // run at the highest speed we can
@@ -895,7 +895,7 @@ TEST_CASE("Visual") {
       if(notcurses_canopen_videos(nc_)){
         int dimy, dimx;
         ncplane_dim_yx(ncp_, &dimy, &dimx);
-        auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv"));
+        auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv").get());
         REQUIRE(ncv);
         for(;;){ // run at the highest speed we can
           int ret = ncvisual_decode(ncv);
@@ -918,7 +918,7 @@ TEST_CASE("Visual") {
     if(notcurses_canopen_videos(nc_)){
       int dimy, dimx;
       ncplane_dim_yx(ncp_, &dimy, &dimx);
-      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv"));
+      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv").get());
       REQUIRE(ncv);
       int ret;
       while((ret = ncvisual_decode(ncv)) == 0){
@@ -945,7 +945,7 @@ TEST_CASE("Visual") {
     if(notcurses_canopen_videos(nc_)){
       int dimy, dimx;
       ncplane_dim_yx(ncp_, &dimy, &dimx);
-      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv"));
+      auto ncv = ncvisual_from_file(find_data("notcursesIII.mkv").get());
       REQUIRE(ncv);
       CHECK(0 == ncvisual_decode(ncv));
       /*CHECK(dimy * 2 == frame->height);
@@ -984,7 +984,7 @@ TEST_CASE("Visual") {
       .flags = NCVISUAL_OPTION_CHILDPLANE,
       .transcolor = 0,
     };
-    auto ncv = ncvisual_from_file(find_data("onedot.png"));
+    auto ncv = ncvisual_from_file(find_data("onedot.png").get());
     REQUIRE(ncv);
     auto child = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(child);


### PR DESCRIPTION
`ncvisual_blit()` performs implicit scaling of the output based on the `ncvisual_options` parameter, but this wasn't happening when compiled without a multimedia engine (or when linking against only `libnotcurses-core`). Now that we have `resize_bitmap()` to perform simple non-interpolative rescaling, use this in the absence of a superior scaling backend. This meant `NSCALE_*` were broken, among other things. Factor out `ffmpeg_resize_internal()`, and use it in both `ffmpeg_blit()` and `ffmpeg_resize()`, eliminating some duplicated code. Stop creating an `AVFrame` when performing only an implicit scaling in `ffmpeg`. Closes #1718.

Also uses a `unique_ptr` for `find_data()` in `notcurses-tester`, so that stops cluttering up leak traces. Huzzah!