### PR TITLE
Dankamongmen/termoverride

### DIFF
--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -720,6 +720,8 @@ fprintf(stderr, "string terminator after %d [%s]\n", inits->stringstate, inits->
       int xversion;
       if(sscanf(inits->runstring, "XTerm(%d)", &xversion) == 1){
         inits->qterm = TERMINAL_XTERM;
+      }else if(strncmp(inits->runstring, "WezTerm ", strlen("WezTerm ")) == 0){
+        inits->qterm = TERMINAL_WEZTERM;
       }
       break;
     }case STATE_XTGETTCAP_TERMNAME1:

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -714,7 +714,7 @@ ruts_string(init_state* inits, initstates_e state){
 
 static int
 stash_string(init_state* inits){
-fprintf(stderr, "string terminator after %d [%s]\n", inits->stringstate, inits->runstring);
+//fprintf(stderr, "string terminator after %d [%s]\n", inits->stringstate, inits->runstring);
   switch(inits->stringstate){
     case STATE_XTVERSION1:{
       int xversion;
@@ -1040,7 +1040,7 @@ control_read(tinfo* tcache, int ttyfd){
       int r = pump_control_read(&inits, buf[idx]);
       if(r == 1){ // success!
         free(buf);
-fprintf(stderr, "at end, derived terminal %d\n", inits.qterm);
+//fprintf(stderr, "at end, derived terminal %d\n", inits.qterm);
         return 0;
       }else if(r < 0){
         goto err;

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -732,7 +732,7 @@ fprintf(stderr, "string terminator after %d [%s]\n", inits->stringstate, inits->
     case STATE_TDA1:
       if(strcmp(inits->runstring, "~VTE") == 0){
         inits->qterm = TERMINAL_VTE;
-      }else if(strcmp(inits->runstring, "\x1bP!|464f4f54\x1b\\") == 0){
+      }else if(strcmp(inits->runstring, "FOOT") == 0){
         inits->qterm = TERMINAL_FOOT;
       }
       break;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1496,8 +1496,9 @@ cellcmp_and_dupfar(egcpool* dampool, nccell* damcell,
 // sets up the input layer, building a trie of escape sequences and their
 // nckey equivalents. if we are connected to a tty, this also completes the
 // terminal detection sequence (we ought have already written our initial
-// queries, ideally as early as possible).
-int ncinputlayer_init(tinfo* tcache, FILE* infp);
+// queries, ideally as early as possible). if we are able to determine the
+// terminal conclusively, it will be written to |detected|.
+int ncinputlayer_init(tinfo* tcache, FILE* infp, queried_terminals_e* detected);
 
 void ncinputlayer_stop(ncinputlayer* nilayer);
 

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -176,6 +176,7 @@ typedef enum {
   TERMINAL_FOOT,          // TDA: "\EP!|464f4f54\E\\"
   TERMINAL_MLTERM,        // XTGETTCAP['TN'] == 'mlterm'
   TERMINAL_WEZTERM,
+  TERMINAL_ALACRITTY,     // can't be detected; match TERM
 } queried_terminals_e;
 
 #ifdef __cplusplus

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -127,7 +127,7 @@ typedef struct tinfo {
   int (*pixel_shutdown)(int fd);  // called during context shutdown
   int (*pixel_clear_all)(int fd); // called during startup, kitty only
   int sprixel_scale_height; // sprixel must be a multiple of this many rows
-  const char* termname;     // determined terminal name
+  const char* termname;     // terminal name from environment variables/init
   struct termios tpreserved; // terminal state upon entry
   ncinputlayer input;       // input layer
   bool bitmap_supported;    // do we support bitmaps (post pixel_query_done)?
@@ -164,6 +164,19 @@ static inline int
 term_supported_styles(const tinfo* ti){
   return ti->supported_styles;
 }
+
+// if the terminal unambiguously identifies itself in response to our
+// queries, go ahead and trust that, overriding TERM.
+enum queried_terminal {
+  TERMINAL_UNKNOWN,       // no useful information from queries; use termname
+  TERMINAL_LINUX,         // ioctl()s
+  TERMINAL_XTERM,
+  TERMINAL_VTE,
+  TERMINAL_ALACRITTY,
+  TERMINAL_KITTY,         // XTGETTCAP['TN']
+  TERMINAL_FOOT,          // TDA: "\EP!|464f4f54\E\\"
+  TERMINAL_WEZTERM,
+};
 
 #ifdef __cplusplus
 }

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -167,7 +167,7 @@ term_supported_styles(const tinfo* ti){
 
 // if the terminal unambiguously identifies itself in response to our
 // queries, go ahead and trust that, overriding TERM.
-enum queried_terminal {
+typedef enum {
   TERMINAL_UNKNOWN,       // no useful information from queries; use termname
   TERMINAL_LINUX,         // ioctl()s
   TERMINAL_XTERM,         // XTVERSION == 'XTerm(ver)'
@@ -176,7 +176,7 @@ enum queried_terminal {
   TERMINAL_FOOT,          // TDA: "\EP!|464f4f54\E\\"
   TERMINAL_MLTERM,        // XTGETTCAP['TN'] == 'mlterm'
   TERMINAL_WEZTERM,
-};
+} queried_terminals_e;
 
 #ifdef __cplusplus
 }

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -170,11 +170,11 @@ term_supported_styles(const tinfo* ti){
 enum queried_terminal {
   TERMINAL_UNKNOWN,       // no useful information from queries; use termname
   TERMINAL_LINUX,         // ioctl()s
-  TERMINAL_XTERM,
-  TERMINAL_VTE,
-  TERMINAL_ALACRITTY,
-  TERMINAL_KITTY,         // XTGETTCAP['TN']
+  TERMINAL_XTERM,         // XTVERSION == 'XTerm(ver)'
+  TERMINAL_VTE,           // TDA: "~VTE"
+  TERMINAL_KITTY,         // XTGETTCAP['TN'] == 'xterm-kitty'
   TERMINAL_FOOT,          // TDA: "\EP!|464f4f54\E\\"
+  TERMINAL_MLTERM,        // XTGETTCAP['TN'] == 'mlterm'
   TERMINAL_WEZTERM,
 };
 


### PR DESCRIPTION
Extract the strings we get in reply to our initial queries, and compare them to known identifiers. Pipe the result back through to `interrogate_terminfo()`, and allow it to override `TERM`. Closes #1761.