### PR TITLE
ncdirectf_geom: move to ncvisual_options #1746

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,8 +15,12 @@ rearrangements of Notcurses.
     replacing and extending its four final arguments. Sorry about the breakage
     here, but `ncdirect_renderf()` was introduced pretty recently (2.3.1).
     As a result, `ncdirect_renderf()` and `ncdirect_stream()` now honor
-    `NCVISUAL_OPTION_BLEND` and `NCVISUAL_OPTION_NOINTERPOLATE`.
+    `NCVISUAL_OPTION_BLEND` and `NCVISUAL_OPTION_NOINTERPOLATE`. All of this
+    also applies to `ncdirect_geomf()`.
   * `ncplayer` now accepts `-n` to force non-interpolative scaling.
+  * A new binary is installed, `notcurses-info`. It prints information about
+    the terminal environment in which it runs. More information is available
+    from its man page, `notcurses-info(1)`.
 
 * 2.3.2 (2021-06-03)
   * Fixed a bug affecting certain scalings of `ncvisual` objects created from

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -118,7 +118,7 @@ typedef struct ncvgeom {
 
 **ncdirectv* ncdirectf_render(struct ncdirect* ***n***, struct ncdirectf* ***frame***, const struct ncvisual_options ***vopts***);**
 
-**int ncdirectf_geom(struct ncdirect* ***n***, struct ncdirectf* ***frame***, ncblitter_e* ***blitter***, ncscale_e ***scale***, int ***maxy***, int ***maxx***, ncvgeom* ***geom***);**
+**int ncdirectf_geom(struct ncdirect* ***n***, struct ncdirectf* ***frame***, const struct ncvisual_options ***vopts***, ncvgeom* ***geom***);**
 
 
 # DESCRIPTION

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -348,6 +348,7 @@ typedef struct ncvgeom {
   int scaley, scalex; // pixels per filled cell
   // only defined for NCBLIT_PIXEL
   int maxpixely, maxpixelx;
+  ncblitter_e blitter;// blitter that will be used
 } ncvgeom;
 
 // Display an image using the specified blitter and scaling. The image may
@@ -394,8 +395,7 @@ API ALLOC ncdirectv* ncdirectf_render(struct ncdirect* n, ncdirectf* frame,
 
 // Having loaded the frame 'frame', get the geometry of a potential render.
 API int ncdirectf_geom(struct ncdirect* n, ncdirectf* frame,
-                       ncblitter_e* blitter, ncscale_e scale,
-                       int maxy, int maxx, ncvgeom* geom)
+                       const struct ncvisual_options* vopts, ncvgeom* geom)
   __attribute__ ((nonnull (1, 2)));
 
 // Load successive frames from a file, invoking 'streamer' on each.

--- a/rust/src/visual/methods.rs
+++ b/rust/src/visual/methods.rs
@@ -528,10 +528,7 @@ impl NcDirectF {
     pub fn ncdirectf_geom(
         &mut self,
         ncd: &mut NcDirect,
-        blitter: &mut NcBlitter,
-        scale: NcScale,
-        max_y: NcDim,
-        max_x: NcDim,
+        options: &NcVisualOptions,
     ) -> NcResult<NcVGeom> {
         let mut geom = NcVGeom::new();
 
@@ -539,10 +536,7 @@ impl NcDirectF {
             crate::ncdirectf_geom(
                 ncd,
                 self,
-                blitter,
-                scale,
-                max_y as i32,
-                max_x as i32,
+                options,
                 &mut geom,
             )
         };
@@ -567,6 +561,7 @@ impl NcVGeom {
             scalex: 0,
             maxpixely: 0,
             maxpixelx: 0,
+            blitter: 0,
         }
     }
 }

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1319,32 +1319,23 @@ ncdirectv* ncdirectf_render(ncdirect* n, ncdirectf* frame, const struct ncvisual
 }
 
 int ncdirectf_geom(ncdirect* n, ncdirectf* frame,
-                   ncblitter_e* blitter, ncscale_e scale,
-                   int maxy, int maxx, ncvgeom* geom){
-  // FIXME wtf do we do about flags here? why aren't we using the entire
-  // ncvisual_options apparatus? what a blunder =[. #1746
-  struct ncvisual_options vopts = {
-    .blitter = blitter ? *blitter : NCBLIT_DEFAULT,
-    .scaling = scale,
-    .leny = maxy,
-    .lenx = maxx,
-  };
+                   const struct ncvisual_options* vopts, ncvgeom* geom){
   geom->cdimy = n->tcache.cellpixy;
   geom->cdimx = n->tcache.cellpixx;
   geom->maxpixely = n->tcache.sixel_maxy;
   geom->maxpixelx = n->tcache.sixel_maxx;
   const struct blitset* bset;
-  int r = ncvisual_blitset_geom(NULL, &n->tcache, frame, &vopts,
+  int r = ncvisual_blitset_geom(NULL, &n->tcache, frame, vopts,
                                 &geom->pixy, &geom->pixx,
                                 &geom->scaley, &geom->scalex,
                                 &geom->rpixy, &geom->rpixx, &bset);
-  // FIXME ncvisual_blitset_geom() ought calculate these two for us; until
-  // then, derive them ourselves. the row count might be short by one if
-  // we're using sixel, and we're not a multiple of 6
-  geom->rcelly = geom->pixy / geom->scaley;
-  geom->rcellx = geom->pixx / geom->scalex;
-  if(r == 0 && blitter){
-    *blitter = bset->geom;
+  if(r == 0){
+    // FIXME ncvisual_blitset_geom() ought calculate these two for us; until
+    // then, derive them ourselves. the row count might be short by one if
+    // we're using sixel, and we're not a multiple of 6
+    geom->rcelly = geom->pixy / geom->scaley;
+    geom->rcellx = geom->pixx / geom->scalex;
+    geom->blitter = bset->geom;
   }
   return r;
 }

--- a/src/poc/vizdirect.c
+++ b/src/poc/vizdirect.c
@@ -11,8 +11,7 @@ partial_image(struct ncdirect* n, const char* file){
   }
   // get the number of pixels
   ncvgeom geom;
-  ncblitter_e blit = NCBLIT_1x1;
-  ncdirectf_geom(n, nf, &blit, NCSCALE_NONE, 0, 0, &geom);
+  ncdirectf_geom(n, nf, NULL, &geom);
   if(geom.cdimy <= 0){
     fprintf(stderr, "no cell dim information\n");
     ncdirectf_free(nf);
@@ -25,7 +24,7 @@ partial_image(struct ncdirect* n, const char* file){
       ncdirectv* v;
       printf("Size: %dx%d\n", cols, rows);
       struct ncvisual_options vopts = {
-        .blitter = blit,
+        .blitter = NCBLIT_1x1,
         .leny = rows * geom.scaley,
         .lenx = cols * geom.scalex,
       };

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -77,15 +77,12 @@ TEST_CASE("DirectMode") {
   SUBCASE("ImageGeom") {
     auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png").get());
     REQUIRE(nullptr != dirf);
-    ncblitter_e blitter = NCBLIT_DEFAULT;
     ncvgeom geom;
-    CHECK(0 == ncdirectf_geom(nc_, dirf, &blitter, NCSCALE_NONE, 0, 0, &geom));
+    CHECK(0 == ncdirectf_geom(nc_, dirf, nullptr, &geom));
     CHECK(475 == geom.pixy);
     CHECK(860 == geom.pixx);
-    CHECK(NCBLIT_DEFAULT != blitter);
-    struct ncvisual_options vopts{};
-    vopts.blitter = blitter;
-    auto ncdv = ncdirectf_render(nc_, dirf, &vopts);
+    CHECK(NCBLIT_DEFAULT != geom.blitter);
+    auto ncdv = ncdirectf_render(nc_, dirf, nullptr);
     CHECK(nullptr != ncdv);
     CHECK(0 == ncdirect_raster_frame(nc_, ncdv, NCALIGN_LEFT));
     ncdirectf_free(dirf);
@@ -95,16 +92,15 @@ TEST_CASE("DirectMode") {
     if(ncdirect_check_pixel_support(nc_) > 0){
       auto dirf = ncdirectf_from_file(nc_, find_data("worldmap.png").get());
       REQUIRE(nullptr != dirf);
-      ncblitter_e blitter = NCBLIT_PIXEL;
+      struct ncvisual_options vopts{};
+      vopts.blitter = NCBLIT_PIXEL;
       ncvgeom geom;
-      CHECK(0 == ncdirectf_geom(nc_, dirf, &blitter, NCSCALE_NONE, 0, 0, &geom));
+      CHECK(0 == ncdirectf_geom(nc_, dirf, &vopts, &geom));
       CHECK(475 == geom.pixy);
       CHECK(860 == geom.pixx);
-      CHECK(NCBLIT_PIXEL == blitter);
+      CHECK(NCBLIT_PIXEL == geom.blitter);
       CHECK(geom.cdimy == geom.scaley);
       CHECK(geom.cdimx == geom.scalex);
-      struct ncvisual_options vopts{};
-      vopts.blitter = blitter;
       auto ncdv = ncdirectf_render(nc_, dirf, &vopts);
       CHECK(nullptr != ncdv);
       CHECK(0 == ncdirect_raster_frame(nc_, ncdv, NCALIGN_LEFT));


### PR DESCRIPTION
After moving `ncdirectf_render()` to `ncvisual_options` yesterday, it makes no sense to leave `ncdirectf_geom()` in the old style. Convert it.