### PR TITLE
Kitty: keep display and load distinct

### DIFF
--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -425,10 +425,8 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np, int xoff){
     if(blocking_write(fileno(n->ttyfp), np->sprite->glyph, np->sprite->glyphlen) < 0){
       return -1;
     }
-    if(n->tcache.pixel_commit){
-      if(n->tcache.pixel_commit(n->ttyfp, np->sprite)){
-        return -1;
-      }
+    if(sprite_commit(&n->tcache, n->ttyfp, np->sprite, true)){
+      return -1;
     }
     return 0;
   }
@@ -592,7 +590,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
     return NULL;
   }
   blitterargs bargs = {};
-  bargs.flags = vopts->flags | NCVISUAL_OPTION_SCROLL;
+  bargs.flags = vopts->flags;
   if(vopts->flags & NCVISUAL_OPTION_ADDALPHA){
     bargs.transcolor = vopts->transcolor | 0x1000000ull;
   }

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -403,8 +403,6 @@ ncdirect_align(struct ncdirect* n, ncalign_e align, int c){
   return INT_MAX;
 }
 
-// FIXME need to run this through a memstream, or else we run into blocking
-// issues with stdio (see ncflush())
 static int
 ncdirect_dump_plane(ncdirect* n, const ncplane* np, int xoff){
   const int toty = ncdirect_dim_y(n);

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -403,6 +403,8 @@ ncdirect_align(struct ncdirect* n, ncalign_e align, int c){
   return INT_MAX;
 }
 
+// FIXME need to run this through a memstream, or else we run into blocking
+// issues with stdio (see ncflush())
 static int
 ncdirect_dump_plane(ncdirect* n, const ncplane* np, int xoff){
   const int toty = ncdirect_dim_y(n);
@@ -424,6 +426,11 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np, int xoff){
     }
     if(blocking_write(fileno(n->ttyfp), np->sprite->glyph, np->sprite->glyphlen) < 0){
       return -1;
+    }
+    if(n->tcache.pixel_commit){
+      if(n->tcache.pixel_commit(n->ttyfp, np->sprite)){
+        return -1;
+      }
     }
     return 0;
   }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -49,10 +49,11 @@ struct ncvisual_details;
 // and we can't go throwing C++ syntax into this header. so it goes.
 
 typedef enum {
-  SPRIXEL_QUIESCENT,   // sprixel has been drawn
-  SPRIXEL_INVALIDATED, // sprixel needs to be redrawn
-  SPRIXEL_HIDE,        // sprixel queued for destruction
-  SPRIXEL_MOVED,       // sprixel needs be moved
+  SPRIXEL_QUIESCENT,   // up-to-date and visible at the proper place
+  SPRIXEL_LOADED,      // loaded, but not yet made visible (kitty-only)
+  SPRIXEL_INVALIDATED, // not up-to-date, need reload, trumps MOVED
+  SPRIXEL_HIDE,        // queued for destruction
+  SPRIXEL_MOVED,       // visible, up-to-date, but in the wrong place
 } sprixel_e;
 
 // elements of the T-A matrix describe transparency and annihilation at a
@@ -796,6 +797,7 @@ void sprixel_invalidate(sprixel* s, int y, int x);
 void sprixel_movefrom(sprixel* s, int y, int x);
 void sprixel_debug(const sprixel* s, FILE* out);
 void sixelmap_free(struct sixelmap *s);
+int kitty_commit(FILE* fp, sprixel* s); // make loaded image visible
 
 // create an auxiliary vector suitable for a sprixcell, and zero it out. there
 // are two bytes per pixel in the cell. kitty uses only one (for an alpha

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -813,6 +813,8 @@ int kitty_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
 
 // update any necessary cells underneath the sprixel pursuant to its removal.
 // for sixel, this *achieves* the removal, and is performed on every cell.
+// returns 1 if the graphic can be immediately freed (which is equivalent to
+// asking whether it was sixel and there were no errors).
 static inline int
 sprite_scrub(const notcurses* n, const ncpile* p, sprixel* s){
 //fprintf(stderr, "Destroying sprite %u\n", s->id);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -779,8 +779,8 @@ sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx);
 sprixel* sprixel_recycle(ncplane* n);
 // takes ownership of s on success.
 int sprixel_load(sprixel* spx, char* s, int bytes, int pixy, int pixx, int parse_start);
-int sixel_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
-int kitty_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s);
+int sixel_scrub(const ncpile* p, sprixel* s);
+int kitty_scrub(const ncpile* p, sprixel* s);
 int kitty_remove(int id, FILE* out);
 int kitty_clear_all(FILE* fp);
 int sixel_init(const tinfo* t, int fd);
@@ -809,11 +809,13 @@ int sixel_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
 int kitty_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
                const blitterargs* bargs, int bpp);
 
+// update any necessary cells underneath the sprixel pursuant to its removal.
+// for sixel, this *achieves* the removal, and is performed on every cell.
 static inline int
-sprite_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
+sprite_scrub(const notcurses* n, const ncpile* p, sprixel* s){
 //fprintf(stderr, "Destroying sprite %u\n", s->id);
 //sprixel_debug(s, stderr);
-  return nc->tcache.pixel_destroy(nc, p, out, s);
+  return n->tcache.pixel_scrub(p, s);
 }
 
 // precondition: s->invalidated is SPRIXEL_INVALIDATED or SPRIXEL_MOVED.

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -579,11 +579,7 @@ int kitty_remove(int id, FILE* out){
 
 // removes the kitty bitmap graphic identified by s->id, and damages those
 // cells which weren't SPRIXCEL_OPAQUE
-int kitty_destroy(const notcurses* nc __attribute__ ((unused)),
-                  const ncpile* p, FILE* out, sprixel* s){
-  if(kitty_remove(s->id, out)){
-    return -1;
-  }
+int kitty_scrub(const ncpile* p, sprixel* s){
 //fprintf(stderr, "FROM: %d/%d state: %d s->n: %p\n", s->movedfromy, s->movedfromx, s->invalidated, s->n);
   for(int yy = s->movedfromy ; yy < s->movedfromy + s->dimy && yy < p->dimy ; ++yy){
     for(int xx = s->movedfromx ; xx < s->movedfromx + s->dimx && xx < p->dimx ; ++xx){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -419,9 +419,9 @@ int kitty_wipe(sprixel* s, int ycell, int xcell){
   return -1;
 }
 
-int kitty_commit(FILE* fp, sprixel* s){
+int kitty_commit(FILE* fp, sprixel* s, unsigned noscroll){
   loginfo("Committing Kitty graphic id %u\n", s->id);
-  fprintf(fp, "\e_Ga=p,i=%u,p=1,q=2\e\\", s->id);
+  fprintf(fp, "\e_Ga=p,i=%u,p=1,q=2%s\e\\", s->id, noscroll ? ",C=1" : "");
   s->invalidated = SPRIXEL_QUIESCENT;
   return 0;
 }
@@ -439,7 +439,6 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
     fclose(fp);
     return -1;
   }
-  bool scroll = bargs->flags & NCVISUAL_OPTION_SCROLL;
   bool translucent = bargs->flags & NCVISUAL_OPTION_BLEND;
   int sprixelid = bargs->u.pixel.spx->id;
   int cdimy = bargs->u.pixel.celldimy;
@@ -455,9 +454,8 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
 //fprintf(stderr, "total: %d chunks = %d, s=%d,v=%d\n", total, chunks, lenx, leny);
   while(chunks--){
     if(totalout == 0){
-      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,p=1,a=t,%c=1%s;",
-                             lenx, leny, sprixelid, chunks ? 'm' : 'q',
-                             scroll ? "" : ",C=1");
+      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,p=1,a=t,%c=1;",
+                             lenx, leny, sprixelid, chunks ? 'm' : 'q');
     }else{
       fprintf(fp, "\e_G%sm=%d;", chunks ? "" : "q=2,", chunks ? 1 : 0);
     }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -383,8 +383,10 @@ int kitty_wipe(sprixel* s, int ycell, int xcell){
       // the maximum number of pixels we can convert is the minimum of the
       // pixels remaining in the target row, and the pixels left in the chunk.
 //fprintf(stderr, "inchunk: %d total: %d triples: %d\n", inchunk, totalpixels, triples);
+//fprintf(stderr, "PRECHOMP:  [%.16s]\n", c + tripbytes);
       int chomped = kitty_null(c + tripbytes, tripskip, thisrow,
                                inchunk - triples * 3, auxvec + auxvecidx);
+//fprintf(stderr, "POSTCHOMP: [%.16s]\n", c + tripbytes);
       assert(chomped >= 0);
       auxvecidx += chomped;
       assert(auxvecidx <= s->cellpxy * s->cellpxx);
@@ -419,7 +421,7 @@ int kitty_wipe(sprixel* s, int ycell, int xcell){
 
 int kitty_commit(FILE* fp, sprixel* s){
   loginfo("Committing Kitty graphic id %u\n", s->id);
-  fprintf(fp, "\e_Ga=p,i=%u,p=1\e\\", s->id);
+  fprintf(fp, "\e_Ga=p,i=%u,p=1,q=2\e\\", s->id);
   s->invalidated = SPRIXEL_QUIESCENT;
   return 0;
 }
@@ -640,7 +642,7 @@ int kitty_move(const ncpile* p, sprixel* s, FILE* out){
 // clears all kitty bitmaps
 int kitty_clear_all(FILE* fp){
 //fprintf(stderr, "KITTY UNIVERSAL ERASE\n");
-  return term_emit("\e_Ga=d\e\\", fp, false);
+  return term_emit("\e_Ga=d,q=2\e\\", fp, false);
 }
 
 int kitty_shutdown(FILE* fp){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -417,6 +417,13 @@ int kitty_wipe(sprixel* s, int ycell, int xcell){
   return -1;
 }
 
+int kitty_commit(FILE* fp, sprixel* s){
+  loginfo("Committing Kitty graphic id %u\n", s->id);
+  fprintf(fp, "\e_Ga=p,i=%u,p=1\e\\", s->id);
+  s->invalidated = SPRIXEL_QUIESCENT;
+  return 0;
+}
+
 // we can only write 4KiB at a time. we're writing base64-encoded RGBA. each
 // pixel is 4B raw (32 bits). each chunk of three pixels is then 12 bytes, or
 // 16 base64-encoded bytes. 4096 / 16 == 256 3-pixel groups, or 768 pixels.
@@ -446,7 +453,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
 //fprintf(stderr, "total: %d chunks = %d, s=%d,v=%d\n", total, chunks, lenx, leny);
   while(chunks--){
     if(totalout == 0){
-      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,p=1,a=T,%c=1%s;",
+      *parse_start = fprintf(fp, "\e_Gf=32,s=%d,v=%d,i=%d,p=1,a=t,%c=1%s;",
                              lenx, leny, sprixelid, chunks ? 'm' : 'q',
                              scroll ? "" : ",C=1");
     }else{
@@ -615,7 +622,7 @@ int kitty_draw(const ncpile* p, sprixel* s, FILE* out){
   if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){
     ret = -1;
   }
-  s->invalidated = SPRIXEL_QUIESCENT;
+  s->invalidated = SPRIXEL_LOADED;
   return ret;
 }
 

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -577,7 +577,7 @@ int kitty_blit(ncplane* n, int linesize, const void* data, int leny, int lenx,
 }
 
 int kitty_remove(int id, FILE* out){
-//fprintf(stderr, "DESTROYING KITTY %d\n", id);
+  loginfo("Removing graphic %u\n", id);
   if(fprintf(out, "\e_Ga=d,d=i,i=%d\e\\", id) < 0){
     return -1;
   }

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -947,7 +947,7 @@ rasterize_sprixels(notcurses* nc, ncpile* p, FILE* out){
         if(goto_location(nc, out, y + nc->margin_t, x + nc->margin_l)){
           return -1;
         }
-        if(nc->tcache.pixel_commit(out, s) < 0){
+        if(sprite_commit(&nc->tcache, out, s, false)){
           return -1;
         }
         nc->rstate.hardcursorpos = true;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -948,6 +948,7 @@ rasterize_sprixels(notcurses* nc, ncpile* p, FILE* out){
         if(nc->tcache.pixel_commit(out, s) < 0){
           return -1;
         }
+        nc->rstate.hardcursorpos = true;
       }
     }else if(s->invalidated == SPRIXEL_HIDE){
       if(nc->tcache.pixel_remove){

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -844,7 +844,7 @@ clean_sprixels(notcurses* nc, ncpile* p, FILE* out){
   while( (s = *parent) ){
     if(s->invalidated == SPRIXEL_HIDE){
 //fprintf(stderr, "OUGHT HIDE %d [%dx%d] %p\n", s->id, s->dimy, s->dimx, s);
-      if(sprite_destroy(nc, p, out, s)){
+      if(sprite_scrub(nc, p, s)){
         return -1;
       }
       if( (*parent = s->next) ){
@@ -857,7 +857,7 @@ clean_sprixels(notcurses* nc, ncpile* p, FILE* out){
 //fprintf(stderr, "1 MOVING BITMAP %d STATE %d AT %d/%d for %p\n", s->id, s->invalidated, y + nc->margin_t, x + nc->margin_l, s->n);
       // without this, kitty flickers
       if(s->invalidated == SPRIXEL_MOVED){
-        sprite_destroy(nc, p, out, s);
+        sprite_scrub(nc, p, s);
       }
       if(goto_location(nc, out, y + nc->margin_t, x + nc->margin_l) == 0){
         int r = sprite_redraw(nc, p, s, out);

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -845,13 +845,12 @@ int sixel_draw(const ncpile* p, sprixel* s, FILE* out){
         }
       }
     }
-    s->invalidated = SPRIXEL_INVALIDATED;
-  }else{
-    if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){
-      return -1;
-    }
-    s->invalidated = SPRIXEL_QUIESCENT;
   }
+  if(fwrite(s->glyph, s->glyphlen, 1, out) != 1){
+    return -1;
+  }
+  s->invalidated = SPRIXEL_QUIESCENT;
+fprintf(stderr, "POSTDRAW: %d %d/%d\n", s->invalidated, s->movedfromy, s->movedfromx);
   return s->glyphlen;
 }
 

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -794,10 +794,8 @@ int sixel_blit(ncplane* n, int linesize, const void* data, int leny, int lenx,
 // to, though, if we've got a new sixel ready to go where the old sixel was
 // (though we'll still need to if the new sprixcell not opaque, and the
 // old and new sprixcell are different in any transparent pixel).
-int sixel_destroy(const notcurses* nc, const ncpile* p, FILE* out, sprixel* s){
+int sixel_scrub(const ncpile* p, sprixel* s){
 //fprintf(stderr, "DESTROYING %d %d %p at %d/%d (%d/%d)\n", s->id, s->invalidated, s->n, s->movedfromy, s->movedfromx, s->dimy, s->dimx);
-  (void)nc;
-  (void)out;
   int starty = s->movedfromy;
   int startx = s->movedfromx;
   for(int yy = starty ; yy < starty + s->dimy && yy < p->dimy ; ++yy){

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -823,7 +823,7 @@ int sixel_scrub(const ncpile* p, sprixel* s){
       }
     }
   }
-  return 0;
+  return 1;
 }
 
 // returns the number of bytes written
@@ -850,7 +850,6 @@ int sixel_draw(const ncpile* p, sprixel* s, FILE* out){
     return -1;
   }
   s->invalidated = SPRIXEL_QUIESCENT;
-fprintf(stderr, "POSTDRAW: %d %d/%d\n", s->invalidated, s->movedfromy, s->movedfromx);
   return s->glyphlen;
 }
 

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -41,6 +41,7 @@ void sprixel_debug(const sprixel* s, FILE* out){
 // doesn't splice us out of any lists, just frees
 void sprixel_free(sprixel* s){
   if(s){
+    loginfo("Destroying sprixel %u\n", s->id);
     if(s->n){
       s->n->sprite = NULL;
     }
@@ -82,13 +83,12 @@ void sprixel_movefrom(sprixel* s, int y, int x){
 
 void sprixel_hide(sprixel* s){
   if(ncplane_pile(s->n) == NULL){ // ncdirect case; destroy now
-//fprintf(stderr, "HIDING %d IMMEDIATELY\n", s->id);
     sprixel_free(s);
     return;
   }
   // otherwise, it'll be killed in the next rendering cycle.
   if(s->invalidated != SPRIXEL_HIDE){
-//fprintf(stderr, "HIDING %d\n", s->id);
+    loginfo("Marking sprixel %u hidden\n", s->id);
     s->invalidated = SPRIXEL_HIDE;
     s->movedfromy = ncplane_abs_y(s->n);
     s->movedfromx = ncplane_abs_x(s->n);

--- a/src/lib/stats.c
+++ b/src/lib/stats.c
@@ -218,8 +218,8 @@ void summarize_stats(notcurses* nc){
             (stats->bgemissions + stats->bgelisions) == 0 ? 0 :
             (stats->bgelisions * 100.0) / (stats->bgemissions + stats->bgelisions));
     char totalbuf[BPREFIXSTRLEN + 1];
-    qprefix(stats->sprixelbytes, 1, totalbuf, 1);
-    fprintf(stderr, "Sprixel emits:elides: %ju:%ju (%.2f%%) %sB ASUs: %ju (%.2f%%)\n",
+    bprefix(stats->sprixelbytes, 1, totalbuf, 1);
+    fprintf(stderr, "Sprixel emits:elides: %ju:%ju (%.2f%%) %sB SUM: %ju (%.2f%%)\n",
             stats->sprixelemissions, stats->sprixelelisions,
             (stats->sprixelemissions + stats->sprixelelisions) == 0 ? 0 :
             (stats->sprixelelisions * 100.0) / (stats->sprixelemissions + stats->sprixelelisions),

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -371,14 +371,10 @@ add_appsync_escapes_dcs(tinfo* ti, size_t* tablelen, size_t* tableused){
 }
 
 // Qui si convien lasciare ogne sospetto; ogne viltà convien che qui sia morta.
-// kitty's ASU implementation is broken through at least 0.21.2, see
-// https://github.com/kovidgoyal/kitty/issues/3779. until it's fixed, we don't
-// want to use kitty ASU, so we disable advertised_appsync for now FIXME.
 static int
 apply_term_heuristics(tinfo* ti, const char* termname, int fd,
                       queried_terminals_e qterm,
-                      size_t* tablelen, size_t* tableused,
-                      unsigned* advertised_appsync){
+                      size_t* tablelen, size_t* tableused){
   if(!termname){
     // setupterm interprets a missing/empty TERM variable as the special value “unknown”.
     termname = "unknown";
@@ -395,7 +391,6 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
     ti->caps.sextants = true; // work since bugfix in 0.19.3
     ti->caps.quadrants = true;
     ti->caps.rgb = true;
-    *advertised_appsync = 0; // FIXME see above
     if(add_smulx_escapes(ti, tablelen, tableused)){
       return -1;
     }
@@ -689,8 +684,7 @@ int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
       }
     }
   }
-  if(apply_term_heuristics(ti, termname, fd, qterm, &tablelen, &tableused,
-                           &appsync_advertised)){
+  if(apply_term_heuristics(ti, termname, fd, qterm, &tablelen, &tableused)){
     ncinputlayer_stop(&ti->input);
     goto err;
   }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -53,7 +53,7 @@ setup_sixel_bitmaps(tinfo* ti, int fd, bool invert80){
   }
   ti->pixel_draw = sixel_draw;
   ti->pixel_remove = NULL;
-  ti->pixel_destroy = sixel_destroy;
+  ti->pixel_scrub = sixel_scrub;
   ti->pixel_wipe = sixel_wipe;
   ti->pixel_shutdown = sixel_shutdown;
   ti->pixel_rebuild = sixel_rebuild;
@@ -67,7 +67,7 @@ setup_sixel_bitmaps(tinfo* ti, int fd, bool invert80){
 static inline void
 setup_kitty_bitmaps(tinfo* ti, int fd, int sixel_maxy_pristine){
   ti->pixel_wipe = kitty_wipe;
-  ti->pixel_destroy = kitty_destroy;
+  ti->pixel_scrub = kitty_scrub;
   ti->pixel_remove = kitty_remove;
   ti->pixel_draw = kitty_draw;
   ti->pixel_move = kitty_move;

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -52,7 +52,6 @@ setup_sixel_bitmaps(tinfo* ti, int fd, bool invert80){
     ti->pixel_init = sixel_init;
   }
   ti->pixel_draw = sixel_draw;
-  ti->pixel_remove = NULL;
   ti->pixel_scrub = sixel_scrub;
   ti->pixel_wipe = sixel_wipe;
   ti->pixel_shutdown = sixel_shutdown;

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -137,7 +137,7 @@ typedef struct tinfo {
   int (*pixel_shutdown)(FILE* fp);  // called during context shutdown
   int (*pixel_clear_all)(FILE* fp); // called during context startup
   // make a loaded graphic visible. only used with kitty.
-  int (*pixel_commit)(FILE* fp, struct sprixel* s);
+  int (*pixel_commit)(FILE* fp, struct sprixel* s, unsigned noscroll);
   uint8_t* (*pixel_trans_auxvec)(const struct tinfo* ti); // create tranparent auxvec
   // sprixel parameters. there are several different sprixel protocols, of
   // which we support sixel and kitty. the kitty protocol is used based

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -136,6 +136,8 @@ typedef struct tinfo {
   int (*pixel_scrub)(const struct ncpile* p, struct sprixel* s);
   int (*pixel_shutdown)(FILE* fp);  // called during context shutdown
   int (*pixel_clear_all)(FILE* fp); // called during context startup
+  // make a loaded graphic visible. only used with kitty.
+  int (*pixel_commit)(FILE* fp, struct sprixel* s);
   uint8_t* (*pixel_trans_auxvec)(const struct tinfo* ti); // create tranparent auxvec
   // sprixel parameters. there are several different sprixel protocols, of
   // which we support sixel and kitty. the kitty protocol is used based

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -133,7 +133,7 @@ typedef struct tinfo {
   int (*pixel_draw)(const struct ncpile* p, struct sprixel* s, FILE* out);
   // execute move (erase old graphic, place at new location) if non-NULL
   int (*pixel_move)(const struct ncpile* p, struct sprixel* s, FILE* out);
-  int (*pixel_destroy)(const struct notcurses* nc, const struct ncpile* p, FILE* out, struct sprixel* s);
+  int (*pixel_scrub)(const struct ncpile* p, struct sprixel* s);
   int (*pixel_shutdown)(FILE* fp);  // called during context shutdown
   int (*pixel_clear_all)(FILE* fp); // called during context startup
   uint8_t* (*pixel_trans_auxvec)(const struct tinfo* ti); // create tranparent auxvec

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -965,12 +965,6 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
     n->sprite = sprixel_recycle(n);
   }
   bargs.u.pixel.spx = n->sprite;
-  // if we are kitty prior to 0.20.0, we set NCVISUAL_OPTION_SCROLL so that
-  // C=1 won't be supplied. we use sixel_maxy_pristine as a side channel to
-  // encode this version information.
-  if(nc->tcache.sixel_maxy_pristine){
-    bargs.flags |= NCVISUAL_OPTION_SCROLL;
-  }
   // FIXME need to pull off the ncpile's sprixellist if anything below fails!
   // at this point, disppixy/disppixx are the output geometry (might be larger
   // than scaledy/scaledx for sixel), while scaledy/scaledx are the scaled


### PR DESCRIPTION
We don't want to transfer Kitty graphics with `a=T`, but instead with `a=t`, and then make them visible once fully up. This gets us about a 11% speedup on `xray`, and eliminates a bit of flicker in `intro` (we started flickering again after disabling Kitty SUM). Closes #1865.