### PR TITLE
Foot has an inverted DECSDM since 1.8.2

### DIFF
--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -802,6 +802,11 @@ int interrogate_terminfo(tinfo* ti, int fd, const char* termname, unsigned utf8,
         invertsixel = true;
       }
     }
+    if(qterm == TERMINAL_FOOT){
+      if(compare_versions(ti->termversion, "1.8.2") >= 0){
+        invertsixel = true;
+      }
+    }
     setup_sixel_bitmaps(ti, fd, invertsixel);
   }
   return 0;


### PR DESCRIPTION
https://codeberg.org/dnkl/foot/commit/fcd989734235c25e64f8fb38ffcfdf381e933873

> There has been some confusion whether enabling DECSDM (private mode
> 80) enables or disables sixel scrolling.
> 
> Foot currently enables scrolling when DECSDM is set, and this patch
> changes this, such that setting DECSDM now *disables* scrolling.
> 
> The confusion is apparently due to a documentation error in the VT340
> manual, as described in
> https://github.com/dankamongmen/notcurses/issues/1782#issuecomment-863603641.
> 
> And that makes sense, in a way: the SDM in DECSDM stands for Sixel
> Display Mode. I.e. it stands to reason that enabling that disables
> scrolling.
> 
> Anyway, this lead to https://github.com/hackerb9/lsix/issues/41, where
> it was eventually proven (by testing on a real VT340), that foot, and
> a large number of other terminals (including XTerm) has it wrong:
> https://github.com/hackerb9/lsix/issues/41#issuecomment-873269599.