### PR TITLE
Kitty: use deflate for initial upload when animating

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 2.3.12 (not yet released)
+
 * 2.3.11 (2021-07-20)
   * Notcurses now requires libz to build. In exchange, it can now generate
     PNGs on the fly, necessary for driving iTerm2's graphics protocol.

--- a/src/demo/intro.c
+++ b/src/demo/intro.c
@@ -244,9 +244,14 @@ int intro(struct notcurses* nc){
     if(!on){
       if(notcurses_check_pixel_support(nc) && notcurses_canopen_images(nc)){
         on = orcashow(nc, rows, cols);
+        if(on == NULL){
+          return -1;
+        }
       }
     }else{
-      orcaride(nc, on, expected_iter);
+      if(orcaride(nc, on, expected_iter)){
+        return -1;
+      }
     }
     int err;
     if( (err = animate(nc, ncp, &flipmode)) ){

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -180,7 +180,7 @@ int xray_demo(struct notcurses* nc){
   marsh.next_frame = 0;
   marsh.last_frame_rendered = -1;
   marsh.lplane = NULL;
-  marsh.dm = notcurses_check_pixel_support(nc) < 1 ? 0.5 * delaymultiplier : 0;
+  marsh.dm = notcurses_check_pixel_support(nc) ? 0 : 0.5 * delaymultiplier;
   int ret = -1;
   // FIXME need do something about SIGINT here, which can leave us locked up
   if(pthread_create(&tid1, NULL, xray_thread, NULL)){

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -173,9 +173,6 @@ int xray_demo(struct notcurses* nc){
   ncchannels_set_bg_alpha(&stdc, NCALPHA_TRANSPARENT);
   ncplane_set_base(notcurses_stdplane(nc), "", 0, stdc);
   // returns non-zero if the selected blitter isn't available
-  if(notcurses_check_pixel_support(nc) < 1){
-    marsh.dm = 0.5 * delaymultiplier;
-  }
   pthread_t tid1, tid2;
   marsh.slider = slider;
   marsh.nc = nc;
@@ -183,6 +180,7 @@ int xray_demo(struct notcurses* nc){
   marsh.next_frame = 0;
   marsh.last_frame_rendered = -1;
   marsh.lplane = NULL;
+  marsh.dm = notcurses_check_pixel_support(nc) < 1 ? 0.5 * delaymultiplier : 0;
   int ret = -1;
   // FIXME need do something about SIGINT here, which can leave us locked up
   if(pthread_create(&tid1, NULL, xray_thread, NULL)){

--- a/src/lib/base64.h
+++ b/src/lib/base64.h
@@ -13,6 +13,10 @@ static unsigned const char b64subs[] =
 // there are only 2 pixels available, those 64 bits become 12 bytes. if there
 // is only 1 pixel available, those 32 bits become 8 bytes. (pcount + 1) * 4
 // bytes are used, plus a null terminator. we thus must receive 17.
+// wipe is referring to the sprixcell state, i.e. whether it was annihilated.
+// it always makes a pixel transparent (by setting alpha to 0). otherwise, we
+// check the pixel against the transcolor. matches (and sufficiently low alpha)
+// are likewise flattened to alpha=0.
 static inline void
 base64_rgba3(const uint32_t* pixels, size_t pcount, char* b64, bool wipe[static 3],
              uint32_t transcolor){

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -689,10 +689,8 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
     bargs.transcolor = vopts->transcolor | 0x1000000ull;
   }
   if(bset->geom == NCBLIT_PIXEL){
-    bargs.u.pixel.celldimx = n->tcache.cellpixx;
-    bargs.u.pixel.celldimy = n->tcache.cellpixy;
     bargs.u.pixel.colorregs = n->tcache.color_registers;
-    if((bargs.u.pixel.spx = sprixel_alloc(ncdv, nopts.rows, nopts.cols)) == NULL){
+    if((bargs.u.pixel.spx = sprixel_alloc(&n->tcache, ncdv, nopts.rows, nopts.cols)) == NULL){
       free_plane(ncdv);
       return NULL;
     }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -393,8 +393,6 @@ typedef struct blitterargs {
       int placex;
     } cell;            // for cells
     struct {
-      int celldimx;    // horizontal pixels per cell
-      int celldimy;    // vertical pixels per cell
       int colorregs;   // number of color registers
       sprixel* spx;    // sprixel object
     } pixel;           // for pixels
@@ -653,7 +651,7 @@ void sprixel_free(sprixel* s);
 void sprixel_hide(sprixel* s);
 
 // dimy and dimx are cell geometry, not pixel.
-sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx);
+sprixel* sprixel_alloc(const tinfo* ti, ncplane* n, int dimy, int dimx);
 sprixel* sprixel_recycle(ncplane* n);
 // takes ownership of s on success.
 int sprixel_load(sprixel* spx, char* s, int bytes, int pixy, int pixx, int parse_start);

--- a/src/lib/iterm.c
+++ b/src/lib/iterm.c
@@ -95,6 +95,7 @@ int iterm_blit(ncplane* n, int linesize, const void* data,
   if(write_iterm_graphic(s, data, leny, linesize, lenx)){
     goto error;
   }
+  scrub_tam_boundaries(tam, leny, lenx, s->cellpxy, s->cellpxx);
   if(plane_blit_sixel(s, s->glyph, s->glyphlen, leny, lenx, parse_start, tam) < 0){
     goto error;
   }

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -550,6 +550,13 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
             const int vyx = (y % cdimy) * cdimx + (x % cdimx);
             tam[tyx].auxvector[vyx] = ncpixel_a(source[e]);
           }
+          if(rgba_trans_p(source[e], transcolor)){
+            if(x % cdimx == 0 && y % cdimy == 0){
+              tam[tyx].state = SPRIXCELL_ANNIHILATED_TRANS;
+            }
+          }else{
+            tam[tyx].state = SPRIXCELL_ANNIHILATED;
+          }
           wipe[e] = 1;
         }else{
           wipe[e] = 0;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -551,6 +551,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
             tam[tyx].auxvector[vyx] = ncpixel_a(source[e]);
           }
           if(rgba_trans_p(source[e], transcolor)){
+            ncpixel_set_a(&source[e], 0); // in case it was transcolor
             if(x % cdimx == 0 && y % cdimy == 0){
               tam[tyx].state = SPRIXCELL_ANNIHILATED_TRANS;
             }
@@ -561,6 +562,7 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
         }else{
           wipe[e] = 0;
           if(rgba_trans_p(source[e], transcolor)){
+            ncpixel_set_a(&source[e], 0); // in case it was transcolor
             if(x % cdimx == 0 && y % cdimy == 0){
               tam[tyx].state = SPRIXCELL_TRANSPARENT;
             }else if(tam[tyx].state == SPRIXCELL_OPAQUE_KITTY){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -303,7 +303,7 @@ int kitty_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
 // size in pixels. posy and posx are the origin of the cell to be copied,
 // again in pixels. data is the image source. around the edges, we might
 // get truncated regions.
-static inline uint8_t*
+static inline void*
 kitty_anim_auxvec(int dimy, int dimx, int posy, int posx,
                   int cellpxy, int cellpxx, const uint32_t* data,
                   int rowstride, uint8_t* existing, uint32_t transcolor){
@@ -380,7 +380,7 @@ sprixel* kitty_recycle(ncplane* n){
   int dimy = hides->dimy;
   int dimx = hides->dimx;
   sprixel_hide(hides);
-  return sprixel_alloc(n, dimy, dimx);
+  return sprixel_alloc(&ncplane_notcurses_const(n)->tcache, n, dimy, dimx);
 }
 
 int kitty_wipe(sprixel* s, int ycell, int xcell){
@@ -501,9 +501,10 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
     return -1;
   }
   bool translucent = bargs->flags & NCVISUAL_OPTION_BLEND;
-  int sprixelid = bargs->u.pixel.spx->id;
-  int cdimy = bargs->u.pixel.celldimy;
-  int cdimx = bargs->u.pixel.celldimx;
+  sprixel* s = bargs->u.pixel.spx;
+  int sprixelid = s->id;
+  int cdimy = s->cellpxy;
+  int cdimx = s->cellpxx;
   uint32_t transcolor = bargs->transcolor;
   int total = leny * lenx; // total number of pixels (4 * total == bytecount)
   // number of 4KiB chunks we'll need

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -580,7 +580,9 @@ prep_deflator(unsigned animated, z_stream* zctx, int pixy, int pixx){
   memset(zctx, 0, sizeof(*zctx));
   if(animated){
     int zret;
-    if((zret = deflateInit(zctx, Z_DEFAULT_COMPRESSION)) != Z_OK){
+    // 2 seems to work well for things that are going to compress up
+    // meaningfully at all, while not taking too much time.
+    if((zret = deflateInit(zctx, 2)) != Z_OK){
       logerror("Couldn't get a deflate context (%d)\n", zret);
       return -1;
     }

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -28,9 +28,9 @@ int fbcon_blit(struct ncplane* n, int linesize, const void* data,
                int leny, int lenx, const struct blitterargs* bargs){
   int cols = bargs->u.pixel.spx->dimx;
   int rows = bargs->u.pixel.spx->dimy;
-  int cdimx = bargs->u.pixel.celldimx;
-  int cdimy = bargs->u.pixel.celldimy;
   sprixel* s = bargs->u.pixel.spx;
+  int cdimx = s->cellpxx;
+  int cdimy = s->cellpxy;
   s->glyphlen = leny * lenx * 4;
   s->glyph = malloc(s->glyphlen);
   if(s->glyph == NULL){
@@ -77,6 +77,7 @@ int fbcon_blit(struct ncplane* n, int linesize, const void* data,
       src += 4;
     }
   }
+  scrub_tam_boundaries(tam, leny, lenx, cdimy, cdimx);
   if(plane_blit_sixel(s, s->glyph, s->glyphlen, leny, lenx, 0, tam) < 0){
     goto error;
   }

--- a/src/lib/png.c
+++ b/src/lib/png.c
@@ -98,6 +98,7 @@ compress_image(const void* data, int rows, int rowstride, int cols, size_t* dlen
       return NULL;
     }
     zctx.avail_in = cols * 4 + 1;
+    // FIXME eliminate sbuf via 2x deflate(Z_NO_FLUSH)
     sbuf[0] = 0;
     memcpy(sbuf + 1, data + rowstride * i, cols * 4);
     zctx.next_in = sbuf;

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -59,7 +59,7 @@ sprixel* sprixel_recycle(ncplane* n){
     int dimy = hides->dimy;
     int dimx = hides->dimx;
     sprixel_hide(hides);
-    return sprixel_alloc(n, dimy, dimx);
+    return sprixel_alloc(&nc->tcache, n, dimy, dimx);
   }
   return n->sprite;
 }
@@ -115,7 +115,7 @@ void sprixel_invalidate(sprixel* s, int y, int x){
   }
 }
 
-sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx){
+sprixel* sprixel_alloc(const tinfo* ti, ncplane* n, int dimy, int dimx){
   sprixel* ret = malloc(sizeof(sprixel));
   if(ret){
     memset(ret, 0, sizeof(*ret));
@@ -128,20 +128,18 @@ sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx){
       sprixelid_nonce = 1;
     }
 //fprintf(stderr, "LOOKING AT %p (p->n = %p)\n", ret, ret->n);
-    if(ncplane_pile(ret->n)){
+    ret->cellpxy = ti->cellpixy;
+    ret->cellpxx = ti->cellpixx;
+    if(ncplane_pile(ret->n)){ // rendered mode
       ncpile* np = ncplane_pile(ret->n);
       if( (ret->next = np->sprixelcache) ){
         ret->next->prev = ret;
       }
       np->sprixelcache = ret;
       ret->prev = NULL;
-      const notcurses* nc = ncplane_notcurses_const(ret->n);
-      ret->cellpxy = nc->tcache.cellpixy;
-      ret->cellpxx = nc->tcache.cellpixx;
 //fprintf(stderr, "%p %p %p\n", nc->sprixelcache, ret, nc->sprixelcache->next);
     }else{ // ncdirect case
       ret->next = ret->prev = NULL;
-      ret->cellpxy = ret->cellpxx = -1;
     }
   }
   return ret;

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -179,7 +179,8 @@ int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
   int idx = s->dimx * ycell + xcell;
   if(s->n->tam[idx].state == SPRIXCELL_TRANSPARENT){
     // need to make a transparent auxvec, because a reload will force us to
-    // update said auxvec.
+    // update said auxvec, but needn't actually change the glyph. auxvec will
+    // be entirely 0s coming from pixel_trans_auxvec().
     if(s->n->tam[idx].auxvector == NULL){
       s->n->tam[idx].auxvector = nc->tcache.pixel_trans_auxvec(&nc->tcache);
       if(s->n->tam[idx].auxvector == NULL){

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -191,7 +191,7 @@ int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
     return 1;
   }
   if(s->n->tam[idx].state == SPRIXCELL_ANNIHILATED_TRANS ||
-      s->n->tam[idx].state == SPRIXCELL_ANNIHILATED){
+     s->n->tam[idx].state == SPRIXCELL_ANNIHILATED){
 //fprintf(stderr, "CACHED WIPE %d %d/%d\n", s->id, ycell, xcell);
     return 0;
   }

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -971,7 +971,6 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
     ncplane_destroy(createdn);
     return NULL;
   }
-//fprintf(stderr, "FOLLOWING PLANE: %d %d %d %d\n", n->absy, n->absx, n->leny, n->lenx);
   // if we created the plane earlier, placex/placey were taken into account, and
   // zeroed out, thus neither of these will have any effect.
   if(flags & NCVISUAL_OPTION_HORALIGNED){

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -951,13 +951,11 @@ ncplane* ncvisual_render_pixels(notcurses* nc, ncvisual* ncv, const struct blits
   bargs.leny = leny;
   bargs.lenx = lenx;
   bargs.flags = flags;
-  bargs.u.pixel.celldimx = nc->tcache.cellpixx;
-  bargs.u.pixel.celldimy = nc->tcache.cellpixy;
   bargs.u.pixel.colorregs = nc->tcache.color_registers;
   if(n->sprite == NULL){
-    int cols = disppixx / bargs.u.pixel.celldimx + !!(disppixx % bargs.u.pixel.celldimx);
-    int rows = outy / bargs.u.pixel.celldimy + !!(outy % bargs.u.pixel.celldimy);
-    if((n->sprite = sprixel_alloc(n, rows, cols)) == NULL){
+    int cols = disppixx / nc->tcache.cellpixx + !!(disppixx % nc->tcache.cellpixx);
+    int rows = outy / nc->tcache.cellpixy + !!(outy % nc->tcache.cellpixy);
+    if((n->sprite = sprixel_alloc(&nc->tcache, n, rows, cols)) == NULL){
       ncplane_destroy(createdn);
       return NULL;
     }

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -20,9 +20,14 @@ git clean -f -d -x
 # Doing general context-free regexery has led several times to heartache. We
 # thus do tightly-coupled, context-sensitive seds for each class of files.
 # Please don't add version numbers where they're not necessary.
+
+# quick sanity checks before and after version update
+grep $OLDVERSION CMakeLists.txt > /dev/null || { echo "Couldn't find OLDVERSION ($OLDVERSION) in CMakeLists.txt" >&2 ; exit 1 ; }
+sed -i -e "s/\(project(notcurses VERSION \)$OLDVERSION/\1$VERSION/" CMakeLists.txt
+grep $VERSION CMakeLists.txt > /dev/null || { echo "Couldn't find VERSION ($VERSION) in CMakeLists.txt" >&2 ; exit 1 ; }
+
 # FIXME we ought probably verify that there has been an actual change, as these
 #       will surely otherwise go out of date.
-sed -i -e "s/\(project(notcurses VERSION \)$OLDVERSION/\1$VERSION/" CMakeLists.txt
 sed -i -e "s/\(PROJECT_NUMBER *= \)$OLDVERSION/\1$VERSION/" doc/Doxyfile
 for i in doc/man/man*/*.md cffi/notcurses-*.md cffi/ncdirect-*.md; do
   sed -i -e "s/% v$OLDVERSION/% v$VERSION/" "$i"


### PR DESCRIPTION
When we're using Kitty animation, we don't need to keep the encoded glyph around and edit it in-place, so feed that fucker through `deflate()` from zlib, using the `o=z` control. For `xray` (admittedly something of a favourable example), this reduces bandwidth by 96%(!). Unfortunately, it's kinda slow right now; the bandwidth savings only yield a net positive when operating over a reasonably slow network like my local wireless. I think we can improve our usage of zlib and make it faster, though.

```c
Samples: 113K of event 'cycles', Event count (approx.): 116203165085
  Children      Self  Command         Shared Object                  Symbol
    28.29%    28.25%  notcurses-demo  libswscale.so.5.7.100          [.] yuv2rgba32_full_X_c
-   16.80%     0.00%  notcurses-demo  [unknown]                      [k] 0000000000000000
   - 0
        7.96% kitty_blit_core
      - 0.99% 0x7f84496ea0b0
           0.98% ff_hscale14to15_X4_ssse3.innerloop
      - 0.76% 0x7f84496ea018
           0.58% rgbaToA_c
-   12.32%    12.30%  notcurses-demo  libnotcurses-core.so.2.3.11    [.] kitty_blit_core
   - 7.95% 0
        kitty_blit_core
     1.72% kitty_blit_core
   - 1.09% 0x24900000000
        kitty_blit_core
-   10.70%    10.68%  notcurses-demo  libz.so.1.2.11                 [.] deflate_slow
     10.14% deflate_slow
-    8.59%     8.58%  notcurses-demo  libswscale.so.5.7.100          [.] ff_hscale14to15_X4_ssse3.inner
   - 4.33% 0
      - 0.98% 0x7f84496ea0b0
           ff_hscale14to15_X4_ssse3.innerloop
   - 4.24% 0x616c665f73777300
        sws_context_to_name
        swscale
        ff_hscale14to15_X4_ssse3.innerloop
-    7.84%     7.83%  notcurses-demo  libz.so.1.2.11                 [.] fill_window
     fill_window
-    6.77%     6.75%  notcurses-demo  libz.so.1.2.11                 [.] longest_match
     longest_match
+    4.34%     0.03%  notcurses-demo  libswscale.so.5.7.100          [.] swscale
+    4.34%     0.00%  notcurses-demo  [unknown]                      [.] 0x616c665f73777300
+    4.34%     0.00%  notcurses-demo  libswscale.so.5.7.100          [.] sws_context_to_name
+    2.82%     2.81%  notcurses-demo  libz.so.1.2.11                 [.] adler32_z
+    2.55%     2.54%  notcurses-demo  libswscale.so.5.7.100          [.] rgbaToA_c
+    2.44%     0.00%  notcurses-demo  libavutil.so.56.51.100         [.] av_default_item_name
```

that's a profile of `xray`. let's see what we can't claw back.

here's a run over my local wireless, showing the potential winnage:

before

```
             runtime│ frames│output(B)│    FPS│%r│%a│%w│TheoFPS║
══╤════════╤════════╪═══════╪═════════╪═══════╪══╪══╪══╪═══════╣
 1│    xray│  65.73s│    486│   1.47Gi│    7.4│ 0│ 0│76│   9.64║
══╧════════╧════════╪═══════╪═════════╪═══════╧══╧══╧══╧═══════╝
              65.73s│    486│   1.47Gi│
```

after

```
             runtime│ frames│output(B)│    FPS│%r│%a│%w│TheoFPS║
══╤════════╤════════╪═══════╪═════════╪═══════╪══╪══╪══╪═══════╣
 1│    xray│  34.11s│    486│  66.33Mi│   14.2│ 0│ 0│ 2│ 592.13║
══╧════════╧════════╪═══════╪═════════╪═══════╧══╧══╧══╧═══════╝
              34.11s│    486│  66.33Mi│
```

Closes #1695.