### PR TITLE
Invert DECSDM when sprixel_cursor_hack is set

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -867,7 +867,7 @@ int sixel_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
 int kitty_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
 int kitty_remove(int id, FILE* out);
 int kitty_clear_all(int fd);
-int sixel_init(int fd);
+int sixel_init(const tinfo* t, int fd);
 int sprite_init(const tinfo* t, int fd);
 int sprite_clear_all(const tinfo* t, int fd);
 int kitty_shutdown(int fd);

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -864,10 +864,15 @@ int sixel_draw(const ncpile* p, sprixel* s, FILE* out){
   return 0;
 }
 
-int sixel_init(int fd){
+int sixel_init(const tinfo* ti, int fd){
   // \e[?8452: DECSDM private "sixel scrolling" mode keeps the sixel from
   // scrolling, but puts it at the current cursor location (as opposed to
   // the upper left corner of the screen).
+  if(ti->sprixel_cursor_hack){
+    // except MLterm (and a few others, possibly including the physical VT340),
+    // which inverts the usual sense of DECSDM.
+    return tty_emit("\e[?80l\e[?8452h", fd);
+  }
   return tty_emit("\e[?80;8452h", fd);
 }
 

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -205,7 +205,7 @@ int sprite_init(const tinfo* t, int fd){
   if(t->pixel_init == NULL){
     return 0;
   }
-  return t->pixel_init(fd);
+  return t->pixel_init(t, fd);
 }
 
 uint8_t* sprixel_auxiliary_vector(const sprixel* s){

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -4,7 +4,7 @@
 
 // we found Sixel support -- set up the API
 static inline void
-setup_sixel_bitmaps(tinfo* ti){
+setup_sixel_bitmaps(tinfo* ti, int fd){
   ti->bitmap_supported = true;
   ti->pixel_init = sixel_init;
   ti->pixel_draw = sixel_draw;
@@ -14,6 +14,7 @@ setup_sixel_bitmaps(tinfo* ti){
   ti->pixel_shutdown = sixel_shutdown;
   ti->pixel_rebuild = sixel_rebuild;
   ti->sprixel_scale_height = 6;
+  sprite_init(ti, fd);
 }
 
 static inline void
@@ -421,11 +422,6 @@ int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
   if(ncinputlayer_init(ti, stdin, &detected)){
     goto err;
   }
-  // our current sixel quantization algorithm requires at least 64 color
-  // registers. we make use of no more than 256.
-  if(ti->color_registers >= 64){
-    setup_sixel_bitmaps(ti);
-  }
   if(nocbreak){
     if(fd >= 0){
       if(tcsetattr(fd, TCSANOW, &ti->tpreserved)){
@@ -438,6 +434,12 @@ int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
   if(apply_term_heuristics(ti, termname, fd, detected)){
     ncinputlayer_stop(&ti->input);
     goto err;
+  }
+  // our current sixel quantization algorithm requires at least 64 color
+  // registers. we make use of no more than 256. this needs to happen
+  // after heuristics, since sixel_init() depends on sprixel_cursor_hack.
+  if(ti->color_registers >= 64){
+    setup_sixel_bitmaps(ti, fd);
   }
   return 0;
 

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -122,7 +122,7 @@ typedef struct tinfo {
   // perform the inverse of pixel_wipe, restoring an annihilated sprixcell.
   int (*pixel_rebuild)(struct sprixel* s, int y, int x, uint8_t* auxvec);
   int (*pixel_remove)(int id, FILE* out); // kitty only, issue actual delete command
-  int (*pixel_init)(int fd);      // called when support is detected
+  int (*pixel_init)(const struct tinfo*, int fd); // called when support is detected
   int (*pixel_draw)(const struct ncpile* p, struct sprixel* s, FILE* out);
   int (*pixel_shutdown)(int fd);  // called during context shutdown
   int (*pixel_clear_all)(int fd); // called during startup, kitty only
@@ -136,8 +136,10 @@ typedef struct tinfo {
   bool AMflag;    // "AM" flag for automatic movement to next line
 
   // mlterm resets the cursor (i.e. makes it visible) any time you print
-  // a sprixel. we work around this spiritedly unorthodox decision.
-  bool sprixel_cursor_hack; // do sprixels reset the cursor? (mlterm)
+  // a sprixel. we work around this spiritedly unorthodox decision. it
+  // furthermore interprets DECSDM in the reverse sense of most terminals
+  // (though possibly in conformance with the actual VT340).
+  bool sprixel_cursor_hack; // mlterm fixes
 } tinfo;
 
 // retrieve the terminfo(5)-style escape 'e' from tdesc (NULL if undefined).


### PR DESCRIPTION
In addition to making the cursor visible whenever a graphic is displayed, MLterm inverts the sense of `DECSDM` compared to most other terminals we know (though perhaps not the physical VT340). Key off `sprixel_cursor_hack` in `sixel_init()` to send `h` rather than `l`. Closes #1782.