### PR TITLE
Add ncvisual_from_rgb_{packed, loose}()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ rearrangements of Notcurses.
     `const ncdirect*`, since they update the term parameters. Sorry!
   * Added `NCDIRECT_OPTION_VERBOSE` and `NCDIRECT_OPTION_VERY_VERBOSE`.
     They map to `NCLOGLEVEL_WARNING` and `NCLOGLEVEL_TRACE`, respectively.
+  * New functions `ncvisual_from_rgb_packed()` and `ncvisual_from_rgb_loose()`.
 
 * 2.3.4 (2021-06-12)
   * Added the flag `NCVISUAL_OPTION_NOINTERPOLATE` to use non-interpolative

--- a/USAGE.md
+++ b/USAGE.md
@@ -1600,7 +1600,7 @@ int ncblit_rgb_loose(const void* data, int linesize,
                      const struct ncvisual_options* vopts, int alpha);
 
 // Same as ncblit_rgba(), but for RGB, with 'alpha' supplied as an alpha value
-// throughout, 0 <= 'alpha' <= 255. linesize ought be a multiple of 3.
+// throughout, 0 <= 'alpha' <= 255.
 int ncblit_rgb_packed(const void* data, int linesize,
                       const struct ncvisual_options* vopts, int alpha);
 
@@ -3086,6 +3086,16 @@ constructed directly from RGBA or BGRA 8bpc memory:
 // which (rows * cols * 4) bytes are actual non-padding data.
 struct ncvisual* ncvisual_from_rgba(const void* rgba, int rows,
                                     int rowstride, int cols);
+
+// ncvisual_from_rgba(), but the pixels are 4-byte RGBx. A is filled in
+// throughout using 'alpha'. rowstride must be a multiple of 4.
+struct ncvisual* ncvisual_from_rgb_packed(const void* rgba, int rows,
+                                          int rowstride, int cols, int alpha);
+
+// ncvisual_from_rgba(), but the pixels are 3-byte RGB. A is filled in
+// throughout using 'alpha'.
+struct ncvisual* ncvisual_from_rgb_loose(const void* rgba, int rows,
+                                         int rowstride, int cols, int alpha);
 
 // ncvisual_from_rgba(), but for BGRA.
 struct ncvisual* ncvisual_from_bgra(struct notcurses* nc, const void* bgra,

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -56,6 +56,10 @@ typedef int (*streamcb)(struct notcurses*, struct ncvisual*, void*);
 
 **struct ncvisual* ncvisual_from_rgba(const void* ***rgba***, int ***rows***, int ***rowstride***, int ***cols***);**
 
+**struct ncvisual* ncvisual_from_rgb_packed(const void* ***rgba***, int ***rows***, int ***rowstride***, int ***cols***, int ***alpha***);**
+
+**struct ncvisual* ncvisual_from_rgb_loose(const void* ***rgba***, int ***rows***, int ***rowstride***, int ***cols***, int ***alpha***);**
+
 **struct ncvisual* ncvisual_from_bgra(const void* ***bgra***, int ***rows***, int ***rowstride***, int ***cols***);**
 
 **struct ncvisual* ncvisual_from_plane(struct ncplane* ***n***, ncblitter_e ***blit***, int ***begy***, int ***begx***, int ***leny***, int ***lenx***);**
@@ -129,10 +133,14 @@ thus must be at least ***rowstride*** * ***rows*** bytes, of which a
 ***cols*** * ***rows*** * 4-byte subset is used. It is not possible to **mmap(2)** an image
 file and use it directly--decompressed, decoded data is necessary. The
 resulting plane will be ceil(**rows**/2) rows, and **cols** columns.
+
+**ncvisual_from_rgb_packed** performs the same using 3-byte RGB source data.
+**ncvisual_from_rgb_loose** uses 4-byte RGBx source data. Both will fill in
+the alpha component of every target pixel with the specified **alpha**.
+
 **ncvisual_from_plane** requires specification of a rectangle via ***begy***,
-***begx***, ***leny***, and ***lenx***. The only valid characters within this
-region are those used by the **NCBLIT_2x2** blitter, though this may change
-in the future.
+***begx***, ***leny***, and ***lenx***, and also a blitter. The only valid
+glyphs within this region are those used by the specified blitter.
 
 **ncvisual_rotate** executes a rotation of ***rads*** radians, in the clockwise
 (positive) or counterclockwise (negative) direction.

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2531,6 +2531,18 @@ API ALLOC struct ncvisual* ncvisual_from_file(const char* file);
 API ALLOC struct ncvisual* ncvisual_from_rgba(const void* rgba, int rows,
                                               int rowstride, int cols);
 
+// ncvisual_from_rgba(), but the pixels are 4-byte RGBx. A is filled in
+// throughout using 'alpha'. rowstride must be a multiple of 4.
+API ALLOC struct ncvisual* ncvisual_from_rgb_packed(const void* rgba, int rows,
+                                                    int rowstride, int cols,
+                                                    int alpha);
+
+// ncvisual_from_rgba(), but the pixels are 3-byte RGB. A is filled in
+// throughout using 'alpha'.
+API ALLOC struct ncvisual* ncvisual_from_rgb_loose(const void* rgba, int rows,
+                                                   int rowstride, int cols,
+                                                   int alpha);
+
 // ncvisual_from_rgba(), but 'bgra' is arranged as BGRA. note that this is a
 // byte-oriented layout, despite being bunched in 32-bit pixels; the lowest
 // memory address ought be B, and A is reached by adding 3 to that address.
@@ -2739,8 +2751,7 @@ API int ncblit_rgba(const void* data, int linesize,
 API int ncblit_bgrx(const void* data, int linesize,
                     const struct ncvisual_options* vopts);
 
-// Supply an alpha value [0..255] to be applied throughout. linesize must be
-// a multiple of 3 for this RGB data.
+// Supply an alpha value [0..255] to be applied throughout.
 API int ncblit_rgb_packed(const void* data, int linesize,
                           const struct ncvisual_options* vopts, int alpha);
 

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -622,10 +622,11 @@ ncvisual* ncvisual_from_rgb_packed(const void* rgba, int rows, int rowstride,
         memcpy(&r, src + rowstride * y + 3 * x, 1);
         memcpy(&g, src + rowstride * y + 3 * x + 1, 1);
         memcpy(&b, src + rowstride * y + 3 * x + 2, 1);
-        ncpixel_set_a(&data[y * cols + x], alpha);
-        ncpixel_set_r(&data[y * cols + x], r);
-        ncpixel_set_g(&data[y * cols + x], g);
-        ncpixel_set_b(&data[y * cols + x], b);
+        ncpixel_set_a(&data[y * ncv->rowstride / 4 + x], alpha);
+        ncpixel_set_r(&data[y * ncv->rowstride / 4 + x], r);
+        ncpixel_set_g(&data[y * ncv->rowstride / 4 + x], g);
+        ncpixel_set_b(&data[y * ncv->rowstride / 4 + x], b);
+//fprintf(stderr, "RGBA: 0x%02x 0x%02x 0x%02x 0x%02x\n", r, g, b, alpha);
       }
     }
     ncvisual_set_data(ncv, data, true);

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -655,7 +655,7 @@ ncvisual* ncvisual_from_rgb_loose(const void* rgba, int rows, int rowstride,
 //fprintf(stderr, "ROWS: %d STRIDE: %d (%d) COLS: %d %08x\n", ncv->pixy, ncv->rowstride, ncv->rowstride / 4, cols, data[ncv->rowstride * y / 4]);
       memcpy(data + (ncv->rowstride * y) / 4, (const char*)rgba + rowstride * y, rowstride);
       for(int x = 0 ; x < cols ; ++x){
-        ncpixel_set_a(&data[y * cols + x], alpha);
+        ncpixel_set_a(&data[y * ncv->rowstride / 4 + x], alpha);
       }
     }
     ncvisual_set_data(ncv, data, true);

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Visual") {
 
   // check that we properly populate RGB + A -> RGBA
   SUBCASE("VisualFromRGBPacked") {
-    unsigned char rgb[13] = "\x88\x77\x66\x55\x44\x33\x22\x11\x00\x99\xaa\xbb";
+    unsigned char rgb[] = "\x88\x77\x66\x55\x44\x33\x22\x11\x00\x99\xaa\xbb";
     unsigned char alpha = 0xff;
     auto ncv = ncvisual_from_rgb_packed(rgb, 2, 6, 2, alpha);
     REQUIRE(nullptr != ncv);
@@ -20,10 +20,27 @@ TEST_CASE("Visual") {
       for(int x = 0 ; x < 2 ; ++x){
         uint32_t p;
         CHECK(0 == ncvisual_at_yx(ncv, y, x, &p));
-fprintf(stderr, "rgba: 0x%02x 0x%02x 0x%02x 0x%02x\n", ncpixel_r(p), ncpixel_g(p), ncpixel_b(p), ncpixel_a(p));
         CHECK(ncpixel_r(p) == rgb[y * 6 + x * 3]);
         CHECK(ncpixel_g(p) == rgb[y * 6 + x * 3 + 1]);
         CHECK(ncpixel_b(p) == rgb[y * 6 + x * 3 + 2]);
+        CHECK(ncpixel_a(p) == alpha);
+      }
+    }
+  }
+
+  // check that we properly populate RGBx + A -> RGBA
+  SUBCASE("VisualFromRGBxPacked") {
+    unsigned char rgb[] = "\x88\x77\x66\x12\x55\x44\x33\x10\x22\x11\x00\xdd\x99\xaa\xbb\xcc";
+    unsigned char alpha = 0xff;
+    auto ncv = ncvisual_from_rgb_loose(rgb, 2, 8, 2, alpha);
+    REQUIRE(nullptr != ncv);
+    for(int y = 0 ; y < 2 ; ++y){
+      for(int x = 0 ; x < 2 ; ++x){
+        uint32_t p;
+        CHECK(0 == ncvisual_at_yx(ncv, y, x, &p));
+        CHECK(ncpixel_r(p) == rgb[y * 8 + x * 4]);
+        CHECK(ncpixel_g(p) == rgb[y * 8 + x * 4 + 1]);
+        CHECK(ncpixel_b(p) == rgb[y * 8 + x * 4 + 2]);
         CHECK(ncpixel_a(p) == alpha);
       }
     }

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -10,6 +10,25 @@ TEST_CASE("Visual") {
   auto n_ = notcurses_stdplane(nc_);
   REQUIRE(n_);
 
+  // check that we properly populate RGB + A -> RGBA
+  SUBCASE("VisualFromRGBPacked") {
+    unsigned char rgb[13] = "\x88\x77\x66\x55\x44\x33\x22\x11\x00\x99\xaa\xbb";
+    unsigned char alpha = 0xff;
+    auto ncv = ncvisual_from_rgb_packed(rgb, 2, 6, 2, alpha);
+    REQUIRE(nullptr != ncv);
+    for(int y = 0 ; y < 2 ; ++y){
+      for(int x = 0 ; x < 2 ; ++x){
+        uint32_t p;
+        CHECK(0 == ncvisual_at_yx(ncv, y, x, &p));
+fprintf(stderr, "rgba: 0x%02x 0x%02x 0x%02x 0x%02x\n", ncpixel_r(p), ncpixel_g(p), ncpixel_b(p), ncpixel_a(p));
+        CHECK(ncpixel_r(p) == rgb[y * 6 + x * 3]);
+        CHECK(ncpixel_g(p) == rgb[y * 6 + x * 3 + 1]);
+        CHECK(ncpixel_b(p) == rgb[y * 6 + x * 3 + 2]);
+        CHECK(ncpixel_a(p) == alpha);
+      }
+    }
+  }
+
   // check that NCVISUAL_OPTION_HORALIGNED works in all three cases
   SUBCASE("VisualAligned") {
     const uint32_t pixels[4] = { htole(0xffff0000), htole(0xff00ff00), htole(0xff0000ff), htole(0xffffffff) };


### PR DESCRIPTION
Add `ncvisual_from_rgb_packed()` and `ncvisual_from_rgb_loose()`, plus unit tests. Closes #1767.