### PR TITLE
ASU: need to emit BSU on the same path as bulk and ESU

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
     - cd build
     - cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_QRCODEGEN=on
     - make -j2
-    - notcurses-info
+    - ./notcurses-info
     - ctest --output-on-failure
     - make install
     - ldconfig

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,7 @@ steps:
     - cd build
     - cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_QRCODEGEN=on
     - make -j2
+    - notcurses-info
     - ctest --output-on-failure
     - make install
     - ldconfig

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -1160,7 +1160,7 @@ raster_and_write(notcurses* nc, ncpile* p, FILE* out){
   // non-zero, we are, and must emit the header. no ASU without a tty, and we
   // can't have the escape without being connected to one...
   const char* basu = get_escape(&nc->tcache, ESCAPE_BSU);
-  unsigned useasu = basu ? true : false;
+  unsigned useasu = basu ? 1 : 0;
   if(notcurses_rasterize_inner(nc, p, out, &useasu) < 0){
     return -1;
   }
@@ -1168,7 +1168,7 @@ raster_and_write(notcurses* nc, ncpile* p, FILE* out){
   sigset_t oldmask;
   block_signals(&oldmask);
   if(useasu){
-    if(tty_emit(basu, nc->ttyfd)){
+    if(term_emit(basu, nc->ttyfp, false)){
       ret = -1;
     }
     ++nc->stats.appsync_updates;


### PR DESCRIPTION
ASU was fucked up when redirected elsewhere than the tty, because the BSU was being pumped out along the ttyfd, and the rest was going to the ttyfp. Unite the destinations. This ought fix the CI.