### PR TITLE
on pile change, clear old sprixels #1875

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -472,6 +472,12 @@ typedef struct notcurses {
   // we keep a copy of the last rendered frame. this facilitates O(1)
   // notcurses_at_yx() and O(1) damage detection (at the cost of some memory).
   nccell* lastframe;// last rasterized framebuffer, NULL until first raster
+  // the last pile we rasterized. NULL until we've rasterized once. might
+  // be invalid due to the pile being destroyed; you are only allowed to
+  // evaluate it for equality to the pile being currently rasterized. when
+  // we switch piles, we need to clear all displayed sprixels, and
+  // invalidate the new pile's, pursuant to their display.
+  ncpile* last_pile;
   egcpool pool;   // egcpool for lastframe
 
   int lfdimx;     // dimensions of lastframe, unchanged by screen resize

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1036,6 +1036,7 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   if(ret == NULL){
     return ret;
   }
+  ret->last_pile = NULL;
   ret->rstate.mstream = NULL;
   ret->rstate.mstreamfp = NULL;
   ret->loglevel = opts->loglevel;


### PR DESCRIPTION
On a pile change, issue a clear-all sprixels (this only has effect on Kitty, but we don't need this for Sixel anyway, so it's perfect). Closes #1875.