### PR TITLE
Process cursor reports through user input path

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ to breaking under incorrect `TERM` values. If you're not using `xterm`, your
 * [UTF-8 Decoder Capability and Stress Test](https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt)
 * [Emoji: how do you get from U+1F355 to 🍕?](https://meowni.ca/posts/emoji-emoji-emoji/)
 * [Glyph Hell: An introduction to glyphs, as used and defined in the FreeType engine](http://chanae.walon.org/pub/ttf/ttf_glyphs.htm)
+* [Text Rendering Hates You](https://gankra.github.io/blah/text-hates-you/)
 * My wiki's [Sixel page](https://nick-black.com/dankwiki/index.php?title=Sixel) and Kitty's [extensions](https://sw.kovidgoyal.net/kitty/protocol-extensions.html).
 
 ### Useful man pages

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ each release. Download it, and install the contents as you deem fit.
   **Narrow**, heh).
 
 * If your terminal supports 3x8bit RGB color via `setaf` and `setbf` (most modern
-  terminals), but doesn't export the `rgb` terminfo capability, you can export
+  terminals), but exports neither the `RGB` nor `Tc` terminfo capability, you can export
   the `COLORTERM` environment variable as `truecolor` or `24bit`. Note that some
   terminals accept a 24-bit specification, but map it down to fewer colors.
   RGB is enabled whenever [Foot, Contour, WezTerm, or Kitty](TERMINALS.md) is identified.

--- a/include/notcurses/nckeys.h
+++ b/include/notcurses/nckeys.h
@@ -113,6 +113,9 @@ extern "C" {
 #define NCKEY_BUTTON10 suppuabize(210)
 #define NCKEY_BUTTON11 suppuabize(211)
 #define NCKEY_RELEASE  suppuabize(212)
+// never returned to the user -- when a cursor location report shows up on
+// the input, it's picked up by our internals, and used.
+#define NCKEY_CURSOR_LOCATION_REPORT suppuabize(213)
 
 // Synonyms (so far as we're concerned)
 #define NCKEY_SCROLL_UP   NCKEY_BUTTON4

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -197,7 +197,7 @@ void Tick(ncpp::NotCurses* nc, uint64_t sec) {
 
 void Ticker(ncpp::NotCurses* nc) {
   do{
-    std::this_thread::sleep_for(std::chrono::seconds{1});
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
     const uint64_t sec = (timenow_to_ns() - start) / NANOSECS_IN_SEC;
     Tick(nc, sec);
   }while(!done);

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -179,6 +179,75 @@ int ncdirect_cursor_disable(ncdirect* nc){
   return -1;
 }
 
+static int
+cursor_yx_get(int ttyfd, const char* u7, int* y, int* x){
+  if(tty_emit(u7, ttyfd)){
+    return -1;
+  }
+  bool done = false;
+  enum { // what we expect now
+    CURSOR_ESC, // 27 (0x1b)
+    CURSOR_LSQUARE,
+    CURSOR_ROW, // delimited by a semicolon
+    CURSOR_COLUMN,
+    CURSOR_R,
+  } state = CURSOR_ESC;
+  int row = 0, column = 0;
+  int r;
+  char in;
+  do{
+    while((r = read(ttyfd, &in, 1)) == 1){
+      bool valid = false;
+      switch(state){
+        case CURSOR_ESC: valid = (in == NCKEY_ESC); state = CURSOR_LSQUARE; break;
+        case CURSOR_LSQUARE: valid = (in == '['); state = CURSOR_ROW; break;
+        case CURSOR_ROW:
+          if(isdigit(in)){
+            row *= 10;
+            row += in - '0';
+            valid = true;
+          }else if(in == ';'){
+            state = CURSOR_COLUMN;
+            valid = true;
+          }
+          break;
+        case CURSOR_COLUMN:
+          if(isdigit(in)){
+            column *= 10;
+            column += in - '0';
+            valid = true;
+          }else if(in == 'R'){
+            state = CURSOR_R;
+            valid = true;
+          }
+          break;
+        case CURSOR_R: default: // logical error, whoops
+          break;
+      }
+      if(!valid){
+        logerror("Unexpected result (%c, %d) from terminal\n", in, in);
+        break;
+      }
+      if(state == CURSOR_R){
+        done = true;
+        break;
+      }
+    }
+    // need to loop 0 to handle slow terminals, see for instance screen =[
+  }while(!done && (r >= 0 || (errno == EINTR || errno == EAGAIN || errno == EBUSY)));
+  if(!done){
+    logerror("Error reading cursor location\n");
+    return -1;
+  }
+  if(y){
+    *y = row;
+  }
+  if(x){
+    *x = column;
+  }
+  return 0;
+}
+
 // if we're lacking hpa/vpa, *and* -1 is passed for one of x/y, *and* we've
 // not got a real ctermfd, we're pretty fucked. we just punt and substitute
 // 0 for that case, which hopefully only happens when running headless unit

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -429,15 +429,21 @@ handle_queued_input(ncinputlayer* nc, ncinput* ni, int leftmargin, int topmargin
   if(ni == NULL){
     ni = &nireal;
   }
-  // if there was some error in getc(), we still dole out the existing queue
-  if(nc->inputbuf_occupied == 0){
-    return -1;
-  }
-  int r = pop_input_keypress(nc);
-  char32_t ret = handle_getc(nc, r, ni, leftmargin, topmargin);
-  if(ret != (char32_t)-1){
-    ni->id = ret;
-  }
+  char32_t ret;
+  do{
+    // if there was some error in getc(), we still dole out the existing queue
+    if(nc->inputbuf_occupied == 0){
+      return -1;
+    }
+    int r = pop_input_keypress(nc);
+    ret = handle_getc(nc, r, ni, leftmargin, topmargin);
+    if(ret != (char32_t)-1){
+      ni->id = ret;
+    }
+    if(ret == NCKEY_CURSOR_LOCATION_REPORT){
+      // process this internally
+    }
+  }while(ret == NCKEY_CURSOR_LOCATION_REPORT);
   return ret;
 }
 

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -467,6 +467,7 @@ handle_queued_input(ncinputlayer* nc, ncinput* ni, int leftmargin, int topmargin
   return ret;
 }
 
+// this is where the user input chain actually calls read(2).
 static char32_t
 handle_input(ncinputlayer* nc, ncinput* ni, int leftmargin, int topmargin,
              const sigset_t* sigmask){

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -441,7 +441,8 @@ enqueue_cursor_report(ncinputlayer* nc, const ncinput* ni){
 }
 
 static char32_t
-handle_queued_input(ncinputlayer* nc, ncinput* ni, int leftmargin, int topmargin){
+handle_queued_input(ncinputlayer* nc, ncinput* ni,
+                    int leftmargin, int topmargin){
   ncinput nireal;
   if(ni == NULL){
     ni = &nireal;

--- a/src/lib/input.h
+++ b/src/lib/input.h
@@ -44,6 +44,11 @@ void ncinputlayer_stop(struct ncinputlayer* nilayer);
 // FIXME absorb into ncinputlayer_init()
 int cbreak_mode(int ttyfd, const struct termios* tpreserved);
 
+// assuming the user context is not active, go through current data looking
+// for a cursor location report. if we find none, block on input, and read if
+// appropriate. we can be interrupted by a new user context.
+void ncinput_extract_clrs(struct ncinputlayer* nilayer);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1161,7 +1161,7 @@ static inline int
 mouse_enable(FILE* out){
 // Sets the shift-escape option, allowing shift+mouse to override the standard
 // mouse protocol (mainly so copy-and-paste can still be performed).
-#define XTSHIFTESCAPE "\x1b>1s"
+#define XTSHIFTESCAPE "\x1b[>1s"
   return term_emit(XTSHIFTESCAPE "\x1b[?" SET_BTN_EVENT_MOUSE ";"
                    /*SET_FOCUS_EVENT_MOUSE ";" */SET_SGR_MODE_MOUSE "h",
                    out, true);

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1252,7 +1252,7 @@ cell_set_blitquadrants(nccell* c, unsigned tl, unsigned tr, unsigned bl, unsigne
 }
 
 // Destroy a plane and all its bound descendants.
-int ncplane_genocide(ncplane *ncp);
+int ncplane_destroy_family(ncplane *ncp);
 
 // Extract the 32-bit background channel from a cell.
 static inline uint32_t

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1159,9 +1159,13 @@ coerce_styles(FILE* out, const tinfo* ti, uint16_t* curstyle,
 
 static inline int
 mouse_enable(FILE* out){
-  return term_emit("\x1b[?" SET_BTN_EVENT_MOUSE ";"
+// Sets the shift-escape option, allowing shift+mouse to override the standard
+// mouse protocol (mainly so copy-and-paste can still be performed).
+#define XTSHIFTESCAPE "\x1b>1s"
+  return term_emit(XTSHIFTESCAPE "\x1b[?" SET_BTN_EVENT_MOUSE ";"
                    /*SET_FOCUS_EVENT_MOUSE ";" */SET_SGR_MODE_MOUSE "h",
                    out, true);
+#undef XTSHIFTESCAPE
 }
 
 static inline int

--- a/src/lib/logging.h
+++ b/src/lib/logging.h
@@ -10,6 +10,16 @@ void nclog(const char* fmt, ...);
 // logging
 extern int loglevel;
 
+#define logpanic(fmt, ...) do{ \
+  if(loglevel >= NCLOGLEVEL_PANIC){ \
+    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+  } while(0);
+
+#define logfatal(fmt, ...) do{ \
+  if(loglevel >= NCLOGLEVEL_FATAL){ \
+    nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \
+  } while(0);
+
 #define logerror(fmt, ...) do{ \
   if(loglevel >= NCLOGLEVEL_ERROR){ \
     nclog("%s:%d:" fmt, __func__, __LINE__, ##__VA_ARGS__); } \

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1159,8 +1159,8 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
     goto err;
   }
   if(ret->rstate.logendy >= 0){ // if either is set, both are
-    if(!ret->suppress_banner){
-      if(locate_cursor_early(ret, &ret->rstate.logendy, &ret->rstate.logendx)){
+    if(!ret->suppress_banner && ret->ttyfd >= 0){
+      if(locate_cursor(&ret->tcache, ret->ttyfd, &ret->rstate.logendy, &ret->rstate.logendx)){
         free_plane(ret->stdplane);
         goto err;
       }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -241,12 +241,12 @@ int update_term_dimensions(int fd, int* rows, int* cols, tinfo* tcache,
   struct winsize ws;
   int i = ioctl(fd, TIOCGWINSZ, &ws);
   if(i < 0){
-    fprintf(stderr, "TIOCGWINSZ failed on %d (%s)\n", fd, strerror(errno));
+    logerror("TIOCGWINSZ failed on %d (%s)\n", fd, strerror(errno));
     return -1;
   }
   if(ws.ws_row <= 0 || ws.ws_col <= 0){
-    fprintf(stderr, "Bogus return from TIOCGWINSZ on %d (%d/%d)\n",
-            fd, ws.ws_row, ws.ws_col);
+    logerror("Bogus return from TIOCGWINSZ on %d (%d/%d)\n",
+           fd, ws.ws_row, ws.ws_col);
     return -1;
   }
   int rowsafe;
@@ -1072,7 +1072,7 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   }
   ret->ttyfd = get_tty_fd(ret->ttyfp);
   if(recursive_lock_init(&ret->pilelock)){
-    fprintf(stderr, "Couldn't initialize pile mutex\n");
+    logfatal("Couldn't initialize pile mutex\n");
     free(ret);
     return NULL;
   }
@@ -1103,7 +1103,7 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   loglevel = opts->loglevel;
   int termerr;
   if(setupterm(opts->termtype, ret->ttyfd, &termerr) != OK){
-    fprintf(stderr, "Terminfo error %d (see terminfo(3ncurses))\n", termerr);
+    logpanic("Terminfo error %d (see terminfo(3ncurses))\n", termerr);
     drop_signals(ret);
     fclose(ret->rstate.mstreamfp);
     pthread_mutex_destroy(&ret->statlock);
@@ -1132,7 +1132,7 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   }
   ret->stdplane = NULL;
   if((ret->stdplane = create_initial_ncplane(ret, dimy, dimx)) == NULL){
-    fprintf(stderr, "Couldn't create the initial plane (bad margins?)\n");
+    logerror("Couldn't create the initial plane (bad margins?)\n");
     goto err;
   }
   reset_term_attributes(&ret->tcache, ret->ttyfp);
@@ -1192,7 +1192,7 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   return ret;
 
 err:
-  fprintf(stderr, "Alas, you will not be going to space today.\n");
+  logpanic("Alas, you will not be going to space today.\n");
   // FIXME looks like we have some memory leaks on this error path?
   if(ret->rstate.mstreamfp){
     fclose(ret->rstate.mstreamfp);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -840,7 +840,7 @@ int ncplane_destroy(ncplane* ncp){
   return ret;
 }
 
-int ncplane_genocide(ncplane *ncp){
+int ncplane_destroy_family(ncplane *ncp){
   if(ncp == NULL){
     return 0;
   }
@@ -850,7 +850,7 @@ int ncplane_genocide(ncplane *ncp){
   }
   int ret = 0;
   while(ncp->blist){
-    ret |= ncplane_genocide(ncp->blist);
+    ret |= ncplane_destroy_family(ncp->blist);
   }
   ret |= ncplane_destroy(ncp);
   return ret;

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -307,7 +307,7 @@ ncreel_draw_tablet(const ncreel* nr, nctablet* t, int frontiertop,
       if(ll){ // must be smaller than the space we provided; add back bottom
         ncplane_resize_simple(t->cbp, ll, cblenx);
       }else{
-        ncplane_genocide(t->cbp);
+        ncplane_destroy_family(t->cbp);
         t->cbp = NULL;
       }
       // resize the borderplane iff we got smaller
@@ -419,7 +419,7 @@ trim_reel_overhang(ncreel* r, nctablet* top, nctablet* bottom){
 //fprintf(stderr, "top: %dx%d @ %d, miny: %d\n", ylen, xlen, y, miny);
   if(boty < miny){
 //fprintf(stderr, "NUKING top!\n");
-    ncplane_genocide(top->p);
+    ncplane_destroy_family(top->p);
     top->p = NULL;
     top->cbp = NULL;
     top = top->next;
@@ -427,7 +427,7 @@ trim_reel_overhang(ncreel* r, nctablet* top, nctablet* bottom){
   }else if(y < miny){
     int ynew = ylen - (miny - y);
     if(ynew <= 0){
-      ncplane_genocide(top->p);
+      ncplane_destroy_family(top->p);
       top->p = NULL;
       top->cbp = NULL;
     }else{
@@ -436,7 +436,7 @@ trim_reel_overhang(ncreel* r, nctablet* top, nctablet* bottom){
       }
       if(top->cbp){
         if(ynew == !(r->ropts.tabletmask & NCBOXMASK_TOP)){
-          ncplane_genocide(top->cbp);
+          ncplane_destroy_family(top->cbp);
           top->cbp = NULL;
         }else{
           ncplane_dim_yx(top->cbp, &ylen, &xlen);
@@ -458,7 +458,7 @@ trim_reel_overhang(ncreel* r, nctablet* top, nctablet* bottom){
 //fprintf(stderr, "bot: %dx%d @ %d, maxy: %d\n", ylen, xlen, y, maxy);
   if(maxy < y){
 //fprintf(stderr, "NUKING bottom!\n");
-    ncplane_genocide(bottom->p);
+    ncplane_destroy_family(bottom->p);
     bottom->p = NULL;
     bottom->cbp = NULL;
     bottom = bottom->prev;
@@ -466,7 +466,7 @@ trim_reel_overhang(ncreel* r, nctablet* top, nctablet* bottom){
   }if(maxy < boty){
     int ynew = ylen - (boty - maxy);
     if(ynew <= 0){
-      ncplane_genocide(bottom->p);
+      ncplane_destroy_family(bottom->p);
       bottom->p = NULL;
       bottom->cbp = NULL;
     }else{
@@ -476,7 +476,7 @@ trim_reel_overhang(ncreel* r, nctablet* top, nctablet* bottom){
 //fprintf(stderr, "TRIMMED bottom %p from %d to %d (%d)\n", bottom->p, ylen, ynew, maxy - boty);
       if(bottom->cbp){
         if(ynew == !(r->ropts.tabletmask & NCBOXMASK_BOTTOM)){
-          ncplane_genocide(bottom->cbp);
+          ncplane_destroy_family(bottom->cbp);
           bottom->cbp = NULL;
         }else{
           ncplane_dim_yx(bottom->cbp, &ylen, &xlen);
@@ -596,18 +596,18 @@ clean_reel(ncreel* r){
   if(vft){
     for(nctablet* n = vft->next ; n->p && n != vft ; n = n->next){
 //fprintf(stderr, "CLEANING NEXT: %p (%p)\n", n, n->p);
-      ncplane_genocide(n->p);
+      ncplane_destroy_family(n->p);
       n->p = NULL;
       n->cbp = NULL;
     }
     for(nctablet* n = vft->prev ; n->p && n != vft ; n = n->prev){
 //fprintf(stderr, "CLEANING PREV: %p (%p)\n", n, n->p);
-      ncplane_genocide(n->p);
+      ncplane_destroy_family(n->p);
       n->p = NULL;
       n->cbp = NULL;
     }
 //fprintf(stderr, "CLEANING VFT: %p (%p)\n", vft, vft->p);
-    ncplane_genocide(vft->p);
+    ncplane_destroy_family(vft->p);
     vft->p = NULL;
     vft->cbp = NULL;
     r->vft = NULL;
@@ -840,7 +840,7 @@ int ncreel_del(ncreel* nr, struct nctablet* t){
   }
   t->next->prev = t->prev;
   if(t->p){
-    ncplane_genocide(t->p);
+    ncplane_destroy_family(t->p);
   }
   free(t);
   --nr->tabletcount;

--- a/src/lib/stats.c
+++ b/src/lib/stats.c
@@ -145,6 +145,7 @@ void notcurses_stats_reset(notcurses* nc, ncstats* stats){
   stash->sprixelelisions += nc->stats.sprixelelisions;
   stash->sprixelbytes += nc->stats.sprixelbytes;
   stash->appsync_updates += nc->stats.appsync_updates;
+  stash->input_errors += nc->stats.input_errors;
 
   stash->fbbytes = nc->stats.fbbytes;
   stash->planes = nc->stats.planes;
@@ -193,13 +194,11 @@ void summarize_stats(notcurses* nc){
             totalbuf, minbuf, avgbuf, maxbuf);
   }
   if(stats->renders || stats->failed_renders){
-    fprintf(stderr, "%ju failed render%s, %ju failed raster%s, %ju refresh%s\n",
-            stats->failed_renders,
-            stats->failed_renders == 1 ? "" : "s",
-            stats->failed_writeouts,
-            stats->failed_writeouts == 1 ? "" : "s",
-            stats->refreshes,
-            stats->refreshes == 1 ? "" : "es");
+    fprintf(stderr, "%ju failed render%s, %ju failed raster%s, %ju refresh%s, %ju input error%s\n",
+            stats->failed_renders, stats->failed_renders == 1 ? "" : "s",
+            stats->failed_writeouts, stats->failed_writeouts == 1 ? "" : "s",
+            stats->refreshes, stats->refreshes == 1 ? "" : "es",
+            stats->input_errors, stats->input_errors == 1 ? "" : "s");
     fprintf(stderr, "RGB emits:elides: def %ju:%ju fg %ju:%ju bg %ju:%ju\n",
             stats->defaultemissions,
             stats->defaultelisions,

--- a/src/lib/stats.c
+++ b/src/lib/stats.c
@@ -164,7 +164,8 @@ void summarize_stats(notcurses* nc){
     qprefix(stats->render_min_ns, NANOSECS_IN_SEC, minbuf, 0);
     qprefix(stats->render_max_ns, NANOSECS_IN_SEC, maxbuf, 0);
     qprefix(stats->render_ns / stats->renders, NANOSECS_IN_SEC, avgbuf, 0);
-    fprintf(stderr, "\n%ju render%s, %ss (%ss min, %ss avg, %ss max)\n",
+    ncfputc('\n', stdout);
+    fprintf(stderr, "%ju render%s, %ss (%ss min, %ss avg, %ss max)\n",
             stats->renders, stats->renders == 1 ? "" : "s",
             totalbuf, minbuf, avgbuf, maxbuf);
     qprefix(stats->raster_ns, NANOSECS_IN_SEC, totalbuf, 0);

--- a/src/lib/tabbed.c
+++ b/src/lib/tabbed.c
@@ -166,7 +166,7 @@ nctabbed* nctabbed_create(ncplane* n, const nctabbed_options* topts){
     nopts.rows = nrows - 1;
     if((nt->p = ncplane_create(n, &nopts)) == NULL){
       logerror("Couldn't create the tab content plane");
-      ncplane_genocide(n);
+      ncplane_destroy_family(n);
       free(nt);
       return NULL;
     }
@@ -174,7 +174,7 @@ nctabbed* nctabbed_create(ncplane* n, const nctabbed_options* topts){
     nopts.rows = 1;
     if((nt->hp = ncplane_create(n, &nopts)) == NULL){
       logerror("Couldn't create the tab headers plane");
-      ncplane_genocide(n);
+      ncplane_destroy_family(n);
       free(nt);
       return NULL;
     }
@@ -184,7 +184,7 @@ nctabbed* nctabbed_create(ncplane* n, const nctabbed_options* topts){
     nopts.rows = 1;
     if((nt->hp = ncplane_create(n, &nopts)) == NULL){
       logerror("Couldn't create the tab headers plane");
-      ncplane_genocide(n);
+      ncplane_destroy_family(n);
       free(nt);
       return NULL;
     }
@@ -192,7 +192,7 @@ nctabbed* nctabbed_create(ncplane* n, const nctabbed_options* topts){
     nopts.rows = nrows - 1;
     if((nt->p = ncplane_create(n, &nopts)) == NULL){
       logerror("Couldn't create the tab content plane");
-      ncplane_genocide(n);
+      ncplane_destroy_family(n);
       free(nt);
       return NULL;
     }
@@ -398,7 +398,7 @@ void nctabbed_destroy(nctabbed* nt){
     free(t);
     t = tmp;
   }
-  ncplane_genocide(nt->ncp);
+  ncplane_destroy_family(nt->ncp);
   free(nt->opts.separator);
   free(nt);
 }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -800,7 +800,7 @@ int locate_cursor(tinfo* ti, int fd, int* cursor_y, int* cursor_x){
     // this can block. we must enter holding the input lock, and it will
     // return to us holding the input lock.
     ncinput_extract_clrs(&ti->input);
-    if((clr = ti->input.creport_queue) == NULL){
+    if( (clr = ti->input.creport_queue) ){
       logdebug("Hustled up a CL report\n");
       break;
     }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -91,19 +91,19 @@ setup_kitty_bitmaps(tinfo* ti, int fd, int sixel_maxy_pristine){
 
 static bool
 query_rgb(void){
-  bool rgb = tigetflag("RGB") == 1;
+  bool rgb = (tigetflag("RGB") > 1 || tigetflag("Tc") > 1);
   if(!rgb){
-    // RGB terminfo capability being a new thing (as of ncurses 6.1), it's not commonly found in
-    // terminal entries today. COLORTERM, however, is a de-facto (if imperfect/kludgy) standard way
-    // of indicating TrueColor support for a terminal. The variable takes one of two case-sensitive
+    // RGB terminfo capability being a new thing (as of ncurses 6.1), it's not
+    // commonly found in terminal entries today. COLORTERM, however, is a
+    // de-facto (if imperfect/kludgy) standard way of indicating TrueColor
+    // support for a terminal. The variable takes one of two case-sensitive
     // values:
     //
     //   truecolor
     //   24bit
     //
-    // https://gist.github.com/XVilka/8346728#true-color-detection gives some more information about
-    // the topic
-    //
+    // https://gist.github.com/XVilka/8346728#true-color-detection gives some
+    // more information about the topic.
     const char* cterm = getenv("COLORTERM");
     rgb = cterm && (strcmp(cterm, "truecolor") == 0 || strcmp(cterm, "24bit") == 0);
   }
@@ -601,7 +601,6 @@ int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
     ti->caps.colors = colors;
   }
   ti->caps.rgb = query_rgb(); // independent of colors
-  // verify that the terminal provides cursor addressing (absolute movement)
   const struct strtdesc {
     escape_e esc;
     const char* tinfo;
@@ -645,6 +644,7 @@ int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
       goto err;
     }
   }
+  // verify that the terminal provides cursor addressing (absolute movement)
   if(ti->escindices[ESCAPE_CUP] == 0){
     fprintf(stderr, "Required terminfo capability 'cup' not defined\n");
     goto err;

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -784,19 +784,19 @@ int locate_cursor(tinfo* ti, int fd, int* cursor_y, int* cursor_x){
   }
   bool emitted_u7 = false; // only want to send one max
   cursorreport* clr;
-  pthread_mutex_lock(&ti->input.creport_lock);
+  pthread_mutex_lock(&ti->input.lock);
   while((clr = ti->input.creport_queue) == NULL){
     if(!emitted_u7){
       // FIXME i'd rather not do this while holding the lock =[
       if(tty_emit(u7, fd)){
-        pthread_mutex_unlock(&ti->input.creport_lock);
+        pthread_mutex_unlock(&ti->input.lock);
         return -1;
       }
       emitted_u7 = true;
     }
-    pthread_cond_wait(&ti->input.creport_cond, &ti->input.creport_lock);
+    pthread_cond_wait(&ti->input.creport_cond, &ti->input.lock);
   }
-  pthread_mutex_unlock(&ti->input.creport_lock);
+  pthread_mutex_unlock(&ti->input.lock);
   *cursor_y = clr->y;
   *cursor_x = clr->x;
   if(ti->inverted_cursor){

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -213,11 +213,7 @@ void free_terminfo_cache(tinfo* ti);
 // return a heap-allocated copy of termname + termversion
 char* termdesc_longterm(const tinfo* ti);
 
-// get the cursor location early (after interrogate_terminfo(), but before
-// handing control back to the user). blocking call. FIXME this should go away
-// once we have proper input handling that separates out control sequences.
-int locate_cursor_early(struct notcurses* nc, int* cursor_y, int* cursor_x);
-int cursor_yx_get(int ttyfd, const char* u7, int* y, int* x);
+int locate_cursor(tinfo* ti, int fd, int* cursor_y, int* cursor_x);
 
 #ifdef __cplusplus
 }

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -103,6 +103,8 @@ typedef struct ncinputlayer {
   uint64_t input_events;
   struct esctrie* inputescapes; // trie of input escapes -> ncspecial_keys
   cursorreport* creport_queue; // queue of cursor reports
+  pthread_mutex_t creport_lock;
+  pthread_cond_t creport_cond;
 } ncinputlayer;
 
 // terminal interface description. most of these are acquired from terminfo(5)

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -107,6 +107,8 @@ typedef struct ncinputlayer {
   struct esctrie* inputescapes; // trie of input escapes -> ncspecial_keys
   cursorreport* creport_queue; // queue of cursor reports
   pthread_cond_t creport_cond;
+  bool user_wants_data;        // a user context is active
+  bool inner_wants_data;       // if we're blocking on input
 } ncinputlayer;
 
 // terminal interface description. most of these are acquired from terminfo(5)

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -84,6 +84,9 @@ typedef struct cursorreport {
 // read data only from stdin and control only from the tty. if we have
 // no connected tty, only data is available.
 typedef struct ncinputlayer {
+  // only allow one reader at a time, whether it's the user trying to do so,
+  // or our desire for a cursor report competing with the user.
+  pthread_mutex_t lock;
   // ttyfd is only valid if we are connected to a tty, *and* stdin is not
   // connected to that tty. in that case, we read control sequences only
   // from ttyfd.
@@ -103,7 +106,6 @@ typedef struct ncinputlayer {
   uint64_t input_events;
   struct esctrie* inputescapes; // trie of input escapes -> ncspecial_keys
   cursorreport* creport_queue; // queue of cursor reports
-  pthread_mutex_t creport_lock;
   pthread_cond_t creport_cond;
 } ncinputlayer;
 

--- a/src/poc/sgr-full.c
+++ b/src/poc/sgr-full.c
@@ -18,8 +18,6 @@ int main(void){
   // FIXME do full permutations?
   ncplane_set_styles(n, NCSTYLE_NONE);
   ncplane_putstr_yx(n, y++, 0, "a ═ none");
-  ncplane_set_styles(n, NCSTYLE_BLINK);
-  ncplane_putstr_yx(n, y++, 0, "a ═ blink");
   ncplane_set_styles(n, NCSTYLE_ITALIC);
   ncplane_putstr_yx(n, y++, 0, "a ═ italic");
   ncplane_set_styles(n, NCSTYLE_BOLD);
@@ -32,16 +30,18 @@ int main(void){
   ncplane_putstr_yx(n, y++, 0, "a ═ struck");
   ncplane_set_styles(n, NCSTYLE_ITALIC | NCSTYLE_BOLD);
   ncplane_putstr_yx(n, y++, 0, "a ═ italic bold");
+  ncplane_set_styles(n, NCSTYLE_ITALIC | NCSTYLE_BOLD | NCSTYLE_STRUCK);
+  ncplane_putstr_yx(n, y++, 0, "a ═ italic bold struck");
   ncplane_set_styles(n, NCSTYLE_ITALIC | NCSTYLE_UNDERCURL);
   ncplane_putstr_yx(n, y++, 0, "a ═ italic undercurl");
   ncplane_set_styles(n, NCSTYLE_ITALIC | NCSTYLE_UNDERLINE);
   ncplane_putstr_yx(n, y++, 0, "a ═ italic underline");
   ncplane_set_styles(n, NCSTYLE_ITALIC | NCSTYLE_STRUCK);
   ncplane_putstr_yx(n, y++, 0, "a ═ italic struck");
-  ncplane_set_styles(n, NCSTYLE_ITALIC | NCSTYLE_STRUCK);
-  ncplane_putstr_yx(n, y++, 0, "a ═ italic struck");
   ncplane_set_styles(n, NCSTYLE_STRUCK | NCSTYLE_BOLD);
   ncplane_putstr_yx(n, y++, 0, "a ═ struck bold");
+  ncplane_set_styles(n, NCSTYLE_STRUCK | NCSTYLE_BOLD | NCSTYLE_ITALIC);
+  ncplane_putstr_yx(n, y++, 0, "a ═ struck bold italic");
   ncplane_set_styles(n, NCSTYLE_STRUCK | NCSTYLE_UNDERCURL);
   ncplane_putstr_yx(n, y++, 0, "a ═ struck undercurl");
   ncplane_set_styles(n, NCSTYLE_STRUCK | NCSTYLE_UNDERLINE);
@@ -66,10 +66,6 @@ int main(void){
   ncplane_putstr_yx(n, y++, 0, "a ═ bold underline italic struck");
   ncplane_set_styles(n, NCSTYLE_BOLD | NCSTYLE_UNDERCURL | NCSTYLE_ITALIC | NCSTYLE_STRUCK);
   ncplane_putstr_yx(n, y++, 0, "a ═ bold undercurl italic struck");
-  ncplane_set_styles(n, NCSTYLE_BOLD | NCSTYLE_UNDERLINE | NCSTYLE_ITALIC | NCSTYLE_STRUCK | NCSTYLE_BLINK);
-  ncplane_putstr_yx(n, y++, 0, "a ═ bold underline italic struck blink");
-  ncplane_set_styles(n, NCSTYLE_BOLD | NCSTYLE_UNDERCURL | NCSTYLE_ITALIC | NCSTYLE_STRUCK | NCSTYLE_BLINK);
-  ncplane_putstr_yx(n, y++, 0, "a ═ bold undercurl italic struck blink");
 
   ncplane_set_styles(n, NCSTYLE_NONE);
   if(notcurses_render(nc)){


### PR DESCRIPTION
With the advent of CLI mode, we'll be needing to get cursor location reports in rendered mode. We can't just call into `read()` on the input fd while the user might be doing that same thing, though. If the user *isn't* looking for input, though, we can't just block and wait for them to do so. Instead, we need be able to trigger `read()`s from both paths, but only allow one to do so at any given time. When we're doing so, as opposed to the user, we go through the buffer of read material, pulling items out, and putting them back if they're not cursor reports. Closes #1692.