### PR TITLE
Use KDFONTOP ioctl on Linux console for font reprogramming

### DIFF
--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -824,7 +824,8 @@ ncdirect* ncdirect_core_init(const char* termtype, FILE* outfp, uint64_t flags){
   }
   shortname_term = termname();
   if(interrogate_terminfo(&ret->tcache, ret->ctermfd, shortname_term, utf8,
-                          1, flags & NCDIRECT_OPTION_INHIBIT_CBREAK)){
+                          1, flags & NCDIRECT_OPTION_INHIBIT_CBREAK,
+                          TERMINAL_UNKNOWN)){
     goto err;
   }
   if(ncvisual_init(NCLOGLEVEL_SILENT)){

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -1156,22 +1156,24 @@ int ncinputlayer_init(tinfo* tcache, FILE* infp, queried_terminals_e* detected,
   nilayer->inputbuf_valid_starts = 0;
   nilayer->inputbuf_write_at = 0;
   nilayer->input_events = 0;
-  int csifd = nilayer->ttyfd >= 0 ? nilayer->ttyfd : nilayer->infd;
-  if(isatty(csifd)){
-    query_state inits = {
-      .tcache = tcache,
-      .state = STATE_NULL,
-      .qterm = TERMINAL_UNKNOWN,
-    };
-    if(control_read(csifd, &inits)){
-      input_free_esctrie(&nilayer->inputescapes);
-      free(inits.version);
-      return -1;
+  if(*detected == TERMINAL_UNKNOWN){
+    int csifd = nilayer->ttyfd >= 0 ? nilayer->ttyfd : nilayer->infd;
+    if(isatty(csifd)){
+      query_state inits = {
+        .tcache = tcache,
+        .state = STATE_NULL,
+        .qterm = TERMINAL_UNKNOWN,
+      };
+      if(control_read(csifd, &inits)){
+        input_free_esctrie(&nilayer->inputescapes);
+        free(inits.version);
+        return -1;
+      }
+      tcache->bg_collides_default = inits.bg;
+      tcache->termversion = inits.version;
+      *detected = inits.qterm;
+      *appsync = inits.appsync;
     }
-    tcache->bg_collides_default = inits.bg;
-    tcache->termversion = inits.version;
-    *detected = inits.qterm;
-    *appsync = inits.appsync;
   }
   return 0;
 }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1,3 +1,4 @@
+#include "input.h"
 #include "version.h"
 #include "egcpool.h"
 #include "internal.h"
@@ -1054,7 +1055,10 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
     return NULL;
   }
   ret->ttyfd = get_tty_fd(ret->ttyfp);
-  is_linux_console(ret, !!(opts->flags & NCOPTION_NO_FONT_CHANGES));
+  queried_terminals_e detected_term = TERMINAL_UNKNOWN;
+  if(is_linux_console(ret, !!(opts->flags & NCOPTION_NO_FONT_CHANGES))){
+    detected_term = TERMINAL_LINUX;
+  }
   if(ret->ttyfd < 0){
     fprintf(stderr, "Defaulting to %dx%d (output is not to a terminal)\n", DEFAULT_ROWS, DEFAULT_COLS);
   }
@@ -1091,7 +1095,8 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   const char* shortname_term = termname();
 // const char* longname_term = longname();
   if(interrogate_terminfo(&ret->tcache, ret->ttyfd, shortname_term, utf8,
-                          opts->flags & NCOPTION_NO_ALTERNATE_SCREEN, 0)){
+                          opts->flags & NCOPTION_NO_ALTERNATE_SCREEN, 0,
+                          detected_term)){
     goto err;
   }
   int dimy, dimx;

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -246,9 +246,8 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
     termname = "Linux console";
     ti->caps.braille = false; // no caps.braille, no caps.sextants in linux console
     // FIXME if the NCOPTION_NO_FONT_CHANGES, this isn't true
-    // FIXME we probably want to do this based off ioctl()s in linux.c
-    // FIXME until #1726 is fixed this definitely is not happening
-    ti->caps.quadrants = false; // we program caps.quadrants on the console
+    // FIXME we probably want to ID based off ioctl()s in linux.c
+    ti->caps.quadrants = true; // we program caps.quadrants on the console
   }
   // run a wcwidth(⣿) to guarantee libc Unicode 3 support, independent of term
   if(wcwidth(L'⣿') < 0){

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -7,6 +7,7 @@ extern "C" {
 
 // internal header, not installed
 
+#include "input.h"
 #include <stdbool.h>
 
 struct ncpile;
@@ -177,8 +178,12 @@ term_supported_styles(const tinfo* ti){
 // initialized. set |utf8| if we've verified UTF8 output encoding.
 // set |noaltscreen| to inhibit alternate screen detection. |fd| ought
 // be connected to a terminal device, or -1 if no terminal is available.
+// if already *certain* of the terminal type (basically, if it's the Linux
+// console, identified via ioctl(2)s), pass it as qterm; otherwise use
+// TERMINAL_UNKNOWN.
 int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
-                         unsigned noaltscreen, unsigned nocbreak);
+                         unsigned noaltscreen, unsigned nocbreak,
+                         queried_terminals_e qterm);
 
 void free_terminfo_cache(tinfo* ti);
 


### PR DESCRIPTION
The `GIO_FONTX` and `PIO_FONTX` `ioctl()`s were removed earlier this year. Move to the crescent fresh `KDFONTOP`, which among other things has dynamic width support. Plug detection of the Linux console through `interrogate_terminfo()` rather than relying on `TERM` there. Closes #1726.