### PR TITLE
[rust] pixel-cell example: make 'em match #1728

### DIFF
--- a/rust/examples/pixel-cell.rs
+++ b/rust/examples/pixel-cell.rs
@@ -46,7 +46,7 @@ fn main() -> NcResult<()> {
     rsleep![&mut nc, 1];
 
     // show the ncvisual, scaled
-    let mut vplane2 = NcPlane::new_bound(&mut stdplane, 6, 2, 4, 4)?;
+    let mut vplane2 = NcPlane::new_bound(&mut stdplane, 6, 2, 5, 4)?;
     let voptions2 = NcVisualOptions::with_plane(
         &mut vplane2,
         NCSCALE_SCALE,

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -918,6 +918,7 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
     ncplane_destroy(createdn);
     return NULL;
   }
+//fprintf(stderr, "FOLLOWING PLANE: %d %d %d %d\n", n->absy, n->absx, n->leny, n->lenx);
   // if we created the plane earlier, placex/placey were taken into account, and
   // zeroed out, thus neither of these will have any effect.
   if(flags & NCVISUAL_OPTION_HORALIGNED){
@@ -945,9 +946,9 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
   // the intended location.
   sprixel* s = n->sprite;
   n->sprite = NULL;
+//fprintf(stderr, "ABOUT TO RESIZE: yoff/xoff: %d/%d\n",  placey, placex);
   // FIXME might need shrink down the TAM and kill unnecessary auxvecs
-  if(ncplane_resize(n, 0, 0, s->dimy, s->dimx, placey - ncplane_y(n),
-                    placex - ncplane_x(n), s->dimy, s->dimx)){
+  if(ncplane_resize(n, 0, 0, s->dimy, s->dimx, placey, placex, s->dimy, s->dimx)){
     sprixel_hide(bargs.u.pixel.spx);
     ncplane_destroy(createdn);
     return NULL;

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -344,7 +344,6 @@ TEST_CASE("Bitmaps") {
     vopts.n = nres;
     vopts.scaling = NCSCALE_SCALE;
     ncvisual_render(nc_, ncv, &vopts);
-    CHECK(5 == ncplane_dim_y(vopts.n));
     CHECK(4 == ncplane_dim_x(vopts.n));
     ncvisual_inflate(ncv, 4);
     vopts.n = nullptr;
@@ -353,8 +352,8 @@ TEST_CASE("Bitmaps") {
     vopts.scaling = NCSCALE_NONE;
     auto ninf = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != ninf);
-    CHECK(5 == ncplane_dim_y(ninf));
-    CHECK(4 == ncplane_dim_x(ninf));
+    CHECK(ncplane_dim_y(nres) == ncplane_dim_y(ninf));
+    CHECK(ncplane_dim_x(nres) == ncplane_dim_x(ninf));
     CHECK(0 == notcurses_render(nc_));
     ncvisual_destroy(ncv);
     CHECK(0 == ncplane_destroy(n));


### PR DESCRIPTION
`NCSCALE_SCALE` needs five rows to match the 4x inflation (sometimes). Closes #1728.