### PR TITLE
[sixel] clean up cells even when under a new sixel #1537

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -792,7 +792,7 @@ uint8_t* kitty_trans_auxvec(const struct tinfo* ti);
 // these three all use absolute coordinates
 void sprixel_invalidate(sprixel* s, int y, int x);
 void sprixel_movefrom(sprixel* s, int y, int x);
-void sprixel_debug(FILE* out, const sprixel* s);
+void sprixel_debug(const sprixel* s, FILE* out);
 void sixelmap_free(struct sixelmap *s);
 
 // create an auxiliary vector suitable for a sprixcell, and zero it out. there
@@ -809,6 +809,8 @@ int kitty_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
 
 static inline int
 sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
+//fprintf(stderr, "Destroying sprite %u\n", s->id);
+//sprixel_debug(s, stderr);
   return nc->tcache.pixel_destroy(nc, p, out, s);
 }
 
@@ -816,7 +818,7 @@ sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
 // returns -1 on error, or the number of bytes written.
 static inline int
 sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-//sprixel_debug(stderr, s);
+//sprixel_debug(s, stderr);
   return n->tcache.pixel_draw(p, s, out);
 }
 
@@ -824,7 +826,7 @@ sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
 // returns -1 on error, or the number of bytes written.
 static inline int
 sprite_redraw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-//sprixel_debug(stderr, s);
+//sprixel_debug(s, stderr);
   if(s->invalidated == SPRIXEL_MOVED && n->tcache.pixel_move){
     return n->tcache.pixel_move(p, s, out);
   }else{

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -4,7 +4,7 @@
 
 static atomic_uint_fast32_t sprixelid_nonce;
 
-void sprixel_debug(FILE* out, const sprixel* s){
+void sprixel_debug(const sprixel* s, FILE* out){
   fprintf(out, "Sprixel %d (%p) %dB %dx%d (%dx%d) @%d/%d state: %d\n",
           s->id, s, s->glyphlen, s->dimy, s->dimx, s->pixy, s->pixx,
           s->n ? s->n->absy : 0, s->n ? s->n->absx : 0,


### PR DESCRIPTION
When we are destroying a sixel, we need consult the new present sixel if one exists. If the sprixcell is anything but opaque, redamage the cell. This is necessary to clean up cruft on Alacritty, XTerm, and foot. Closes #1537.