### PR TITLE
Rearrange the termdesc/input layer a bit

### DIFF
--- a/src/lib/input.h
+++ b/src/lib/input.h
@@ -1,0 +1,48 @@
+#ifndef NOTCURSES_INPUT
+#define NOTCURSES_INPUT
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// internal header, not installed
+
+#include <stdio.h>
+
+struct tinfo;
+struct termios;
+struct ncinputlayer;
+
+typedef enum {
+    TERMINAL_UNKNOWN,       // no useful information from queries; use termname
+    TERMINAL_LINUX,         // ioctl()s
+    TERMINAL_XTERM,         // XTVERSION == 'XTerm(ver)'
+    TERMINAL_VTE,           // TDA: "~VTE"
+    TERMINAL_KITTY,         // XTGETTCAP['TN'] == 'xterm-kitty'
+    TERMINAL_FOOT,          // TDA: "\EP!|464f4f54\E\\"
+    TERMINAL_MLTERM,        // XTGETTCAP['TN'] == 'mlterm'
+    TERMINAL_WEZTERM,       // XTVERSION == 'WezTerm *'
+    TERMINAL_ALACRITTY,     // can't be detected; match TERM
+    TERMINAL_CONTOUR,       // XTVERSION == 'console *'
+} queried_terminals_e;
+
+// sets up the input layer, building a trie of escape sequences and their
+// nckey equivalents. if we are connected to a tty, this also completes the
+// terminal detection sequence (we ought have already written our initial
+// queries, ideally as early as possible). if we are able to determine the
+// terminal conclusively, it will be written to |detected|. if the terminal
+// advertised support for application-sychronized updates, |appsync| will be
+// non-zero.
+int ncinputlayer_init(struct tinfo* tcache, FILE* infp,
+                      queried_terminals_e* detected, unsigned* appsync);
+
+void ncinputlayer_stop(struct ncinputlayer* nilayer);
+
+// FIXME absorb into ncinputlayer_init()
+int cbreak_mode(int ttyfd, const struct termios* tpreserved);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1495,18 +1495,6 @@ cellcmp_and_dupfar(egcpool* dampool, nccell* damcell,
   return 1;
 }
 
-// sets up the input layer, building a trie of escape sequences and their
-// nckey equivalents. if we are connected to a tty, this also completes the
-// terminal detection sequence (we ought have already written our initial
-// queries, ideally as early as possible). if we are able to determine the
-// terminal conclusively, it will be written to |detected|.
-int ncinputlayer_init(tinfo* tcache, FILE* infp, queried_terminals_e* detected);
-
-void ncinputlayer_stop(ncinputlayer* nilayer);
-
-// FIXME absorb into ncinputlayer_init()
-int cbreak_mode(int ttyfd, const struct termios* tpreserved);
-
 int set_fd_nonblocking(int fd, unsigned state, unsigned* oldstate);
 
 int get_tty_fd(FILE* ttyfp);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -390,13 +390,11 @@ int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
     ti->escindices[ESCAPE_SMCUP] = 0;
     ti->escindices[ESCAPE_RMCUP] = 0;
   }
-  // check that the terminal provides automatic margins
-  ti->AMflag = tigetflag("am") == 1;
-  if(!ti->AMflag){
+  // ensure that the terminal provides automatic margins
+  if(tigetflag("am") != 1){
     fprintf(stderr, "Required terminfo capability 'am' not defined\n");
     goto err;
   }
-  ti->BCEflag = tigetflag("bce") == 1;
   if(get_escape(ti, ESCAPE_CIVIS) == NULL){
     char* chts;
     if(terminfostr(&chts, "chts") == 0){

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -61,6 +61,10 @@ typedef enum {
   ESCAPE_INITC,    // "initc" set up palette entry
   ESCAPE_GETM,     // "getm" get mouse events
   ESCAPE_DSRCPR,   // "u7" cursor position report
+  // Application synchronized updates, not present in terminfo
+  // (https://gitlab.com/gnachman/iterm2/-/wikis/synchronized-updates-spec)
+  ESCAPE_BSU,      // Begin Synchronized Update
+  ESCAPE_ESU,      // End Synchronized Update
   ESCAPE_MAX
 } escape_e;
 

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -1,5 +1,5 @@
-#ifndef NOTCURSES_TERM
-#define NOTCURSES_TERM
+#ifndef NOTCURSES_TERMDESC
+#define NOTCURSES_TERMDESC
 
 #ifdef __cplusplus
 extern "C" {
@@ -169,21 +169,6 @@ static inline int
 term_supported_styles(const tinfo* ti){
   return ti->supported_styles;
 }
-
-// if the terminal unambiguously identifies itself in response to our
-// queries, go ahead and trust that, overriding TERM.
-typedef enum {
-  TERMINAL_UNKNOWN,       // no useful information from queries; use termname
-  TERMINAL_LINUX,         // ioctl()s
-  TERMINAL_XTERM,         // XTVERSION == 'XTerm(ver)'
-  TERMINAL_VTE,           // TDA: "~VTE"
-  TERMINAL_KITTY,         // XTGETTCAP['TN'] == 'xterm-kitty'
-  TERMINAL_FOOT,          // TDA: "\EP!|464f4f54\E\\"
-  TERMINAL_MLTERM,        // XTGETTCAP['TN'] == 'mlterm'
-  TERMINAL_WEZTERM,       // XTVERSION == 'WezTerm *'
-  TERMINAL_ALACRITTY,     // can't be detected; match TERM
-  TERMINAL_CONTOUR,       // XTVERSION == 'console *'
-} queried_terminals_e;
 
 #ifdef __cplusplus
 }

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -143,8 +143,6 @@ typedef struct tinfo {
   struct termios tpreserved; // terminal state upon entry
   ncinputlayer input;       // input layer
   bool bitmap_supported;    // do we support bitmaps (post pixel_query_done)?
-  bool BCEflag;   // "BCE" flag for erases with background color
-  bool AMflag;    // "AM" flag for automatic movement to next line
 
   // mlterm resets the cursor (i.e. makes it visible) any time you print
   // a sprixel. we work around this spiritedly unorthodox decision. it


### PR DESCRIPTION
In preparation for Application Synchronized Update support detection (#1582), rearrange the termdesc/input interface a bit. This will play into #1798 as well, so merging it now.