### PR TITLE
Don't use C=1 on Kitty before 0.20.0

### DIFF
--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -964,11 +964,11 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
     n->sprite = sprixel_recycle(n);
   }
   bargs.u.pixel.spx = n->sprite;
-  // FIXME only set this if cursor is indeed hidden
-  if(nc->tcache.sprixel_cursor_hack){
-    bargs.u.pixel.cursor_hack = get_escape(&nc->tcache, ESCAPE_CIVIS);
-  }else{
-    bargs.u.pixel.cursor_hack = NULL;
+  bargs.u.pixel.cursor_hack = NULL;
+  if(nc->cursory < 0){
+    if(nc->tcache.sprixel_cursor_hack){
+      bargs.u.pixel.cursor_hack = get_escape(&nc->tcache, ESCAPE_CIVIS);
+    }
   }
   // FIXME need to pull off the ncpile's sprixellist if anything below fails!
   // at this point, disppixy/disppixx are the output geometry (might be larger

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -970,6 +970,12 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
       bargs.u.pixel.cursor_hack = get_escape(&nc->tcache, ESCAPE_CIVIS);
     }
   }
+  // if we are kitty prior to 0.20.0, we set NCVISUAL_OPTION_SCROLL so that
+  // C=1 won't be supplied. we use sixel_maxy_pristine as a side channel to
+  // encode this version information.
+  if(nc->tcache.sixel_maxy_pristine){
+    bargs.flags |= NCVISUAL_OPTION_SCROLL;
+  }
   // FIXME need to pull off the ncpile's sprixellist if anything below fails!
   // at this point, disppixy/disppixx are the output geometry (might be larger
   // than scaledy/scaledx for sixel), while scaledy/scaledx are the scaled

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -201,7 +201,7 @@ force_rgba(ncvisual* n){
         av_freep(&n->details->frame);
       }
     }
-    ncvisual_set_data(n, sframe->data[0], false);
+    ncvisual_set_data(n, sframe->data[0], true);
   }
   n->details->frame = sframe;
   return 0;
@@ -538,7 +538,7 @@ int ffmpeg_resize(ncvisual* n, int rows, int cols){
   if(n->owndata){
     av_frame_unref(n->details->frame);
   }
-  ncvisual_set_data(n, sframe->data[0], false);
+  ncvisual_set_data(n, sframe->data[0], true);
   n->details->frame = sframe;
 //fprintf(stderr, "SIZE SCALED: %d %d (%u)\n", n->details->frame->height, n->details->frame->width, n->details->frame->linesize[0]);
   return 0;
@@ -566,7 +566,7 @@ int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
 }
 
 void ffmpeg_details_seed(ncvisual* ncv){
-  ncv->details->frame->data[0] = NULL;
+  ncv->details->frame->data[0] = (uint8_t*)ncv->data;
   ncv->details->frame->data[1] = NULL;
   ncv->details->frame->linesize[0] = ncv->rowstride;
   ncv->details->frame->linesize[1] = 0;

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -201,7 +201,7 @@ force_rgba(ncvisual* n){
         av_freep(&n->details->frame);
       }
     }
-    ncvisual_set_data(n, sframe->data[0], true);
+    ncvisual_set_data(n, sframe->data[0], false);
   }
   n->details->frame = sframe;
   return 0;
@@ -538,7 +538,7 @@ int ffmpeg_resize(ncvisual* n, int rows, int cols){
   if(n->owndata){
     av_frame_unref(n->details->frame);
   }
-  ncvisual_set_data(n, sframe->data[0], true);
+  ncvisual_set_data(n, sframe->data[0], false);
   n->details->frame = sframe;
 //fprintf(stderr, "SIZE SCALED: %d %d (%u)\n", n->details->frame->height, n->details->frame->width, n->details->frame->linesize[0]);
   return 0;
@@ -566,7 +566,7 @@ int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
 }
 
 void ffmpeg_details_seed(ncvisual* ncv){
-  ncv->details->frame->data[0] = (uint8_t*)ncv->data;
+  ncv->details->frame->data[0] = NULL;
   ncv->details->frame->data[1] = NULL;
   ncv->details->frame->linesize[0] = ncv->rowstride;
   ncv->details->frame->linesize[1] = 0;


### PR DESCRIPTION
Kitty prior to 0.20.0 rejects graphics with `C=1`. If we can't get a version, or we do and it's less than 0.20.0, set `sixel_maxy_pristine` in a disgusting hack, which cascades to set `NCVISUAL_OPTION_SCROLL` in a disgusting hack, which results in `C=1` being exempted. Together with `sixel_maxy_pristine` being set (and thus not emitting the bottom row), these combine to get `NCBLIT_PIXEL` working on older Kitty.

Also, don't perform the MLterm cursor hack if the cursor isn't hidden, eliminating a FIXME.