### PR TITLE
Add late blit pass for framebuffer console

### DIFF
--- a/src/info/main.c
+++ b/src/info/main.c
@@ -338,7 +338,7 @@ tinfo_debug_bitmaps(struct ncplane* n, const tinfo* ti, const char* indent){
                  ti->bg_collides_default & 0xfffffful,
                  (ti->bg_collides_default & 0x01000000) ? "" : "not ");
   finish_line(n);
-  if(!ti->pixel_draw){
+  if(!ti->pixel_draw && !ti->pixel_draw_late){
     ncplane_printf(n, "%sno bitmap graphics detected", indent);
   }else{ // we do have support; draw one
     if(ti->color_registers){
@@ -348,10 +348,8 @@ tinfo_debug_bitmaps(struct ncplane* n, const tinfo* ti, const char* indent){
       }else{
         ncplane_printf(n, "%ssixel colorregs: %u", indent, ti->color_registers);
       }
-#ifdef __linux__
-    }else if(ti->linux_fb_fd >= 0){
+    }else if(ti->pixel_draw_late){
       ncplane_printf(n, "%sframebuffer graphics supported", indent);
-#endif
     }else if(ti->pixel_move == NULL){
       ncplane_printf(n, "%siTerm2 graphics support", indent);
     }else if(ti->sixel_maxy_pristine){

--- a/src/lib/blit.c
+++ b/src/lib/blit.c
@@ -930,7 +930,7 @@ const struct blitset* lookup_blitset(const tinfo* tcache, ncblitter_e setid, boo
     }
   }
   // without bitmap support, NCBLIT_PIXEL decays to NCBLIT_3x2
-  if(!tcache->pixel_draw && setid == NCBLIT_PIXEL){
+  if(!tcache->pixel_draw && !tcache->pixel_draw_late && setid == NCBLIT_PIXEL){
     if(may_degrade){
       setid = NCBLIT_3x2;
     }else{

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -730,9 +730,14 @@ sprite_scrub(const notcurses* n, const ncpile* p, sprixel* s){
 static inline int
 sprite_draw(const tinfo* ti, const ncpile* p, sprixel* s, fbuf* f,
             int y, int x){
+  if(!ti->pixel_draw){
+    return 0;
+  }
+  int offy, offx;
+  ncplane_yx(s->n, &offy, &offx);
 //sprixel_debug(s, stderr);
   logdebug("sprixel %u state %d\n", s->id, s->invalidated);
-  return ti->pixel_draw(ti, p, s, f, y, x);
+  return ti->pixel_draw(ti, p, s, f, y + offy, x + offx);
 }
 
 // precondition: s->invalidated is SPRIXEL_MOVED or SPRIXEL_INVALIDATED
@@ -749,6 +754,9 @@ sprite_redraw(const tinfo* ti, const ncpile* p, sprixel* s, fbuf* f,
     bool noscroll = !ti->sixel_maxy_pristine;
     return ti->pixel_move(s, f, noscroll);
   }else{
+    if(!ti->pixel_draw){
+      return 0;
+    }
     return ti->pixel_draw(ti, p, s, f, y, x);
   }
 }

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -120,10 +120,7 @@ error:
 }
 
 int fbcon_scrub(const struct ncpile* p, sprixel* s){
-  (void)p;
-  (void)s;
-  return 0;
-  //return sixel_scrub(p, s);
+  return sixel_scrub(p, s);
 }
 
 #ifdef __linux__
@@ -172,9 +169,7 @@ int fbcon_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
   return 1;
 }
 
-int fbcon_draw(const tinfo* ti, const struct ncpile *p, sprixel* s, fbuf* f, int y, int x){
-  (void)p;
-  (void)f; // we don't write to the stream
+int fbcon_draw(const tinfo* ti, sprixel* s, int y, int x){
   int wrote = 0;
   for(unsigned l = 0 ; l < (unsigned)s->pixy && l + y * ti->cellpixy < ti->pixy ; ++l){
     // FIXME pixel size isn't necessarily 4B, line isn't necessarily psize*pixx
@@ -688,11 +683,9 @@ int fbcon_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
   return 0;
 }
 
-int fbcon_draw(const tinfo* ti, const struct ncpile *p, sprixel* s, fbuf* f, int y, int x){
+int fbcon_draw(const tinfo* ti, sprixel* s, int y, int x){
   (void)ti;
-  (void)p;
   (void)s;
-  (void)f;
   (void)y;
   (void)x;
   return 0;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1041,7 +1041,7 @@ recursive_lock_init(pthread_mutex_t *lock){
 }
 
 int notcurses_check_pixel_support(const notcurses* nc){
-  if(nc->tcache.pixel_draw){
+  if(nc->tcache.pixel_draw || nc->tcache.pixel_draw_late){
     return 1;
   }
   return 0;

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -205,8 +205,7 @@ int kitty_blit_selfref(struct ncplane* nc, int linesize, const void* data,
                        int leny, int lenx, const struct blitterargs* bargs);
 int fbcon_blit(struct ncplane* nc, int linesize, const void* data,
                int leny, int lenx, const struct blitterargs* bargs);
-int fbcon_draw(const tinfo* ti, const struct ncpile *p, sprixel* s,
-               fbuf* f, int y, int x);
+int fbcon_draw(const tinfo* ti, sprixel* s, int y, int x);
 void fbcon_scroll(const struct ncpile* p, tinfo* ti, int rows);
 
 typedef enum {

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -53,6 +53,7 @@ setup_sixel_bitmaps(tinfo* ti, int fd, bool invert80){
     ti->pixel_init = sixel_init;
   }
   ti->pixel_draw = sixel_draw;
+  ti->pixel_draw_late = NULL;
   ti->pixel_scrub = sixel_scrub;
   ti->pixel_wipe = sixel_wipe;
   ti->pixel_remove = NULL;
@@ -79,6 +80,7 @@ setup_iterm_bitmaps(tinfo* ti, int fd){
   ti->pixel_scrub = sixel_scrub;
   ti->pixel_scroll = NULL;
   ti->pixel_draw = iterm_draw;
+  ti->pixel_draw_late = NULL;
   ti->pixel_wipe = iterm_wipe;
   ti->pixel_rebuild = iterm_rebuild;
   ti->pixel_trans_auxvec = kitty_trans_auxvec;
@@ -94,6 +96,7 @@ setup_kitty_bitmaps(tinfo* ti, int fd, kitty_graphics_e level){
   ti->pixel_scrub = kitty_scrub;
   ti->pixel_remove = kitty_remove;
   ti->pixel_draw = kitty_draw;
+  ti->pixel_draw_late = NULL;
   ti->pixel_commit = kitty_commit;
   ti->pixel_move = kitty_move;
   ti->pixel_scroll = NULL;
@@ -124,7 +127,8 @@ static inline void
 setup_fbcon_bitmaps(tinfo* ti, int fd){
   ti->pixel_rebuild = fbcon_rebuild;
   ti->pixel_wipe = fbcon_wipe;
-  ti->pixel_draw = fbcon_draw;
+  ti->pixel_draw = NULL;
+  ti->pixel_draw_late = fbcon_draw;
   ti->pixel_scroll = fbcon_scroll;
   ti->pixel_scrub = fbcon_scrub;
   ti->pixel_trans_auxvec = kitty_trans_auxvec;
@@ -887,7 +891,7 @@ int interrogate_terminfo(tinfo* ti, const char* termtype, FILE* out, unsigned ut
     goto err;
   }
   build_supported_styles(ti);
-  if(ti->pixel_draw == NULL){
+  if(ti->pixel_draw == NULL && ti->pixel_draw_late == NULL){
     if(kittygraphs){
       setup_kitty_bitmaps(ti, ti->ttyfd, KITTY_SELFREF);
     }

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -159,6 +159,7 @@ typedef struct tinfo {
   int (*pixel_init)(const struct tinfo*, int fd); // called when support is detected
   int (*pixel_draw)(const struct tinfo*, const struct ncpile* p,
                     struct sprixel* s, fbuf* f, int y, int x);
+  int (*pixel_draw_late)(const struct tinfo*, struct sprixel* s, int y, int x);
   // execute move (erase old graphic, place at new location) if non-NULL
   int (*pixel_move)(struct sprixel* s, fbuf* f, unsigned noscroll);
   int (*pixel_scrub)(const struct ncpile* p, struct sprixel* s);


### PR DESCRIPTION
The framebuffer console draws graphics in a fundamentally different way than any other backend, writing directly to a memory map rather than writing it into the bytestream. It would thus be applied first, before anything else is written in the frame. This doesn't work with our system, so instead add a late phase, used only when `pixel_draw_late` is defined (it is mutually exclusive with `pixel_draw`). This resolves both the blockiness and false annihilation we were seeing in the framebuffer console. Closes #1997. Closes #2045.