### PR TITLE
scroll framebuffer console graphics

### DIFF
--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -573,7 +573,7 @@ reprogram_linux_font(int fd, struct console_font_op* cfo,
   return 0;
 }
 
-int reprogram_console_font(int fd, unsigned no_font_changes, bool* quadrants){
+int reprogram_console_font(tinfo* ti, unsigned no_font_changes, bool* quadrants){
   struct console_font_op cfo = {
     .op = KD_FONT_OP_GET,
     .charcount = 512,
@@ -595,7 +595,7 @@ int reprogram_console_font(int fd, unsigned no_font_changes, bool* quadrants){
     free(cfo.data);
     return -1;
   }
-  int r = reprogram_linux_font(fd, &cfo, &map, no_font_changes, quadrants);
+  int r = reprogram_linux_font(ti->linux_fb_fd, &cfo, &map, no_font_changes, quadrants);
   free(cfo.data);
   free(map.entries);
   return r;

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -573,8 +573,7 @@ reprogram_linux_font(int fd, struct console_font_op* cfo,
   return 0;
 }
 
-static int
-reprogram_console_font(int fd, unsigned no_font_changes, bool* quadrants){
+int reprogram_console_font(int fd, unsigned no_font_changes, bool* quadrants){
   struct console_font_op cfo = {
     .op = KD_FONT_OP_GET,
     .charcount = 512,
@@ -605,7 +604,7 @@ reprogram_console_font(int fd, unsigned no_font_changes, bool* quadrants){
 // is the provided fd a Linux console? if so, returns true. if it is indeed
 // a Linux console, and the console font has the quadrant glyphs (either
 // because they were already present, or we added them), quadrants is set high.
-bool is_linux_console(int fd, unsigned no_font_changes, bool* quadrants){
+bool is_linux_console(int fd){
   if(fd < 0){
     return false;
   }
@@ -615,7 +614,6 @@ bool is_linux_console(int fd, unsigned no_font_changes, bool* quadrants){
     return false;
   }
   loginfo("Verified Linux console, mode %d\n", mode);
-  reprogram_console_font(fd, no_font_changes, quadrants);
   return true;
 }
 

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -193,7 +193,7 @@ int fbcon_draw(const tinfo* ti, const struct ncpile *p, sprixel* s, fbuf* f, int
 }
 
 void fbcon_scroll(const struct ncpile* p, tinfo* ti, int rows){
-  if(ti->cellpixy){
+  if(ti->cellpixy < 1){
     return;
   }
   int totalrows = ti->cellpixy * p->dimy;

--- a/src/lib/linux.h
+++ b/src/lib/linux.h
@@ -15,7 +15,7 @@ bool is_linux_console(int fd);
 // attempt to reprogram the console font, if necessary, to include all the
 // quadrant glyphs. |quadrants| will be true if the quadrants are available,
 // whether that required a reprogramming or not.
-int reprogram_console_font(int fd, unsigned no_font_changes, bool* quadrants);
+int reprogram_console_font(struct tinfo* ti, unsigned no_font_changes, bool* quadrants);
 
 // if is_linux_console() returned true, call this to determine whether it is
 // a drawable framebuffer console. do not call if not a verified console!

--- a/src/lib/linux.h
+++ b/src/lib/linux.h
@@ -9,7 +9,13 @@ extern "C" {
 
 struct tinfo;
 
-bool is_linux_console(int fd, unsigned no_font_changes, bool* quadrants);
+// is this a linux virtual console?
+bool is_linux_console(int fd);
+
+// attempt to reprogram the console font, if necessary, to include all the
+// quadrant glyphs. |quadrants| will be true if the quadrants are available,
+// whether that required a reprogramming or not.
+int reprogram_console_font(int fd, unsigned no_font_changes, bool* quadrants);
 
 // if is_linux_console() returned true, call this to determine whether it is
 // a drawable framebuffer console. do not call if not a verified console!

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -587,7 +587,7 @@ apply_term_heuristics(tinfo* ti, const char* termname, queried_terminals_e qterm
     }else{
       termname = "Linux console";
     }
-    reprogram_console_font(ti->linux_fb_fd, nonewfonts, &ti->caps.quadrants);
+    reprogram_console_font(ti, nonewfonts, &ti->caps.quadrants);
     ti->caps.braille = false; // no caps.braille, no caps.sextants in linux console
 #else
 (void)nonewfonts;

--- a/src/poc/fbconscroll.c
+++ b/src/poc/fbconscroll.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <notcurses/notcurses.h>
+
+int main(int argc, char** argv){
+  int rows = 1;
+  if(argc > 2){
+    fprintf(stderr, "usage: fbconscroll [rows]\n");
+    return EXIT_FAILURE;
+  }else if(argc == 2){
+    rows = atoi(argv[1]);
+    if(rows < 1){
+      fprintf(stderr, "usage: fbconscroll [rows]\n");
+      return EXIT_FAILURE;
+    }
+  }
+  struct notcurses_options nopts = {
+    .flags = NCOPTION_NO_ALTERNATE_SCREEN
+             | NCOPTION_NO_CLEAR_BITMAPS
+             | NCOPTION_SUPPRESS_BANNERS
+             | NCOPTION_NO_FONT_CHANGES
+             | NCOPTION_PRESERVE_CURSOR,
+  };
+  struct notcurses* nc = notcurses_init(&nopts, NULL);
+  if(nc == NULL){
+    return EXIT_FAILURE;
+  }
+  int dimy, dimx;
+  struct ncplane* n = notcurses_stddim_yx(nc, &dimy, &dimx);
+  ncplane_set_scrolling(n, true);
+  for(int i = 0 ; i < rows ; ++i){
+    int r;
+    if((r = ncplane_putchar(n, '\n')) != 0){
+      notcurses_stop(nc);
+      fprintf(stderr, "RET: %d\n", r);
+      return EXIT_FAILURE;
+    }
+  }
+  notcurses_render(nc);
+  notcurses_stop(nc);
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Add the `fbconscroll` PoC. Reorder the console font reprogramming and grabbing the framebuffer, so we don't clear existing graphics (closes #2046). Fix scrolling of framebuffer graphics (closes #2010).