### PR TITLE
Expose non-interpolative scaling in direct mode and ncplayer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,11 @@ rearrangements of Notcurses.
   * `ncvisual_inflate()` has been rewritten as a wrapper around the new
     function `ncvisual_resize_noninterpolative()`, and deprecated. It will be
     removed for ABI3. Godspeed, `ncvisual_inflate()`; we hardly knew ye.
+  * `ncdirect_renderf()` has been changed to accept a `ncvisual_options`,
+    replacing and extending its four final arguments. Sorry about the breakage
+    here, but `ncdirect_renderf()` was introduced pretty recently (2.3.1).
+    As a result, `ncdirect_renderf()` and `ncdirect_stream()` now honor
+    `NCVISUAL_OPTION_BLEND` and `NCVISUAL_OPTION_NOINTERPOLATE`.
 
 * 2.3.2 (2021-06-03)
   * Fixed a bug affecting certain scalings of `ncvisual` objects created from

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ rearrangements of Notcurses.
     here, but `ncdirect_renderf()` was introduced pretty recently (2.3.1).
     As a result, `ncdirect_renderf()` and `ncdirect_stream()` now honor
     `NCVISUAL_OPTION_BLEND` and `NCVISUAL_OPTION_NOINTERPOLATE`.
+  * `ncplayer` now accepts `-n` to force non-interpolative scaling.
 
 * 2.3.2 (2021-06-03)
   * Fixed a bug affecting certain scalings of `ncvisual` objects created from

--- a/doc/man/man1/ncplayer.1.md
+++ b/doc/man/man1/ncplayer.1.md
@@ -8,7 +8,7 @@ ncplayer - Render images and video to a terminal
 
 # SYNOPSIS
 
-**ncplayer** [**-h**] [**-V**] [**-q**] [**-d** ***delaymult***] [**-l** ***loglevel***] [**-b** ***blitter***] [**-s** ***scalemode***] [**-k**] [**-L**] [**-t** ***seconds***] [**-a**] files
+**ncplayer** [**-h**] [**-V**] [**-q**] [**-d** ***delaymult***] [**-l** ***loglevel***] [**-b** ***blitter***] [**-s** ***scalemode***] [**-k**] [**-L**] [**-t** ***seconds***] [**-n**] [**-a**] files
 
 # DESCRIPTION
 
@@ -42,6 +42,8 @@ be any non-negative number.
 **-q**: Print neither frame/timing information along the top of the screen, nor the output summary on exit.
 
 **-a**: Treat color 0x000000 as if it were transparent.
+
+**-n**: Use non-interpolative scaling. The result is usually less pleasing to the eye, but it doesn't introduce new colors.
 
 **-V**: Print the program name and version, and exit with success.
 

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -116,7 +116,7 @@ typedef struct ncvgeom {
 
 **void ncdirectf_free(struct ncdirectf* ***frame***);**
 
-**ncdirectv* ncdirectf_render(struct ncdirect* ***n***, struct ncdirectf* ***frame***, struct ncvisual_options ***vopts***);**
+**ncdirectv* ncdirectf_render(struct ncdirect* ***n***, struct ncdirectf* ***frame***, const struct ncvisual_options ***vopts***);**
 
 **int ncdirectf_geom(struct ncdirect* ***n***, struct ncdirectf* ***frame***, ncblitter_e* ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***, ncvgeom* ***geom***);**
 

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -116,7 +116,7 @@ typedef struct ncvgeom {
 
 **void ncdirectf_free(struct ncdirectf* ***frame***);**
 
-**ncdirectv* ncdirectf_render(struct ncdirect* ***n***, struct ncdirectf* ***frame***, ncblitter_e ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***);**
+**ncdirectv* ncdirectf_render(struct ncdirect* ***n***, struct ncdirectf* ***frame***, struct ncvisual_options ***vopts***);**
 
 **int ncdirectf_geom(struct ncdirect* ***n***, struct ncdirectf* ***frame***, ncblitter_e* ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***, ncvgeom* ***geom***);**
 

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -389,7 +389,7 @@ API void ncdirectf_free(ncdirectf* frame);
 // loaded. A loaded frame may be rendered in different ways before it is
 // destroyed.
 API ALLOC ncdirectv* ncdirectf_render(struct ncdirect* n, ncdirectf* frame,
-                                      struct ncvisual_options* vopts)
+                                      const struct ncvisual_options* vopts)
   __attribute__ ((nonnull (1, 2)));
 
 // Having loaded the frame 'frame', get the geometry of a potential render.

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -389,8 +389,7 @@ API void ncdirectf_free(ncdirectf* frame);
 // loaded. A loaded frame may be rendered in different ways before it is
 // destroyed.
 API ALLOC ncdirectv* ncdirectf_render(struct ncdirect* n, ncdirectf* frame,
-                                      ncblitter_e blitter, ncscale_e scale,
-                                      int maxy, int maxx)
+                                      struct ncvisual_options* vopts)
   __attribute__ ((nonnull (1, 2)));
 
 // Having loaded the frame 'frame', get the geometry of a potential render.

--- a/rust/examples/issue-1716.rs
+++ b/rust/examples/issue-1716.rs
@@ -19,7 +19,9 @@ fn main() {
     }
 
     let vframe1 = NcDirectF::from_bgra(&buffer, H, W * 4, W).expect("couldn’t create visual");
-    let v = vframe1.ncdirectf_render(nc, NCBLIT_PIXEL, NCSCALE_NONE, 0, 0).expect("failed to render image to sixels");
+    let mut voptions1 = NcVisualOptions::without_plane(0, 0, 0, 0, H, W, NCBLIT_PIXEL, 0, 0);
+    let v = vframe1.ncdirectf_render(nc, &mut voptions1)
+        .expect("failed to render image to sixels");
     nc.raster_frame(v, NCALIGN_LEFT).expect("failed to print sixels");
     vframe1.ncdirectf_free();
     nc.stop().expect("failed to destroy ncdirect context");

--- a/rust/src/visual/methods.rs
+++ b/rust/src/visual/methods.rs
@@ -513,14 +513,11 @@ impl NcDirectF {
     pub fn ncdirectf_render(
         &mut self,
         ncd: &mut NcDirect,
-        blitter: NcBlitter,
-        scale: NcScale,
-        max_y: NcDim,
-        max_x: NcDim,
+        options: &mut NcVisualOptions,
     ) -> NcResult<&mut NcDirectV> {
         error_ref_mut![
             unsafe {
-                crate::ncdirectf_render(ncd, self, blitter, scale, max_y as i32, max_x as i32)
+                crate::ncdirectf_render(ncd, self, options)
             },
             "NcVisual.render()"
         ]

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -626,6 +626,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv, struct ncvisual_options* vopt
     return NULL;
   }
   blitterargs bargs = {};
+  bargs.flags = vopts->flags;
   if(vopts->flags & NCVISUAL_OPTION_ADDALPHA){
     bargs.transcolor = vopts->transcolor | 0x1000000ull;
   }

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -545,7 +545,8 @@ int ncdirect_raster_frame(ncdirect* n, ncdirectv* ncdv, ncalign_e align){
 }
 
 static ncdirectv*
-ncdirect_render_visual(ncdirect* n, ncvisual* ncv, struct ncvisual_options* vopts){
+ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
+                       const struct ncvisual_options* vopts){
   struct ncvisual_options defvopts = {};
   if(!vopts){
     vopts = &defvopts;
@@ -1313,7 +1314,7 @@ void ncdirectf_free(ncdirectf* frame){
   ncvisual_destroy(frame);
 }
 
-ncdirectv* ncdirectf_render(ncdirect* n, ncdirectf* frame, struct ncvisual_options* vopts){
+ncdirectv* ncdirectf_render(ncdirect* n, ncdirectf* frame, const struct ncvisual_options* vopts){
   return ncdirect_render_visual(n, frame, vopts);
 }
 

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -372,7 +372,9 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
   struct ncplane_options nopts{};
   // leave a line at the bottom. perhaps one day we'll put information there.
   // for now, this keeps us from scrolling when we use bitmaps.
-  nopts.margin_b = 1;
+  if(nopts.margin_b == 0){
+    nopts.margin_b = 1;
+  }
   nopts.name = "play";
   nopts.resizecb = ncplane_resize_marginalized;
   nopts.flags = NCPLANE_OPTION_MARGINALIZED;

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -24,7 +24,12 @@ partial_image(struct ncdirect* n, const char* file){
       int cols = x;
       ncdirectv* v;
       printf("Size: %dx%d\n", cols, rows);
-      if((v = ncdirectf_render(n, nf, blit, NCSCALE_NONE, rows, cols)) == NULL){
+      struct ncvisual_options vopts = {
+        .blitter = blit,
+        .leny = rows * geom.scaley,
+        .lenx = cols * geom.scalex,
+      };
+      if((v = ncdirectf_render(n, nf, &vopts)) == NULL){
         ncdirectf_free(nf);
         return -1;
       }

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -83,7 +83,9 @@ TEST_CASE("DirectMode") {
     CHECK(475 == geom.pixy);
     CHECK(860 == geom.pixx);
     CHECK(NCBLIT_DEFAULT != blitter);
-    auto ncdv = ncdirectf_render(nc_, dirf, blitter, NCSCALE_NONE, 0, 0);
+    struct ncvisual_options vopts{};
+    vopts.blitter = blitter;
+    auto ncdv = ncdirectf_render(nc_, dirf, &vopts);
     CHECK(nullptr != ncdv);
     CHECK(0 == ncdirect_raster_frame(nc_, ncdv, NCALIGN_LEFT));
     ncdirectf_free(dirf);
@@ -101,7 +103,9 @@ TEST_CASE("DirectMode") {
       CHECK(NCBLIT_PIXEL == blitter);
       CHECK(geom.cdimy == geom.scaley);
       CHECK(geom.cdimx == geom.scalex);
-      auto ncdv = ncdirectf_render(nc_, dirf, blitter, NCSCALE_NONE, 0, 0);
+      struct ncvisual_options vopts{};
+      vopts.blitter = blitter;
+      auto ncdv = ncdirectf_render(nc_, dirf, &vopts);
       CHECK(nullptr != ncdv);
       CHECK(0 == ncdirect_raster_frame(nc_, ncdv, NCALIGN_LEFT));
       ncdirectf_free(dirf);
@@ -112,7 +116,9 @@ TEST_CASE("DirectMode") {
     if(is_test_tty()){
       auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png").get());
       REQUIRE(nullptr != dirf);
-      auto ncdv = ncdirectf_render(nc_, dirf, NCBLIT_1x1, NCSCALE_NONE, 0, 0);
+      struct ncvisual_options vopts{};
+      vopts.blitter = NCBLIT_1x1;
+      auto ncdv = ncdirectf_render(nc_, dirf, &vopts);
       CHECK(nullptr != ncdv);
       CHECK(0 == ncdirect_raster_frame(nc_, ncdv, NCALIGN_LEFT));
       ncdirectf_free(dirf);
@@ -132,7 +138,10 @@ TEST_CASE("DirectMode") {
       if(ncdirect_check_pixel_support(nc_) > 0){
         auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png").get());
         REQUIRE(nullptr != dirf);
-        auto ncdv = ncdirectf_render(nc_, dirf, NCBLIT_PIXEL, NCSCALE_NONE, 0, 0);
+        struct ncvisual_options vopts{};
+        vopts.blitter = NCBLIT_PIXEL;
+        vopts.flags = NCVISUAL_OPTION_NODEGRADE;
+        auto ncdv = ncdirectf_render(nc_, dirf, &vopts);
         CHECK(nullptr != ncdv);
         CHECK(0 == ncdirect_raster_frame(nc_, ncdv, NCALIGN_LEFT));
         ncdirectf_free(dirf);


### PR DESCRIPTION
`ncplayer` now accepts `-n` to force non-interpolative scaling; it works with both direct mode and rendered mode. `ncdirectf_render()` has been changed to take a `ncvisual_options`, and now honors most of the parameters therein, including `NCVISUAL_OPTION_NOINTERPOLATE`. Closes #1738.