### PR TITLE
Handle Type-1 DVB subtitles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ rearrangements of Notcurses.
     the media of an `ncvisual`. As a result, it now returns a `ncplane*`
     rather than `char*`. I don't think anyone was using this, so hopefully
     that's ok.
+  * Add `ncvisual_from_palidx()`, which does what you would think.
 
 * 2.3.11 (2021-07-20)
   * Notcurses now requires libz to build. In exchange, it can now generate

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@ rearrangements of Notcurses.
   * Added `nccell_cols()`, which is just `nccell_width()` except it doesn't
     require the first `const ncplane*` argument, and it's `static inline`.
     `nccell_width()` has been deprecated, and will be removed in ABI3.
+  * `ncvisual_subtitles()` now handles Type-1 DVB subtitles when found in
+    the media of an `ncvisual`. As a result, it now returns a `ncplane*`
+    rather than `char*`. I don't think anyone was using this, so hopefully
+    that's ok.
 
 * 2.3.11 (2021-07-20)
   * Notcurses now requires libz to build. In exchange, it can now generate

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,10 +16,10 @@ rearrangements of Notcurses.
   * Added `nccell_cols()`, which is just `nccell_width()` except it doesn't
     require the first `const ncplane*` argument, and it's `static inline`.
     `nccell_width()` has been deprecated, and will be removed in ABI3.
-  * `ncvisual_subtitles()` now handles Type-1 DVB subtitles when found in
-    the media of an `ncvisual`. As a result, it now returns a `ncplane*`
-    rather than `char*`. I don't think anyone was using this, so hopefully
-    that's ok.
+  * `ncvisual_subtitle_plane()` now handles all LibAV subtitle types,
+    including Type-1 DVB (bitmap subtitles), so long as a pixel blitter is
+    available. `ncvisual_subtitle()` has been deprecated, and will be
+    removed in ABI3.
   * Add `ncvisual_from_palidx()`, which does what you would think.
 
 * 2.3.11 (2021-07-20)

--- a/USAGE.md
+++ b/USAGE.md
@@ -3184,9 +3184,11 @@ int ncvisual_at_yx(const struct ncvisual* n, int y, int x, uint32_t* pixel);
 // Set the specified pixel in the specified ncvisual.
 int ncvisual_set_yx(const struct ncvisual* n, int y, int x, uint32_t pixel);
 
-// If a subtitle ought be displayed at this time, return a heap-allocated copy
-// of the UTF8 text.
-char* ncvisual_subtitle(const struct ncvisual* ncv);
+// If a subtitle ought be displayed at this time, return a new plane (bound
+// to 'parent' containing the subtitle, which might be text or graphics
+// (depending on the input format).
+struct ncplane* ncvisual_subtitle(struct ncplane* parent,
+                                  const struct ncvisual* ncv);
 ```
 
 And finally, the `ncvisual` can be blitted to one or more `ncplane`s:

--- a/USAGE.md
+++ b/USAGE.md
@@ -3134,6 +3134,13 @@ struct ncvisual* ncvisual_from_rgb_loose(const void* rgba, int rows,
 // ncvisual_from_rgba(), but for BGRA.
 struct ncvisual* ncvisual_from_bgra(struct notcurses* nc, const void* bgra,
                                     int rows, int rowstride, int cols);
+
+// ncvisual_from_rgba(), but 'data' is 'pstride'-byte palette-indexed pixels,
+// arranged in 'rows' lines of 'rowstride' bytes each, composed of 'cols'
+// pixels. 'palette' is an array of at least 'palsize' ncchannels.
+struct ncvisual* ncvisual_from_palidx(const void* data, int rows,
+                                      int rowstride, int cols, int palsize,
+                                      int pstride, const uint32_t* palette);
 ```
 
 `ncvisual`s can also be loaded from the contents of a plane:

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -62,6 +62,8 @@ typedef int (*streamcb)(struct notcurses*, struct ncvisual*, void*);
 
 **struct ncvisual* ncvisual_from_bgra(const void* ***bgra***, int ***rows***, int ***rowstride***, int ***cols***);**
 
+**struct ncvisual* ncvisual_from_palidx(const void* ***data***, int ***rows***, int ***rowstride***, int ***cols***, int ***palsize***, int ***pstride***, const uint32_t* ***palette***);**
+
 **struct ncvisual* ncvisual_from_plane(struct ncplane* ***n***, ncblitter_e ***blit***, int ***begy***, int ***begx***, int ***leny***, int ***lenx***);**
 
 **int ncvisual_blitter_geom(const struct notcurses* ***nc***, const struct ncvisual* ***n***, const struct ncvisual_options* ***vopts***, int* ***y***, int* ***x***, int* ***scaley***, int* ***scalex***, ncblitter_e* ***blitter***);**
@@ -137,6 +139,10 @@ resulting plane will be ceil(**rows**/2) rows, and **cols** columns.
 **ncvisual_from_rgb_packed** performs the same using 3-byte RGB source data.
 **ncvisual_from_rgb_loose** uses 4-byte RGBx source data. Both will fill in
 the alpha component of every target pixel with the specified **alpha**.
+
+**ncvisual_from_palidx** requires a ***palette*** of at least ***palsize***
+**ncchannel**s. Pixels are ***pstride*** bytes each, arranged as ***cols*** pixels
+per row, with each row occupying ***rowstride*** bytes, across ***rows*** rows.
 
 **ncvisual_from_plane** requires specification of a rectangle via ***begy***,
 ***begx***, ***leny***, and ***lenx***, and also a blitter. The only valid

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -90,7 +90,7 @@ typedef int (*streamcb)(struct notcurses*, struct ncvisual*, void*);
 
 **int ncvisual_set_yx(const struct ncvisual* ***n***, int ***y***, int ***x***, uint32_t ***pixel***);**
 
-**char* ncvisual_subtitle(const struct ncvisual* ***ncv***);**
+**struct ncplane* ncvisual_subtitle(struct ncplane* ***parent***, const struct ncvisual* ***ncv***);**
 
 **int notcurses_lex_scalemode(const char* ***op***, ncscale_e* ***scaling***);**
 

--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -76,10 +76,10 @@ namespace ncpp
 			return error_guard<int> (ncvisual_stream (get_notcurses (), visual, timescale, streamer, vopts, curry), -1);
 		}
 
-		ncplane* subtitle (Plane& p) const noexcept
+		/*char* subtitle () const noexcept
 		{
-			return ncvisual_subtitle (p, visual);
-		}
+			return ncvisual_subtitle (visual);
+		}*/
 
 		bool rotate (double rads) const NOEXCEPT_MAYBE
 		{

--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -76,9 +76,9 @@ namespace ncpp
 			return error_guard<int> (ncvisual_stream (get_notcurses (), visual, timescale, streamer, vopts, curry), -1);
 		}
 
-		char* subtitle () const noexcept
+		ncplane* subtitle (Plane& p) const noexcept
 		{
-			return ncvisual_subtitle (visual);
+			return ncvisual_subtitle (p, visual);
 		}
 
 		bool rotate (double rads) const NOEXCEPT_MAYBE

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2568,7 +2568,8 @@ ncplane_double_box_sized(struct ncplane* n, uint32_t styles, uint64_t channels,
 
 // Open a visual at 'file', extract a codec and parameters, decode the first
 // image to memory.
-API ALLOC struct ncvisual* ncvisual_from_file(const char* file);
+API ALLOC struct ncvisual* ncvisual_from_file(const char* file)
+  __attribute__ ((nonnull (1)));
 
 // Prepare an ncvisual, and its underlying plane, based off RGBA content in
 // memory at 'rgba'. 'rgba' is laid out as 'rows' lines, each of which is
@@ -2577,25 +2578,38 @@ API ALLOC struct ncvisual* ncvisual_from_file(const char* file);
 // of padding). The total size of 'rgba' is thus (rows * rowstride) bytes, of
 // which (rows * cols * 4) bytes are actual non-padding data.
 API ALLOC struct ncvisual* ncvisual_from_rgba(const void* rgba, int rows,
-                                              int rowstride, int cols);
+                                              int rowstride, int cols)
+  __attribute__ ((nonnull (1)));
 
 // ncvisual_from_rgba(), but the pixels are 3-byte RGB. A is filled in
 // throughout using 'alpha'.
 API ALLOC struct ncvisual* ncvisual_from_rgb_packed(const void* rgba, int rows,
                                                     int rowstride, int cols,
-                                                    int alpha);
+                                                    int alpha)
+  __attribute__ ((nonnull (1)));
 
 // ncvisual_from_rgba(), but the pixels are 4-byte RGBx. A is filled in
 // throughout using 'alpha'. rowstride must be a multiple of 4.
 API ALLOC struct ncvisual* ncvisual_from_rgb_loose(const void* rgba, int rows,
                                                    int rowstride, int cols,
-                                                   int alpha);
+                                                   int alpha)
+  __attribute__ ((nonnull (1)));
 
 // ncvisual_from_rgba(), but 'bgra' is arranged as BGRA. note that this is a
 // byte-oriented layout, despite being bunched in 32-bit pixels; the lowest
 // memory address ought be B, and A is reached by adding 3 to that address.
 API ALLOC struct ncvisual* ncvisual_from_bgra(const void* bgra, int rows,
-                                              int rowstride, int cols);
+                                              int rowstride, int cols)
+  __attribute__ ((nonnull (1)));
+
+// ncvisual_from_rgba(), but 'data' is 'pstride'-byte palette-indexed pixels,
+// arranged in 'rows' lines of 'rowstride' bytes each, composed of 'cols'
+// pixels. 'palette' is an array of at least 'palsize' ncchannels.
+API ALLOC struct ncvisual* ncvisual_from_palidx(const void* data, int rows,
+                                                int rowstride, int cols,
+                                                int palsize, int pstride,
+                                                const uint32_t* palette)
+  __attribute__ ((nonnull (1, 7)));
 
 // Promote an ncplane 'n' to an ncvisual. The plane may contain only spaces,
 // half blocks, and full blocks. The latter will be checked, and any other

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2762,7 +2762,8 @@ ncvisualplane_create(struct ncplane* n, const struct ncplane_options* opts,
 // If a subtitle ought be displayed at this time, return a new plane (bound
 // to 'parent' containing the subtitle, which might be text or graphics
 // (depending on the input format).
-API ALLOC struct ncplane* ncvisual_subtitle(struct ncplane* parent, const struct ncvisual* ncv)
+API ALLOC struct ncplane* ncvisual_subtitle_plane(struct ncplane* parent,
+                                                  const struct ncvisual* ncv)
   __attribute__ ((nonnull (1, 2)));
 
 // Get the default *media* (not plot) blitter for this environment when using
@@ -4424,6 +4425,9 @@ API uint32_t notcurses_getc(struct notcurses* n, const struct timespec* ts,
   __attribute__ ((deprecated)) __attribute__ ((nonnull (1)));
 
 __attribute__ ((deprecated)) API int nccell_width(const struct ncplane* n, const nccell* c);
+
+API ALLOC char* ncvisual_subtitle(const struct ncvisual* ncv)
+  __attribute__ ((nonnull (1))) __attribute__ ((deprecated));
 
 #define CELL_ALPHA_HIGHCONTRAST NCALPHA_HIGHCONTRAST
 #define CELL_ALPHA_TRANSPARENT  NCALPHA_TRANSPARENT

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2745,10 +2745,11 @@ ncvisualplane_create(struct ncplane* n, const struct ncplane_options* opts,
   return newn;
 }
 
-// If a subtitle ought be displayed at this time, return a heap-allocated copy
-// of the UTF8 text.
-API ALLOC char* ncvisual_subtitle(const struct ncvisual* ncv)
-  __attribute__ ((nonnull (1)));
+// If a subtitle ought be displayed at this time, return a new plane (bound
+// to 'parent' containing the subtitle, which might be text or graphics
+// (depending on the input format).
+API ALLOC struct ncplane* ncvisual_subtitle(struct ncplane* parent, const struct ncvisual* ncv)
+  __attribute__ ((nonnull (1, 2)));
 
 // Get the default *media* (not plot) blitter for this environment when using
 // the specified scaling method. Currently, this means:

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1710,7 +1710,7 @@ typedef struct ncvisual_implementation {
   int (*visual_decode_loop)(struct ncvisual* nc);
   int (*visual_stream)(notcurses* nc, struct ncvisual* ncv, float timescale,
                        ncstreamcb streamer, const struct ncvisual_options* vopts, void* curry);
-  char* (*visual_subtitle)(const struct ncvisual* ncv);
+  struct ncplane* (*visual_subtitle)(struct ncplane* parent, const struct ncvisual* ncv);
   int rowalign; // rowstride base, can be 0 for no padding
   // do a persistent resize, changing the ncv itself
   int (*visual_resize)(struct ncvisual* ncv, int rows, int cols);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -508,9 +508,12 @@ apply_term_heuristics(tinfo* ti, const char* termname, int fd,
     if(add_smulx_escapes(ti, tablelen, tableused)){
       return -1;
     }
-    if(compare_versions(ti->termversion, "0.22.0") >= 0){
+    // FIXME not yet ready
+    //   https://github.com/kovidgoyal/kitty/issues/3874#issuecomment-887636216
+    //   https://github.com/dankamongmen/notcurses/issues/1990
+    /*if(compare_versions(ti->termversion, "0.22.0") >= 0){
       setup_kitty_bitmaps(ti, fd, KITTY_SELFREF);
-    }else if(compare_versions(ti->termversion, "0.20.0") >= 0){
+    }else*/ if(compare_versions(ti->termversion, "0.20.0") >= 0){
       setup_kitty_bitmaps(ti, fd, KITTY_ANIMATION);
     }else{
       setup_kitty_bitmaps(ti, fd, KITTY_ALWAYS_SCROLLS);

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -63,11 +63,11 @@ int ncvisual_stream(notcurses* nc, ncvisual* ncv, float timescale,
   return visual_implementation.visual_stream(nc, ncv, timescale, streamer, vopts, curry);
 }
 
-char* ncvisual_subtitle(const ncvisual* ncv){
+ncplane* ncvisual_subtitle(ncplane* parent, const ncvisual* ncv){
   if(!visual_implementation.visual_subtitle){
     return NULL;
   }
-  return visual_implementation.visual_subtitle(ncv);
+  return visual_implementation.visual_subtitle(parent, ncv);
 }
 
 int ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
@@ -1084,14 +1084,14 @@ int ncvisual_simple_streamer(ncvisual* ncv, struct ncvisual_options* vopts,
   }
   int ret = 0;
   if(curry){
+    // FIXME improve this hrmmmmm
     ncplane* subncp = curry;
-    char* subtitle = ncvisual_subtitle(ncv);
-    if(subtitle){
-      if(ncplane_putstr_yx(subncp, 0, 0, subtitle) < 0){
-        ret = -1;
-      }
-      free(subtitle);
+    if(subncp->blist){
+fprintf(stderr, "KILLING %p\n", subncp->blist);
+      ncplane_destroy(subncp->blist);
+      subncp->blist = NULL;
     }
+    struct ncplane* subtitle = ncvisual_subtitle(subncp, ncv);
   }
   clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, tspec, NULL);
   return ret;

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -1140,7 +1140,6 @@ int ncvisual_simple_streamer(ncvisual* ncv, struct ncvisual_options* vopts,
     // FIXME improve this hrmmmmm
     ncplane* subncp = curry;
     if(subncp->blist){
-fprintf(stderr, "KILLING %p\n", subncp->blist);
       ncplane_destroy(subncp->blist);
       subncp->blist = NULL;
     }

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -566,6 +566,9 @@ static inline size_t
 pad_for_image(size_t stride, int cols){
   if(visual_implementation.rowalign == 0){
     return 4 * cols;
+  }else if(stride < cols * 4u){
+    return (4 * cols + visual_implementation.rowalign) /
+            visual_implementation.rowalign * visual_implementation.rowalign;
   }else if(stride % visual_implementation.rowalign == 0){
     return stride;
   }

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -703,6 +703,10 @@ ncvisual* ncvisual_from_palidx(const void* pdata, int rows, int rowstride,
     logerror("bad pstride (%d) for rowstride (%d)\n", pstride, rowstride);
     return NULL;
   }
+  if(palsize > 256 || palsize <= 0){
+    logerror("palettes size (%d) is unsupported\n", palsize);
+    return NULL;
+  }
   ncvisual* ncv = ncvisual_create();
   if(ncv){
     ncv->rowstride = pad_for_image(rowstride, cols);
@@ -724,10 +728,15 @@ ncvisual* ncvisual_from_palidx(const void* pdata, int rows, int rowstride,
         }
         uint32_t src = palette[palidx];
         uint32_t* dst = &data[ncv->rowstride * y / 4 + x];
-        ncpixel_set_a(dst, 255);
-        ncpixel_set_r(dst, 255);
-        ncpixel_set_g(dst, 255);
-        ncpixel_set_b(dst, 255); // FIXME pull out of palette
+        if(ncchannel_default_p(src)){
+          // FIXME use default color as detected, or just 0xffffff
+          ncpixel_set_a(dst, 255 - palidx);
+          ncpixel_set_r(dst, palidx);
+          ncpixel_set_g(dst, 220 - (palidx / 2));
+          ncpixel_set_b(dst, palidx);
+        }else{
+          *dst = 0;
+        }
 //fprintf(stderr, "BGRA PIXEL: %02x%02x%02x%02x RGBA result: %02x%02x%02x%02x\n", ((const char*)&src)[0], ((const char*)&src)[1], ((const char*)&src)[2], ((const char*)&src)[3], ((const char*)dst)[0], ((const char*)dst)[1], ((const char*)dst)[2], ((const char*)dst)[3]);
       }
     }

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -63,11 +63,16 @@ int ncvisual_stream(notcurses* nc, ncvisual* ncv, float timescale,
   return visual_implementation.visual_stream(nc, ncv, timescale, streamer, vopts, curry);
 }
 
-ncplane* ncvisual_subtitle(ncplane* parent, const ncvisual* ncv){
+ncplane* ncvisual_subtitle_plane(ncplane* parent, const ncvisual* ncv){
   if(!visual_implementation.visual_subtitle){
     return NULL;
   }
   return visual_implementation.visual_subtitle(parent, ncv);
+}
+
+char* ncvisual_subtitle(const ncvisual* ncv){
+  (void)ncv; // FIXME remove for abi3
+  return NULL;
 }
 
 int ncvisual_blit(ncvisual* ncv, int rows, int cols, ncplane* n,
@@ -1135,6 +1140,7 @@ int ncvisual_simple_streamer(ncvisual* ncv, struct ncvisual_options* vopts,
   if(notcurses_render(ncplane_notcurses(vopts->n))){
     return -1;
   }
+  struct ncplane* subtitle = NULL;
   int ret = 0;
   if(curry){
     // FIXME improve this hrmmmmm
@@ -1143,9 +1149,10 @@ int ncvisual_simple_streamer(ncvisual* ncv, struct ncvisual_options* vopts,
       ncplane_destroy(subncp->blist);
       subncp->blist = NULL;
     }
-    struct ncplane* subtitle = ncvisual_subtitle(subncp, ncv);
+    subtitle = ncvisual_subtitle_plane(subncp, ncv);
   }
   clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, tspec, NULL);
+  ncplane_destroy(subtitle);
   return ret;
 }
 

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -179,9 +179,11 @@ struct ncplane* ffmpeg_subtitle(ncplane* parent, const ncvisual* ncv){
       if(v == NULL){
         return NULL;
       }
+      int rows = (rect->h + nc->tcache.cellpixy - 1) / nc->tcache.cellpixy;
       struct ncplane_options nopts = {
-        .rows = (rect->h + nc->tcache.cellpixy - 1) / nc->tcache.cellpixy,
+        .rows = rows,
         .cols = (rect->w + nc->tcache.cellpixx - 1) / nc->tcache.cellpixx,
+        .y = ncplane_dim_y(parent) - rows - 1,
       };
       struct ncplane* vn = ncplane_create(parent, &nopts);
       if(vn == NULL){

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -131,6 +131,7 @@ subtitle_plane_from_text(ncplane* parent, const char* text){
     .y = ncplane_dim_y(parent) - (rows + 1),
     .rows = rows,
     .cols = ncplane_dim_x(parent),
+    .name = "subt",
   };
   struct ncplane* n = ncplane_create(parent, &nopts);
   if(n == NULL){
@@ -138,10 +139,13 @@ subtitle_plane_from_text(ncplane* parent, const char* text){
     return NULL;
   }
   uint64_t channels = 0;
-  ncchannels_set_fg_alpha(&channels, NCALPHA_TRANSPARENT);
-  ncchannels_set_bg_alpha(&channels, NCALPHA_TRANSPARENT);
-  ncplane_set_base(n, "", 0, channels);
+  ncchannels_set_fg_alpha(&channels, NCALPHA_HIGHCONTRAST);
+  ncchannels_set_fg_rgb8(&channels, 0x88, 0x88, 0x88);
+  ncplane_stain(n, -1, -1, channels, channels, channels, channels);
+  ncchannels_set_fg_default(&channels);
   ncplane_puttext(n, 0, NCALIGN_LEFT, text, NULL);
+  ncchannels_set_bg_alpha(&channels, NCALPHA_TRANSPARENT);
+  ncplane_set_base(n, " ", 0, channels);
   return n;
 }
 
@@ -184,6 +188,7 @@ struct ncplane* ffmpeg_subtitle(ncplane* parent, const ncvisual* ncv){
         .rows = rows,
         .cols = (rect->w + nc->tcache.cellpixx - 1) / nc->tcache.cellpixx,
         .y = ncplane_dim_y(parent) - rows - 1,
+        .name = "t1st",
       };
       struct ncplane* vn = ncplane_create(parent, &nopts);
       if(vn == NULL){

--- a/src/media/oiio-indep.c
+++ b/src/media/oiio-indep.c
@@ -64,11 +64,6 @@ int oiio_stream(struct notcurses* nc, ncvisual* ncv, float timescale,
   return -1;
 }
 
-char* oiio_subtitle(const ncvisual* ncv) { // no support in OIIO
-  (void)ncv;
-  return NULL;
-}
-
 int oiio_init(int logl __attribute__ ((unused))) {
   // FIXME set OIIO global attribute "debug" based on loglevel
   // FIXME check OIIO_VERSION_STRING components against linked openimageio_version()
@@ -85,7 +80,6 @@ const ncvisual_implementation local_visual_implementation = {
   .visual_decode = oiio_decode,
   .visual_decode_loop = oiio_decode_loop,
   .visual_stream = oiio_stream,
-  .visual_subtitle = oiio_subtitle,
   .visual_resize = oiio_resize,
   .visual_destroy = oiio_destroy,
   .canopen_images = true,

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -144,6 +144,7 @@ auto perframe(struct ncvisual* ncv, struct ncvisual_options* vopts,
     }
     if(keyp == ' '){
       if((keyp = nc.get(true)) == (uint32_t)-1){
+        ncplane_destroy(subp);
         return -1;
       }
     }
@@ -175,8 +176,10 @@ auto perframe(struct ncvisual* ncv, struct ncvisual_options* vopts,
       // FIXME move backwards
       continue;
     }
+    ncplane_destroy(subp);
     return 1;
   }
+  ncplane_destroy(subp);
   return 0;
 }
 

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -38,43 +38,10 @@ void usage(std::ostream& o, const char* name, int exitcode){
 }
 
 struct marshal {
-  struct ncplane* subtitle_plane;
   int framecount;
   bool quiet;
   ncblitter_e blitter; // can be changed while streaming, must propagate out
 };
-
-/*
-auto handle_subtitle(struct ncplane* subp, struct marshal* marsh,
-                     const ncvisual_options* vopts) -> void {
-  if(!marsh->subtitle_plane){
-    int dimx, dimy;
-    ncplane_dim_yx(vopts->n, &dimy, &dimx);
-    struct ncplane_options nopts = {
-      .y = dimy - 1,
-      .x = 0,
-      .rows = 1,
-      .cols = dimx,
-      .userptr = nullptr,
-      .name = "subt",
-      .resizecb = nullptr,
-      .flags = 0,
-      .margin_b = 0,
-      .margin_r = 0,
-    };
-    marsh->subtitle_plane = ncplane_create(vopts->n, &nopts);
-    uint64_t channels = 0;
-    ncchannels_set_fg_alpha(&channels, NCALPHA_TRANSPARENT);
-    ncchannels_set_bg_alpha(&channels, NCALPHA_TRANSPARENT);
-    ncplane_set_base(marsh->subtitle_plane, "", 0, channels);
-    ncplane_set_fg_rgb(marsh->subtitle_plane, 0x00ffff);
-    ncplane_set_fg_alpha(marsh->subtitle_plane, NCALPHA_HIGHCONTRAST);
-    ncplane_set_bg_alpha(marsh->subtitle_plane, NCALPHA_TRANSPARENT);
-  }else{
-    ncplane_erase(marsh->subtitle_plane);
-  }
-}
-*/
 
 // frame count is in the curry. original time is kept in n's userptr.
 auto perframe(struct ncvisual* ncv, struct ncvisual_options* vopts,
@@ -107,9 +74,6 @@ auto perframe(struct ncvisual* ncv, struct ncvisual_options* vopts,
                  notcurses_str_blitter(vopts->blitter));
   }
   struct ncplane* subp = ncvisual_subtitle(*stdn, ncv);
-  //if(subtitle){
-  //  handle_subtitle(subtitle, marsh, vopts);
-  //}
   const int64_t h = ns / (60 * 60 * NANOSECS_IN_SEC);
   ns -= h * (60 * 60 * NANOSECS_IN_SEC);
   const int64_t m = ns / (60 * NANOSECS_IN_SEC);
@@ -424,7 +388,6 @@ int rendered_mode_player_inner(NotCurses& nc, int argc, char** argv,
     ncplane_erase(n);
     do{
       struct marshal marsh = {
-        .subtitle_plane = nullptr,
         .framecount = 0,
         .quiet = quiet,
         .blitter = vopts.blitter,

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -44,7 +44,8 @@ struct marshal {
   ncblitter_e blitter; // can be changed while streaming, must propagate out
 };
 
-auto handle_subtitle(char* subtitle, struct marshal* marsh,
+/*
+auto handle_subtitle(struct ncplane* subp, struct marshal* marsh,
                      const ncvisual_options* vopts) -> void {
   if(!marsh->subtitle_plane){
     int dimx, dimy;
@@ -72,9 +73,8 @@ auto handle_subtitle(char* subtitle, struct marshal* marsh,
   }else{
     ncplane_erase(marsh->subtitle_plane);
   }
-  ncplane_printf_yx(marsh->subtitle_plane, 0, 0, "%s", subtitle);
-  free(subtitle);
 }
+*/
 
 // frame count is in the curry. original time is kept in n's userptr.
 auto perframe(struct ncvisual* ncv, struct ncvisual_options* vopts,
@@ -106,10 +106,10 @@ auto perframe(struct ncvisual* ncv, struct ncvisual_options* vopts,
     stdn->printf(0, NCAlign::Left, "frame %06d (%s)", marsh->framecount,
                  notcurses_str_blitter(vopts->blitter));
   }
-  char* subtitle = ncvisual_subtitle(ncv);
-  if(subtitle){
-    handle_subtitle(subtitle, marsh, vopts);
-  }
+  struct ncplane* subp = ncvisual_subtitle(*stdn, ncv);
+  //if(subtitle){
+  //  handle_subtitle(subtitle, marsh, vopts);
+  //}
   const int64_t h = ns / (60 * 60 * NANOSECS_IN_SEC);
   ns -= h * (60 * 60 * NANOSECS_IN_SEC);
   const int64_t m = ns / (60 * NANOSECS_IN_SEC);

--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -73,7 +73,7 @@ auto perframe(struct ncvisual* ncv, struct ncvisual_options* vopts,
     stdn->printf(0, NCAlign::Left, "frame %06d (%s)", marsh->framecount,
                  notcurses_str_blitter(vopts->blitter));
   }
-  struct ncplane* subp = ncvisual_subtitle(*stdn, ncv);
+  struct ncplane* subp = ncvisual_subtitle_plane(*stdn, ncv);
   const int64_t h = ns / (60 * 60 * NANOSECS_IN_SEC);
   ns -= h * (60 * 60 * NANOSECS_IN_SEC);
   const int64_t m = ns / (60 * NANOSECS_IN_SEC);


### PR DESCRIPTION
We've always handled text subtitles, but Type-1s are bitmaps. Now that we have `NCBLIT_PIXEL`, go ahead and make such subtitles available as pixel planes when requested. Works surprisingly well, ended up being a pretty easy get. Added `ncvisual_from_palidx()` along the way. Closes #1311.