### PR TITLE
ci: revise windows gha workflow

### DIFF
--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -2,52 +2,55 @@
 name: Windows
 
 on:
-  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   tests:
+    defaults:
+      run:
+        shell: msys2 {0}
     env:
       COLORTERM: truecolor
       NPROC: 2
       TERM: xterm
     name: 🏁 build, test, & install
     runs-on: windows-latest
+
     steps:
 
       - name: Install tools and libraries via MSYS2
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: UCRT64
           update: true
-          # installing mingw-w64-x86_64-libxml2 is a workaround for:
-          # https://github.com/msys2/MINGW-packages/issues/8658
           install: >
             base-devel
             git
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ffmpeg
-            mingw-w64-x86_64-libunistring
-            mingw-w64-x86_64-libxml2
-            mingw-w64-x86_64-ncurses
-            mingw-w64-x86_64-rust
-            mingw-w64-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ffmpeg
+            mingw-w64-ucrt-x86_64-libunistring
+            mingw-w64-ucrt-x86_64-ncurses
+            mingw-w64-ucrt-x86_64-rust
+            mingw-w64-ucrt-x86_64-toolchain
 
       - uses: actions/checkout@v2
 
-      - name: cmake
+      - name: Build libqrcodegen
         run: |
-          pushd .
           mkdir "${HOME}/repos" && cd "${HOME}/repos"
           git clone https://github.com/nayuki/QR-Code-generator.git
           cd QR-Code-generator/c
-          AR="$(which ar)"
-          make AR="${AR}"
-          PREFIX=/mingw64
-          cd ${PREFIX}/include && \
-            ln -s "${HOME}/repos/QR-Code-generator/c" qrcodegen
-          cd ${PREFIX}/lib && \
-            ln -s "${HOME}/repos/QR-Code-generator/c/libqrcodegen.a" .
-          popd
+          make
+          cd /ucrt64/include && \
+            ln -s "${HOME}/repos/QR-Code-generator/c" ./qrcodegen
+          cd /ucrt64/lib && \
+            ln -s "${HOME}/repos/QR-Code-generator/c/libqrcodegen.a" ./libqrcodegen.a
+
+      - name: cmake
+        run: |
           mkdir build && cd build
           cmake .. \
             -G "MSYS Makefiles" \
@@ -69,8 +72,7 @@ jobs:
       - name: make install
         run: |
           cd build
-          sudo make install
-          sudo ldconfig
+          make install
 
       - name: python wrappers
         run: |
@@ -78,7 +80,7 @@ jobs:
           pip install pypandoc
           cd cffi
           python3 setup.py sdist build
-          sudo python3 setup.py install
+          python3 setup.py install
           notcurses-pydemo > /dev/null
           ncdirect-pydemo > /dev/null
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ sudo apt-get update
 [![Build](https://drone.dsscaw.com:4443/api/badges/dankamongmen/notcurses/status.svg)](https://drone.dsscaw.com:4443/dankamongmen/notcurses)
 [![Ubuntu](https://github.com/dankamongmen/notcurses/actions/workflows/ubuntu_test.yml/badge.svg?branch=master)](https://github.com/dankamongmen/notcurses/actions/workflows/ubuntu_test.yml?query=branch%3Amaster)
 [![macOS](https://github.com/dankamongmen/notcurses/actions/workflows/macos_test.yml/badge.svg?branch=master)](https://github.com/dankamongmen/notcurses/actions/workflows/macos_test.yml?query=branch%3Amaster)
+[![Windows](https://github.com/dankamongmen/notcurses/actions/workflows/windows_test.yml/badge.svg?branch=master)](https://github.com/dankamongmen/notcurses/actions/workflows/windows_test.yml?query=branch%3Amaster)
 
 [![pypi_version](https://img.shields.io/pypi/v/notcurses?label=pypi)](https://pypi.org/project/notcurses)
 [![crates.io](https://img.shields.io/crates/v/libnotcurses-sys.svg)](https://crates.io/crates/libnotcurses-sys)

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -20,6 +20,9 @@
 #elif defined(__APPLE__)
 #include <libkern/OSByteOrder.h>
 #define htole(x) (OSSwapInt32(htonl(x)))
+#elif defined(__MINGW64__)
+#include <winsock.h>
+#define htole(x) (bswap32(htonl(x)))
 #else
 #include <sys/endian.h>
 #define htole(x) (bswap32(htonl(x)))


### PR DESCRIPTION
Related to #463 and #1922.

This is just a start, and I don't really know (yet) what I'm doing when making changes to the `.h` files, etc.

For example: `<sys/endian.h>` doesn't exist on Windows + mingw-w64-ucrt-x86_64. However, I found an example where someone was using `<winsock.h>` in its place, so I tried that. My `define htole(x) (bswap32(htonl(x)))` is just a guess, copied from the one in the `else` clause.

`<poll.h>` is also not available, that's the next thing the compiler tripped on when running the `make` step. If it's commented out (just to see what happens), then it fails re: `termios.h` not being available. For that, [`termiWin`](https://github.com/veeso/termiWin) seems like it might be helpful, but it's GPLv3. Maybe there's an altogether better solution.

Hopefully, some other folks who want to see notcurses running on Windows can jump in and help.

Note that the GHA workflow for Windows still needs to be triggered manually from the *Actions* panel.