### PR TITLE
Use move functionality for Kitty graphics

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -849,6 +849,7 @@ void sprixel_free(sprixel* s);
 void sprixel_hide(sprixel* s);
 
 int kitty_draw(const ncpile *p, sprixel* s, FILE* out);
+int kitty_move(const ncpile *p, sprixel* s, FILE* out);
 int sixel_draw(const ncpile *p, sprixel* s, FILE* out);
 // dimy and dimx are cell geometry, not pixel.
 sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx);
@@ -893,6 +894,18 @@ static inline int
 sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
 //sprixel_debug(stderr, s);
   return n->tcache.pixel_draw(p, s, out);
+}
+
+// precondition: s->invalidated is SPRIXEL_MOVED or SPRIXEL_INVALIDATED
+// returns -1 on error, or the number of bytes written.
+static inline int
+sprite_redraw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
+//sprixel_debug(stderr, s);
+  if(s->invalidated == SPRIXEL_MOVED && n->tcache.pixel_move){
+    return n->tcache.pixel_move(p, s, out);
+  }else{
+    return n->tcache.pixel_draw(p, s, out);
+  }
 }
 
 static inline int

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -314,6 +314,7 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
 //fprintf(stderr, "CLEARED ROW, TARGY: %d\n", targy - 1);
         if(--targy == 0){
           s->n->tam[s->dimx * ycell + xcell].state = state;
+          s->invalidated = SPRIXEL_INVALIDATED;
           return 0;
         }
         thisrow = targx;
@@ -393,9 +394,7 @@ int kitty_wipe(sprixel* s, int ycell, int xcell){
 //fprintf(stderr, "CLEARED ROW, TARGY: %d\n", targy - 1);
         if(--targy == 0){
           s->n->tam[s->dimx * ycell + xcell].auxvector = auxvec;
-          if(s->invalidated == SPRIXEL_QUIESCENT){
-            s->invalidated = SPRIXEL_INVALIDATED;
-          }
+          s->invalidated = SPRIXEL_INVALIDATED;
           return 1;
         }
         thisrow = targx;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -393,7 +393,9 @@ int kitty_wipe(sprixel* s, int ycell, int xcell){
 //fprintf(stderr, "CLEARED ROW, TARGY: %d\n", targy - 1);
         if(--targy == 0){
           s->n->tam[s->dimx * ycell + xcell].auxvector = auxvec;
-          s->invalidated = SPRIXEL_INVALIDATED;
+          if(s->invalidated == SPRIXEL_QUIESCENT){
+            s->invalidated = SPRIXEL_INVALIDATED;
+          }
           return 1;
         }
         thisrow = targx;
@@ -612,7 +614,6 @@ int kitty_destroy(const notcurses* nc __attribute__ ((unused)),
 
 // returns the number of bytes written
 int kitty_draw(const ncpile* p, sprixel* s, FILE* out){
-fprintf(stderr, "DRAWING %d\n", s->id);
   (void)p;
   int ret = s->glyphlen;
   if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){
@@ -623,7 +624,6 @@ fprintf(stderr, "DRAWING %d\n", s->id);
 }
 
 int kitty_move(const ncpile* p, sprixel* s, FILE* out){
-fprintf(stderr, "MOVING %d\n", s->id);
   (void)p;
   int ret = 0;
   if(fprintf(out, "\e_Ga=p,i=%d,p=1,q=2\e\\", s->id) < 0){
@@ -631,7 +631,6 @@ fprintf(stderr, "MOVING %d\n", s->id);
   }
   s->invalidated = SPRIXEL_QUIESCENT;
   return ret;
-  //return kitty_draw(p, s, out);
 }
 
 // clears all kitty bitmaps

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -444,7 +444,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
 //fprintf(stderr, "total: %d chunks = %d, s=%d,v=%d\n", total, chunks, lenx, leny);
   while(chunks--){
     if(totalout == 0){
-      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,a=T,%c=1%s;",
+      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,p=1,a=T,%c=1%s;",
                              lenx, leny, sprixelid, chunks ? 'm' : 'q',
                              scroll ? "" : ",C=1");
     }else{

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -622,6 +622,7 @@ int kitty_draw(const ncpile* p, sprixel* s, FILE* out){
   return ret;
 }
 
+// returns -1 on failure, 0 on success (move bytes do not count for sprixel stats)
 int kitty_move(const ncpile* p, sprixel* s, FILE* out){
   (void)p;
   int ret = 0;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -612,7 +612,7 @@ int kitty_destroy(const notcurses* nc __attribute__ ((unused)),
 
 // returns the number of bytes written
 int kitty_draw(const ncpile* p, sprixel* s, FILE* out){
-//fprintf(stderr, "DRAWING %d\n", s->id);
+fprintf(stderr, "DRAWING %d\n", s->id);
   (void)p;
   int ret = s->glyphlen;
   if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){
@@ -620,6 +620,18 @@ int kitty_draw(const ncpile* p, sprixel* s, FILE* out){
   }
   s->invalidated = SPRIXEL_QUIESCENT;
   return ret;
+}
+
+int kitty_move(const ncpile* p, sprixel* s, FILE* out){
+fprintf(stderr, "MOVING %d\n", s->id);
+  (void)p;
+  int ret = 0;
+  if(fprintf(out, "\e_Ga=p,i=%d,p=1,q=2\e\\", s->id) < 0){
+    ret = -1;
+  }
+  s->invalidated = SPRIXEL_QUIESCENT;
+  return ret;
+  //return kitty_draw(p, s, out);
 }
 
 // clears all kitty bitmaps

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -918,14 +918,13 @@ clean_sprixels(notcurses* nc, ncpile* p, FILE* out){
     }else if(s->invalidated == SPRIXEL_MOVED || s->invalidated == SPRIXEL_INVALIDATED){
       int y, x;
       ncplane_yx(s->n, &y, &x);
-      // FIXME clean this up, don't use sprite_draw, etc.
-      // without this, kitty flickers
 //fprintf(stderr, "1 MOVING BITMAP %d STATE %d AT %d/%d for %p\n", s->id, s->invalidated, y + nc->margin_t, x + nc->margin_l, s->n);
+      // without this, kitty flickers
       if(s->invalidated == SPRIXEL_MOVED){
         sprite_destroy(nc, p, out, s);
       }
       if(goto_location(nc, out, y + nc->margin_t, x + nc->margin_l) == 0){
-        int r = sprite_draw(nc, p, s, out);
+        int r = sprite_redraw(nc, p, s, out);
         if(r < 0){
           return -1;
         }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -25,6 +25,7 @@ setup_kitty_bitmaps(tinfo* ti, int fd){
   ti->pixel_destroy = kitty_destroy;
   ti->pixel_remove = kitty_remove;
   ti->pixel_draw = kitty_draw;
+  ti->pixel_move = kitty_move;
   ti->pixel_shutdown = kitty_shutdown;
   ti->sprixel_scale_height = 1;
   ti->pixel_rebuild = kitty_rebuild;

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -140,6 +140,8 @@ typedef struct tinfo {
   int (*pixel_remove)(int id, FILE* out); // kitty only, issue actual delete command
   int (*pixel_init)(const struct tinfo*, int fd); // called when support is detected
   int (*pixel_draw)(const struct ncpile* p, struct sprixel* s, FILE* out);
+  // execute move (erase old graphic, place at new location) if non-NULL
+  int (*pixel_move)(const struct ncpile* p, struct sprixel* s, FILE* out);
   int (*pixel_shutdown)(int fd);  // called during context shutdown
   int (*pixel_clear_all)(int fd); // called during startup, kitty only
   int sprixel_scale_height; // sprixel must be a multiple of this many rows


### PR DESCRIPTION
Change `kitty_wipe()` to only set `SPRIXEL_INVALIDATED` when in `SPRIXEL_QUIESCENT`, allowing us to use more moves. Introduce `sprite_move()`, pipe it through to new function `kitty_move()`. When we can move, it's a drastic reduction in both emitted bytes and flicker over our previous solution of delete+redraw. Closes #1395.