### PR TITLE
Added compile target for dummy python module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -884,3 +884,9 @@ install(
     NAMELINK_COMPONENT Development
 )
 endif()
+
+option(DUMMY_PYTHON "Build dummy python module used for compile check and Clangd" OFF)
+if(${DUMMY_PYTHON})
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+add_subdirectory("./python")
+endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,33 @@
+include(FindPkgConfig)
+pkg_search_module(PYTHON3 REQUIRED python3)
+
+set(NOTCURSES_PYTHON_SRC
+    notcurses/context.c
+    notcurses/misc.c
+    notcurses/channels.c
+    notcurses/main.c
+    notcurses/notcurses-python.h
+    notcurses/plane.c
+)
+
+add_library(
+    dummy_python MODULE
+    ${NOTCURSES_PYTHON_SRC}
+)
+
+target_include_directories(
+    dummy_python
+    PRIVATE ${PYTHON3_INCLUDE_DIRS}
+    PRIVATE "${PROJECT_SOURCE_DIR}/include"
+)
+
+target_link_libraries(
+    dummy_python
+    PRIVATE
+    notcurses
+)
+
+target_compile_options(
+    dummy_python
+    PRIVATE -Wall -Wextra
+)


### PR DESCRIPTION
Mostly used to check compilation and for Clangd LSP.

Not very familiar with CMake but I think I made it not compile by default.