### PR TITLE
Properly recover from EINTR/EAGAIN/... in control_read().

### DIFF
--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -1562,7 +1562,7 @@ control_read(int ttyfd, query_state* qstate){
           free(buf);
 //fprintf(stderr, "at end, derived terminal %d\n", qstate->qterm);
           return 0;
-        }else if(r < 0){
+        }else if (r < 0 && (errno != EINTR && errno != EAGAIN && errno != EBUSY && errno != EWOULDBLOCK)){
           goto err;
         }
       }


### PR DESCRIPTION
Fixes the funny error found by executing `notcurses-info` that reads out loud like this:

```
Reading control replies failed on 0 (Interrupted system call)
notcurses_core_init:1230:Alas, you will not be going to space today.
```

That should furthermore satisfy https://github.com/contour-terminal/contour/issues/365.