### PR TITLE
[kitty] separate image transfer from placement

### DIFF
--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -101,8 +101,13 @@ get_next_frame(struct ncvisual* ncv, struct ncvisual_options* vopts){
   ret = marsh.next_frame++;
   if(ncvisual_decode(ncv)){
     ret = -1;
-  }else if(ncvisual_render(marsh.nc, ncv, vopts) == NULL){
-    ret = -1;
+  }else{
+    struct ncplane* n = ncvisual_render(marsh.nc, ncv, vopts);
+    if(n == NULL){
+      ret = -1;
+    }else{
+      vopts->n = n;
+    }
   }
   pthread_mutex_unlock(&lock);
   return ret;
@@ -121,10 +126,10 @@ xray_thread(void *v){
               | NCVISUAL_OPTION_ADDALPHA,
   };
   int ret;
+  if(make_plane(marsh.nc, &vopts.n)){
+    return NULL;
+  }
   do{
-    if(make_plane(marsh.nc, &vopts.n)){
-      return NULL;
-    }
     if((frame = get_next_frame(marsh.ncv, &vopts)) < 0){
       return NULL;
     }
@@ -138,15 +143,14 @@ xray_thread(void *v){
     if(ncplane_move_yx(marsh.slider, 1, x - 1) == 0){
       ncplane_reparent(vopts.n, notcurses_stdplane(marsh.nc));
       ncplane_move_top(vopts.n);
-      ncplane_destroy(marsh.lplane);
       ret = demo_render(marsh.nc);
     }
     marsh.last_frame_rendered = frame;
-    marsh.lplane = vopts.n;
     pthread_mutex_unlock(&render_lock);
     pthread_cond_signal(&cond);
-    vopts.n = NULL;
   }while(ret == 0);
+  ncplane_destroy(vopts.n);
+  vopts.n = NULL;
   return NULL;
 }
 

--- a/src/info/main.c
+++ b/src/info/main.c
@@ -181,12 +181,16 @@ tinfo_debug_bitmaps(struct ncplane* n, const tinfo* ti, const char* indent){
         ncplane_printf(n, "%ssixel colorregs: %u", indent, ti->color_registers);
       }
     }else{
-      ncplane_printf(n, "%srgba pixel graphics supported", indent);
+      if(ti->sixel_maxy_pristine){
+        ncplane_printf(n, "%srgba pixel graphics supported", indent);
+      }else{
+        ncplane_printf(n, "%srgba animation supported", indent);
+      }
     }
     char* path = prefix_data("notcurses.png");
     if(path){
       // FIXME hold off until #1649 is resolved
-      //display_logo(ti, n, path);
+      display_logo(ti, n, path);
       free(path);
     }
   }

--- a/src/info/main.c
+++ b/src/info/main.c
@@ -190,7 +190,7 @@ tinfo_debug_bitmaps(struct ncplane* n, const tinfo* ti, const char* indent){
     char* path = prefix_data("notcurses.png");
     if(path){
       // FIXME hold off until #1649 is resolved
-      display_logo(ti, n, path);
+      //display_logo(ti, n, path);
       free(path);
     }
   }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -627,6 +627,16 @@ plane_debug(const ncplane* n, bool details){
   }
 }
 
+static inline sprixel*
+sprite_recycle(struct ncplane* n){
+  assert(n->sprite);
+  const struct notcurses* nc = ncplane_notcurses_const(n);
+  if(nc->tcache.pixel_recycle){
+    return nc->tcache.pixel_recycle(n);
+  }
+  return n->sprite;
+}
+
 static inline int
 sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
 //fprintf(stderr, "Destroying sprite %u\n", s->id);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -30,6 +30,7 @@ extern "C" {
 #include "compat/compat.h"
 #include "termdesc.h"
 #include "egcpool.h"
+#include "sprite.h"
 
 #define API __attribute__((visibility("default")))
 #define ALLOC __attribute__((malloc)) __attribute__((warn_unused_result))
@@ -48,144 +49,12 @@ struct ncvisual_details;
 // we can't define multipart ncvisual here, because OIIO requires C++ syntax,
 // and we can't go throwing C++ syntax into this header. so it goes.
 
-typedef enum {
-  SPRIXEL_QUIESCENT,   // sprixel has been drawn
-  SPRIXEL_INVALIDATED, // sprixel needs to be redrawn
-  SPRIXEL_HIDE,        // sprixel queued for destruction
-  SPRIXEL_MOVED,       // sprixel needs be moved
-} sprixel_e;
-
-// elements of the T-A matrix describe transparency and annihilation at a
-// per-cell basis, making up something of a state machine. when a sprixel
-// plane is first created, the TAM is (meaninglessly) initialized to all
-// zeroes (SPRIXCELL_OPAQUE). during the construction of the sprixel from
-// an RGBA frame, OPAQUE entries are possibly marked MIXED or TRANSPARENT.
-// subsequent sprixels blitted to the same plane will reuse the TAM, and
-// retain any SPRIXCELL_ANNIHILATED entries, cutting them out of the
-// sprixel.
-//
-// sixel can transition to ANNIHILATED via a no-op; kitty can transition
-// to ANNIHILATED only by wiping the cell (removing it from the sprixel via
-// all-0 alphas), deleting the bitmap, and displaying it once more. sixel
-// bitmaps are removed by obliterating them with new output, while kitty
-// bitmaps are removed by a fixed-length terminal escape. an important
-// implication is that sixels cannot be progressively reduced by emitting
-// progressively more transparent sixels atop one another--to remove a
-// cell from a Sixel sprixel, it is necessary to print a glyph. the same
-// goes for Kitty sprixels, but there we delete and rerender bitmaps
-// in toto without glyph involvement.
-//
-// a glyph above an OPAQUE sprixel requires annihilating the underlying cell,
-// and emitting the glyph only after annihilation is complete. a glyph below
-// an OPAQUE sprixel should never be emitted (update the lastframe to
-// contain it, but do not mark the cell damaged). should the sprixel be
-// removed, the cell will be marked damaged, and the glyph will be updated.
-//
-// a glyph above a MIXED sprixcell requires the same process as one above an
-// OPAQUE sprixcell. a glyph below a MIXED sprixcell can be emitted, but a
-// Sixel-based sprixel must then be printed afresh. a Kitty-based sprixel
-// needn't be touched in this case.
-//
-// a glyph above a TRANSPARENT sprixcell requires annihilating the underlying
-// cell, but this is a special annihilation which never requires a wipe nor
-// redisplay, just the O(1) state transition. a glyph below a TRANSPARENT
-// sprixcell can be emitted with no change to the sprixcell. TRANSPARENT
-// sprixcells move to ANNIHILATED_TRANS upon annihilation.
-//
-// a glyph above an ANNIHILATED sprixcell can be emitted with no change to
-// the sprixcell. it does not make sense to emit a glyph below an ANNIHILATED
-// sprixcell; if there is no longer a glyph above the sprixcell, the sprixcell
-// must transition back to its original state (see below).
-//
-// rendering a new RGBA frame into the same sprixel plane can result in changes
-// between OPAQUE, MIXED, and TRANSPARENT. an OPAQUE sprixcell which becomes
-// TRANSPARENT or MIXED upon rendering a new RGBA frame must damage its cell,
-// since the glyph underneath might have changed without being emitted. the
-// new glyph must be emitted prior to redisplay of the sprixel.
-//
-// an ANNIHILATED sprixcell with no glyph above it must be restored to its
-// original form (from the most recent RGBA frame). this requires the original
-// pixel data. for Sixel, we must keep the palette indices in an auxiliary
-// vector, hung off the TAM, updated each time we convert an RGBA frame into a
-// partially- or wholly-ANNIHILATED sprixel. for Kitty, we must keep the
-// original alpha values. the new state can be solved from this data. if the
-// new state is either OPAQUE or MIXED, the sprixel must be redisplayed. if the
-// new state is TRANSPARENT, this cell requires no such redisplay, and the
-// payload needn't be modified. to special-case this O(1) conversion, we keep a
-// distinct state, ANNIHILATED_TRANS. only a TRANSPARENT sprixcell can enter
-// into this state.
-//
-// when a sprixel is removed from the rendering pile, in Sixel all cells it
-// covered must be marked damaged, so that they are rendered, obliterating
-// the bitmap. in Kitty the bitmap can simply be deleted, except for those
-// cells which were SPRIXCELL_OPAQUE (they must be damaged).
-//
-// when a sprixel is moved, its TAM must be updated. OPAQUE, MIXED, and
-// TRANSPARENT cells retain their entries. ANNIHILATED cells remain
-// ANNIHILATED if their new absolute position corresponds to an ANNIHILATED
-// cell; they otherwise transition back as outlined above. this is because
-// ANNIHILATION is a property of those glyphs above us, while the other
-// three are internal, intrinsic properties. for Sixel, all cells no longer
-// covered must be damaged for rerendering, and the sprixel must subsequently
-// be displayed at its new position. for Kitty, the sprixel must be deleted,
-// and all cells no longer covered but which were previously under an OPAQUE
-// cell must be damaged for rerendering (not to erase the bitmap, but because
-// they might have changed without being emitted while obstructed by the
-// sprixel). the sprixel should be displayed at its new position. using Kitty's
-// bitmap movement is also acceptable, rather than a deletion and rerender.
-// whichever method is used, it is necessary to recover any ANNIHILATED cells
-// before moving or redisplaying the sprixel.
-//
-// all emissions take place at rasterization time. cell wiping happens at
-// rendering time. cell reconstruction happens at rendering time (for
-// ANNIHILATED cells which are no longer ANNIHILATED), or at blittime for
-// a new RGBA frame.
-typedef enum {
-  SPRIXCELL_OPAQUE_SIXEL,      // no transparent pixels in this cell
-  SPRIXCELL_OPAQUE_KITTY,
-  SPRIXCELL_MIXED_SIXEL,       // this cell has both opaque and transparent pixels
-  SPRIXCELL_MIXED_KITTY,
-  SPRIXCELL_TRANSPARENT,       // all pixels are naturally transparent
-  SPRIXCELL_ANNIHILATED,       // this cell has been wiped (all trans)
-  SPRIXCELL_ANNIHILATED_TRANS, // this transparent cell is covered
-} sprixcell_e;
-
 // a TAM entry is a sprixcell_e state plus a possible auxiliary vector for
 // reconstruction of annihilated cells, valid only for SPRIXCELL_ANNIHILATED.
 typedef struct tament {
   sprixcell_e state;
   uint8_t* auxvector; // palette entries for sixel, alphas for kitty
 } tament;
-
-// a sprixel represents a bitmap, using whatever local protocol is available.
-// there is a list of sprixels per ncpile. there ought never be very many
-// associated with a context (a dozen or so at max). with the kitty protocol,
-// we can register them, and then manipulate them by id. with the sixel
-// protocol, we just have to rewrite them. there's a doubly-linked list of
-// sprixels per ncpile, to which the pile keeps a head link.
-typedef struct sprixel {
-  char* glyph;          // glyph; can be quite large
-  int glyphlen;         // length of the glyph in bytes
-  uint32_t id;          // embedded into gcluster field of nccell, 24 bits
-  // both the plane and visual can die before the sprixel does. they are
-  // responsible in such a case for NULLing out this link themselves.
-  struct ncplane* n;    // associated ncplane
-  sprixel_e invalidated;// sprixel invalidation state
-  struct sprixel* next;
-  struct sprixel* prev;
-  int dimy, dimx;       // cell geometry
-  int pixy, pixx;       // pixel geometry (might be smaller than cell geo)
-  int cellpxy, cellpxx; // cell-pixel geometry at time of creation
-  // each tacache entry is one of 0 (standard opaque cell), 1 (cell with
-  // some transparency), 2 (annihilated, excised)
-  int movedfromy;       // for SPRIXEL_MOVED, the starting absolute position,
-  int movedfromx;       // so that we can damage old cells when redrawn
-  // only used for kitty-based sprixels
-  int parse_start;      // where to start parsing for cell wipes
-  // only used for sixel-based sprixels
-  struct sixelmap* smap;  // copy of palette indices + transparency bits
-  bool wipes_outstanding; // do we need rebuild the sixel next render?
-} sprixel;
 
 // A plane is memory for some rectilinear virtual window, plus current cursor
 // state for that window, and part of a pile. Each pile has a total order along
@@ -757,57 +626,6 @@ plane_debug(const ncplane* n, bool details){
     }
   }
 }
-
-// cell coordinates *within the sprixel*, not absolute
-int sprite_wipe(const notcurses* nc, sprixel* s, int y, int x);
-int sixel_wipe(sprixel* s, int ycell, int xcell);
-// nulls out a cell from a kitty bitmap via changing the alpha value
-// throughout to 0. the same trick doesn't work on sixel, but there we
-// can just print directly over the bitmap.
-int kitty_wipe(sprixel* s, int ycell, int xcell);
-int sixel_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
-int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
-
-void sprixel_free(sprixel* s);
-void sprixel_hide(sprixel* s);
-
-int kitty_draw(const ncpile *p, sprixel* s, FILE* out);
-int kitty_move(const ncpile *p, sprixel* s, FILE* out);
-int sixel_draw(const ncpile *p, sprixel* s, FILE* out);
-// dimy and dimx are cell geometry, not pixel.
-sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx);
-sprixel* sprixel_recycle(ncplane* n);
-// takes ownership of s on success.
-int sprixel_load(sprixel* spx, char* s, int bytes, int pixy, int pixx, int parse_start);
-int sixel_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
-int kitty_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
-int kitty_remove(int id, FILE* out);
-int kitty_clear_all(FILE* fp);
-int sixel_init(const tinfo* t, int fd);
-int sixel_init_inverted(const tinfo* t, int fd);
-int sprite_init(const tinfo* t, int fd);
-int sprite_clear_all(const tinfo* t, FILE* fp);
-int kitty_shutdown(FILE* fp);
-int sixel_shutdown(FILE* fp);
-uint8_t* sixel_trans_auxvec(const struct tinfo* ti);
-uint8_t* kitty_trans_auxvec(const struct tinfo* ti);
-// these three all use absolute coordinates
-void sprixel_invalidate(sprixel* s, int y, int x);
-void sprixel_movefrom(sprixel* s, int y, int x);
-void sprixel_debug(const sprixel* s, FILE* out);
-void sixelmap_free(struct sixelmap *s);
-
-// create an auxiliary vector suitable for a sprixcell, and zero it out. there
-// are two bytes per pixel in the cell. kitty uses only one (for an alpha
-// value). sixel uses both (for palette index, and transparency). FIXME fold
-// the transparency vector up into 1/8th as many bytes.
-uint8_t* sprixel_auxiliary_vector(const sprixel* s);
-
-int sixel_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
-               const blitterargs* bargs, int bpp);
-
-int kitty_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
-               const blitterargs* bargs, int bpp);
 
 static inline int
 sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -640,8 +640,8 @@ sprite_recycle(struct ncplane* n){
 
 static inline int
 sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
-//fprintf(stderr, "Destroying sprite %u\n", s->id);
-//sprixel_debug(s, stderr);
+fprintf(stderr, "Destroying sprite %u\n", s->id);
+sprixel_debug(s, stderr);
   return nc->tcache.pixel_destroy(nc, p, out, s);
 }
 
@@ -649,7 +649,8 @@ sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
 // returns -1 on error, or the number of bytes written.
 static inline int
 sprite_draw(const notcurses* n, const ncpile* p, sprixel* s, FILE* out){
-//sprixel_debug(s, stderr);
+fprintf(stderr, "Drawing sprite %u\n", s->id);
+sprixel_debug(s, stderr);
   return n->tcache.pixel_draw(p, s, out);
 }
 

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -390,11 +390,12 @@ typedef struct blitterargs {
       int placex;
     } cell;            // for cells
     struct {
-      int celldimx;    // horizontal pixels per cell
-      int celldimy;    // vertical pixels per cell
-      int colorregs;   // number of color registers
-      sprixel* spx;    // sprixel object
-    } pixel;           // for pixels
+      sprixel* spx;     // sprixel object
+      int celldimx;     // horizontal pixels per cell
+      int celldimy;     // vertical pixels per cell
+      int colorregs;    // number of color registers
+      unsigned replaced;// id of replaced sprixel
+    } pixel;            // for pixels
   } u;
 } blitterargs;
 

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -319,7 +319,7 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
 //fprintf(stderr, "pixoffset: %d next: %d tripbytes: %d tripskip: %d thisrow: %d\n", pixoffset, nextpixel, tripbytes, tripskip, thisrow);
       // the maximum number of pixels we can convert is the minimum of the
       // pixels remaining in the target row, and the pixels left in the chunk.
-//fprintf(stderr, "inchunk: %d total: %d triples: %d\n", inchunk, totalpixels, triples);
+fprintf(stderr, "restore %u inchunk: %d total: %d triples: %d\n", s->id, inchunk, totalpixels, triples);
       int chomped = kitty_restore(c + tripbytes, tripskip, thisrow,
                                   inchunk - triples * 3, auxvec + auxvecidx,
                                   &state);
@@ -354,7 +354,7 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
 }
 
 int kitty_wipe(sprixel* s, int ycell, int xcell){
-//fprintf(stderr, "NEW WIPE %d %d/%d\n", s->id, ycell, xcell);
+fprintf(stderr, "NEW WIPE %d %d/%d\n", s->id, ycell, xcell);
   uint8_t* auxvec = sprixel_auxiliary_vector(s);
   const int totalpixels = s->pixy * s->pixx;
   const int xpixels = s->cellpxx;
@@ -399,7 +399,7 @@ int kitty_wipe(sprixel* s, int ycell, int xcell){
 //fprintf(stderr, "pixoffset: %d next: %d tripbytes: %d tripskip: %d thisrow: %d\n", pixoffset, nextpixel, tripbytes, tripskip, thisrow);
       // the maximum number of pixels we can convert is the minimum of the
       // pixels remaining in the target row, and the pixels left in the chunk.
-//fprintf(stderr, "inchunk: %d total: %d triples: %d\n", inchunk, totalpixels, triples);
+fprintf(stderr, "wipe %u inchunk: %d total: %d triples: %d\n", s->id, inchunk, totalpixels, triples);
       int chomped = kitty_null(c + tripbytes, tripskip, thisrow,
                                inchunk - triples * 3, auxvec + auxvecidx);
       assert(chomped >= 0);
@@ -460,7 +460,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
   int y = 0; // position within source image (pixels)
   int x = 0;
   int targetout = 0; // number of pixels expected out after this chunk
-//fprintf(stderr, "total: %d chunks = %d, s=%d,v=%d\n", total, chunks, lenx, leny);
+fprintf(stderr, "write %u total: %d chunks = %d, s=%d,v=%d\n", sprixelid, total, chunks, lenx, leny);
   while(chunks--){
     if(totalout == 0){
       *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,p=1,a=t,%s%d%s;",
@@ -535,6 +535,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
   if(bargs->u.pixel.replaced){
     kitty_remove(bargs->u.pixel.replaced, fp);
   }
+fprintf(stderr, "SHOWING %u\n", sprixelid);
   fprintf(fp, "\e_Ga=p,i=%d,p=1,q=%d\e\\", sprixelid, loglevel_to_kittyq(loglevel));
   if(fclose(fp) == EOF){
     return -1;
@@ -597,7 +598,7 @@ int kitty_blit(ncplane* n, int linesize, const void* data, int leny, int lenx,
 }
 
 int kitty_remove(int id, FILE* out){
-//fprintf(stderr, "DESTROYING KITTY %d\n", id);
+fprintf(stderr, "DESTROYING KITTY %d\n", id);
   if(fprintf(out, "\e_Ga=d,d=i,i=%d\e\\", id) < 0){
     return -1;
   }
@@ -689,6 +690,6 @@ sprixel* kitty_recycle(ncplane* n){
   sprixel* hides = n->sprite;
   int dimy = hides->dimy;
   int dimx = hides->dimx;
-  sprixel_hide(hides);
+  sprixel_hide(hides, true);
   return sprixel_alloc(n, dimy, dimx);
 }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -442,7 +442,7 @@ static int
 write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
                  const uint32_t* data, const blitterargs* bargs,
                  tament* tam, int* parse_start){
-//fprintf(stderr, "drawing kitty %p\n", tam);
+fprintf(stderr, "drawing kitty %p %d\n", tam, bargs->u.pixel.spx->id);
   if(linesize % sizeof(*data)){
     fclose(fp);
     return -1;
@@ -460,8 +460,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
   int y = 0; // position within source image (pixels)
   int x = 0;
   int targetout = 0; // number of pixels expected out after this chunk
-fprintf(stderr, "write %u total: %d chunks = %d, s=%d,v=%d\n", sprixelid, total, chunks, lenx, leny);
-  while(chunks--){
+fprintf(stderr, "write %u total: %d chunks = %d, s=%d,v=%d\n", sprixelid, total, chunks, lenx, leny); while(chunks--){
     if(totalout == 0){
       *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,p=1,a=t,%s%d%s;",
                              lenx, leny, sprixelid,
@@ -598,7 +597,7 @@ int kitty_blit(ncplane* n, int linesize, const void* data, int leny, int lenx,
 }
 
 int kitty_remove(int id, FILE* out){
-fprintf(stderr, "DESTROYING KITTY %d\n", id);
+fprintf(stderr, "REMOVING KITTY %d\n", id);
   if(fprintf(out, "\e_Ga=d,d=i,i=%d\e\\", id) < 0){
     return -1;
   }
@@ -609,6 +608,7 @@ fprintf(stderr, "DESTROYING KITTY %d\n", id);
 // cells which weren't SPRIXCEL_OPAQUE
 int kitty_destroy(const notcurses* nc __attribute__ ((unused)),
                   const ncpile* p, FILE* out, sprixel* s){
+fprintf(stderr, "DESTROYING KITTY %d\n", s->id);
   if(kitty_remove(s->id, out)){
     return -1;
   }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -320,9 +320,11 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
       // the maximum number of pixels we can convert is the minimum of the
       // pixels remaining in the target row, and the pixels left in the chunk.
 fprintf(stderr, "restore %u inchunk: %d total: %d triples: %d\n", s->id, inchunk, totalpixels, triples);
+fprintf(stderr, "BEFORE: [%.256s]\n", c + tripbytes);
       int chomped = kitty_restore(c + tripbytes, tripskip, thisrow,
                                   inchunk - triples * 3, auxvec + auxvecidx,
                                   &state);
+fprintf(stderr, "AFTER: [%.256s]\n", c + tripbytes);
       assert(chomped >= 0);
       auxvecidx += chomped;
       thisrow -= chomped;
@@ -400,8 +402,10 @@ fprintf(stderr, "NEW WIPE %d %d/%d\n", s->id, ycell, xcell);
       // the maximum number of pixels we can convert is the minimum of the
       // pixels remaining in the target row, and the pixels left in the chunk.
 fprintf(stderr, "wipe %u inchunk: %d total: %d triples: %d\n", s->id, inchunk, totalpixels, triples);
+fprintf(stderr, "BEFORE: [%.24s]\n", c + tripbytes);
       int chomped = kitty_null(c + tripbytes, tripskip, thisrow,
                                inchunk - triples * 3, auxvec + auxvecidx);
+fprintf(stderr, "AFTER: [%.24s]\n", c + tripbytes);
       assert(chomped >= 0);
       auxvecidx += chomped;
       assert(auxvecidx <= s->cellpxy * s->cellpxx);
@@ -412,6 +416,7 @@ fprintf(stderr, "wipe %u inchunk: %d total: %d triples: %d\n", s->id, inchunk, t
         if(--targy == 0){
           s->n->tam[s->dimx * ycell + xcell].auxvector = auxvec;
           s->invalidated = SPRIXEL_INVALIDATED;
+sprixel_debug(s, stderr);
           return 1;
         }
         thisrow = targx;
@@ -462,7 +467,7 @@ fprintf(stderr, "drawing kitty %p %d\n", tam, bargs->u.pixel.spx->id);
   int targetout = 0; // number of pixels expected out after this chunk
 fprintf(stderr, "write %u total: %d chunks = %d, s=%d,v=%d\n", sprixelid, total, chunks, lenx, leny); while(chunks--){
     if(totalout == 0){
-      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,p=1,a=t,%s%d%s;",
+      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,p=1,a=T,%s%d%s;",
                              lenx, leny, sprixelid,
                              chunks ? "m=" : "q=",
                              chunks ? 1 : loglevel_to_kittyq(loglevel),
@@ -534,7 +539,7 @@ fprintf(stderr, "write %u total: %d chunks = %d, s=%d,v=%d\n", sprixelid, total,
   if(bargs->u.pixel.replaced){
     kitty_remove(bargs->u.pixel.replaced, fp);
   }
-fprintf(stderr, "SHOWING %u\n", sprixelid);
+//fprintf(stderr, "SHOWING %u\n", sprixelid);
   fprintf(fp, "\e_Ga=p,i=%d,p=1,q=%d\e\\", sprixelid, loglevel_to_kittyq(loglevel));
   if(fclose(fp) == EOF){
     return -1;
@@ -642,7 +647,7 @@ fprintf(stderr, "DESTROYING KITTY %d\n", s->id);
 
 // returns the number of bytes written
 int kitty_draw(const ncpile* p, sprixel* s, FILE* out){
-//fprintf(stderr, "KITTY DRAW: %u\n", s->id);
+fprintf(stderr, "KITTY DRAW: %u [%s]\n", s->id, s->glyph);
   (void)p;
   int ret = s->glyphlen;
   if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){
@@ -654,7 +659,7 @@ int kitty_draw(const ncpile* p, sprixel* s, FILE* out){
 
 // returns -1 on failure, 0 on success (move bytes do not count for sprixel stats)
 int kitty_move(const ncpile* p, sprixel* s, FILE* out){
-//fprintf(stderr, "KITTY MOVE: %u\n", s->id);
+fprintf(stderr, "KITTY MOVE: %u\n", s->id);
   (void)p;
   int ret = 0;
   if(fprintf(out, "\e_Ga=p,i=%d,p=1,q=%d\e\\", s->id, loglevel_to_kittyq(loglevel)) < 0){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -666,7 +666,7 @@ int kitty_move(const ncpile* p, sprixel* s, FILE* out){
 
 // clears all kitty bitmaps
 int kitty_clear_all(FILE* fp){
-//fprintf(stderr, "KITTY UNIVERSAL ERASE\n");
+fprintf(stderr, "KITTY UNIVERSAL ERASE\n");
   return term_emit("\e_Ga=d\e\\", fp, false);
 }
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -323,7 +323,7 @@ void free_plane(ncplane* p){
       }
     }
     if(p->sprite){
-      sprixel_hide(p->sprite);
+      sprixel_hide(p->sprite, false);
     }
     if(p->tam){
       for(int y = 0 ; y < p->leny ; ++y){
@@ -689,7 +689,7 @@ int ncplane_resize_internal(ncplane* n, int keepy, int keepx, int keepleny,
   }
   notcurses* nc = ncplane_notcurses(n);
   if(n->sprite){
-    sprixel_hide(n->sprite);
+    sprixel_hide(n->sprite, false);
   }
   // we're good to resize. we'll need alloc up a new framebuffer, and copy in
   // those elements we're retaining, zeroing out the rest. alternatively, if
@@ -2085,7 +2085,7 @@ void ncplane_yx(const ncplane* n, int* y, int* x){
 
 void ncplane_erase(ncplane* n){
   if(n->sprite){
-    sprixel_hide(n->sprite);
+    sprixel_hide(n->sprite, false);
   }
   // we must preserve the background, but a pure nccell_duplicate() would be
   // wiped out by the egcpool_dump(). do a duplication (to get the stylemask

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -895,6 +895,7 @@ static int64_t
 rasterize_sprixels(notcurses* nc, ncpile* p, FILE* out){
   int64_t bytesemitted = 0;
   for(sprixel* s = p->sprixelcache ; s ; s = s->next){
+sprixel_debug(s, stderr);
     if(s->invalidated == SPRIXEL_INVALIDATED){
       int y, x;
       ncplane_yx(s->n, &y, &x);

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -1100,7 +1100,6 @@ notcurses_rasterize_inner(notcurses* nc, ncpile* p, FILE* out, unsigned* asu){
   if(ncflush(out)){
     return -1;
   }
-  nc->last_pile = p;
   return nc->rstate.mstrsize;
 }
 

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -1100,6 +1100,7 @@ notcurses_rasterize_inner(notcurses* nc, ncpile* p, FILE* out, unsigned* asu){
   if(ncflush(out)){
     return -1;
   }
+  nc->last_pile = p;
   return nc->rstate.mstrsize;
 }
 

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -54,19 +54,6 @@ void sprixel_free(sprixel* s){
   }
 }
 
-sprixel* sprite_recycle(ncplane* n){
-  assert(n->sprite);
-  const notcurses* nc = ncplane_notcurses_const(n);
-  if(nc->tcache.pixel_shutdown == kitty_shutdown){
-    sprixel* hides = n->sprite;
-    int dimy = hides->dimy;
-    int dimx = hides->dimx;
-    sprixel_hide(hides);
-    return sprixel_alloc(n, dimy, dimx);
-  }
-  return n->sprite;
-}
-
 // store the original (absolute) coordinates from which we moved, so that
 // we can invalidate them in sprite_draw().
 void sprixel_movefrom(sprixel* s, int y, int x){

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -57,7 +57,7 @@ void sprixel_free(sprixel* s){
 // store the original (absolute) coordinates from which we moved, so that
 // we can invalidate them in sprite_draw().
 void sprixel_movefrom(sprixel* s, int y, int x){
-  if(s->invalidated != SPRIXEL_HIDE){
+  if(s->invalidated != SPRIXEL_HIDE && s->invalidated != SPRIXEL_REPLACED){
     if(s->invalidated != SPRIXEL_MOVED){
     // FIXME if we're Sixel, we need to effect any wipes that were run
     // (we normally don't because redisplaying sixel doesn't change
@@ -71,16 +71,16 @@ void sprixel_movefrom(sprixel* s, int y, int x){
   }
 }
 
-void sprixel_hide(sprixel* s){
+void sprixel_hide(sprixel* s, unsigned replace){
   if(ncplane_pile(s->n) == NULL){ // ncdirect case; destroy now
 //fprintf(stderr, "HIDING %d IMMEDIATELY\n", s->id);
     sprixel_free(s);
     return;
   }
   // otherwise, it'll be killed in the next rendering cycle.
-  if(s->invalidated != SPRIXEL_HIDE){
+  if(s->invalidated != SPRIXEL_HIDE && s->invalidated != SPRIXEL_REPLACED){
 //fprintf(stderr, "HIDING %d\n", s->id);
-    s->invalidated = SPRIXEL_HIDE;
+    s->invalidated = replace ? SPRIXEL_REPLACED : SPRIXEL_HIDE;
     s->movedfromy = ncplane_abs_y(s->n);
     s->movedfromx = ncplane_abs_x(s->n);
     // guard; might have already been replaced

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -1,11 +1,15 @@
+#include "sprite.h"
 #include "internal.h"
 #include "visual-details.h"
 #include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
 
 static atomic_uint_fast32_t sprixelid_nonce;
 
 void sprixel_debug(const sprixel* s, FILE* out){
-  fprintf(out, "Sprixel %d (%p) %dB %dx%d (%dx%d) @%d/%d state: %d\n",
+  fprintf(out, "Sprixel %d (%p) %zuB %dx%d (%dx%d) @%d/%d state: %d\n",
           s->id, s, s->glyphlen, s->dimy, s->dimx, s->pixy, s->pixx,
           s->n ? s->n->absy : 0, s->n ? s->n->absx : 0,
           s->invalidated);
@@ -50,7 +54,7 @@ void sprixel_free(sprixel* s){
   }
 }
 
-sprixel* sprixel_recycle(ncplane* n){
+sprixel* sprite_recycle(ncplane* n){
   assert(n->sprite);
   const notcurses* nc = ncplane_notcurses_const(n);
   if(nc->tcache.pixel_shutdown == kitty_shutdown){

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -1,0 +1,212 @@
+#ifndef NOTCURSES_SPRITE
+#define NOTCURSES_SPRITE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// internal header, not installed
+
+#include "input.h"
+#include "termdesc.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <termios.h>
+
+struct ncpile;
+struct notcurses;
+struct blitterargs;
+
+typedef enum {
+  SPRIXEL_QUIESCENT,   // sprixel has been drawn
+  SPRIXEL_INVALIDATED, // sprixel needs to be redrawn
+  SPRIXEL_HIDE,        // sprixel queued for destruction
+  SPRIXEL_MOVED,       // sprixel needs be moved
+} sprixel_e;
+
+// elements of the T-A matrix describe transparency and annihilation at a
+// per-cell basis, making up something of a state machine. when a sprixel
+// plane is first created, the TAM is (meaninglessly) initialized to all
+// zeroes (SPRIXCELL_OPAQUE). during the construction of the sprixel from
+// an RGBA frame, OPAQUE entries are possibly marked MIXED or TRANSPARENT.
+// subsequent sprixels blitted to the same plane will reuse the TAM, and
+// retain any SPRIXCELL_ANNIHILATED entries, cutting them out of the
+// sprixel.
+//
+// sixel can transition to ANNIHILATED via a no-op; kitty can transition
+// to ANNIHILATED only by wiping the cell (removing it from the sprixel via
+// all-0 alphas), deleting the bitmap, and displaying it once more. sixel
+// bitmaps are removed by obliterating them with new output, while kitty
+// bitmaps are removed by a fixed-length terminal escape. an important
+// implication is that sixels cannot be progressively reduced by emitting
+// progressively more transparent sixels atop one another--to remove a
+// cell from a Sixel sprixel, it is necessary to print a glyph. the same
+// goes for Kitty sprixels, but there we delete and rerender bitmaps
+// in toto without glyph involvement.
+//
+// a glyph above an OPAQUE sprixel requires annihilating the underlying cell,
+// and emitting the glyph only after annihilation is complete. a glyph below
+// an OPAQUE sprixel should never be emitted (update the lastframe to
+// contain it, but do not mark the cell damaged). should the sprixel be
+// removed, the cell will be marked damaged, and the glyph will be updated.
+//
+// a glyph above a MIXED sprixcell requires the same process as one above an
+// OPAQUE sprixcell. a glyph below a MIXED sprixcell can be emitted, but a
+// Sixel-based sprixel must then be printed afresh. a Kitty-based sprixel
+// needn't be touched in this case.
+//
+// a glyph above a TRANSPARENT sprixcell requires annihilating the underlying
+// cell, but this is a special annihilation which never requires a wipe nor
+// redisplay, just the O(1) state transition. a glyph below a TRANSPARENT
+// sprixcell can be emitted with no change to the sprixcell. TRANSPARENT
+// sprixcells move to ANNIHILATED_TRANS upon annihilation.
+//
+// a glyph above an ANNIHILATED sprixcell can be emitted with no change to
+// the sprixcell. it does not make sense to emit a glyph below an ANNIHILATED
+// sprixcell; if there is no longer a glyph above the sprixcell, the sprixcell
+// must transition back to its original state (see below).
+//
+// rendering a new RGBA frame into the same sprixel plane can result in changes
+// between OPAQUE, MIXED, and TRANSPARENT. an OPAQUE sprixcell which becomes
+// TRANSPARENT or MIXED upon rendering a new RGBA frame must damage its cell,
+// since the glyph underneath might have changed without being emitted. the
+// new glyph must be emitted prior to redisplay of the sprixel.
+//
+// an ANNIHILATED sprixcell with no glyph above it must be restored to its
+// original form (from the most recent RGBA frame). this requires the original
+// pixel data. for Sixel, we must keep the palette indices in an auxiliary
+// vector, hung off the TAM, updated each time we convert an RGBA frame into a
+// partially- or wholly-ANNIHILATED sprixel. for Kitty, we must keep the
+// original alpha values. the new state can be solved from this data. if the
+// new state is either OPAQUE or MIXED, the sprixel must be redisplayed. if the
+// new state is TRANSPARENT, this cell requires no such redisplay, and the
+// payload needn't be modified. to special-case this O(1) conversion, we keep a
+// distinct state, ANNIHILATED_TRANS. only a TRANSPARENT sprixcell can enter
+// into this state.
+//
+// when a sprixel is removed from the rendering pile, in Sixel all cells it
+// covered must be marked damaged, so that they are rendered, obliterating
+// the bitmap. in Kitty the bitmap can simply be deleted, except for those
+// cells which were SPRIXCELL_OPAQUE (they must be damaged).
+//
+// when a sprixel is moved, its TAM must be updated. OPAQUE, MIXED, and
+// TRANSPARENT cells retain their entries. ANNIHILATED cells remain
+// ANNIHILATED if their new absolute position corresponds to an ANNIHILATED
+// cell; they otherwise transition back as outlined above. this is because
+// ANNIHILATION is a property of those glyphs above us, while the other
+// three are internal, intrinsic properties. for Sixel, all cells no longer
+// covered must be damaged for rerendering, and the sprixel must subsequently
+// be displayed at its new position. for Kitty, the sprixel must be deleted,
+// and all cells no longer covered but which were previously under an OPAQUE
+// cell must be damaged for rerendering (not to erase the bitmap, but because
+// they might have changed without being emitted while obstructed by the
+// sprixel). the sprixel should be displayed at its new position. using Kitty's
+// bitmap movement is also acceptable, rather than a deletion and rerender.
+// whichever method is used, it is necessary to recover any ANNIHILATED cells
+// before moving or redisplaying the sprixel.
+//
+// all emissions take place at rasterization time. cell wiping happens at
+// rendering time. cell reconstruction happens at rendering time (for
+// ANNIHILATED cells which are no longer ANNIHILATED), or at blittime for
+// a new RGBA frame.
+typedef enum {
+  SPRIXCELL_OPAQUE_SIXEL,      // no transparent pixels in this cell
+  SPRIXCELL_OPAQUE_KITTY,
+  SPRIXCELL_MIXED_SIXEL,       // this cell has both opaque and transparent pixels
+  SPRIXCELL_MIXED_KITTY,
+  SPRIXCELL_TRANSPARENT,       // all pixels are naturally transparent
+  SPRIXCELL_ANNIHILATED,       // this cell has been wiped (all trans)
+  SPRIXCELL_ANNIHILATED_TRANS, // this transparent cell is covered
+} sprixcell_e;
+
+// a sprixel represents a bitmap, using whatever local protocol is available.
+// there is a list of sprixels per ncpile. there ought never be very many
+// associated with a context (a dozen or so at max). with the kitty protocol,
+// we can register them, and then manipulate them by id. with the sixel
+// protocol, we just have to rewrite them. there's a doubly-linked list of
+// sprixels per ncpile, to which the pile keeps a head link.
+typedef struct sprixel {
+  char* glyph;          // glyph; can be quite large
+  size_t glyphlen;      // length of the glyph in bytes
+  uint32_t id;          // embedded into gcluster field of nccell, 24 bits
+  // both the plane and visual can die before the sprixel does. they are
+  // responsible in such a case for NULLing out this link themselves.
+  struct ncplane* n;    // associated ncplane
+  sprixel_e invalidated;// sprixel invalidation state
+  struct sprixel* next;
+  struct sprixel* prev;
+  int dimy, dimx;       // cell geometry
+  int pixy, pixx;       // pixel geometry (might be smaller than cell geo)
+  int cellpxy, cellpxx; // cell-pixel geometry at time of creation
+  // each tacache entry is one of 0 (standard opaque cell), 1 (cell with
+  // some transparency), 2 (annihilated, excised)
+  int movedfromy;       // for SPRIXEL_MOVED, the starting absolute position,
+  int movedfromx;       // so that we can damage old cells when redrawn
+  // only used for kitty-based sprixels
+  int parse_start;      // where to start parsing for cell wipes
+  // only used for sixel-based sprixels
+  struct sixelmap* smap;  // copy of palette indices + transparency bits
+  FILE* mstreamfp;        // mstream for writing animation-type updates,
+                          // (only available for kitty animation sprixels)
+  bool wipes_outstanding; // do we need rebuild the sixel next render?
+} sprixel;
+
+// cell coordinates *within the sprixel*, not absolute
+int sprite_wipe(const struct notcurses* nc, sprixel* s, int y, int x);
+int sixel_wipe(sprixel* s, int ycell, int xcell);
+// nulls out a cell from a kitty bitmap via changing the alpha value
+// throughout to 0. the same trick doesn't work on sixel, but there we
+// can just print directly over the bitmap.
+int kitty_wipe(sprixel* s, int ycell, int xcell);
+// nulls out a cell from a kitty bitmap by overlaying an animation
+// block atop it composed of all 0s.
+int kitty_wipe_animation(sprixel* s, int ycell, int xcell);
+int sixel_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
+int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
+int kitty_rebuild_animation(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
+
+void sprixel_free(sprixel* s);
+void sprixel_hide(sprixel* s);
+
+struct sprixel* sprite_recycle(struct ncplane* n);
+struct sprixel* kitty_recycle(struct ncplane* n);
+int kitty_draw(const struct ncpile *p, sprixel* s, FILE* out);
+int kitty_move(const struct ncpile *p, sprixel* s, FILE* out);
+int sixel_draw(const struct ncpile *p, sprixel* s, FILE* out);
+// dimy and dimx are cell geometry, not pixel.
+sprixel* sprixel_alloc(struct ncplane* n, int dimy, int dimx);
+// takes ownership of s on success.
+int sprixel_load(sprixel* spx, char* s, int bytes, int pixy, int pixx, int parse_start);
+int sixel_destroy(const struct notcurses* nc, const struct ncpile* p, FILE* out, sprixel* s);
+int kitty_destroy(const struct notcurses* nc, const struct ncpile* p, FILE* out, sprixel* s);
+int kitty_remove(int id, FILE* out);
+int kitty_clear_all(FILE* fp);
+int sixel_init(const tinfo* t, int fd);
+int sixel_init_inverted(const tinfo* t, int fd);
+int sprite_init(const tinfo* t, int fd);
+int sprite_clear_all(const tinfo* t, FILE* fp);
+int kitty_shutdown(FILE* fp);
+int sixel_shutdown(FILE* fp);
+uint8_t* sixel_trans_auxvec(const tinfo* ti);
+uint8_t* kitty_trans_auxvec(const tinfo* ti);
+uint8_t* kitty_transanim_auxvec(const sprixel* s);
+uint8_t* sprixel_auxiliary_vector(const sprixel* s);
+// these three all use absolute coordinates
+void sprixel_invalidate(sprixel* s, int y, int x);
+void sprixel_movefrom(sprixel* s, int y, int x);
+void sprixel_debug(const sprixel* s, FILE* out);
+void sixelmap_free(struct sixelmap *s);
+
+int sixel_blit(struct ncplane* nc, int linesize, const void* data,
+               int leny, int lenx,
+               const struct blitterargs* bargs, int bpp);
+
+int kitty_blit(struct ncplane* nc, int linesize, const void* data,
+               int leny, int lenx,
+               const struct blitterargs* bargs, int bpp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -168,8 +168,7 @@ int kitty_rebuild_animation(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 void sprixel_free(sprixel* s);
 void sprixel_hide(sprixel* s);
 
-struct sprixel* sprite_recycle(struct ncplane* n);
-struct sprixel* kitty_recycle(struct ncplane* n);
+sprixel* kitty_recycle(struct ncplane* n);
 int kitty_draw(const struct ncpile *p, sprixel* s, FILE* out);
 int kitty_move(const struct ncpile *p, sprixel* s, FILE* out);
 int sixel_draw(const struct ncpile *p, sprixel* s, FILE* out);

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -22,6 +22,7 @@ typedef enum {
   SPRIXEL_INVALIDATED, // sprixel needs to be redrawn
   SPRIXEL_HIDE,        // sprixel queued for destruction
   SPRIXEL_MOVED,       // sprixel needs be moved
+  SPRIXEL_REPLACED,    // sprixel needs be killed between load and display
 } sprixel_e;
 
 // elements of the T-A matrix describe transparency and annihilation at a
@@ -166,7 +167,7 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 int kitty_rebuild_animation(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 
 void sprixel_free(sprixel* s);
-void sprixel_hide(sprixel* s);
+void sprixel_hide(sprixel* s, unsigned replaced);
 
 sprixel* kitty_recycle(struct ncplane* n);
 int kitty_draw(const struct ncpile *p, sprixel* s, FILE* out);

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -8,8 +8,10 @@ extern "C" {
 // internal header, not installed
 
 #include "input.h"
+#include <stdint.h>
 #include <stdbool.h>
 #include <termios.h>
+#include <notcurses/notcurses.h>
 
 struct ncpile;
 struct sprixel;

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -137,6 +137,7 @@ typedef struct tinfo {
   int (*pixel_move)(const struct ncpile* p, struct sprixel* s, FILE* out);
   int (*pixel_destroy)(const struct notcurses* nc, const struct ncpile* p, FILE* out, struct sprixel* s);
   int (*pixel_shutdown)(FILE* fp);  // called during context shutdown
+  struct sprixel* (*pixel_recycle)(struct ncplane* n);
   int (*pixel_clear_all)(FILE* fp); // called during context startup
   uint8_t* (*pixel_trans_auxvec)(const struct tinfo* ti); // create tranparent auxvec
   // sprixel parameters. there are several different sprixel protocols, of

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -962,7 +962,11 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
       return NULL;
     }
   }else{
+    bargs.u.pixel.replaced = n->sprite->id;
     n->sprite = sprite_recycle(n);
+    if(n->sprite->id == bargs.u.pixel.replaced){
+      bargs.u.pixel.replaced = 0;
+    }
   }
   bargs.u.pixel.spx = n->sprite;
   // if we are kitty prior to 0.20.0, we set NCVISUAL_OPTION_SCROLL so that

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -961,7 +961,9 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
       ncplane_destroy(createdn);
       return NULL;
     }
+    bargs.u.pixel.replaced = 0;
   }else{
+fprintf(stderr, "n->sprite: %p id: %u\n", n->sprite, n->sprite->id);
     bargs.u.pixel.replaced = n->sprite->id;
     n->sprite = sprite_recycle(n);
     if(n->sprite->id == bargs.u.pixel.replaced){

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -1014,7 +1014,7 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
 //fprintf(stderr, "ABOUT TO RESIZE: yoff/xoff: %d/%d\n",  placey, placex);
   // FIXME might need shrink down the TAM and kill unnecessary auxvecs
   if(ncplane_resize(n, 0, 0, s->dimy, s->dimx, placey, placex, s->dimy, s->dimx)){
-    sprixel_hide(bargs.u.pixel.spx);
+    sprixel_hide(bargs.u.pixel.spx, false);
     ncplane_destroy(createdn);
     return NULL;
   }

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -962,7 +962,7 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
       return NULL;
     }
   }else{
-    n->sprite = sprixel_recycle(n);
+    n->sprite = sprite_recycle(n);
   }
   bargs.u.pixel.spx = n->sprite;
   // if we are kitty prior to 0.20.0, we set NCVISUAL_OPTION_SCROLL so that

--- a/src/media/oiio-indep.c
+++ b/src/media/oiio-indep.c
@@ -50,6 +50,7 @@ int oiio_stream(struct notcurses* nc, ncvisual* ncv, float timescale,
     }
     if(r){
       if(activevopts.n != vopts->n){
+fprintf(stderr, "DESTROYING IT!\n");
         ncplane_destroy(activevopts.n);
       }
       return r;


### PR DESCRIPTION
in order to reliably eliminate kitty flicker, we need transfer image data in a distinct operation from displaying it. do so. closes #1865.