### PR TITLE
Emit kitty graphics to the bottom row using C=1

### DIFF
--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2450,6 +2450,7 @@ API ALLOC struct ncvisual* ncvisual_from_plane(const struct ncplane* n,
 #define NCVISUAL_OPTION_ADDALPHA      0x0010ull // transcolor is in effect
 #define NCVISUAL_OPTION_CHILDPLANE    0x0020ull // interpret n as parent
 #define NCVISUAL_OPTION_NOINTERPOLATE 0x0040ull // non-interpolative scaling
+                                                // 0x0080 is used internally
 
 struct ncvisual_options {
   // if no ncplane is provided, one will be created using the exact size

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -627,7 +627,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
     return NULL;
   }
   blitterargs bargs = {};
-  bargs.flags = vopts->flags;
+  bargs.flags = vopts->flags | NCVISUAL_OPTION_SCROLL;
   if(vopts->flags & NCVISUAL_OPTION_ADDALPHA){
     bargs.transcolor = vopts->transcolor | 0x1000000ull;
   }
@@ -1322,7 +1322,7 @@ int ncdirectf_geom(ncdirect* n, ncdirectf* frame,
                    ncblitter_e* blitter, ncscale_e scale,
                    int maxy, int maxx, ncvgeom* geom){
   // FIXME wtf do we do about flags here? why aren't we using the entire
-  // ncvisual_options apparatus? what a blunder =[.
+  // ncvisual_options apparatus? what a blunder =[. #1746
   struct ncvisual_options vopts = {
     .blitter = blitter ? *blitter : NCBLIT_DEFAULT,
     .scaling = scale,

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -497,6 +497,10 @@ typedef struct notcurses {
   unsigned stdio_blocking_save; // was stdio blocking at entry? restore on stop.
 } notcurses;
 
+// this flag is used internally, by direct mode (which might want
+// to scroll with the output). rendered mode never sets it.
+#define NCVISUAL_OPTION_SCROLL 0x0080ull // ought we scroll with the output?
+
 typedef struct blitterargs {
   // FIXME begy/begx are really only of interest to scaling; they ought be
   // consumed there, and blitters ought always work with the scaled output.

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -428,7 +428,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
     fclose(fp);
     return -1;
   }
-  bool scroll = false; // FIXME
+  bool scroll = bargs->flags & NCVISUAL_OPTION_SCROLL;
   bool translucent = bargs->flags & NCVISUAL_OPTION_BLEND;
   int sprixelid = bargs->u.pixel.spx->id;
   int cdimy = bargs->u.pixel.celldimy;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -428,6 +428,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
     fclose(fp);
     return -1;
   }
+  bool scroll = false; // FIXME
   bool translucent = bargs->flags & NCVISUAL_OPTION_BLEND;
   int sprixelid = bargs->u.pixel.spx->id;
   int cdimy = bargs->u.pixel.celldimy;
@@ -443,8 +444,9 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
 //fprintf(stderr, "total: %d chunks = %d, s=%d,v=%d\n", total, chunks, lenx, leny);
   while(chunks--){
     if(totalout == 0){
-      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,a=T,%c=1;",
-                             lenx, leny, sprixelid, chunks ? 'm' : 'q');
+      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,a=T,%c=1%s;",
+                             lenx, leny, sprixelid, chunks ? 'm' : 'q',
+                             scroll ? "" : ",C=1");
     }else{
       fprintf(fp, "\e_G%sm=%d;", chunks ? "" : "q=2,", chunks ? 1 : 0);
     }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -21,6 +21,7 @@ setup_sixel_bitmaps(tinfo* ti){
 
 static inline void
 setup_kitty_bitmaps(tinfo* ti, int fd){
+  ti->bitmap_supported = true;
   ti->pixel_wipe = kitty_wipe;
   ti->pixel_destroy = kitty_destroy;
   ti->pixel_remove = kitty_remove;
@@ -29,6 +30,7 @@ setup_kitty_bitmaps(tinfo* ti, int fd){
   ti->sprixel_scale_height = 1;
   ti->pixel_rebuild = kitty_rebuild;
   ti->pixel_clear_all = kitty_clear_all;
+  ti->bitmap_lowest_line = true;
   set_pixel_blitter(kitty_blit);
   sprite_init(ti, fd);
 }
@@ -91,7 +93,6 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd){
     ti->sextants = true; // work since bugfix in 0.19.3
     ti->quadrants = true;
     ti->pixel_query_done = true;
-    ti->bitmap_supported = true;
     ti->RGBflag = true;
     setup_kitty_bitmaps(ti, fd);
   }else if(strstr(termname, "alacritty")){

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -121,6 +121,7 @@ typedef struct tinfo {
   struct termios tpreserved; // terminal state upon entry
   ncinputlayer input;       // input layer
   bool bitmap_supported;    // do we support bitmaps (post pixel_query_done)?
+  bool bitmap_lowest_line;  // can we render pixels to the bottom row?
   bool pixel_query_done;    // have we yet performed pixel query?
   bool RGBflag;   // "RGB" flag for 24bpc truecolor
   bool CCCflag;   // "CCC" flag for palette set capability

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -773,7 +773,10 @@ make_sprixel_plane(notcurses* nc, ncplane* parent, ncvisual* ncv,
   if(scaling != NCSCALE_NONE && scaling != NCSCALE_NONE_HIRES){
     ncplane_dim_yx(parent, disppixy, disppixx);
     if(*placey + *disppixy >= ncplane_dim_y(notcurses_stdplane_const(nc))){
-      *disppixy = ncplane_dim_y(notcurses_stdplane_const(nc)) - *placey - 1;
+      *disppixy = ncplane_dim_y(notcurses_stdplane_const(nc)) - *placey;
+      if(!nc->tcache.bitmap_lowest_line){
+        --*disppixy;
+      }
     }
     if(!(flags & NCVISUAL_OPTION_VERALIGNED)){
       *disppixy -= *placey;

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -382,11 +382,6 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
   ncchannels_set_bg_alpha(&transchan, CELL_ALPHA_TRANSPARENT);
   stdn->set_base("", 0, transchan);
   struct ncplane_options nopts{};
-  // leave a line at the bottom. perhaps one day we'll put information there.
-  // for now, this keeps us from scrolling when we use bitmaps.
-  if(nopts.margin_b == 0){
-    //nopts.margin_b = 1;
-  }
   nopts.name = "play";
   nopts.resizecb = ncplane_resize_marginalized;
   nopts.flags = NCPLANE_OPTION_MARGINALIZED;

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -385,7 +385,7 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
   // leave a line at the bottom. perhaps one day we'll put information there.
   // for now, this keeps us from scrolling when we use bitmaps.
   if(nopts.margin_b == 0){
-    nopts.margin_b = 1;
+    //nopts.margin_b = 1;
   }
   nopts.name = "play";
   nopts.resizecb = ncplane_resize_marginalized;


### PR DESCRIPTION
Now that kitty has `C=1` to inhibit scrolling along with a graphic, we can emit to the last line. Plumb this through. Closes #1733.