### PR TITLE
Query for the current background

### DIFF
--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -67,11 +67,8 @@ tinfo_debug_caps(const tinfo* ti, FILE* debugfp, int rows, int cols,
     fprintf(debugfp, "%s ⎛%ls⎞ ▔🭶🭷🭸🭹🭺🭻▁                                                   ⎪▕▉⎪\n", indent, get_blitter_egcs(NCBLIT_8x1));
     fprintf(debugfp, "%s ⎝%s⎠ ▏🭰🭱🭲🭳🭴🭵▕                                                   ⎩ █⎭\n", indent, "█🮆🮅🮄▀🮃🮂▔ ");
   }
-  if(ti->bg_collides_default){
-    fprintf(debugfp, "%sbackground of 0x%06lx is considered transparent\n", indent, ti->bg_collides_default & 0xfffffful);
-  }else{
-    fprintf(debugfp, "%sbackground isn't interpreted as transparent\n", indent);
-  }
+  fprintf(debugfp, "%sbackground of 0x%06lx is %sconsidered transparent\n", indent, ti->bg_collides_default & 0xfffffful,
+                   (ti->bg_collides_default & 0x01000000) ? "" : "not ");
   fprintf(debugfp, "%scup: %c vpa: %c hpa: %c\n",
           indent, capyn(get_escape(ti, ESCAPE_CUP)),
                   capyn(get_escape(ti, ESCAPE_VPA)),

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -41,31 +41,31 @@ tinfo_debug_caps(const tinfo* ti, FILE* debugfp, int rows, int cols,
           capbool(ti->sextants), capbool(ti->braille),
           capbool(images), capbool(videos));
   if(ti->utf8){
-    fprintf(debugfp, "%s  halves {%ls}   quads {%ls} light ⎧%.6ls%.3ls⎫ heavy ⎧%.6ls%.3ls⎫ ⎧█ ⎫ 🯰🯱\n", indent,
+    fprintf(debugfp, "%s{%ls} {%ls} ⎧%.122ls⎫ ⎧%.6ls%.3ls⎫ ⎧%.6ls%.3ls⎫ ⎧█ ⎫ 🯰🯱\n", indent,
             get_blitter_egcs(NCBLIT_2x1), get_blitter_egcs(NCBLIT_2x2),
+            get_blitter_egcs(NCBLIT_3x2),
             NCBOXLIGHTW, NCBOXLIGHTW + 4,
             NCBOXHEAVYW, NCBOXHEAVYW + 4);
-    fprintf(debugfp, "%ssextants ⎧%.122ls⎫       ⎩%.6ls%.3ls⎭       ⎩%.6ls%.3ls⎭ ⎪🮋▏⎪ 🯲🯳\n", indent,
-            get_blitter_egcs(NCBLIT_3x2),
+    fprintf(debugfp, "%s                          ⎩%ls⎭ ⎩%.6ls%.3ls⎭ ⎩%.6ls%.3ls⎭ ⎪🮋▏⎪ 🯲🯳\n", indent,
+            get_blitter_egcs(NCBLIT_3x2) + 32,
             NCBOXLIGHTW + 2, NCBOXLIGHTW + 5,
             NCBOXHEAVYW + 2, NCBOXHEAVYW + 5);
-    fprintf(debugfp, "%s         ⎩%ls⎭ round ⎧%.6ls%.3ls⎫ frame ⎧%.6ls%.3ls⎫ ⎪🮊▎⎪ 🯴🯵\n", indent,
-            get_blitter_egcs(NCBLIT_3x2) + 32,
+    fprintf(debugfp, "%s                                                            ⎧%.6ls%.3ls⎫ ⎧%.6ls%.3ls⎫ ⎪🮊▎⎪ 🯴🯵\n", indent,
             NCBOXROUNDW, NCBOXROUNDW + 4,
             NCBOXDOUBLEW, NCBOXDOUBLEW + 4);
-    fprintf(debugfp, "%s                                                 ⎩%.6ls%.3ls⎭       ⎩%.6ls%.3ls⎭ ⎪🮉▍⎪ 🯶🯷\n", indent,
+    fprintf(debugfp, "%s                                                            ⎩%.6ls%.3ls⎭ ⎩%.6ls%.3ls⎭ ⎪🮉▍⎪ 🯶🯷\n", indent,
             NCBOXROUNDW + 2, NCBOXROUNDW + 5,
             NCBOXDOUBLEW + 2, NCBOXDOUBLEW + 5);
-    fprintf(debugfp, "%s⎡%.192ls⎤ ⎪🮉▍⎪ 🯸🯹\n", indent,
+    fprintf(debugfp, "%s⎡%.192ls⎤      ⎪🮉▍⎪ 🯸🯹\n", indent,
             get_blitter_egcs(NCBLIT_BRAILLE));
-    fprintf(debugfp, "%s⎢%.192ls⎥ ⎨▐▌⎬\n", indent,
+    fprintf(debugfp, "%s⎢%.192ls⎥      ⎨▐▌⎬\n", indent,
             get_blitter_egcs(NCBLIT_BRAILLE) + 64);
-    fprintf(debugfp, "%s⎢%.192ls⎥ ⎪🮈▋⎪\n", indent,
+    fprintf(debugfp, "%s⎢%.192ls⎥      ⎪🮈▋⎪\n", indent,
             get_blitter_egcs(NCBLIT_BRAILLE) + 128);
-    fprintf(debugfp, "%s⎣%.192ls⎦ ⎪🮇▊⎪\n", indent,
+    fprintf(debugfp, "%s⎣%.192ls⎦      ⎪🮇▊⎪\n", indent,
             get_blitter_egcs(NCBLIT_BRAILLE) + 192);
-    fprintf(debugfp, "%s vert ⅛s ⎛%ls⎞ ▔🭶🭷🭸🭹🭺🭻▁                                      ⎪▕▉⎪\n", indent, get_blitter_egcs(NCBLIT_8x1));
-    fprintf(debugfp, "%s         ⎝%s⎠                                               ⎩ █⎭\n", indent, "█🮆🮅🮄▀🮃🮂▔ ");
+    fprintf(debugfp, "%s ⎛%ls⎞ ▔🭶🭷🭸🭹🭺🭻▁                                                   ⎪▕▉⎪\n", indent, get_blitter_egcs(NCBLIT_8x1));
+    fprintf(debugfp, "%s ⎝%s⎠ ▏🭰🭱🭲🭳🭴🭵▕                                                   ⎩ █⎭\n", indent, "█🮆🮅🮄▀🮃🮂▔ ");
   }
   if(ti->bg_collides_default){
     fprintf(debugfp, "%sbackground of 0x%06lx is considered transparent\n", indent, ti->bg_collides_default & 0xfffffful);

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -744,12 +744,16 @@ stash_string(init_state* inits){
       break;
     case STATE_BG1:{
       int r, g, b;
-      if(sscanf(inits->runstring, "rgb:%04x/%04x/%04x", &r, &g, &b) == 3){
+      if(sscanf(inits->runstring, "rgb:%02x/%02x/%02x", &r, &g, &b) == 3){
+        // great! =]
+      }else if(sscanf(inits->runstring, "rgb:%04x/%04x/%04x", &r, &g, &b) == 3){
         r /= 256;
         g /= 256;
         b /= 256;
-        inits->bg = (r << 16u) | (g << 8u) | b;
+      }else{
+        break;
       }
+      inits->bg = (r << 16u) | (g << 8u) | b;
       break;
     }default:
       fprintf(stderr, "invalid string stashed %d\n", inits->stringstate);

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -752,7 +752,7 @@ stash_string(init_state* inits){
 // ought be fed to the machine, and -1 on an invalid state transition.
 static int
 pump_control_read(init_state* inits, unsigned char c){
-//fprintf(stderr, "state: %2d char: %1c %3d %02x\n", inits->state, isprint(c) ? c : ' ', c, c);
+fprintf(stderr, "state: %2d char: %1c %3d %02x\n", inits->state, isprint(c) ? c : ' ', c, c);
   if(c == NCKEY_ESC){
     /*if(inits->state != STATE_NULL && inits->state != STATE_DCS && inits->state != STATE_DCS_DRAIN && inits->state != STATE_XTVERSION2 && inits->state != STATE_XTGETTCAP3 && inits->state != STATE_DA_DRAIN){
       fprintf(stderr, "Unexpected escape in state %d\n", inits->state);

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -718,7 +718,7 @@ ruts_string(init_state* inits, initstates_e state){
 
 static int
 stash_string(init_state* inits){
-fprintf(stderr, "string terminator after %d [%s]\n", inits->stringstate, inits->runstring);
+//fprintf(stderr, "string terminator after %d [%s]\n", inits->stringstate, inits->runstring);
   switch(inits->stringstate){
     case STATE_XTVERSION1:{
       int xversion;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -706,7 +706,11 @@ term_bg_rgb8(const tinfo* ti, FILE* out, unsigned r, unsigned g, unsigned b){
       if((r == (ti->bg_collides_default & 0xff0000lu)) &&
          (g == (ti->bg_collides_default & 0xff00lu)) &&
          (b == (ti->bg_collides_default & 0xfflu))){
-        ++b; // what if it's 255 FIXME
+        if(b < 255){
+          ++b;
+        }else{
+          --b;
+        }
       }
     }
     return term_esc_rgb(out, false, r, g, b);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -214,13 +214,24 @@ init_terminfo_esc(tinfo* ti, const char* name, escape_e idx,
 //   ⇒  CSI ? 6 4 ; Ps c  ("VT420")
 #define ESC_DA "\e[c"
 
+// query background, replies in X color https://www.x.org/releases/X11R7.7/doc/man/man7/X.7.xhtml#heading11
+#define CSI_BGQ "\e]11;?\e\\\\\\"
+
 // we send an XTSMGRAPHICS to set up 256 color registers (the most we can
 // currently take advantage of; we need at least 64 to use sixel at all.
 // maybe that works, maybe it doesn't. then query both color registers
 // and geometry. send XTGETTCAP for terminal name.
 static int
 send_initial_queries(int fd){
-  const char queries[] = "\x1b[=0c\x1b[>c\x1b[>q\x1bP+q544e\x1b\\\x1b[?1;3;256S\x1b[?2;1;0S\x1b[?1;1;0S" ESC_DA;
+  const char queries[] = CSI_BGQ
+                         "\x1b[=0c"
+                         "\x1b[>c"
+                         "\x1b[>q"
+                         "\x1bP+q544e\x1b\\"
+                         "\x1b[?1;3;256S"
+                         "\x1b[?2;1;0S"
+                         "\x1b[?1;1;0S"
+                         ESC_DA;
   if(blocking_write(fd, queries, strlen(queries))){
     return -1;
   }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -101,9 +101,7 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
   if(qterm == TERMINAL_KITTY){ // kitty (https://sw.kovidgoyal.net/kitty/)
     termname = "Kitty";
     // see https://sw.kovidgoyal.net/kitty/protocol-extensions.html
-    // FIXME detect the actual default background color; this assumes it to
-    // be RGB(0, 0, 0) (the default). we could also just set it, i guess.
-    ti->bg_collides_default = 0x1000000;
+    ti->bg_collides_default |= 0x1000000;
     ti->sextants = true; // work since bugfix in 0.19.3
     ti->quadrants = true;
     ti->RGBflag = true;

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -213,7 +213,7 @@ init_terminfo_esc(tinfo* ti, const char* name, escape_e idx,
 #define ESC_DA "\e[c"
 
 // query background, replies in X color https://www.x.org/releases/X11R7.7/doc/man/man7/X.7.xhtml#heading11
-#define CSI_BGQ "\e]11;?\e\\\\\\"
+#define CSI_BGQ "\e]11;?\e\\"
 
 // we send an XTSMGRAPHICS to set up 256 color registers (the most we can
 // currently take advantage of; we need at least 64 to use sixel at all.

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -105,7 +105,7 @@ typedef struct tinfo {
   // kitty interprets an RGB background that matches the default background
   // color *as* the default background, meaning it'll be translucent if
   // background_opaque is in use. detect this, and avoid the default if so.
-  // bg_collides_default is either 0x0000000 or 0x1RRGGBB.
+  // bg_collides_default is either 0x0000000 or (if in use) 0x1RRGGBB.
   uint32_t bg_collides_default;
 
   // sprixel support. there are several different sprixel protocols, of


### PR DESCRIPTION
Send `\e]11;?` to query for the current background color, ideally in RGB. Tested with XTerm, Kitty, Alacritty, and foot, looks good. This allows us to now properly work around Kitty's replacement of an explicitly-specified background equal to the default background with the default background semantics, finally.