### PR TITLE
Detect and send application-synchronized updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ rearrangements of Notcurses.
     `ncpile_render_to_file()`. Rewrote `notcurses_render_to_buffer()` and
     `notcurses_render_to_file()` as trivial wrappers around these functions,
     and deprecated the latter. They will be removed in ABI3.
+  * Added support for application-synchronized updates, and a new stat.
 
 * 2.3.4 (2021-06-12)
   * Added the flag `NCVISUAL_OPTION_NOINTERPOLATE` to use non-interpolative

--- a/USAGE.md
+++ b/USAGE.md
@@ -3399,6 +3399,7 @@ typedef struct ncstats {
   uint64_t sprixelemissions; // sprixel draw count
   uint64_t sprixelelisions;  // sprixel elision count
   uint64_t sprixelbytes;     // sprixel bytes emitted
+  uint64_t appsync_updates;  // application-synchronized updates
 
   // current state -- these can decrease
   uint64_t fbbytes;          // total bytes devoted to all active framebuffers

--- a/doc/man/man3/notcurses_stats.3.md
+++ b/doc/man/man3/notcurses_stats.3.md
@@ -41,6 +41,7 @@ typedef struct ncstats {
   uint64_t sprixelemissions; // sprixel draw count
   uint64_t sprixelelisions;  // sprixel elision count
   uint64_t sprixelbytes;     // sprixel bytes emitted
+  uint64_t appsync_updates;  // application-synchronized updates
 
   // current state -- these can decrease
   uint64_t fbbytes;          // bytes devoted to framebuffers

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1393,6 +1393,7 @@ typedef struct ncstats {
   uint64_t defaultelisions;  // default color was emitted
   uint64_t defaultemissions; // default color was elided
   uint64_t refreshes;        // refresh requests (non-optimized redraw)
+  uint64_t appsync_updates;  // how many application-synchronized updates?
 
   // current state -- these can decrease
   uint64_t fbbytes;          // total bytes devoted to all active framebuffers

--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -51,10 +51,11 @@ static void
 tinfo_debug_caps(const tinfo* ti, FILE* debugfp, int rows, int cols,
                  unsigned images, unsigned videos){
   const char indent[] = " ";
-  fprintf(debugfp, "%scolors: %u rgb: %c ccc: %c setaf: %c setab: %c\n",
+  fprintf(debugfp, "%scolors: %u rgb: %c ccc: %c setaf: %c setab: %c app-sync: %c\n",
           indent, ti->caps.colors, capbool(ti->caps.rgb), capbool(ti->caps.can_change_colors),
           capyn(get_escape(ti, ESCAPE_SETAF)),
-          capyn(get_escape(ti, ESCAPE_SETAB)));
+          capyn(get_escape(ti, ESCAPE_SETAB)),
+          capyn(get_escape(ti, ESCAPE_BSU)));
   fprintf(debugfp, "%ssgr: %c sgr0: %c op: %c fgop: %c bgop: %c\n",
           indent, capyn(get_escape(ti, ESCAPE_SGR)),
                   capyn(get_escape(ti, ESCAPE_SGR0)),

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -819,7 +819,7 @@ stash_string(query_state* inits){
 // ought be fed to the machine, and -1 on an invalid state transition.
 static int
 pump_control_read(query_state* inits, unsigned char c){
-fprintf(stderr, "state: %2d char: %1c %3d %02x\n", inits->state, isprint(c) ? c : ' ', c, c);
+//fprintf(stderr, "state: %2d char: %1c %3d %02x\n", inits->state, isprint(c) ? c : ' ', c, c);
   if(c == NCKEY_ESC){
     inits->state = STATE_ESC;
     return 0;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -1157,8 +1157,10 @@ notcurses_rasterize_inner(notcurses* nc, ncpile* p, FILE* out, unsigned* asu){
 static int
 raster_and_write(notcurses* nc, ncpile* p, FILE* out){
   // will we be using application-synchronized updates? if this comes back as
-  // non-zero, we are, and must emit the header. no ASU without a tty.
-  unsigned useasu = nc->ttyfd >= 0 ? true : false;
+  // non-zero, we are, and must emit the header. no ASU without a tty, and we
+  // can't have the escape without being connected to one...
+  const char* basu = get_escape(&nc->tcache, ESCAPE_BSU);
+  unsigned useasu = basu ? true : false;
   if(notcurses_rasterize_inner(nc, p, out, &useasu) < 0){
     return -1;
   }
@@ -1166,7 +1168,6 @@ raster_and_write(notcurses* nc, ncpile* p, FILE* out){
   sigset_t oldmask;
   block_signals(&oldmask);
   if(useasu){
-    const char* basu = get_escape(&nc->tcache, ESCAPE_BSU);
     if(tty_emit(basu, nc->ttyfd)){
       ret = -1;
     }

--- a/src/lib/stats.c
+++ b/src/lib/stats.c
@@ -144,6 +144,7 @@ void notcurses_stats_reset(notcurses* nc, ncstats* stats){
   stash->sprixelemissions += nc->stats.sprixelemissions;
   stash->sprixelelisions += nc->stats.sprixelelisions;
   stash->sprixelbytes += nc->stats.sprixelbytes;
+  stash->appsync_updates += nc->stats.appsync_updates;
 
   stash->fbbytes = nc->stats.fbbytes;
   stash->planes = nc->stats.planes;
@@ -214,10 +215,10 @@ void summarize_stats(notcurses* nc){
             (stats->bgelisions * 100.0) / (stats->bgemissions + stats->bgelisions));
     char totalbuf[BPREFIXSTRLEN + 1];
     qprefix(stats->sprixelbytes, 1, totalbuf, 1);
-    fprintf(stderr, "Sprixel emits:elides: %ju:%ju (%.2f%%) %sB\n",
+    fprintf(stderr, "Sprixel emits:elides: %ju:%ju (%.2f%%) %sB ASUs: %ju\n",
             stats->sprixelemissions, stats->sprixelelisions,
             (stats->sprixelemissions + stats->sprixelelisions) == 0 ? 0 :
             (stats->sprixelelisions * 100.0) / (stats->sprixelemissions + stats->sprixelelisions),
-            totalbuf);
+            totalbuf, stats->appsync_updates);
   }
 }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -288,7 +288,7 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
 static int
 send_initial_queries(int fd){
   const char queries[] = CSI_BGQ
-                         "\x1b[?2026$p"      // App-Sync Update support
+                         "\x1b[?2026$p"      // query for App-sync updates
                          "\x1b[=0c"          // Tertiary Device Attributes
                          "\x1b[>0q"          // XTVERSION
                          "\x1bP+q544e\x1b\\" // XTGETTCAP['TN']

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -288,6 +288,7 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
 static int
 send_initial_queries(int fd){
   const char queries[] = CSI_BGQ
+                         "\x1b[?2026$p"      // App-Sync Update support
                          "\x1b[=0c"          // Tertiary Device Attributes
                          "\x1b[>0q"          // XTVERSION
                          "\x1bP+q544e\x1b\\" // XTGETTCAP['TN']


### PR DESCRIPTION
Detect ?2026, Application-Synchronized Updates. Display whether we detected support in `notcurses-info`. Send an ASU when connected to a tty and we generate a sufficiently large frame. Closes #1582.