### PR TITLE
Fix up ffmpeg memory layer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ rearrangements of Notcurses.
     plane and inhibition of the alternate screen, this allows rendered mode
     to easily be used for scrolling shell environment programs.
   * `ncls` now defaults to `NCBLIT_PIXEL`.
+  * Added `ncplane_scrolling_p()` to retrieve a plane's scrolling status.
 
 * 2.3.6 (2021-06-23)
   * Fixed (harmless) warning with `-Wformat-security`.

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -204,6 +204,8 @@ typedef struct ncplane_options {
 
 **bool ncplane_set_scrolling(struct ncplane* ***n***, bool ***scrollp***);**
 
+**bool ncplane_scrolling_p(const struct ncplane* ***n***);**
+
 **int ncplane_rotate_cw(struct ncplane* ***n***);**
 
 **int ncplane_rotate_ccw(struct ncplane* ***n***);**

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1209,14 +1209,16 @@ API struct ncplane* ncplane_reparent(struct ncplane* n, struct ncplane* newparen
 // The same as ncplane_reparent(), except any planes bound to 'n' come along
 // with it to its new destination. Their z-order is maintained. If 'newparent'
 // is an ancestor of 'n', NULL is returned, and no changes are made.
-API struct ncplane* ncplane_reparent_family(struct ncplane* n, struct ncplane* newparent);
+API struct ncplane* ncplane_reparent_family(struct ncplane* n, struct ncplane* newparent)
+  __attribute__ ((nonnull (1, 2)));
 
 // Duplicate an existing ncplane. The new plane will have the same geometry,
 // will duplicate all content, and will start with the same rendering state.
 // The new plane will be immediately above the old one on the z axis, and will
 // be bound to the same parent. Bound planes are *not* duplicated; the new
 // plane is bound to the parent of 'n', but has no bound planes.
-API ALLOC struct ncplane* ncplane_dup(const struct ncplane* n, void* opaque);
+API ALLOC struct ncplane* ncplane_dup(const struct ncplane* n, void* opaque)
+  __attribute__ ((nonnull (1)));
 
 // provided a coordinate relative to the origin of 'src', map it to the same
 // absolute coordinate relative to the origin of 'dst'. either or both of 'y'
@@ -1228,12 +1230,17 @@ API void ncplane_translate(const struct ncplane* src, const struct ncplane* dst,
 // within the ncplane 'n'. If not, return false. If so, return true. Either
 // way, translate the absolute coordinates relative to 'n'. If the point is not
 // within 'n', these coordinates will not be within the dimensions of the plane.
-API bool ncplane_translate_abs(const struct ncplane* n, int* RESTRICT y, int* RESTRICT x);
+API bool ncplane_translate_abs(const struct ncplane* n, int* RESTRICT y, int* RESTRICT x)
+  __attribute__ ((nonnull (1)));
 
 // All planes are created with scrolling disabled. Scrolling can be dynamically
 // controlled with ncplane_set_scrolling(). Returns true if scrolling was
 // previously enabled, or false if it was disabled.
-API bool ncplane_set_scrolling(struct ncplane* n, bool scrollp);
+API bool ncplane_set_scrolling(struct ncplane* n, bool scrollp)
+  __attribute__ ((nonnull (1)));
+
+API bool ncplane_scrolling_p(const struct ncplane* n)
+  __attribute__ ((nonnull (1)));
 
 // Palette API. Some terminals only support 256 colors, but allow the full
 // palette to be specified with arbitrary RGB colors. In all cases, it's more

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -340,7 +340,7 @@ block_on_input(int fd, const struct timespec* ts, const sigset_t* sigmask){
   if(sigmask){
     memcpy(&scratchmask, sigmask, sizeof(*sigmask));
   }else{
-    pthread_sigmask(0, NULL, &scratchmask);
+    sigfillset(&scratchmask);
   }
   sigdelset(&scratchmask, SIGCONT);
   sigdelset(&scratchmask, SIGWINCH);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2573,6 +2573,10 @@ bool ncplane_set_scrolling(ncplane* n, bool scrollp){
   return old;
 }
 
+bool ncplane_scrolling_p(const ncplane* n){
+  return n->scrolling;
+}
+
 // extract an integer, which must be non-negative, and followed by either a
 // comma or a NUL terminator.
 static int

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -299,6 +299,9 @@ add_u7_escape(tinfo* ti, size_t* tablelen, size_t* tableused){
 
 static int
 add_smulx_escapes(tinfo* ti, size_t* tablelen, size_t* tableused){
+  if(get_escape(ti, ESCAPE_SMULX)){
+    return 0;
+  }
   if(grow_esc_table(ti, "\x1b[4:3m", ESCAPE_SMULX, tablelen, tableused) ||
      grow_esc_table(ti, "\x1b[4:0m", ESCAPE_SMULNOX, tablelen, tableused)){
     return -1;
@@ -308,6 +311,9 @@ add_smulx_escapes(tinfo* ti, size_t* tablelen, size_t* tableused){
 
 static int
 add_appsync_escapes(tinfo* ti, size_t* tablelen, size_t* tableused){
+  if(get_escape(ti, ESCAPE_BSU)){
+    return 0;
+  }
   if(grow_esc_table(ti, "\x1bP=1s\x1b\\", ESCAPE_BSU, tablelen, tableused) ||
      grow_esc_table(ti, "\x1bP=2s\x1b\\", ESCAPE_ESU, tablelen, tableused)){
     return -1;

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -507,9 +507,6 @@ rotate_bounding_box(double stheta, double ctheta, int* leny, int* lenx,
 int ncvisual_rotate(ncvisual* ncv, double rads){
   assert(ncv->rowstride / 4 >= ncv->pixx);
   rads = -rads; // we're a left-handed Cartesian
-  if(ncv->data == NULL){
-    return -1;
-  }
   int centy, centx;
   ncvisual_center(ncv, &centy, &centx); // pixel center (center of 'data')
   double stheta, ctheta; // sine, cosine
@@ -523,11 +520,13 @@ int ncvisual_rotate(ncvisual* ncv, double rads){
   int bboffy = 0;
   int bboffx = 0;
   if(ncvisual_bounding_box(ncv, &bby, &bbx, &bboffy, &bboffx) <= 0){
+    logerror("Couldn't find a bounding box\n");
     return -1;
   }
   int bbarea;
   bbarea = rotate_bounding_box(stheta, ctheta, &bby, &bbx, &bboffy, &bboffx);
   if(bbarea <= 0){
+    logerror("Couldn't rotate the visual (%d, %d, %d, %d)\n", bby, bbx, bboffy, bboffx);
     return -1;
   }
   int bbcentx = bbx, bbcenty = bby;

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -566,7 +566,7 @@ int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
 }
 
 void ffmpeg_details_seed(ncvisual* ncv){
-  ncv->details->frame->data[0] = (uint8_t*)ncv->data;
+  ncv->details->frame->data[0] = NULL;
   ncv->details->frame->data[1] = NULL;
   ncv->details->frame->linesize[0] = ncv->rowstride;
   ncv->details->frame->linesize[1] = 0;

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -201,7 +201,7 @@ force_rgba(ncvisual* n){
         av_freep(&n->details->frame);
       }
     }
-    ncvisual_set_data(n, sframe->data[0], true);
+    ncvisual_set_data(n, sframe->data[0], false);
   }
   n->details->frame = sframe;
   return 0;
@@ -538,7 +538,7 @@ int ffmpeg_resize(ncvisual* n, int rows, int cols){
   if(n->owndata){
     av_frame_unref(n->details->frame);
   }
-  ncvisual_set_data(n, sframe->data[0], true);
+  ncvisual_set_data(n, sframe->data[0], false);
   n->details->frame = sframe;
 //fprintf(stderr, "SIZE SCALED: %d %d (%u)\n", n->details->frame->height, n->details->frame->width, n->details->frame->linesize[0]);
   return 0;

--- a/src/poc/interp.c
+++ b/src/poc/interp.c
@@ -36,12 +36,14 @@ interp(struct notcurses* nc, int cellpixy, int cellpixx){
   if(ncvisual_render(nc, ncv, &vopts) == NULL){
     return -1;
   }
+  ncplane_putstr_yx(stdn, 2, 4, "scale");
   struct ncplane* scalepni = ncplane_create(stdn, &popts);
   vopts.n = scalepni;
   vopts.flags = NCVISUAL_OPTION_NOINTERPOLATE;
   if(ncvisual_render(nc, ncv, &vopts) == NULL){
     return -1;
   }
+  ncplane_putstr_yx(stdn, 2, 15, "scale(no)");
   popts.x += ncplane_dim_x(scalepni) + 1;
   struct ncplane* resizep = ncplane_create(stdn, &popts);
   if(resizep == NULL){
@@ -56,6 +58,7 @@ interp(struct notcurses* nc, int cellpixy, int cellpixx){
   if(ncvisual_render(nc, ncv, &vopts) == NULL){
     return -1;
   }
+  ncplane_putstr_yx(stdn, 2, 30, "resize");
   ncvisual_destroy(ncv);
   ncv = ncvisual_from_rgb_packed(randrgb, cellpixy, cellpixx * 3, cellpixx, 0xff);
   popts.x += ncplane_dim_x(scalepni) + 1;
@@ -70,6 +73,7 @@ interp(struct notcurses* nc, int cellpixy, int cellpixx){
   if(ncvisual_render(nc, ncv, &vopts) == NULL){
     return -1;
   }
+  ncplane_putstr_yx(stdn, 2, 41, "resize(no)");
   notcurses_render(nc);
   ncplane_destroy(ncvp);
   ncplane_destroy(scalep);

--- a/src/poc/rotate.c
+++ b/src/poc/rotate.c
@@ -10,7 +10,7 @@
 int main(int argc, char** argv){
   struct timespec ts = {
     .tv_sec = 0,
-    .tv_nsec = 250000000,
+    .tv_nsec = 100000000,
   };
   const char* file = "../data/changes.jpg";
   setlocale(LC_ALL, "");

--- a/src/tests/media.cpp
+++ b/src/tests/media.cpp
@@ -25,8 +25,6 @@ TEST_CASE("Media") {
   SUBCASE("ResizeThenRotateFromFile") {
     auto ncv = ncvisual_from_file(find_data("changes.jpg").get());
     REQUIRE(nullptr != ncv);
-    CHECK(0 == ncvisual_resize(ncv, 20, 20));
-    CHECK(0 == ncvisual_rotate(ncv, M_PI / 2));
     struct ncvisual_options vopts{};
     vopts.x = NCALIGN_CENTER;
     vopts.y = NCALIGN_CENTER;
@@ -34,7 +32,24 @@ TEST_CASE("Media") {
     auto p = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != p);
     CHECK(0 == notcurses_render(nc_));
-    ncplane_destroy(p);
+sleep(1);
+    CHECK(0 == ncplane_destroy(p));
+    CHECK(0 == ncvisual_resize(ncv, 20, 20));
+    p = ncvisual_render(nc_, ncv, &vopts);
+    CHECK(0 == notcurses_render(nc_));
+sleep(1);
+    CHECK(0 == ncplane_destroy(p));
+    p = ncvisual_render(nc_, ncv, &vopts);
+    REQUIRE(nullptr != p);
+    CHECK(0 == notcurses_render(nc_));
+sleep(1);
+    CHECK(0 == ncplane_destroy(p));
+    CHECK(0 == ncvisual_rotate(ncv, M_PI / 2));
+    p = ncvisual_render(nc_, ncv, &vopts);
+    REQUIRE(nullptr != p);
+    CHECK(0 == notcurses_render(nc_));
+sleep(1);
+    CHECK(0 == ncplane_destroy(p));
     ncvisual_destroy(ncv);
   }
 

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -78,22 +78,16 @@ TEST_CASE("Visual") {
     auto p = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != p);
     CHECK(0 == notcurses_render(nc_));
-fprintf(stderr, "FIRST RECNDER %p\n", ncv->data);
-sleep(1);
     CHECK(0 == ncplane_destroy(p));
     CHECK(0 == ncvisual_resize(ncv, 20, 20));
     p = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != p);
     CHECK(0 == notcurses_render(nc_));
-fprintf(stderr, "2ND RECNDER %p\n", ncv->data);
-sleep(1);
     CHECK(0 == ncplane_destroy(p));
     CHECK(0 == ncvisual_rotate(ncv, M_PI / 2));
     p = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != p);
     CHECK(0 == notcurses_render(nc_));
-fprintf(stderr, "3RD RECNDER %p\n", ncv->data);
-sleep(1);
     CHECK(0 == ncplane_destroy(p));
     ncvisual_destroy(ncv);
   }

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -71,8 +71,6 @@ TEST_CASE("Visual") {
     memset(rgb, 0, sizeof(rgb));
     auto ncv = ncvisual_from_rgb_packed(rgb, 10, 10 * 3, 10, 0xff);
     REQUIRE(nullptr != ncv);
-    CHECK(0 == ncvisual_resize(ncv, 20, 20));
-    CHECK(0 == ncvisual_rotate(ncv, M_PI / 2));
     struct ncvisual_options vopts{};
     vopts.x = NCALIGN_CENTER;
     vopts.y = NCALIGN_CENTER;
@@ -80,7 +78,23 @@ TEST_CASE("Visual") {
     auto p = ncvisual_render(nc_, ncv, &vopts);
     REQUIRE(nullptr != p);
     CHECK(0 == notcurses_render(nc_));
-    ncplane_destroy(p);
+fprintf(stderr, "FIRST RECNDER %p\n", ncv->data);
+sleep(1);
+    CHECK(0 == ncplane_destroy(p));
+    CHECK(0 == ncvisual_resize(ncv, 20, 20));
+    p = ncvisual_render(nc_, ncv, &vopts);
+    REQUIRE(nullptr != p);
+    CHECK(0 == notcurses_render(nc_));
+fprintf(stderr, "2ND RECNDER %p\n", ncv->data);
+sleep(1);
+    CHECK(0 == ncplane_destroy(p));
+    CHECK(0 == ncvisual_rotate(ncv, M_PI / 2));
+    p = ncvisual_render(nc_, ncv, &vopts);
+    REQUIRE(nullptr != p);
+    CHECK(0 == notcurses_render(nc_));
+fprintf(stderr, "3RD RECNDER %p\n", ncv->data);
+sleep(1);
+    CHECK(0 == ncplane_destroy(p));
     ncvisual_destroy(ncv);
   }
 


### PR DESCRIPTION
Our memory tracking for the ffmpeg backend was all screwy. I believe I've repaired it all the way through this time. Add two new unit tests, `RotateAndResizeFrom{Memory,File}`, addressing the situation seen in #1800 where `rotate` was segfaulting on exit. They both now pass without leaks or Valgrind errors. Closes #1800.

Also adds `ncplane_scrolling_p()` as requested in #1841. Closes #1841.