### PR TITLE
Reflective, stateless kitty wipes/restores using 0.21.3's composition

### DIFF
--- a/src/info/main.c
+++ b/src/info/main.c
@@ -45,7 +45,7 @@ tinfo_debug_style(struct ncplane* n, const char* name, int style, char ch){
 }
 
 static int
-braille_viz(ncplane* n, wchar_t l, const wchar_t* egcs, wchar_t r,
+braille_viz(struct ncplane* n, wchar_t l, const wchar_t* egcs, wchar_t r,
             const char* indent, wchar_t suit,
             const wchar_t* bounds, wchar_t r8, wchar_t l8){
   ncplane_printf(n, "%s%lc", indent, l);
@@ -194,8 +194,8 @@ vertviz(struct ncplane* n, wchar_t l, wchar_t li, wchar_t ri, wchar_t r){
 }
 
 static int
-unicodedumper(struct ncplane* n, tinfo* ti, const char* indent){
-  if(ti->caps.utf8){
+unicodedumper(struct ncplane* n, const char* indent){
+  if(notcurses_canutf8(ncplane_notcurses_const(n))){
     // all NCHALFBLOCKS are contained within NCQUADBLOCKS
     ncplane_printf(n, "%s%ls ⎧", indent, NCQUADBLOCKS);
     sex_viz(n, NCSEXBLOCKS, L'⎫', L"🯰🯱🯲🯳🯴🯵🯶🯷🯸🯹\u2157\u2158\u2159\u215a\u215b");
@@ -288,13 +288,15 @@ unicodedumper(struct ncplane* n, tinfo* ti, const char* indent){
 }
 
 static int
-display_logo(const tinfo* ti, struct ncplane* n, const char* path){
+display_logo(struct ncplane* n, const char* path){
+  int cpixy, cpixx;
+  ncplane_pixelgeom(n, NULL, NULL, &cpixy, &cpixx, NULL, NULL);
   struct ncvisual* ncv = ncvisual_from_file(path);
   if(ncv == NULL){
     return -1;
   }
   // FIXME ought be exactly 4:1
-  if(ncvisual_resize(ncv, 3 * ti->cellpixy, 24 * ti->cellpixx)){
+  if(ncvisual_resize(ncv, 3 * cpixy, 24 * cpixx)){
     ncvisual_destroy(ncv);
     return -1;
   }
@@ -425,10 +427,10 @@ int main(int argc, const char** argv){
   tinfo_debug_caps(stdn, &nc->tcache, indent);
   tinfo_debug_styles(nc, stdn, indent);
   tinfo_debug_bitmaps(stdn, &nc->tcache, indent);
-  unicodedumper(stdn, &nc->tcache, indent);
+  unicodedumper(stdn, indent);
   char* path = prefix_data("notcurses.png");
   if(path){
-    display_logo(&nc->tcache, stdn, path);
+    display_logo(stdn, path);
     free(path);
   }
   if(notcurses_render(nc)){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -352,7 +352,7 @@ int kitty_wipe_animation(sprixel* s, int ycell, int xcell){
   }
   logdebug("Wiping sprixel %u at %d/%d\n", s->id, ycell, xcell);
   FILE* fp = s->mstreamfp;
-  fprintf(fp, "\e_Ga=f,x=%d,y=%d,s=%d,v=%d,i=%d,X=1,c=1,q=2;",
+  fprintf(fp, "\e_Ga=f,x=%d,y=%d,s=%d,v=%d,i=%d,X=1,r=1,q=2;",
           xcell * s->cellpxx,
           ycell * s->cellpxy,
           s->cellpxx,

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -728,8 +728,9 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
         // old-style animated auxvecs carry the entirety of the replacement
         // data in them. on the first pixel of the cell, ditch the previous
         // auxvec in its entirety, and copy over the entire cell.
-        if(level == KITTY_ANIMATION){
-          if(x % cdimx == 0 && y % cdimy == 0){
+// FIXME HERE
+        if(x % cdimx == 0 && y % cdimy == 0){
+          if(level == KITTY_ANIMATION){
             uint8_t* tmp;
             tmp = kitty_anim_auxvec(leny, lenx, y, x, cdimy, cdimx,
                                     data, linesize, tam[tyx].auxvector,
@@ -738,6 +739,8 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
               goto err;
             }
             tam[tyx].auxvector = tmp;
+          }else if(level == KITTY_SELFREF){
+            tam[tyx].auxvector = malloc(1);
           }
         }
         if(tam[tyx].state >= SPRIXCELL_ANNIHILATED){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -695,18 +695,20 @@ write_kitty_data(FILE* fp, int linesize, int leny, int lenx, int cols,
         int ycell = y / cdimy;
         int tyx = xcell + ycell * cols;
 //fprintf(stderr, "Tyx: %d y: %d (%d) * %d x: %d (%d) state %d %p\n", tyx, y, y / cdimy, cols, x, x / cdimx, tam[tyx].state, tam[tyx].auxvector);
-        // animated auxvecs carry the entirety of the replacement data in
-        // them. on the first pixel of the cell, ditch the previous auxvec
-        // in its entirety, and copy over the entire cell.
-        if(animated && x % cdimx == 0 && y % cdimy == 0){
-          uint8_t* tmp;
-          tmp = kitty_anim_auxvec(leny, lenx, y, x, cdimy, cdimx,
-                                  data, linesize, tam[tyx].auxvector,
-                                  transcolor);
-          if(tmp == NULL){
-            goto err;
+        // old-style animated auxvecs carry the entirety of the replacement
+        // data in them. on the first pixel of the cell, ditch the previous
+        // auxvec in its entirety, and copy over the entire cell.
+        if(level == KITTY_ANIMATION){
+          if(x % cdimx == 0 && y % cdimy == 0){
+            uint8_t* tmp;
+            tmp = kitty_anim_auxvec(leny, lenx, y, x, cdimy, cdimx,
+                                    data, linesize, tam[tyx].auxvector,
+                                    transcolor);
+            if(tmp == NULL){
+              goto err;
+            }
+            tam[tyx].auxvector = tmp;
           }
-          tam[tyx].auxvector = tmp;
         }
         if(tam[tyx].state >= SPRIXCELL_ANNIHILATED){
           if(!animated){

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -352,7 +352,7 @@ int kitty_wipe_animation(sprixel* s, int ycell, int xcell){
   }
   logdebug("Wiping sprixel %u at %d/%d\n", s->id, ycell, xcell);
   FILE* fp = s->mstreamfp;
-  fprintf(fp, "\e_Ga=f,x=%d,y=%d,s=%d,v=%d,i=%d,X=1,r=1,q=2;",
+  fprintf(fp, "\e_Ga=f,x=%d,y=%d,s=%d,v=%d,i=%d,X=1,c=1,q=2;",
           xcell * s->cellpxx,
           ycell * s->cellpxy,
           s->cellpxx,
@@ -788,7 +788,7 @@ int kitty_rebuild_selfref(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
   const int xlen = xstart + s->cellpxx > s->pixx ? s->pixx - xstart : s->cellpxx;
   const int ylen = ystart + s->cellpxy > s->pixy ? s->pixy - ystart : s->cellpxy;
   logdebug("rematerializing %u at %d/%d (%dx%d)\n", s->id, ycell, xcell, ylen, xlen);
-  fprintf(fp, "\e_Ga=c,x=%d,y=%d,X=%d,Y=%d,w=%d,h=%d,i=%d,r=1,q=2;\x1b\\",
+  fprintf(fp, "\e_Ga=c,x=%d,y=%d,X=%d,Y=%d,w=%d,h=%d,i=%d,c=2,r=1,q=2;\x1b\\",
           xcell * s->cellpxx, ycell * s->cellpxy,
           xcell * s->cellpxx, ycell * s->cellpxy,
           xlen, ylen, s->id);

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -883,10 +883,10 @@ clean_sprixels(notcurses* nc, ncpile* p, FILE* out){
 // "%d tardies to work off, by far the most in the class!\n", p->scrolls
 static int
 rasterize_scrolls(ncpile* p, FILE* out){
-  logdebug("Order-%d scroll\n", p->scrolls);
   if(p->scrolls == 0){
     return 0;
   }
+  logdebug("Order-%d scroll\n", p->scrolls);
   if(p->nc->rstate.logendy >= 0){
     p->nc->rstate.logendy -= p->scrolls;
     if(p->nc->rstate.logendy < 0){

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -164,6 +164,7 @@ int kitty_wipe(sprixel* s, int ycell, int xcell);
 // wipes out a cell by animating an all-transparent cell, and integrating
 // it with the original image using the animation protocol of 0.20.0+.
 int kitty_wipe_animation(sprixel* s, int ycell, int xcell);
+int kitty_wipe_selfref(sprixel* s, int ycell, int xcell);
 // wipes out a cell by changing the alpha value throughout the PNG cell to 0.
 int iterm_wipe(sprixel* s, int ycell, int xcell);
 int fbcon_wipe(sprixel* s, int ycell, int xcell);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -103,13 +103,14 @@ setup_kitty_bitmaps(tinfo* ti, int fd, kitty_graphics_e level){
     ti->sixel_maxy_pristine = INT_MAX;
     set_pixel_blitter(kitty_blit);
   }else{
-    ti->pixel_wipe = kitty_wipe_animation;
     if(level == KITTY_ANIMATION){
+      ti->pixel_wipe = kitty_wipe_animation;
       ti->pixel_rebuild = kitty_rebuild_animation;
       set_pixel_blitter(kitty_blit_animated);
     }else{
+      ti->pixel_wipe = kitty_wipe_selfref;
       ti->pixel_rebuild = kitty_rebuild_selfref;
-      set_pixel_blitter(kitty_blit_selfref);
+      set_pixel_blitter(kitty_blit_animated);
     }
   }
   sprite_init(ti, fd);
@@ -507,7 +508,7 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
     if(add_smulx_escapes(ti, tablelen, tableused)){
       return -1;
     }
-    if(compare_versions(ti->termversion, "0.21.3") >= 0){
+    if(compare_versions(ti->termversion, "0.21.2") >= 0){
       setup_kitty_bitmaps(ti, fd, KITTY_SELFREF);
     }else if(compare_versions(ti->termversion, "0.20.0") >= 0){
       setup_kitty_bitmaps(ti, fd, KITTY_ANIMATION);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -508,7 +508,7 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
     if(add_smulx_escapes(ti, tablelen, tableused)){
       return -1;
     }
-    if(compare_versions(ti->termversion, "0.21.2") >= 0){
+    if(compare_versions(ti->termversion, "0.21.3") >= 0){
       setup_kitty_bitmaps(ti, fd, KITTY_SELFREF);
     }else if(compare_versions(ti->termversion, "0.20.0") >= 0){
       setup_kitty_bitmaps(ti, fd, KITTY_ANIMATION);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -110,7 +110,7 @@ setup_kitty_bitmaps(tinfo* ti, int fd, kitty_graphics_e level){
     }else{
       ti->pixel_wipe = kitty_wipe_selfref;
       ti->pixel_rebuild = kitty_rebuild_selfref;
-      set_pixel_blitter(kitty_blit_animated);
+      set_pixel_blitter(kitty_blit_selfref);
     }
   }
   sprite_init(ti, fd);

--- a/src/poc/statepixel.c
+++ b/src/poc/statepixel.c
@@ -62,7 +62,7 @@ handle(struct notcurses* nc, const char* fn){
     ncvisual_destroy(ncv);
     return -1;
   }
-  uint64_t channels = NCCHANNELS_INITIALIZER(0xff, 0xff, 0xff, 0xff, 0xff, 0xff);
+  uint64_t channels = NCCHANNELS_INITIALIZER(0, 0, 0, 0xff, 0xff, 0xff);
   ncplane_set_base(t, " ", 0, channels);
   notcurses_render(nc);
   clock_nanosleep(CLOCK_MONOTONIC, 0, &ds, NULL);


### PR DESCRIPTION
Closes #1900. Kitty 0.21.3 brings a new graphics capability I proposed [here](https://github.com/kovidgoyal/kitty/issues/3809). This allows us to compose with an existing frame. We do so, and by doing so no longer keep around the copy of the RGBA data in the auxvecs. This will save many hundreds of KiB for each visual.