### PR TITLE
Always access margins through context

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,10 @@ rearrangements of Notcurses.
     `nccells_ascii_box()`. All are `static inline`.
   * A bug was fixed in `ncplane_move_yx()`: root planes were being moved
     relatively instead of absolutely. This was never the intended behavior.
+  * It used to be possible to pass `NULL` as the second parameter of
+    `ncplane_mergedown_simple()`, and have the standard plane be used as
+    the destination. This is no longer supported, since the source plane
+    could be in another pile. An error will instead be returned.
 
 * 2.3.2 (2021-06-03)
   * Fixed a bug affecting certain scalings of `ncvisual` objects created from

--- a/USAGE.md
+++ b/USAGE.md
@@ -825,9 +825,10 @@ struct ncplane* ncplane_dup(struct ncplane* n, void* opaque);
 // this operation. Do not supply the same plane for both 'src' and 'dst'.
 int ncplane_mergedown(struct ncplane* restrict src, struct ncplane* restrict dst);
 
-// If 'src' does not intersect with 'dst', 'dst' will not be changed, but it is
-// not an error. If 'dst' is NULL, the operation will target the standard plane.
-int ncplane_mergedown_simple(const ncplane* restrict src, ncplane* restrict dst);
+// Merge the entirety of 'src' down onto the ncplane 'dst'. If 'src' does not
+// intersect with 'dst', 'dst' will not be changed, but it is not an error.
+int ncplane_mergedown_simple(struct ncplane* restrict src,
+                             struct ncplane* restrict dst);
 
 // Erase every cell in the ncplane, resetting all attributes to normal, all
 // colors to the default color, and all cells to undrawn. All cells associated

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1966,8 +1966,8 @@ API int ncplane_format(struct ncplane* n, int ystop, int xstop, uint32_t stylema
 API int ncplane_stain(struct ncplane* n, int ystop, int xstop, uint64_t ul,
                       uint64_t ur, uint64_t ll, uint64_t lr);
 
-// If 'src' does not intersect with 'dst', 'dst' will not be changed, but it is
-// not an error. If 'dst' is NULL, the operation will target the standard plane.
+// Merge the entirety of 'src' down onto the ncplane 'dst'. If 'src' does not
+// intersect with 'dst', 'dst' will not be changed, but it is not an error.
 API int ncplane_mergedown_simple(struct ncplane* RESTRICT src,
                                  struct ncplane* RESTRICT dst);
 

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -577,20 +577,21 @@ int kitty_remove(int id, FILE* out){
 
 // removes the kitty bitmap graphic identified by s->id, and damages those
 // cells which weren't SPRIXCEL_OPAQUE
-int kitty_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
+int kitty_destroy(const notcurses* nc __attribute__ ((unused)),
+                  const ncpile* p, FILE* out, sprixel* s){
   if(kitty_remove(s->id, out)){
     return -1;
   }
 //fprintf(stderr, "FROM: %d/%d state: %d s->n: %p\n", s->movedfromy, s->movedfromx, s->invalidated, s->n);
   for(int yy = s->movedfromy ; yy < s->movedfromy + s->dimy && yy < p->dimy ; ++yy){
     for(int xx = s->movedfromx ; xx < s->movedfromx + s->dimx && xx < p->dimx ; ++xx){
-      const int ridx = (yy - nc->margin_t) * p->dimx + (xx - nc->margin_l);
+      const int ridx = yy * p->dimx + xx;
       struct crender *r = &p->crender[ridx];
       if(!r->sprixel){
         if(s->n){
 //fprintf(stderr, "CHECKING %d/%d\n", yy - s->movedfromy, xx - s->movedfromx);
-          sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy - nc->margin_t,
-                                              xx - s->movedfromx + s->n->absx - nc->margin_l);
+          sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy,
+                                              xx - s->movedfromx + s->n->absx);
           if(state == SPRIXCELL_OPAQUE_KITTY){
             r->s.damaged = 1;
           }else if(s->invalidated == SPRIXEL_MOVED){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -582,16 +582,15 @@ int kitty_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
     return -1;
   }
 //fprintf(stderr, "FROM: %d/%d state: %d s->n: %p\n", s->movedfromy, s->movedfromx, s->invalidated, s->n);
-  const ncplane* stdn = notcurses_stdplane_const(nc);
   for(int yy = s->movedfromy ; yy < s->movedfromy + s->dimy && yy < p->dimy ; ++yy){
     for(int xx = s->movedfromx ; xx < s->movedfromx + s->dimx && xx < p->dimx ; ++xx){
-      const int ridx = (yy - stdn->absy) * p->dimx + (xx - stdn->absx);
+      const int ridx = (yy - nc->margin_t) * p->dimx + (xx - nc->margin_l);
       struct crender *r = &p->crender[ridx];
       if(!r->sprixel){
         if(s->n){
 //fprintf(stderr, "CHECKING %d/%d\n", yy - s->movedfromy, xx - s->movedfromx);
-          sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy - stdn->absy,
-                                              xx - s->movedfromx + s->n->absx - stdn->absx);
+          sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy - nc->margin_t,
+                                              xx - s->movedfromx + s->n->absx - nc->margin_l);
           if(state == SPRIXCELL_OPAQUE_KITTY){
             r->s.damaged = 1;
           }else if(s->invalidated == SPRIXEL_MOVED){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -486,8 +486,7 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
 static ncplane*
 create_initial_ncplane(notcurses* nc, int dimy, int dimx){
   ncplane_options nopts = {
-    .y = nc->margin_t,
-    .x = nc->margin_l,
+    .y = 0, .x = 0,
     .rows = dimy - (nc->margin_t + nc->margin_b),
     .cols = dimx - (nc->margin_l + nc->margin_r),
     .userptr = NULL,
@@ -566,10 +565,8 @@ inline int ncplane_cursor_move_yx(ncplane* n, int y, int x){
 ncplane* ncplane_dup(const ncplane* n, void* opaque){
   int dimy = n->leny;
   int dimx = n->lenx;
-  // if we're duping the standard plane, we need adjust for marginalia
-  const struct notcurses* nc = ncplane_notcurses_const(n);
-  const int placey = n->absy - nc->margin_t;
-  const int placex = n->absx - nc->margin_l;
+  const int placey = n->absy;
+  const int placex = n->absx;
   struct ncplane_options nopts = {
     .y = placey,
     .x = placex,
@@ -2019,14 +2016,14 @@ int ncplane_move_yx(ncplane* n, int y, int x){
 
 int ncplane_y(const ncplane* n){
   if(n->boundto == n){
-    return n->absy - ncplane_notcurses_const(n)->margin_t;
+    return n->absy;
   }
   return n->absy - n->boundto->absy;
 }
 
 int ncplane_x(const ncplane* n){
   if(n->boundto == n){
-    return n->absx - ncplane_notcurses_const(n)->margin_t;
+    return n->absx;
   }
   return n->absx - n->boundto->absx;
 }

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -811,13 +811,13 @@ int sixel_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
   int startx = s->movedfromx;
   for(int yy = starty ; yy < starty + s->dimy && yy < p->dimy ; ++yy){
     for(int xx = startx ; xx < startx + s->dimx && xx < p->dimx ; ++xx){
-      int ridx = (yy - nc->margin_t) * p->dimx + (xx - nc->margin_l);
+      int ridx = yy * p->dimx + xx;
       struct crender *r = &p->crender[ridx];
       if(!r->sprixel){
         if(s->n){
 //fprintf(stderr, "CHECKING %d/%d\n", yy - s->movedfromy, xx - s->movedfromx);
-          sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy - nc->margin_t,
-                                            xx - s->movedfromx + s->n->absx - nc->margin_l);
+          sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy,
+                                            xx - s->movedfromx + s->n->absx);
           if(state == SPRIXCELL_OPAQUE_SIXEL || state == SPRIXCELL_MIXED_SIXEL){
             r->s.damaged = 1;
           }else if(s->invalidated == SPRIXEL_MOVED){

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -809,16 +809,15 @@ int sixel_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
   (void)out;
   int starty = s->movedfromy;
   int startx = s->movedfromx;
-  const ncplane* stdn = notcurses_stdplane_const(nc);
   for(int yy = starty ; yy < starty + s->dimy && yy < p->dimy ; ++yy){
     for(int xx = startx ; xx < startx + s->dimx && xx < p->dimx ; ++xx){
-      int ridx = (yy - stdn->absy) * p->dimx + (xx - stdn->absx);
+      int ridx = (yy - nc->margin_t) * p->dimx + (xx - nc->margin_l);
       struct crender *r = &p->crender[ridx];
       if(!r->sprixel){
         if(s->n){
 //fprintf(stderr, "CHECKING %d/%d\n", yy - s->movedfromy, xx - s->movedfromx);
-          sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy - stdn->absy,
-                                            xx - s->movedfromx + s->n->absx - stdn->absx);
+          sprixcell_e state = sprixel_state(s, yy - s->movedfromy + s->n->absy - nc->margin_t,
+                                            xx - s->movedfromx + s->n->absx - nc->margin_l);
           if(state == SPRIXCELL_OPAQUE_SIXEL || state == SPRIXCELL_MIXED_SIXEL){
             r->s.damaged = 1;
           }else if(s->invalidated == SPRIXEL_MOVED){

--- a/src/tests/fills.cpp
+++ b/src/tests/fills.cpp
@@ -444,7 +444,7 @@ TEST_CASE("Fills") {
     CHECK(0 == notcurses_render(nc_));
     // make sure nulls do not replace glyphs
     auto p2 = ncplane_create(n_, &nopts);
-    CHECK(0 == ncplane_mergedown_simple(p2, nullptr));
+    CHECK(0 == ncplane_mergedown_simple(p2, n_));
     ncplane_destroy(p2);
     for(int i = 0 ; i < 10 ; ++i){
       CHECK(0 < ncplane_at_yx_cell(n_, 0, i, &cbase));

--- a/src/tests/fills.cpp
+++ b/src/tests/fills.cpp
@@ -434,7 +434,7 @@ TEST_CASE("Fills") {
     CHECK(0 == ncplane_cursor_move_yx(p3, 0, 0));
     // make sure glyphs replace glyps
     CHECK(0 < ncplane_putstr(p3, "🞵🞶🞷🞸🞹█▀▄▌▐"));
-    CHECK(0 == ncplane_mergedown_simple(p3, nullptr));
+    CHECK(0 == ncplane_mergedown_simple(p3, n_));
     nccell c3 = CELL_TRIVIAL_INITIALIZER;
     for(int i = 0 ; i < 10 ; ++i){
       CHECK(0 < ncplane_at_yx_cell(n_, 0, i, &cbase));


### PR DESCRIPTION
In many places, we referred to the margins implicitly through `stdplane->abs{xy}`, but this was arguably unsafe, and definitely bad form. instead, use them explicitly through the `notcurses` struct. furthermore, don't even set them in `stdplane->abs{yx}`, which are now always 0. this simplifies a lot of code. closes #1615.