### PR TITLE
Draw bitmaps to linux console framebuffer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ rearrangements of Notcurses.
 * 2.3.11 (not yet released)
   * Notcurses now requires libz to build. In exchange, it can now generate
     PNGs on the fly, necessary for driving iTerm2's graphics protocol.
+  * Experimental code has been added to draw graphics using both the iTerm2
+    protocol and directly to the Linux console framebuffer. This functionality
+    is still quite raw, but can be played with.
   * Added `NCPLANE_OPTION_FIXED`, to prevent a plane bound to a scrolling
     plane from scrolling along with it. Otherwise, bound planes will scroll
     along with the parent plane so long as the planes intersect.

--- a/src/info/main.c
+++ b/src/info/main.c
@@ -334,6 +334,8 @@ tinfo_debug_bitmaps(struct ncplane* n, const tinfo* ti, const char* indent){
       }else{
         ncplane_printf(n, "%ssixel colorregs: %u\n", indent, ti->color_registers);
       }
+    }else if(ti->linux_fb_fd >= 0){
+      ncplane_printf(n, "%sframebuffer graphics supported\n", indent);
     }else if(ti->pixel_move == NULL){
       ncplane_printf(n, "%siTerm2 graphics support\n", indent);
     }else if(ti->sixel_maxy_pristine){

--- a/src/lib/input.h
+++ b/src/lib/input.h
@@ -16,7 +16,11 @@ struct ncsharedstats;
 
 typedef enum {
     TERMINAL_UNKNOWN,       // no useful information from queries; use termname
+    // the very limited linux VGA/serial console, or possibly the (deprecated,
+    // pixel-drawable, RGBA8888) linux framebuffer console. *not* fbterm.
     TERMINAL_LINUX,         // ioctl()s
+    // the linux KMS/DRM console, *not* kmscon, but DRM direct dumb buffers
+    TERMINAL_LINUXDRM,      // ioctl()s
     TERMINAL_XTERM,         // XTVERSION == 'XTerm(ver)'
     TERMINAL_VTE,           // TDA: "~VTE"
     TERMINAL_KITTY,         // XTGETTCAP['TN'] == 'xterm-kitty'

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -10,6 +10,28 @@
 #include <linux/kd.h>
 #include <sys/ioctl.h>
 
+
+int fbcon_blit(struct ncplane* nc, int linesize, const void* data,
+               int leny, int lenx, const struct blitterargs* bargs, int bpp){
+  (void)nc;
+  (void)linesize;
+  (void)data;
+  (void)leny;
+  (void)lenx;
+  (void)bargs;
+  (void)bpp;
+  logerror("Haven't implemented yet FIXME\n");
+  return -1;
+}
+
+int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out){
+  (void)p;
+  (void)s;
+  (void)out;
+  logerror("Haven't implemented yet FIXME\n");
+  return -1;
+}
+
 // each row is a contiguous set of bits, starting at the msb
 static inline size_t
 row_bytes(const struct console_font_op* cfo){

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -1,15 +1,6 @@
 #include "linux.h"
 #include "internal.h"
 
-#ifdef __linux__
-#include <sys/mman.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <linux/fb.h>
-#include <linux/kd.h>
-#include <sys/ioctl.h>
-
 int fbcon_wipe(sprixel* s, int ycell, int xcell){
   (void)s;
   (void)ycell;
@@ -100,6 +91,15 @@ int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x){
   }
   return 0;
 }
+
+#ifdef __linux__
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <linux/fb.h>
+#include <linux/kd.h>
+#include <sys/ioctl.h>
 
 // each row is a contiguous set of bits, starting at the msb
 static inline size_t

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -98,7 +98,6 @@ int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x){
     const char* src = s->glyph + (l * s->pixx * 4);
     memcpy(tl, src, lsize);
   }
-  logerror("Haven't implemented yet FIXME\n");
   return 0;
 }
 

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -18,6 +18,15 @@ int fbcon_wipe(sprixel* s, int ycell, int xcell){
   return -1;
 }
 
+int fbcon_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
+  (void)s;
+  (void)ycell;
+  (void)xcell;
+  (void)auxvec;
+  logerror("Not yet implemented\n");
+  return -1;
+}
+
 int fbcon_blit(struct ncplane* n, int linesize, const void* data,
                int leny, int lenx, const struct blitterargs* bargs){
   int cols = bargs->u.pixel.spx->dimx;
@@ -84,9 +93,8 @@ int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x){
   for(int l = 0 ; l < s->pixy ; ++l){
     // FIXME pixel size isn't necessarily 4B, line isn't necessarily psize*pixx
     size_t offset = ((l + y) * ti->pixx + x) * 4;
-    size_t lsize = ti->pixx * 4;
+    size_t lsize = s->pixx * 4;
     uint8_t* tl = ti->linux_fbuffer + offset;
-    // FIXME draw line
     const char* src = s->glyph + (l * s->pixx * 4);
     memcpy(tl, src, lsize);
   }

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -23,6 +23,12 @@ int fbcon_blit(struct ncplane* nc, int linesize, const void* data,
   return -1;
 }
 
+int fbcon_scrub(const struct ncpile* p, sprixel* s){
+  (void)p;
+  (void)s;
+  return -1;
+}
+
 int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x){
   (void)p;
   (void)s;

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -92,10 +92,10 @@ int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x){
   const tinfo* ti = &p->nc->tcache;
   for(int l = 0 ; l < s->pixy ; ++l){
     // FIXME pixel size isn't necessarily 4B, line isn't necessarily psize*pixx
-    size_t offset = ((l + y) * ti->pixx + x) * 4;
-    size_t lsize = s->pixx * 4;
+    size_t offset = ((l + y * ti->cellpixy) * ti->pixx + x * ti->cellpixx) * 4;
     uint8_t* tl = ti->linux_fbuffer + offset;
     const char* src = s->glyph + (l * s->pixx * 4);
+    size_t lsize = s->pixx * 4;
     memcpy(tl, src, lsize);
   }
   return 0;

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -12,22 +12,23 @@
 
 
 int fbcon_blit(struct ncplane* nc, int linesize, const void* data,
-               int leny, int lenx, const struct blitterargs* bargs, int bpp){
+               int leny, int lenx, const struct blitterargs* bargs){
   (void)nc;
   (void)linesize;
   (void)data;
   (void)leny;
   (void)lenx;
   (void)bargs;
-  (void)bpp;
   logerror("Haven't implemented yet FIXME\n");
   return -1;
 }
 
-int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out){
+int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x){
   (void)p;
   (void)s;
   (void)out;
+  (void)y;
+  (void)x;
   logerror("Haven't implemented yet FIXME\n");
   return -1;
 }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -262,15 +262,14 @@ int update_term_dimensions(int fd, int* rows, int* cols, tinfo* tcache,
     *cols = ws.ws_col;
   }
   if(tcache){
-    unsigned y, x;
     if(tcache->linux_fb_fd >= 0){
-      get_linux_fb_pixelgeom(tcache, &y, &x);
+      get_linux_fb_pixelgeom(tcache, &tcache->pixy, &tcache->pixx);
     }else{
-      y = ws.ws_ypixel;
-      x = ws.ws_xpixel;
+      tcache->pixy = ws.ws_ypixel;
+      tcache->pixx = ws.ws_xpixel;
     }
-    tcache->cellpixy = ws.ws_row ? y / ws.ws_row : 0;
-    tcache->cellpixx = ws.ws_col ? x / ws.ws_col : 0;
+    tcache->cellpixy = ws.ws_row ? tcache->pixy / ws.ws_row : 0;
+    tcache->cellpixx = ws.ws_col ? tcache->pixx / ws.ws_col : 0;
     if(tcache->cellpixy == 0 || tcache->cellpixx == 0){
       tcache->pixel_draw = NULL; // disable support
     }

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -193,6 +193,9 @@ int iterm_blit(struct ncplane* nc, int linesize, const void* data,
                int leny, int lenx, const struct blitterargs* bargs);
 int kitty_blit_animated(struct ncplane* n, int linesize, const void* data,
                         int leny, int lenx, const struct blitterargs* bargs);
+int fbcon_blit(struct ncplane* nc, int linesize, const void* data,
+               int leny, int lenx, const struct blitterargs* bargs);
+int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out);
 
 #ifdef __cplusplus
 }

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -176,6 +176,7 @@ int iterm_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x);
 int kitty_move(sprixel* s, FILE* out, unsigned noscroll);
 int sixel_scrub(const struct ncpile* p, sprixel* s);
 int kitty_scrub(const struct ncpile* p, sprixel* s);
+int fbcon_scrub(const struct ncpile* p, sprixel* s);
 int kitty_remove(int id, FILE* out);
 int kitty_clear_all(FILE* fp);
 int sixel_init(const tinfo* t, int fd);

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -166,6 +166,7 @@ int kitty_wipe(sprixel* s, int ycell, int xcell);
 int kitty_wipe_animation(sprixel* s, int ycell, int xcell);
 // wipes out a cell by changing the alpha value throughout the PNG cell to 0.
 int iterm_wipe(sprixel* s, int ycell, int xcell);
+int fbcon_wipe(sprixel* s, int ycell, int xcell);
 int sixel_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 int iterm_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -170,6 +170,7 @@ int fbcon_wipe(sprixel* s, int ycell, int xcell);
 int sixel_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 int iterm_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
+int fbcon_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 int kitty_rebuild_animation(sprixel* s, int ycell, int xcell, uint8_t* auxvec);
 int sixel_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x);
 int kitty_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x);

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -195,7 +195,7 @@ int kitty_blit_animated(struct ncplane* n, int linesize, const void* data,
                         int leny, int lenx, const struct blitterargs* bargs);
 int fbcon_blit(struct ncplane* nc, int linesize, const void* data,
                int leny, int lenx, const struct blitterargs* bargs);
-int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out);
+int fbcon_draw(const struct ncpile *p, sprixel* s, FILE* out, int y, int x);
 
 #ifdef __cplusplus
 }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -114,6 +114,7 @@ setup_kitty_bitmaps(tinfo* ti, int fd, int sixel_maxy_pristine){
 static inline void
 setup_fbcon_bitmaps(tinfo* ti){
   // FIXME
+  ti->pixel_wipe = fbcon_wipe;
   ti->pixel_draw = fbcon_draw;
   ti->pixel_scrub = fbcon_scrub;
   set_pixel_blitter(fbcon_blit);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -109,6 +109,15 @@ setup_kitty_bitmaps(tinfo* ti, int fd, int sixel_maxy_pristine){
   sprite_init(ti, fd);
 }
 
+// kitty 0.19.3 didn't have C=1, and thus needs sixel_maxy_pristine. it also
+// lacked animation, and thus requires the older interface.
+static inline void
+setup_fbcon_bitmaps(tinfo* ti){
+  // FIXME
+  ti->pixel_draw = fbcon_draw;
+  set_pixel_blitter(fbcon_blit);
+}
+
 static bool
 query_rgb(void){
   bool rgb = (tigetflag("RGB") > 1 || tigetflag("Tc") > 1);
@@ -543,6 +552,7 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
     }
     if(ti->linux_fb_fd >= 0){
       termname = "Linux framebuffer";
+      setup_fbcon_bitmaps(ti);
     }else{
       termname = "Linux console";
     }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -115,6 +115,7 @@ static inline void
 setup_fbcon_bitmaps(tinfo* ti){
   // FIXME
   ti->pixel_draw = fbcon_draw;
+  ti->pixel_scrub = fbcon_scrub;
   set_pixel_blitter(fbcon_blit);
 }
 

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -112,12 +112,13 @@ setup_kitty_bitmaps(tinfo* ti, int fd, int sixel_maxy_pristine){
 // kitty 0.19.3 didn't have C=1, and thus needs sixel_maxy_pristine. it also
 // lacked animation, and thus requires the older interface.
 static inline void
-setup_fbcon_bitmaps(tinfo* ti){
-  // FIXME
+setup_fbcon_bitmaps(tinfo* ti, int fd){
+  ti->pixel_rebuild = fbcon_rebuild;
   ti->pixel_wipe = fbcon_wipe;
   ti->pixel_draw = fbcon_draw;
   ti->pixel_scrub = fbcon_scrub;
   set_pixel_blitter(fbcon_blit);
+  sprite_init(ti, fd);
 }
 
 static bool
@@ -554,7 +555,7 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
     }
     if(ti->linux_fb_fd >= 0){
       termname = "Linux framebuffer";
-      setup_fbcon_bitmaps(ti);
+      setup_fbcon_bitmaps(ti, ti->linux_fb_fd);
     }else{
       termname = "Linux console";
     }

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -129,6 +129,8 @@ typedef struct tinfo {
   uint16_t escindices[ESCAPE_MAX]; // table of 1-biased indices into esctable
   char* esctable;                  // packed table of escape sequences
   nccapabilities caps;             // exported to the user, when requested
+  unsigned pixy;                   // total pixel geometry, height
+  unsigned pixx;                   // total pixel geometry, width
   // we use the cell's size in pixels for pixel blitting. this information can
   // be acquired on all terminals with pixel support.
   int cellpixy;   // cell pixel height, might be 0


### PR DESCRIPTION
On Linux, if we're in a framebuffer, mmap(2) that sumbitch up and blit RGBA directly into it. This is pretty experimental, and we definitely have some problems, but the basics work. We don't yet have wipe/rebuild support of any kind, most of the demos do not yet work, and multiframe `ncplayer` does not work. With that said....

![PXL_20210718_221436932](https://user-images.githubusercontent.com/143473/126083837-3995bfd5-e3c9-4228-a007-cffab509fe31.jpg)

https://user-images.githubusercontent.com/143473/126083839-b24c2c47-bf0f-44dd-8fba-3d1f7b2bdb20.mp4

So it's a good start!