### PR TITLE
Kitty: update glyph on damage due to delete+redraw cycle

### DIFF
--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -159,6 +159,7 @@ paint_sprixel(ncplane* p, struct crender* rvec, int starty, int startx,
         if(state == SPRIXCELL_ANNIHILATED || state == SPRIXCELL_ANNIHILATED_TRANS){
 //fprintf(stderr, "REBUILDING AT %d/%d\n", y, x);
           sprite_rebuild(nc, s, y, x);
+//fprintf(stderr, "damaging due to rebuild [%s] %d/%d\n", nccell_extended_gcluster(crender->p, &crender->c), absy, absx);
         }
       }
     }
@@ -326,7 +327,7 @@ paint(ncplane* p, struct crender* rvec, int dstleny, int dstlenx,
         // side of a wide glyph (nor the null codepoint).
         if( (targc->gcluster = vis->gcluster) ){ // index copy only
           if(crender->sprixel && crender->sprixel->invalidated == SPRIXEL_HIDE){
-//fprintf(stderr, "damaged due to hide\n");
+//fprintf(stderr, "damaged due to hide %d/%d\n", y, x);
             crender->s.damaged = 1;
           }
           crender->s.blittedquads = cell_blittedquadrants(vis);
@@ -413,12 +414,16 @@ postpaint_cell(nccell* lastframe, int dimx, struct crender* crender,
 //fprintf(stderr, "damaging due to cmp [%s] %d %d\n", nccell_extended_gcluster(crender->p, &crender->c), y, *x);
     if(crender->sprixel){
       sprixcell_e state = sprixel_state(crender->sprixel, y, *x);
-      if(!crender->s.p_beats_sprixel && state != SPRIXCELL_OPAQUE_KITTY && state != SPRIXCELL_OPAQUE_SIXEL){
-//fprintf(stderr, "damaged due to opaque\n");
+//fprintf(stderr, "state under candidate sprixel: %d %d/%d\n", state, y, *x);
+      // we don't need to change it when under an opaque Sixel cell, because
+      // that's always printed on top. we need to change it under kitty until
+      // we start using the animation protocol to do cuts without redraws FIXME.
+      if(!crender->s.p_beats_sprixel && state != SPRIXCELL_OPAQUE_SIXEL){
+//fprintf(stderr, "damaged due to opaque %d/%d\n", y, *x);
         crender->s.damaged = 1;
       }
     }else{
-//fprintf(stderr, "damaged due to opaque else %d %d\n", y, *x);
+//fprintf(stderr, "damaged due to opaque else %d/%d\n", y, *x);
       crender->s.damaged = 1;
     }
     assert(!nccell_wide_right_p(targc));
@@ -434,7 +439,7 @@ postpaint_cell(nccell* lastframe, int dimx, struct crender* crender,
       targc->channels = crender[-i].c.channels;
       targc->stylemask = crender[-i].c.stylemask;
       if(cellcmp_and_dupfar(pool, prevcell, crender->p, targc) > 0){
-//fprintf(stderr, "damaging due to cmp2\n");
+//fprintf(stderr, "damaging due to cmp2 %d/%d\n", y, *x);
         crender->s.damaged = 1;
       }
     }

--- a/src/poc/statepixel.c
+++ b/src/poc/statepixel.c
@@ -18,6 +18,9 @@ across_row(struct notcurses* nc, int y, struct ncplane* n, struct ncplane* t,
   return 0;
 }
 
+// we should see the 1x1 white cell move across the face of the sprixel, hiding
+// that cell of the sprixel, but leaving all others as they were. there ought
+// be no flicker.
 static int
 handle(struct notcurses* nc, const char* fn){
   struct ncvisual* ncv = ncvisual_from_file(fn);
@@ -57,6 +60,7 @@ handle(struct notcurses* nc, const char* fn){
     if(across_row(nc, y, n, t, &ds)){
       ncplane_destroy(n);
       ncvisual_destroy(ncv);
+      return -1;
     }
   }
   // now make it big and throw it over the bottom
@@ -87,7 +91,9 @@ int main(int argc, char **argv){
     return EXIT_FAILURE;
   }
   char** a = argv + 1;
-  struct notcurses_options opts = { };
+  struct notcurses_options opts = {
+    .flags = NCOPTION_NO_ALTERNATE_SCREEN,
+  };
   struct notcurses* nc = notcurses_init(&opts, NULL);
   if(notcurses_check_pixel_support(nc) <= 0){
     notcurses_stop(nc);


### PR DESCRIPTION
Kitty currently requires a delete + redraw to effect a wipe or rebuild. It's thus necessary to update any obscured glyphs, even if totally obscured, because otherwise the old glyph can sometimes be seen in this cycle. Ideally, we'll use animations for these operations, eliminating the redraw. At that point, we can return to lazy updates of totally obscured glyphs, as we're retaining for sixel. Closes #1704.