### PR TITLE
Braille reverse array

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ rearrangements of Notcurses.
     terminals, however, will be retrieved independently of `TERM`; they'll
     be made available for use if supported by the connected terminal, and
     others will not, even if your `TERM` variable implies they ought.
+  * `ncplane_as_rgba()`/`ncvisual_from_plane()` now support `NCBLIT_BRAILLE`.
   * `CELL_ALPHA_*` macros are now `NCALPHA_*`. The former will remain
     `#define`d until ABI3.
 

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -104,7 +104,7 @@ typedef struct ncplane_options {
 
 **int ncplane_at_yx_cell(struct ncplane* ***n***, int ***y***, int ***x***, nccell* ***c***);**
 
-**uint32_t* ncplane_as_rgba(const struct ncplane* ***nc***, int ***begy***, int ***begx***, int ***leny***, int ***lenx***, int* ***pxdimy***, int* ***pxdimx***);**
+**uint32_t* ncplane_as_rgba(const struct ncplane* ***nc***, ncblitter_e ***blit***, int ***begy***, int ***begx***, int ***leny***, int ***lenx***, int* ***pxdimy***, int* ***pxdimx***);**
 
 **char* ncplane_contents(const struct ncplane* ***nc***, int ***begy***, int ***begx***, int ***leny***, int ***lenx***);**
 

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -31,6 +31,20 @@ trilerp(uint32_t c0, uint32_t c1, uint32_t c2){
   return ret;
 }
 
+// take a sum over channels, and the sample count, write back lerped channel
+static inline uint32_t
+generalerp(unsigned rsum, unsigned gsum, unsigned bsum, int count){
+  if(count == 0){
+    assert(0 == rsum);
+    assert(0 == gsum);
+    assert(0 == bsum);
+    return 0;
+  }
+  return CHANNEL_RGB_INITIALIZER((rsum + (count - 1)) / count,
+                                 (gsum + (count - 1)) / count,
+                                 (bsum + (count - 1)) / count);
+}
+
 static inline unsigned
 rgba_trans_q(const unsigned char* p, uint32_t transcolor){
   uint32_t q;
@@ -495,20 +509,6 @@ quadrant_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
   return total;
 }
 
-// take a sum over channels, and the sample count, write back lerped channel
-static inline uint32_t
-generalerp(unsigned rsum, unsigned gsum, unsigned bsum, int count){
-  if(count == 0){
-    assert(0 == rsum);
-    assert(0 == gsum);
-    assert(0 == bsum);
-    return 0;
-  }
-  return CHANNEL_RGB_INITIALIZER((rsum + (count - 1)) / count,
-                                 (gsum + (count - 1)) / count,
-                                 (bsum + (count - 1)) / count);
-}
-
 // Solve for the cell rendered by this 3x2 sample. None of the input pixels may
 // be transparent (that ought already have been handled). We use exhaustive
 // search, which might be quite computationally intensive for the worst case
@@ -781,6 +781,11 @@ braille_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
           }
         }
       }
+      // braille block is ordered (where 1 is the LSB)
+      //  1 4
+      //  2 5
+      //  3 6
+      //  4 7
       // FIXME fold this into the above?
       if(!rgba_trans_p(*rgbbase_l0, bargs->transcolor)){
         egcidx |= 1u;
@@ -871,8 +876,23 @@ static struct blitset notcurses_blitters[] = {
      .plotegcs = L" 🬞🬦▐🬏🬭🬵🬷🬓🬱🬹🬻▌🬲🬺█",
      .blit = sextant_blit,   .name = "sex",           .fill = false, },
    { .geom = NCBLIT_BRAILLE, .width = 2, .height = 4,
-     .egcs = L"\u2800⠁⠈⠉⠂⠃⠊⠋⠐⠑⠘⠙⠒⠓⠚⠛⠄⠅⠌⠍⠎⠏⠔⠕⠜⠝⠞⠟⠠⠡⠨⠩⠢⠣⠪⠫⠰⠱⠸⠹⠲⠳⠺⠻⠤⠥⠬⠭⠮⠯⠴⠵⠼⠽⠶⠷⠾⠿",
-     // FIXME 192 more, ugh
+     .egcs =
+       L"\u2800\u2801\u2808\u2809\u2802\u2803\u280a\u280b\u2810\u2811\u2818\u2819\u2812\u2813\u281a\u281b"
+        "\u2804\u2805\u280c\u280d\u2806\u2807\u280e\u280f\u2814\u2815\u281c\u281d\u2816\u2817\u281e\u281f"
+        "\u2820\u2821\u2828\u2829\u2822\u2823\u282a\u282b\u2830\u2831\u2838\u2839\u2832\u2833\u283a\u283b"
+        "\u2824\u2825\u282c\u282d\u2826\u2827\u282e\u282f\u2834\u2835\u283c\u283d\u2836\u2837\u283e\u283f"
+        "\u2840\u2841\u2848\u2849\u2842\u2843\u284a\u284b\u2850\u2851\u2858\u2859\u2852\u2853\u285a\u285b"
+        "\u2844\u2845\u284c\u284d\u2846\u2847\u284e\u284f\u2854\u2855\u285c\u285d\u2856\u2857\u285e\u285f"
+        "\u2860\u2861\u2868\u2869\u2862\u2863\u286a\u286b\u2870\u2871\u2878\u2879\u2872\u2873\u287a\u287b"
+        "\u2864\u2865\u286c\u286d\u2866\u2867\u286e\u286f\u2874\u2875\u287c\u287d\u2876\u2877\u287e\u287f"
+        "\u2880\u2881\u2888\u2889\u2882\u2883\u288a\u288b\u2890\u2891\u2898\u2899\u2892\u2893\u289a\u289b"
+        "\u2884\u2885\u288c\u288d\u2886\u2887\u288e\u288f\u2894\u2895\u289c\u289d\u2896\u2897\u289e\u289f"
+        "\u28a0\u28a1\u28a8\u28a9\u28a2\u28a3\u28aa\u28ab\u28b0\u28b1\u28b8\u28b9\u28b2\u28b3\u28ba\u28bb"
+        "\u28a4\u28a5\u28ac\u28ad\u28a6\u28a7\u28ae\u28af\u28b4\u28b5\u28bc\u28bd\u28b6\u28b7\u28be\u28bf"
+        "\u28c0\u28c1\u28c8\u28c9\u28c2\u28c3\u28ca\u28cb\u28d0\u28d1\u28d8\u28d9\u28d2\u28d3\u28da\u28db"
+        "\u28c4\u28c5\u28cc\u28cd\u28c6\u28c7\u28ce\u28cf\u28d4\u28d5\u28dc\u28dd\u28d6\u28d7\u28de\u28df"
+        "\u28e0\u28e1\u28e8\u28e9\u28e2\u28e3\u28ea\u28eb\u28f0\u28f1\u28f8\u28f9\u28f2\u28f3\u28fa\u28fb"
+        "\u28e4\u28e5\u28ec\u28ed\u28e6\u28e7\u28ee\u28ef\u28f4\u28f5\u28fc\u28fd\u28f6\u28f7\u28fe\u28ff",
      .plotegcs = L"⠀⢀⢠⢰⢸⡀⣀⣠⣰⣸⡄⣄⣤⣴⣼⡆⣆⣦⣶⣾⡇⣇⣧⣷⣿",
      .blit = braille_blit,   .name = "braille",       .fill = true,  },
    { .geom = NCBLIT_PIXEL,   .width = 1, .height = 1,

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -871,7 +871,9 @@ static struct blitset notcurses_blitters[] = {
      .plotegcs = L" 🬞🬦▐🬏🬭🬵🬷🬓🬱🬹🬻▌🬲🬺█",
      .blit = sextant_blit,   .name = "sex",           .fill = false, },
    { .geom = NCBLIT_BRAILLE, .width = 2, .height = 4,
-     .egcs = NULL, .plotegcs = L"⠀⢀⢠⢰⢸⡀⣀⣠⣰⣸⡄⣄⣤⣴⣼⡆⣆⣦⣶⣾⡇⣇⣧⣷⣿", // FIXME
+     .egcs = L"\u2800⠁⠈⠉⠂⠃⠊⠋⠐⠑⠘⠙⠒⠓⠚⠛⠄⠅⠌⠍⠎⠏⠔⠕⠜⠝⠞⠟⠠⠡⠨⠩⠢⠣⠪⠫⠰⠱⠸⠹⠲⠳⠺⠻⠤⠥⠬⠭⠮⠯⠴⠵⠼⠽⠶⠷⠾⠿",
+     // FIXME 192 more, ugh
+     .plotegcs = L"⠀⢀⢠⢰⢸⡀⣀⣠⣰⣸⡄⣄⣤⣴⣼⡆⣆⣦⣶⣾⡇⣇⣧⣷⣿",
      .blit = braille_blit,   .name = "braille",       .fill = true,  },
    { .geom = NCBLIT_PIXEL,   .width = 1, .height = 1,
      .egcs = L"", .plotegcs = NULL,

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -53,16 +53,17 @@ tinfo_debug_caps(const tinfo* ti, FILE* debugfp, int rows, int cols,
             get_blitter_egcs(NCBLIT_3x2) + 32,
             NCBOXROUNDW, NCBOXROUNDW + 4,
             NCBOXDOUBLEW, NCBOXDOUBLEW + 4);
-    fprintf(debugfp, "%s braille ⎡%.96ls⎤      ⎩%.6ls%.3ls⎭       ⎩%.6ls%.3ls⎭ ⎪🮉▍⎪ 🯶🯷\n", indent,
-            get_blitter_egcs(NCBLIT_BRAILLE),
+    fprintf(debugfp, "%s                                                 ⎩%.6ls%.3ls⎭       ⎩%.6ls%.3ls⎭ ⎪🮉▍⎪ 🯶🯷\n", indent,
             NCBOXROUNDW + 2, NCBOXROUNDW + 5,
             NCBOXDOUBLEW + 2, NCBOXDOUBLEW + 5);
-    fprintf(debugfp, "%s         ⎢%.96ls⎥                        ⎨▐▌⎬ 🯸🯹\n", indent,
-            get_blitter_egcs(NCBLIT_BRAILLE) + 32);
-    fprintf(debugfp, "%s         ⎢%.96ls⎥                        ⎪🮈▋⎪\n", indent,
-            get_blitter_egcs(NCBLIT_BRAILLE)); // FIXME
-    fprintf(debugfp, "%s         ⎣%.96ls⎦                        ⎪🮇▊⎪\n", indent,
-            get_blitter_egcs(NCBLIT_BRAILLE) + 32); // FIXME
+    fprintf(debugfp, "%s⎡%.192ls⎤ ⎪🮉▍⎪ 🯸🯹\n", indent,
+            get_blitter_egcs(NCBLIT_BRAILLE));
+    fprintf(debugfp, "%s⎢%.192ls⎥ ⎨▐▌⎬\n", indent,
+            get_blitter_egcs(NCBLIT_BRAILLE) + 64);
+    fprintf(debugfp, "%s⎢%.192ls⎥ ⎪🮈▋⎪\n", indent,
+            get_blitter_egcs(NCBLIT_BRAILLE) + 128);
+    fprintf(debugfp, "%s⎣%.192ls⎦ ⎪🮇▊⎪\n", indent,
+            get_blitter_egcs(NCBLIT_BRAILLE) + 192);
     fprintf(debugfp, "%s vert ⅛s ⎛%ls⎞ ▔🭶🭷🭸🭹🭺🭻▁                                      ⎪▕▉⎪\n", indent, get_blitter_egcs(NCBLIT_8x1));
     fprintf(debugfp, "%s         ⎝%s⎠                                               ⎩ █⎭\n", indent, "█🮆🮅🮄▀🮃🮂▔ ");
   }

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -45,7 +45,7 @@ tinfo_debug_caps(const tinfo* ti, FILE* debugfp, int rows, int cols,
             get_blitter_egcs(NCBLIT_2x1), get_blitter_egcs(NCBLIT_2x2),
             NCBOXLIGHTW, NCBOXLIGHTW + 4,
             NCBOXHEAVYW, NCBOXHEAVYW + 4);
-    fprintf(debugfp, "%ssextants ⎧%.120ls⎫       ⎩%.6ls%.3ls⎭       ⎩%.6ls%.3ls⎭ ⎪🮋▏⎪ 🯲🯳\n", indent,
+    fprintf(debugfp, "%ssextants ⎧%.122ls⎫       ⎩%.6ls%.3ls⎭       ⎩%.6ls%.3ls⎭ ⎪🮋▏⎪ 🯲🯳\n", indent,
             get_blitter_egcs(NCBLIT_3x2),
             NCBOXLIGHTW + 2, NCBOXLIGHTW + 5,
             NCBOXHEAVYW + 2, NCBOXHEAVYW + 5);
@@ -53,13 +53,16 @@ tinfo_debug_caps(const tinfo* ti, FILE* debugfp, int rows, int cols,
             get_blitter_egcs(NCBLIT_3x2) + 32,
             NCBOXROUNDW, NCBOXROUNDW + 4,
             NCBOXDOUBLEW, NCBOXDOUBLEW + 4);
-    fprintf(debugfp, "%s braille ⎡%.120ls⎤             ⎩%.6ls%.3ls⎭       ⎩%.6ls%.3ls⎭ ⎪🮉▍⎪ 🯶🯷\n", indent,
+    fprintf(debugfp, "%s braille ⎡%.96ls⎤      ⎩%.6ls%.3ls⎭       ⎩%.6ls%.3ls⎭ ⎪🮉▍⎪ 🯶🯷\n", indent,
             get_blitter_egcs(NCBLIT_BRAILLE),
             NCBOXROUNDW + 2, NCBOXROUNDW + 5,
             NCBOXDOUBLEW + 2, NCBOXDOUBLEW + 5);
-    fprintf(debugfp, "%s         ⎢%ls⎥                               ⎨▐▌⎬ 🯸🯹\n", indent, get_blitter_egcs(NCBLIT_BRAILLE)); // FIXME
-    fprintf(debugfp, "%s         ⎢%ls⎥                               ⎪🮈▋⎪\n", indent, get_blitter_egcs(NCBLIT_BRAILLE)); // FIXME
-    fprintf(debugfp, "%s         ⎣%ls⎦                               ⎪🮇▊⎪\n", indent, get_blitter_egcs(NCBLIT_BRAILLE)); // FIXME
+    fprintf(debugfp, "%s         ⎢%.96ls⎥                        ⎨▐▌⎬ 🯸🯹\n", indent,
+            get_blitter_egcs(NCBLIT_BRAILLE) + 32);
+    fprintf(debugfp, "%s         ⎢%.96ls⎥                        ⎪🮈▋⎪\n", indent,
+            get_blitter_egcs(NCBLIT_BRAILLE)); // FIXME
+    fprintf(debugfp, "%s         ⎣%.96ls⎦                        ⎪🮇▊⎪\n", indent,
+            get_blitter_egcs(NCBLIT_BRAILLE) + 32); // FIXME
     fprintf(debugfp, "%s vert ⅛s ⎛%ls⎞ ▔🭶🭷🭸🭹🭺🭻▁                                      ⎪▕▉⎪\n", indent, get_blitter_egcs(NCBLIT_8x1));
     fprintf(debugfp, "%s         ⎝%s⎠                                               ⎩ █⎭\n", indent, "█🮆🮅🮄▀🮃🮂▔ ");
   }


### PR DESCRIPTION
Support `NCBLIT_BRAILLE` in `ncplane_as_rgba()` and thus `ncvisual_from_plane()`. Show the entire 256-element Braille block in `notcurses_debug_caps()`. Closes #1441.