### PR TITLE
Recover from XTSMGRAPHICS failures

### DIFF
--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -573,7 +573,9 @@ query_sixel(tinfo* ti, int fd){
     }
   }
   if(ti->bitmap_supported){
-    query_sixel_details(ti, fd);
+    if(query_sixel_details(ti, fd)){
+      ti->bitmap_supported = false;
+    }
   }
   return 0;
 }

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -139,6 +139,7 @@ typedef struct tinfo {
   // reply to DSA with CSI?6c, meaning VT102, but no VT102 had Sixel support,
   // so if the TERM variable contains "alacritty", *and* we get VT102, we go
   // ahead and query XTSMGRAPHICS.
+  // FIXME we can get rid of this with proper input handling #1469
   bool alacritty_sixel_hack;
 
   // mlterm resets the cursor (i.e. makes it visible) any time you print


### PR DESCRIPTION
It's possible that a terminal doesn't support `XTSMGRAPHICS`, never sending a reply. Follow up `XTSMGRAPHICS` with a Device Attributes, which most terminals reply to with some escape sequence ending in 'c'. Extend the `XTSMGRAPHICS` state machine to consume up through a DA reply. This allows us to enable the alacritty graphics support, and work with both `upstream/master` and `ayosec/graphics` variants of alacritty. See #1469.