### PR TITLE
display images with iterm2 protocol

### DIFF
--- a/src/info/main.c
+++ b/src/info/main.c
@@ -334,11 +334,11 @@ tinfo_debug_bitmaps(struct ncplane* n, const tinfo* ti, const char* indent){
         ncplane_printf(n, "%ssixel colorregs: %u\n", indent, ti->color_registers);
       }
     }else if(ti->pixel_move == NULL){
-      ncplane_printf(n, "%siTerm2 graphics supported\n", indent);
+      ncplane_printf(n, "%siTerm2 graphics support\n", indent);
     }else if(ti->sixel_maxy_pristine){
-      ncplane_printf(n, "%srgba pixel graphics supported\n", indent);
+      ncplane_printf(n, "%srgba pixel graphics support\n", indent);
     }else{
-      ncplane_printf(n, "%srgba pixel animation supported\n", indent);
+      ncplane_printf(n, "%srgba pixel animation support\n", indent);
     }
     char* path = prefix_data("notcurses.png");
     if(path){

--- a/src/info/main.c
+++ b/src/info/main.c
@@ -333,6 +333,8 @@ tinfo_debug_bitmaps(struct ncplane* n, const tinfo* ti, const char* indent){
       }else{
         ncplane_printf(n, "%ssixel colorregs: %u\n", indent, ti->color_registers);
       }
+    }else if(ti->pixel_move == NULL){
+      ncplane_printf(n, "%siTerm2 graphics supported\n", indent);
     }else if(ti->sixel_maxy_pristine){
       ncplane_printf(n, "%srgba pixel graphics supported\n", indent);
     }else{

--- a/src/lib/base64.h
+++ b/src/lib/base64.h
@@ -83,6 +83,29 @@ base64x3(const unsigned char* src, char* b64){
   b64[3] = b64subs[d];
 }
 
+// finalize a base64 stream with 3 or fewer 8-bit bytes
+static inline void
+base64final(const unsigned char* src, char* b64, size_t b){
+  if(b == 3){
+    base64x3(src, b64);
+  }else if(b == 2){
+    uint8_t s0 = src[0] >> 2u;
+    uint8_t s1 = ((src[0] & 0x3u) << 4u) + ((src[1] & 0xf0u) >> 4u);
+    uint8_t s2 = ((src[1] & 0x0fu) << 2u);
+    b64[0] = b64subs[s0];
+    b64[1] = b64subs[s1];
+    b64[2] = b64subs[s2];
+    b64[3] = '=';
+  }else{ // b == 1
+    uint8_t s0 = src[0] >> 2u;
+    uint8_t s1 = (src[0] & 0x3u) << 4u;
+    b64[0] = b64subs[s0];
+    b64[1] = b64subs[s1];
+    b64[2] = '=';
+    b64[3] = '=';
+  }
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/base64.h
+++ b/src/lib/base64.h
@@ -75,7 +75,7 @@ static inline void
 base64x3(const unsigned char* src, char* b64){
   uint8_t a = src[0] >> 2u;
   uint8_t b = ((src[0] & 0x3u) << 4u) + ((src[1] & 0xf0u) >> 4u);
-  uint8_t c = ((src[1] & 0x0fu) << 2u) + ((src[2] & 0xb0u) >> 6u);
+  uint8_t c = ((src[1] & 0x0fu) << 2u) + ((src[2] & 0xc0u) >> 6u);
   uint8_t d = src[2] & 0x3f;
   b64[0] = b64subs[a];
   b64[1] = b64subs[b];

--- a/src/lib/base64.h
+++ b/src/lib/base64.h
@@ -1,0 +1,90 @@
+#ifndef NOTCURSES_PNG
+#define NOTCURSES_PNG
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// lookup table for base64
+static unsigned const char b64subs[] =
+ "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+// every 3 RGBA pixels (96 bits) become 16 base64-encoded bytes (128 bits). if
+// there are only 2 pixels available, those 64 bits become 12 bytes. if there
+// is only 1 pixel available, those 32 bits become 8 bytes. (pcount + 1) * 4
+// bytes are used, plus a null terminator. we thus must receive 17.
+static inline void
+base64_rgba3(const uint32_t* pixels, size_t pcount, char* b64, bool wipe[static 3],
+             uint32_t transcolor){
+  uint32_t pixel = *pixels++;
+  unsigned r = ncpixel_r(pixel);
+  unsigned g = ncpixel_g(pixel);
+  unsigned b = ncpixel_b(pixel);
+  // we go ahead and take advantage of kitty's ability to reproduce 8-bit
+  // alphas by copying it in directly, rather than mapping to {0, 255}.
+  unsigned a = ncpixel_a(pixel);
+  if(wipe[0] || rgba_trans_p(pixel, transcolor)){
+    a = 0;
+  }
+  b64[0] = b64subs[(r & 0xfc) >> 2];
+  b64[1] = b64subs[(r & 0x3 << 4) | ((g & 0xf0) >> 4)];
+  b64[2] = b64subs[((g & 0xf) << 2) | ((b & 0xc0) >> 6)];
+  b64[3] = b64subs[b & 0x3f];
+  b64[4] = b64subs[(a & 0xfc) >> 2];
+  if(pcount == 1){
+    b64[5] = b64subs[(a & 0x3) << 4];
+    b64[6] = '=';
+    b64[7] = '=';
+    b64[8] = '\0';
+    return;
+  }
+  b64[5] = (a & 0x3) << 4;
+  pixel = *pixels++;
+  r = ncpixel_r(pixel);
+  g = ncpixel_g(pixel);
+  b = ncpixel_b(pixel);
+  a = wipe[1] ? 0 : rgba_trans_p(pixel, transcolor) ? 0 : 255;
+  b64[5] = b64subs[b64[5] | ((r & 0xf0) >> 4)];
+  b64[6] = b64subs[((r & 0xf) << 2) | ((g & 0xc0) >> 6u)];
+  b64[7] = b64subs[g & 0x3f];
+  b64[8] = b64subs[(b & 0xfc) >> 2];
+  b64[9] = b64subs[((b & 0x3) << 4) | ((a & 0xf0) >> 4)];
+  if(pcount == 2){
+    b64[10] = b64subs[(a & 0xf) << 2];
+    b64[11] = '=';
+    b64[12] = '\0';
+    return;
+  }
+  b64[10] = (a & 0xf) << 2;
+  pixel = *pixels;
+  r = ncpixel_r(pixel);
+  g = ncpixel_g(pixel);
+  b = ncpixel_b(pixel);
+  a = wipe[2] ? 0 : rgba_trans_p(pixel, transcolor) ? 0 : 255;
+  b64[10] = b64subs[b64[10] | ((r & 0xc0) >> 6)];
+  b64[11] = b64subs[r & 0x3f];
+  b64[12] = b64subs[(g & 0xfc) >> 2];
+  b64[13] = b64subs[((g & 0x3) << 4) | ((b & 0xf0) >> 4)];
+  b64[14] = b64subs[((b & 0xf) << 2) | ((a & 0xc0) >> 6)];
+  b64[15] = b64subs[a & 0x3f];
+  b64[16] = '\0';
+}
+
+// convert 3 8-bit bytes into 4 base64-encoded characters
+static inline void
+base64x3(const unsigned char* src, char* b64){
+  uint8_t a = src[0] >> 2u;
+  uint8_t b = ((src[0] & 0x3u) << 4u) + ((src[1] & 0xf0u) >> 4u);
+  uint8_t c = ((src[1] & 0x0fu) << 2u) + ((src[2] & 0xb0u) >> 6u);
+  uint8_t d = src[2] & 0x3f;
+  b64[0] = b64subs[a];
+  b64[1] = b64subs[b];
+  b64[2] = b64subs[c];
+  b64[3] = b64subs[d];
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -63,8 +63,7 @@ rgba_trans_q(const unsigned char* p, uint32_t transcolor){
 // Retarded RGBA blitter (ASCII only).
 static inline int
 tria_blit_ascii(ncplane* nc, int linesize, const void* data,
-                int leny, int lenx, const blitterargs* bargs,
-                int bpp){
+                int leny, int lenx, const blitterargs* bargs){
 //fprintf(stderr, "ASCII %d X %d @ %d X %d (%p) place: %d X %d\n", leny, lenx, bargs->begy, bargs->begx, data, bargs->u.cell.placey, bargs->u.cell.placex);
   const bool blendcolors = bargs->flags & NCVISUAL_OPTION_BLEND;
   int dimy, dimx, x, y;
@@ -85,8 +84,8 @@ tria_blit_ascii(ncplane* nc, int linesize, const void* data,
       if(x < 0){
         continue;
       }
-      const unsigned char* rgbbase_up = dat + (linesize * visy) + (visx * bpp / CHAR_BIT);
-//fprintf(stderr, "[%04d/%04d] bpp: %d lsize: %d %02x %02x %02x %02x\n", y, x, bpp, linesize, rgbbase_up[0], rgbbase_up[1], rgbbase_up[2], rgbbase_up[3]);
+      const unsigned char* rgbbase_up = dat + (linesize * visy) + (visx * 4);
+//fprintf(stderr, "[%04d/%04d] lsize: %d %02x %02x %02x %02x\n", y, x, linesize, rgbbase_up[0], rgbbase_up[1], rgbbase_up[2], rgbbase_up[3]);
       nccell* c = ncplane_cell_ref_yx(nc, y, x);
       // use the default for the background, as that's the only way it's
       // effective in that case anyway
@@ -118,7 +117,7 @@ tria_blit_ascii(ncplane* nc, int linesize, const void* data,
 // combined with 1:1 pixel aspect ratio.
 static inline int
 tria_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
-          const blitterargs* bargs, int bpp){
+          const blitterargs* bargs){
   const bool blendcolors = bargs->flags & NCVISUAL_OPTION_BLEND;
 //fprintf(stderr, "HALF %d X %d @ %d X %d (%p) place: %d X %d\n", leny, lenx, bargs->begy, bargs->begx, data, bargs->u.cell.placey, bargs->u.cell.placex);
   uint32_t transcolor = bargs->transcolor;
@@ -140,12 +139,12 @@ tria_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
       if(x < 0){
         continue;
       }
-      const unsigned char* rgbbase_up = dat + (linesize * visy) + (visx * bpp / CHAR_BIT);
+      const unsigned char* rgbbase_up = dat + (linesize * visy) + (visx * 4);
       const unsigned char* rgbbase_down = zeroes;
       if(visy < bargs->begy + leny - 1){
-        rgbbase_down = dat + (linesize * (visy + 1)) + (visx * bpp / CHAR_BIT);
+        rgbbase_down = dat + (linesize * (visy + 1)) + (visx * 4);
       }
-//fprintf(stderr, "[%04d/%04d] bpp: %d lsize: %d %02x %02x %02x %02x\n", y, x, bpp, linesize, rgbbase_up[0], rgbbase_up[1], rgbbase_up[2], rgbbase_up[3]);
+//fprintf(stderr, "[%04d/%04d] lsize: %d %02x %02x %02x %02x\n", y, x, linesize, rgbbase_up[0], rgbbase_up[1], rgbbase_up[2], rgbbase_up[3]);
       nccell* c = ncplane_cell_ref_yx(nc, y, x);
       // use the default for the background, as that's the only way it's
       // effective in that case anyway
@@ -450,7 +449,7 @@ qtrans_check(nccell* c, unsigned blendcolors,
 // our disposal (foreground and background), we lose some fidelity.
 static inline int
 quadrant_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
-              const blitterargs* bargs, int bpp){
+              const blitterargs* bargs){
   const unsigned nointerpolate = bargs->flags & NCVISUAL_OPTION_NOINTERPOLATE;
   const bool blendcolors = bargs->flags & NCVISUAL_OPTION_BLEND;
   int dimy, dimx, x, y;
@@ -472,20 +471,20 @@ quadrant_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
       if(x < 0){
         continue;
       }
-      const unsigned char* rgbbase_tl = dat + (linesize * visy) + (visx * bpp / CHAR_BIT);
+      const unsigned char* rgbbase_tl = dat + (linesize * visy) + (visx * 4);
       const unsigned char* rgbbase_tr = zeroes;
       const unsigned char* rgbbase_bl = zeroes;
       const unsigned char* rgbbase_br = zeroes;
       if(visx < bargs->begx + lenx - 1){
-        rgbbase_tr = dat + (linesize * visy) + ((visx + 1) * bpp / CHAR_BIT);
+        rgbbase_tr = dat + (linesize * visy) + ((visx + 1) * 4);
         if(visy < bargs->begy + leny - 1){
-          rgbbase_br = dat + (linesize * (visy + 1)) + ((visx + 1) * bpp / CHAR_BIT);
+          rgbbase_br = dat + (linesize * (visy + 1)) + ((visx + 1) * 4);
         }
       }
       if(visy < bargs->begy + leny - 1){
-        rgbbase_bl = dat + (linesize * (visy + 1)) + (visx * bpp / CHAR_BIT);
+        rgbbase_bl = dat + (linesize * (visy + 1)) + (visx * 4);
       }
-//fprintf(stderr, "[%04d/%04d] bpp: %d lsize: %d %02x %02x %02x %02x\n", y, x, bpp, linesize, rgbbase_tl[0], rgbbase_tr[1], rgbbase_bl[2], rgbbase_br[3]);
+//fprintf(stderr, "[%04d/%04d] lsize: %d %02x %02x %02x %02x\n", y, x, linesize, rgbbase_tl[0], rgbbase_tr[1], rgbbase_bl[2], rgbbase_br[3]);
       nccell* c = ncplane_cell_ref_yx(nc, y, x);
       c->channels = 0;
       c->stylemask = 0;
@@ -671,7 +670,7 @@ sex_trans_check(cell* c, const uint32_t rgbas[6], unsigned blendcolors,
 // our disposal (foreground and background), we lose some fidelity.
 static inline int
 sextant_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
-             const blitterargs* bargs, int bpp){
+             const blitterargs* bargs){
   const unsigned nointerpolate = bargs->flags & NCVISUAL_OPTION_NOINTERPOLATE;
   const bool blendcolors = bargs->flags & NCVISUAL_OPTION_BLEND;
   int dimy, dimx, x, y;
@@ -693,20 +692,20 @@ sextant_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
         continue;
       }
       uint32_t rgbas[6] = { 0, 0, 0, 0, 0, 0 };
-      memcpy(&rgbas[0], (dat + (linesize * visy) + (visx * bpp / CHAR_BIT)), sizeof(*rgbas));
+      memcpy(&rgbas[0], (dat + (linesize * visy) + (visx * 4)), sizeof(*rgbas));
       if(visx < bargs->begx + lenx - 1){
-        memcpy(&rgbas[1], (dat + (linesize * visy) + ((visx + 1) * bpp / CHAR_BIT)), sizeof(*rgbas));
+        memcpy(&rgbas[1], (dat + (linesize * visy) + ((visx + 1) * 4)), sizeof(*rgbas));
         if(visy < bargs->begy + leny - 1){
-          memcpy(&rgbas[3], (dat + (linesize * (visy + 1)) + ((visx + 1) * bpp / CHAR_BIT)), sizeof(*rgbas));
+          memcpy(&rgbas[3], (dat + (linesize * (visy + 1)) + ((visx + 1) * 4)), sizeof(*rgbas));
           if(visy < bargs->begy + leny - 2){
-            memcpy(&rgbas[5], (dat + (linesize * (visy + 2)) + ((visx + 1) * bpp / CHAR_BIT)), sizeof(*rgbas));
+            memcpy(&rgbas[5], (dat + (linesize * (visy + 2)) + ((visx + 1) * 4)), sizeof(*rgbas));
           }
         }
       }
       if(visy < bargs->begy + leny - 1){
-        memcpy(&rgbas[2], (dat + (linesize * (visy + 1)) + (visx * bpp / CHAR_BIT)), sizeof(*rgbas));
+        memcpy(&rgbas[2], (dat + (linesize * (visy + 1)) + (visx * 4)), sizeof(*rgbas));
         if(visy < bargs->begy + leny - 2){
-          memcpy(&rgbas[4], (dat + (linesize * (visy + 2)) + (visx * bpp / CHAR_BIT)), sizeof(*rgbas));
+          memcpy(&rgbas[4], (dat + (linesize * (visy + 2)) + (visx * 4)), sizeof(*rgbas));
         }
       }
       nccell* c = ncplane_cell_ref_yx(nc, y, x);
@@ -746,7 +745,7 @@ fold_rgb8(unsigned* restrict r, unsigned* restrict g, unsigned* restrict b,
 // resolution. always transparent background.
 static inline int
 braille_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
-             const blitterargs* bargs, int bpp){
+             const blitterargs* bargs){
   const bool blendcolors = bargs->flags & NCVISUAL_OPTION_BLEND;
   int dimy, dimx, x, y;
   int total = 0; // number of cells written
@@ -766,7 +765,7 @@ braille_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
       if(x < 0){
         continue;
       }
-      const uint32_t* rgbbase_l0 = (const uint32_t*)(dat + (linesize * visy) + (visx * bpp / CHAR_BIT));
+      const uint32_t* rgbbase_l0 = (const uint32_t*)(dat + (linesize * visy) + (visx * 4));
       const uint32_t* rgbbase_r0 = &zeroes32;
       const uint32_t* rgbbase_l1 = &zeroes32;
       const uint32_t* rgbbase_r1 = &zeroes32;
@@ -778,23 +777,23 @@ braille_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
       unsigned blends = 0;
       unsigned egcidx = 0;
       if(visx < bargs->begx + lenx - 1){
-        rgbbase_r0 = (const uint32_t*)(dat + (linesize * visy) + ((visx + 1) * bpp / CHAR_BIT));
+        rgbbase_r0 = (const uint32_t*)(dat + (linesize * visy) + ((visx + 1) * 4));
         if(visy < bargs->begy + leny - 1){
-          rgbbase_r1 = (const uint32_t*)(dat + (linesize * (visy + 1)) + ((visx + 1) * bpp / CHAR_BIT));
+          rgbbase_r1 = (const uint32_t*)(dat + (linesize * (visy + 1)) + ((visx + 1) * 4));
           if(visy < bargs->begy + leny - 2){
-            rgbbase_r2 = (const uint32_t*)(dat + (linesize * (visy + 2)) + ((visx + 1) * bpp / CHAR_BIT));
+            rgbbase_r2 = (const uint32_t*)(dat + (linesize * (visy + 2)) + ((visx + 1) * 4));
             if(visy < bargs->begy + leny - 3){
-              rgbbase_r3 = (const uint32_t*)(dat + (linesize * (visy + 3)) + ((visx + 1) * bpp / CHAR_BIT));
+              rgbbase_r3 = (const uint32_t*)(dat + (linesize * (visy + 3)) + ((visx + 1) * 4));
             }
           }
         }
       }
       if(visy < bargs->begy + leny - 1){
-        rgbbase_l1 = (const uint32_t*)(dat + (linesize * (visy + 1)) + (visx * bpp / CHAR_BIT));
+        rgbbase_l1 = (const uint32_t*)(dat + (linesize * (visy + 1)) + (visx * 4));
         if(visy < bargs->begy + leny - 2){
-          rgbbase_l2 = (const uint32_t*)(dat + (linesize * (visy + 2)) + (visx * bpp / CHAR_BIT));
+          rgbbase_l2 = (const uint32_t*)(dat + (linesize * (visy + 2)) + (visx * 4));
           if(visy < bargs->begy + leny - 3){
-            rgbbase_l3 = (const uint32_t*)(dat + (linesize * (visy + 3)) + (visx * bpp / CHAR_BIT));
+            rgbbase_l3 = (const uint32_t*)(dat + (linesize * (visy + 3)) + (visx * 4));
           }
         }
       }
@@ -836,7 +835,7 @@ braille_blit(ncplane* nc, int linesize, const void* data, int leny, int lenx,
         egcidx |= 128u;
         fold_rgb8(&r, &g, &b, rgbbase_r3, &blends);
       }
-//fprintf(stderr, "[%04d/%04d] bpp: %d lsize: %d %02x %02x %02x %02x\n", y, x, bpp, linesize, rgbbase_up[0], rgbbase_up[1], rgbbase_up[2], rgbbase_up[3]);
+//fprintf(stderr, "[%04d/%04d] lsize: %d %02x %02x %02x %02x\n", y, x, linesize, rgbbase_up[0], rgbbase_up[1], rgbbase_up[2], rgbbase_up[3]);
       nccell* c = ncplane_cell_ref_yx(nc, y, x);
       // use the default for the background, as that's the only way it's
       // effective in that case anyway
@@ -1076,7 +1075,7 @@ int ncblit_rgba(const void* data, int linesize, const struct ncvisual_options* v
       },
     },
   };
-  return bset->blit(nc, linesize, data, leny, lenx, &bargs, 32);
+  return bset->blit(nc, linesize, data, leny, lenx, &bargs);
 }
 
 ncblitter_e ncvisual_media_defblitter(const notcurses* nc, ncscale_e scale){

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -404,8 +404,7 @@ typedef struct blitterargs {
 // from scaling. we might actually need more pixels due to framing concerns,
 // in which case just assume transparent input pixels where needed.
 typedef int (*ncblitter)(struct ncplane* n, int linesize, const void* data,
-                         int scaledy, int scaledx, const blitterargs* bargs,
-                         int bpp);
+                         int scaledy, int scaledx, const blitterargs* bargs);
 
 // a system for rendering RGBA pixels as text glyphs or sixel/kitty bitmaps
 struct blitset {
@@ -1599,9 +1598,8 @@ const struct blitset* lookup_blitset(const tinfo* tcache, ncblitter_e setid, boo
 static inline int
 rgba_blit_dispatch(ncplane* nc, const struct blitset* bset,
                    int linesize, const void* data,
-                   int leny, int lenx, const blitterargs* bargs,
-                   int bpp){
-  return bset->blit(nc, linesize, data, leny, lenx, bargs, bpp);
+                   int leny, int lenx, const blitterargs* bargs){
+  return bset->blit(nc, linesize, data, leny, lenx, bargs);
 }
 
 static inline const struct blitset*

--- a/src/lib/iterm.c
+++ b/src/lib/iterm.c
@@ -1,0 +1,33 @@
+// the iterm2 graphics protocol is based entirely around containerized formats
+// https://iterm2.com/documentation-images.html
+
+#include <stdio.h>
+#include "termdesc.h"
+#include "sprite.h"
+
+// yank a cell out of the PNG by setting all of its alphas to 0. the alphas
+// will be preserved in the auxvec.
+int iterm_wipe(sprixel* s, int ycell, int xcell){
+  return 0;
+}
+
+// build a cell of the PNG back up by copying auxvec alphas to it.
+int iterm_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
+  return 0;
+}
+
+// spit out the control sequence and data.
+int iterm_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x){
+  return 0;
+}
+
+// damage any cells underneath the graphic, destroying it.
+int iterm_scrub(const struct ncpile* p, sprixel* s){
+  return 0;
+}
+
+// create an iterm2 control sequence complete with base64-encoded PNG.
+int iterm_blit(struct ncplane* nc, int linesize, const void* data,
+               int leny, int lenx, const struct blitterargs* bargs){
+  return 0;
+}

--- a/src/lib/iterm.c
+++ b/src/lib/iterm.c
@@ -53,11 +53,13 @@ int iterm_blit(ncplane* n, int linesize, const void* data,
     }
     memset(tam, 0, sizeof(*tam) * rows * cols);
   }
+  // FIXME will we need to pass TAM into create_png_mmap()?
   size_t bsize;
   png = create_png_mmap(data, leny, linesize, lenx, &bsize, -1);
   if(png == NULL){
     goto error;
   }
+  // FIXME set up glyph/glyphlen
   if(plane_blit_sixel(s, s->glyph, s->glyphlen, leny, lenx, parse_start, tam) < 0){
     goto error;
   }

--- a/src/lib/iterm.c
+++ b/src/lib/iterm.c
@@ -38,7 +38,7 @@ write_iterm_graphic(sprixel* s, const void* data, int leny, int stride, int lenx
   if(fp == NULL){
     return -1;
   }
-  if(ncfputs("\e]1337;inline=1:", fp) == EOF){
+  if(ncfputs("\e]1337;File=inline=1:", fp) == EOF){
     goto err;
   }
   // FIXME won't we need to pass TAM into write_png_b64()?

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -782,13 +782,12 @@ error:
 }
 
 int kitty_blit(ncplane* n, int linesize, const void* data, int leny, int lenx,
-               const blitterargs* bargs, int bpp __attribute__ ((unused))){
+               const blitterargs* bargs){
   return kitty_blit_core(n, linesize, data, leny, lenx, bargs, false);
 }
 
 int kitty_blit_animated(ncplane* n, int linesize, const void* data,
-                        int leny, int lenx, const blitterargs* bargs,
-                        int bpp __attribute__ ((unused))){
+                        int leny, int lenx, const blitterargs* bargs){
   return kitty_blit_core(n, linesize, data, leny, lenx, bargs, true);
 }
 
@@ -800,8 +799,7 @@ int kitty_remove(int id, FILE* out){
   return 0;
 }
 
-// removes the kitty bitmap graphic identified by s->id, and damages those
-// cells which weren't SPRIXCELL_OPAQUE
+// damages cells underneath the graphic which weren't SPRIXCELL_OPAQUE
 int kitty_scrub(const ncpile* p, sprixel* s){
 //fprintf(stderr, "FROM: %d/%d state: %d s->n: %p\n", s->movedfromy, s->movedfromx, s->invalidated, s->n);
   for(int yy = s->movedfromy ; yy < s->movedfromy + s->dimy && yy < p->dimy ; ++yy){

--- a/src/lib/png.c
+++ b/src/lib/png.c
@@ -390,6 +390,12 @@ int write_png_b64(const void* data, int rows, int rowstride, int cols, FILE* fp)
   if(fwrite64(IEND, sizeof(IEND) - 1, fp, &bctx) != 1){
     return -1;
   }
-  // FIXME flush bctx
+  if(bctx.srcidx){
+    char b64[4];
+    base64final(bctx.src, b64, bctx.srcidx);
+    if(fwrite(b64, 4, 1, fp) != 1){
+      return -1;
+    }
+  }
   return 0;
 }

--- a/src/lib/png.h
+++ b/src/lib/png.h
@@ -5,12 +5,17 @@
 extern "C" {
 #endif
 
+#include <stdio.h>
 #include <sys/mman.h>
 
 struct ncvisual;
 
 void* create_png_mmap(const void* data, int rows, int rowstride, int cols,
                       size_t* bsize, int fd);
+
+// create the PNG, encode it using base64, and write it to |fp|
+int write_png_b64(const void* data, int rows, int rowstride, int cols,
+                  FILE* fp);
 
 #ifdef __cplusplus
 }

--- a/src/lib/png.h
+++ b/src/lib/png.h
@@ -9,7 +9,8 @@ extern "C" {
 
 struct ncvisual;
 
-void* create_png_mmap(const struct ncvisual* ncv, size_t* bsize, int fd);
+void* create_png_mmap(const void* data, int rows, int rowstride, int cols,
+                      size_t* bsize, int fd);
 
 #ifdef __cplusplus
 }

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -728,7 +728,7 @@ sixel_blit_inner(int leny, int lenx, sixeltable* stab,
 // |leny| and |lenx| are the scaled output geometry. we take |leny| up to the
 // nearest multiple of six greater than or equal to |leny|.
 int sixel_blit(ncplane* n, int linesize, const void* data, int leny, int lenx,
-               const blitterargs* bargs, int bpp __attribute__ ((unused))){
+               const blitterargs* bargs){
   int colorregs = bargs->u.pixel.colorregs;
   if(colorregs > 256){
     colorregs = 256;

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -164,14 +164,19 @@ int kitty_wipe(sprixel* s, int ycell, int xcell);
 // wipes out a cell by animating an all-transparent cell, and integrating
 // it with the original image using the animation protocol of 0.20.0+.
 int kitty_wipe_animation(sprixel* s, int ycell, int xcell);
+// wipes out a cell by changing the alpha value throughout the PNG cell to 0.
+int iterm_wipe(sprixel* s, int ycell, int xcell);
 int sixel_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
+int iterm_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 int kitty_rebuild_animation(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
-int kitty_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x);
-int kitty_move(sprixel* s, FILE* out, unsigned noscroll);
 int sixel_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x);
+int kitty_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x);
+int iterm_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x);
+int kitty_move(sprixel* s, FILE* out, unsigned noscroll);
 int sixel_scrub(const struct ncpile* p, sprixel* s);
 int kitty_scrub(const struct ncpile* p, sprixel* s);
+int iterm_scrub(const struct ncpile* p, sprixel* s);
 int kitty_remove(int id, FILE* out);
 int kitty_clear_all(FILE* fp);
 int sixel_init(const tinfo* t, int fd);
@@ -182,12 +187,13 @@ uint8_t* sixel_trans_auxvec(const struct tinfo* ti);
 uint8_t* kitty_trans_auxvec(const struct tinfo* ti);
 int kitty_commit(FILE* fp, sprixel* s, unsigned noscroll);
 int sixel_blit(struct ncplane* nc, int linesize, const void* data,
-               int leny, int lenx, const struct blitterargs* bargs, int bpp);
+               int leny, int lenx, const struct blitterargs* bargs);
 int kitty_blit(struct ncplane* nc, int linesize, const void* data,
-               int leny, int lenx, const struct blitterargs* bargs, int bpp);
+               int leny, int lenx, const struct blitterargs* bargs);
+int iterm_blit(struct ncplane* nc, int linesize, const void* data,
+               int leny, int lenx, const struct blitterargs* bargs);
 int kitty_blit_animated(struct ncplane* n, int linesize, const void* data,
-                        int leny, int lenx, const struct blitterargs* bargs,
-                        int bpp);
+                        int leny, int lenx, const struct blitterargs* bargs);
 
 #ifdef __cplusplus
 }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -518,7 +518,8 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
         return -1;
       }
     }
-    setup_iterm_bitmaps(ti, fd);
+    // we don't yet want to use the iterm2 protocol in place of sixel
+    //setup_iterm_bitmaps(ti, fd);
   }else if(qterm == TERMINAL_XTERM){
     termname = "XTerm";
     // xterm 357 added color palette escapes XT{PUSH,POP,REPORT}COLORS

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -55,6 +55,8 @@ setup_sixel_bitmaps(tinfo* ti, int fd, bool invert80){
   ti->pixel_draw = sixel_draw;
   ti->pixel_scrub = sixel_scrub;
   ti->pixel_wipe = sixel_wipe;
+  ti->pixel_remove = NULL;
+  ti->pixel_move = NULL;
   ti->pixel_shutdown = sixel_shutdown;
   ti->pixel_rebuild = sixel_rebuild;
   ti->pixel_trans_auxvec = sixel_trans_auxvec;
@@ -66,6 +68,14 @@ setup_sixel_bitmaps(tinfo* ti, int fd, bool invert80){
 // iterm2 has a container-based protocol
 static inline void
 setup_iterm_bitmaps(tinfo* ti, int fd){
+  ti->pixel_init = NULL;
+  ti->pixel_shutdown = NULL;
+  ti->sprixel_scale_height = 1;
+  ti->pixel_remove = NULL;
+  // be awarre: absence of pixel_move plus absence of sixel details is used by
+  // notcurses-info to determine iTerm2 support.
+  ti->pixel_move = NULL;
+  ti->color_registers = 0;
   ti->pixel_draw = iterm_draw;
   ti->pixel_scrub = iterm_scrub;
   ti->pixel_wipe = iterm_wipe;
@@ -508,6 +518,7 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
         return -1;
       }
     }
+    setup_iterm_bitmaps(ti, fd);
   }else if(qterm == TERMINAL_XTERM){
     termname = "XTerm";
     // xterm 357 added color palette escapes XT{PUSH,POP,REPORT}COLORS

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -8,8 +8,11 @@ extern "C" {
 // internal header, not installed
 
 #include "input.h"
+#include <stdint.h>
+#include <pthread.h>
 #include <stdbool.h>
 #include <termios.h>
+#include <notcurses/notcurses.h>
 
 struct ncpile;
 struct sprixel;

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -88,7 +88,7 @@ int ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
     return -1;
   }
   int ret = -1;
-  if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, barg, 32) >= 0){
+  if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, barg) >= 0){
     ret = 0;
   }
   if(data != ncv->data){

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -542,7 +542,7 @@ int ffmpeg_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
   }
 //fprintf(stderr, "WHN NCV: %d/%d bargslen: %d/%d targ: %d/%d\n", inframe->width, inframe->height, bargs->leny, bargs->lenx, rows, cols);
   int ret = 0;
-  if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, bargs, 32) < 0){
+  if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, bargs) < 0){
 //fprintf(stderr, "rgba dispatch failed!\n");
     ret = -1;
   }

--- a/src/media/oiio-indep.c
+++ b/src/media/oiio-indep.c
@@ -6,9 +6,8 @@
 
 int oiio_blit_dispatch(struct ncplane* nc, const struct blitset* bset,
                        int linesize, const void* data,
-                       int leny, int lenx, const blitterargs* bargs,
-                       int bpp){
-  if(rgba_blit_dispatch(nc, bset, linesize, data, leny, lenx, bargs, bpp) < 0){
+                       int leny, int lenx, const blitterargs* bargs){
+  if(rgba_blit_dispatch(nc, bset, linesize, data, leny, lenx, bargs) < 0){
     return -1;
   }
   return 0;

--- a/src/media/oiio.cpp
+++ b/src/media/oiio.cpp
@@ -150,7 +150,6 @@ int oiio_blit(struct ncvisual* ncv, int rows, int cols,
 //fprintf(stderr, "%d/%d -> %d/%d on the resize\n", ncv->pixy, ncv->pixx, rows, cols);
   void* data = nullptr;
   int stride;
-  int pstride;
   auto ibuf = std::make_unique<OIIO::ImageBuf>();
   if(ncv->details->ibuf && (ncv->pixx != cols || ncv->pixy != rows)){ // scale it
     // FIXME need to honor leny/lenx and begy/begx
@@ -158,17 +157,15 @@ int oiio_blit(struct ncvisual* ncv, int rows, int cols,
     if(!OIIO::ImageBufAlgo::resize(*ibuf, *ncv->details->ibuf, "", 0, roi)){
       return -1;
     }
-    pstride = ibuf->pixel_stride();
     stride = ibuf->scanline_stride();
     data = ibuf->localpixels();
 //fprintf(stderr, "HAVE SOME NEW DATA: %p\n", ibuf->localpixels());
   }else{
     data = ncv->data;
     stride = ncv->rowstride;
-    pstride = 4; // FIXME need pixel_stride() if loaded from oiio...
   }
 //std::cerr << "output: " << ibuf->roi() << " stride: " << stride << " pstride: " << pstride << std::endl;
-  return oiio_blit_dispatch(n, bset, stride, data, rows, cols, bargs, pstride * CHAR_BIT);
+  return oiio_blit_dispatch(n, bset, stride, data, rows, cols, bargs);
 }
 
 // FIXME before we can enable this, we need build an OIIO::APPBUFFER-style

--- a/src/media/oiio.h
+++ b/src/media/oiio.h
@@ -21,8 +21,7 @@ ncvisual* oiio_create(void);
 void oiio_destroy(ncvisual* ncv);
 int oiio_blit_dispatch(struct ncplane* nc, const struct blitset* bset,
                        int linesize, const void* data,
-                       int leny, int lenx, const blitterargs* bargs,
-                       int bpp);
+                       int leny, int lenx, const blitterargs* bargs);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Get the iTerm2 protocol working up through image display. Wipes and restores are not yet implemented, and will be tremendous pains in the ass for reasons discussed in #1420. This required general base64 encoding, zlib deflation, and PNG emission, but they've all come together. Now that we can generate PNGs on the fly, we might start using them with Kitty to reduce consumed bandwidth, and we might switch WezTerm to the iTerm2 protocol once it's fully implemented for Notcurses. Closes #1420.