### PR TITLE
Convert end of notcurses-demo to CLI mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 2.3.17 (not yet released)
+  * Added `notcurses_enter_alternate_screen()` and
+    `notcurses_leave_alternate_screen()`.
+
 * 2.3.16 (2021-08-19)
   * Fix `ncdirect_set_*_rgb()` for the case where an emulator has fewer than
     8 colors, i.e. vt100. This release exists to make unit tests work again

--- a/USAGE.md
+++ b/USAGE.md
@@ -162,7 +162,21 @@ int notcurses_stop(struct notcurses* nc);
 `notcurses_stop` should be called before exiting your program to restore the
 terminal settings and free resources.
 
-notcurses does not typically generate diagnostics (aside from the intro banner
+An application can freely enter and exit the alternate screen:
+
+```c
+// Shift to the alternate screen, if available. If already using the alternate
+// screen, this returns 0 immediately. If the alternate screen is not
+// available, this returns -1 immediately. Entering the alternate screen turns
+// off scrolling for the standard plane.
+int notcurses_enter_alternate_screen(struct notcurses* nc);
+
+// Exit the alternate screen. Immediately returns 0 if not currently using the
+// alternate screen.
+int notcurses_leave_alternate_screen(struct notcurses* nc);
+```
+
+Notcurses does not typically generate diagnostics (aside from the intro banner
 and outro performance summary). When `stderr` is connected to the same terminal
 to which graphics are being printed, printing to stderr will corrupt the output.
 Setting `loglevel` to a value higher than `NCLOGLEVEL_SILENT` will cause

--- a/USAGE.md
+++ b/USAGE.md
@@ -126,9 +126,6 @@ typedef struct notcurses_options {
   // the environment variable TERM is used. Failure to open the terminal
   // definition will result in failure to initialize Notcurses.
   const char* termtype;
-  // If non-NULL, notcurses_render() will write each rendered frame to this
-  // FILE* in addition to outfp. This is used primarily for debugging.
-  FILE* renderfp;
   // Progressively higher log levels result in more logging to stderr. By
   // default, nothing is printed to stderr once fullscreen service begins.
   ncloglevel_e loglevel;
@@ -172,10 +169,10 @@ Setting `loglevel` to a value higher than `NCLOGLEVEL_SILENT` will cause
 diagnostics to be printed to `stderr`: you could ensure `stderr` is redirected
 if you make use of this functionality.
 
-It's probably wise to export `NCOPTION_NO_ALTERNATE_SCREEN` to the user (e.g. via
-command line option or environment variable). Developers and motivated users
-might appreciate the ability to manipulate `loglevel` and `renderfp`. The
-remaining options are typically of use only to application authors.
+It's probably wise to export `NCOPTION_NO_ALTERNATE_SCREEN` to the user (e.g.
+via command line option or environment variable). Motivated users might
+appreciate the ability to manipulate `loglevel`. The remaining options are
+typically of use only to application authors.
 
 The Notcurses API draws almost entirely into the virtual buffers of `ncplane`s.
 Only upon a call to `notcurses_render` will the visible terminal display be

--- a/doc/man/man1/notcurses-demo.1.md
+++ b/doc/man/man1/notcurses-demo.1.md
@@ -9,7 +9,7 @@ notcurses-demo - Show off some Notcurses features
 # SYNOPSIS
 
 **notcurses-demo** [**-h**|**--help**] [**-p** ***path***] [**-d** ***delaymult***]
- [**-l** ***loglevel***] [**-f** ***renderfile***] [**-J** ***jsonfile***] [**-m** ***margins***]
+ [**-l** ***loglevel***] [**-J** ***jsonfile***] [**-m** ***margins***]
  [**-V**|**--version**] [**-kc**] ***demospec***
 
 # DESCRIPTION

--- a/doc/man/man3/notcurses_init.3.md
+++ b/doc/man/man3/notcurses_init.3.md
@@ -34,7 +34,6 @@ typedef enum {
 
 typedef struct notcurses_options {
   const char* termtype;
-  FILE* renderfp;
   ncloglevel_e loglevel;
   int margin_t, margin_r, margin_b, margin_l;
   uint64_t flags; // from NCOPTION_* bits

--- a/doc/man/man3/notcurses_stdplane.3.md
+++ b/doc/man/man3/notcurses_stdplane.3.md
@@ -18,6 +18,10 @@ notcurses_stdplane - acquire the standard ncplane
 
 **static inline const struct ncplane* notcurses_stddim_yx_const(const struct notcurses* ***nc***, int* restrict ***y***, int* restrict ***x***);**
 
+**int notcurses_enter_alternate_screen(struct notcurses* ***nc***);**
+
+**int notcurses_leave_alternate_screen(struct notcurses* ***nc***);**
+
 # DESCRIPTION
 
 **notcurses_stdplane** returns a handle to the standard ncplane for the context
@@ -40,13 +44,29 @@ non-**NULL** parameters among **y** and **x**.
 A resize event does not invalidate these references. They can be used until
 **notcurses_stop(3)** is called on the associated **nc**.
 
+**notcurses_enter_alternate_screen** and **notcurses_leave_alternate_screen**
+only have meaning if the terminal implements the "alternate screen" via the
+**smcup** and **rmcup** **terminfo(5)** capabilities (see the discussion of
+**NCOPTION_NO_ALTERNATE_SCREEN** in **notcurses_init(3)**). If not currently
+using the alternate screen, and assuming it is supported,
+**notcurses_enter_alternate_screen** will switch to the alternate screen. This
+redraws the contents, repositions the cursor, and usually makes scrollback
+unavailable. The standard plane will have scrolling disabled upon a move to
+the alternate plane.
+
 # RETURN VALUES
 
-These functions cannot fail when provided a valid **struct notcurses**. They
+**notcurses_enter_alternate_screen** will return -1 if the alternate screen
+is unavailable. Both it and **notcurses_leave_alternate_screen** will return
+-1 on an I/O failure.
+
+Other functions cannot fail when provided a valid **struct notcurses**. They
 will always return a valid pointer to the standard plane.
 
 # SEE ALSO
 
 **notcurses(3)**,
+**notcurses_init(3)**,
 **notcurses_plane(3)**,
-**notcurses_stop(3)**
+**notcurses_stop(3)**,
+**terminfo(5)**

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -944,6 +944,18 @@ API ALLOC struct notcurses* notcurses_core_init(const notcurses_options* opts, F
 // Destroy a Notcurses context.
 API int notcurses_stop(struct notcurses* nc);
 
+// Shift to the alternate screen, if available. If already using the alternate
+// screen, this returns 0 immediately. If the alternate screen is not
+// available, this returns -1 immediately. Entering the alternate screen turns
+// off scrolling for the standard plane.
+API int notcurses_enter_alternate_screen(struct notcurses* nc)
+  __attribute__ ((nonnull (1)));
+
+// Exit the alternate screen. Immediately returns 0 if not currently using the
+// alternate screen.
+API int notcurses_leave_alternate_screen(struct notcurses* nc)
+  __attribute__ ((nonnull (1)));
+
 // Return the topmost plane of the pile containing 'n'.
 API struct ncplane* ncpile_top(struct ncplane* n);
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -898,9 +898,7 @@ typedef struct notcurses_options {
   // the environment variable TERM is used. Failure to open the terminal
   // definition will result in failure to initialize notcurses.
   const char* termtype;
-  // If non-NULL, notcurses_render() will write each rendered frame to this
-  // FILE* in addition to outfp. This is used primarily for debugging.
-  FILE* renderfp;
+  FILE* renderfp; // deprecated, must be NULL, will be removed for ABI3 FIXME
   // Progressively higher log levels result in more logging to stderr. By
   // default, nothing is printed to stderr once fullscreen service begins.
   ncloglevel_e loglevel;

--- a/python/notcurses/context.c
+++ b/python/notcurses/context.c
@@ -68,7 +68,6 @@ Notcurses_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     PyObject *main_fd_object = NULL;
 
     const char *term_type = NULL;
-    PyObject *render_fd_object = NULL;
     int log_level = {0};
     const char *margins_str = NULL;
     PyObject *margin_top = NULL, *margin_right = NULL, *margin_bottom = NULL, *margin_left = NULL;

--- a/python/notcurses/context.c
+++ b/python/notcurses/context.c
@@ -82,7 +82,7 @@ Notcurses_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
 
     GNU_PY_CHECK_BOOL(PyArg_ParseTupleAndKeywords(args, kwds, "|O!sO!isO!O!O!O!K", keywords,
                                                   &PyLong_Type, &main_fd_object,
-                                                  &term_type, &PyLong_Type, &render_fd_object, &log_level,
+                                                  &term_type, &PyLong_Type, &log_level,
                                                   &margins_str,
                                                   &PyLong_Type, &margin_top, &PyLong_Type, &margin_right, &PyLong_Type, &margin_bottom, &PyLong_Type, &margin_left,
                                                   &flags));
@@ -90,20 +90,6 @@ Notcurses_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     notcurses_options options = {0};
 
     options.termtype = term_type;
-
-    if (NULL != render_fd_object)
-    {
-        long render_fd = GNU_PY_LONG_CHECK(render_fd_object);
-
-        FILE *renderfp = fdopen((int)render_fd, "w");
-        if (NULL == renderfp)
-        {
-            PyErr_SetString(PyExc_ValueError, "Failed to open render file descriptor.");
-            return NULL;
-        }
-
-        options.renderfp = renderfp;
-    }
 
     options.loglevel = (ncloglevel_e)log_level;
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -67,7 +67,6 @@ use libnotcurses_sys::*;
 fn main() {
     let options = ffi::notcurses_options {
         termtype: null(),
-        renderfp: null_mut(),
         loglevel: 0,
         margin_t: 0,
         margin_r: 0,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -73,7 +73,6 @@
 //! fn main() {
 //!     let options = ffi::notcurses_options {
 //!         termtype: null(),
-//!         renderfp: null_mut(),
 //!         loglevel: 0,
 //!         margin_t: 0,
 //!         margin_r: 0,

--- a/rust/src/notcurses/methods.rs
+++ b/rust/src/notcurses/methods.rs
@@ -68,7 +68,6 @@ impl NcOptions {
     ) -> Self {
         Self {
             termtype: null(),
-            renderfp: null_mut(),
             loglevel,
             margin_t: margin_t as i32,
             margin_r: margin_r as i32,

--- a/rust/src/notcurses/methods.rs
+++ b/rust/src/notcurses/methods.rs
@@ -69,6 +69,7 @@ impl NcOptions {
         Self {
             termtype: null(),
             loglevel,
+            renderfp: null_mut(),
             margin_t: margin_t as i32,
             margin_r: margin_r as i32,
             margin_b: margin_b as i32,

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -413,7 +413,7 @@ summary_table(struct ncdirect* nc, const char* spec, bool canimage, bool canvide
       rescolor = 0x32CD32;
     }
     ncdirect_set_fg_rgb(nc, rescolor);
-    printf("%2zu", i + 1);
+    printf("%2llu", (unsigned long long)(i + 1)); // windows has %zu problems
     ncdirect_set_fg_rgb8(nc, 178, 102, 255);
     printf("│");
     ncdirect_set_fg_rgb(nc, rescolor);

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -799,7 +799,7 @@ prep_special_keys(ncinputlayer* nc){
       continue;
     }
     if(seq[0] != NCKEY_ESC){
-      loginfo("%s is not an escape sequence (%zub)\n", k->tinfo, strlen(seq));
+      loginfo("%s is not an escape sequence\n", k->tinfo);
       continue;
     }
     logdebug("support for terminfo's %s: %s\n", k->tinfo, seq);
@@ -1680,10 +1680,10 @@ void ncinput_extract_clrs(ncinputlayer* ni){
       if(rlen >= sizeof(ni->inputbuf) / sizeof(*ni->inputbuf) - ni->inputbuf_write_at){
         rlen = sizeof(ni->inputbuf) / sizeof(*ni->inputbuf) - ni->inputbuf_write_at;
       }
-      logdebug("Reading %zu from %d\n", rlen, ni->infd);
+      logdebug("Reading %llu from %d\n", rlen, ni->infd);
       ssize_t r;
       if((r = read(ni->infd, ni->inputbuf + ni->inputbuf_write_at, rlen)) > 0){
-        logdebug("Read %zu from %d\n", r, ni->infd);
+        logdebug("Read %llu from %d\n", r, ni->infd);
         ni->inputbuf_write_at += r;
         if(ni->inputbuf_write_at == sizeof(ni->inputbuf) / sizeof(*ni->inputbuf)){
           ni->inputbuf_write_at = 0;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -365,7 +365,6 @@ typedef struct notcurses {
   ncstats stashed_stats; // retain across a context reset, for closing banner
 
   FILE* ttyfp;    // FILE* for writing rasterized data
-  FILE* renderfp; // debugging FILE* to which renderings are written
   tinfo tcache;   // terminfo cache
   pthread_mutex_t pilelock; // guards pile list, locks resize in render
   bool suppress_banner; // from notcurses_options

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -29,7 +29,11 @@ void notcurses_version_components(int* major, int* minor, int* patch, int* tweak
 }
 
 int notcurses_enter_alternate_screen(notcurses* nc){
-  return enter_alternate_screen(nc->ttyfp, &nc->tcache, true);
+  if(enter_alternate_screen(nc->ttyfp, &nc->tcache, true)){
+    return -1;
+  }
+  ncplane_set_scrolling(notcurses_stdplane(nc), false);
+  return 0;
 }
 
 int notcurses_leave_alternate_screen(notcurses* nc){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1099,7 +1099,6 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   reset_stats(&ret->stats.s);
   reset_stats(&ret->stashed_stats);
   ret->ttyfp = outfp;
-  ret->renderfp = opts->renderfp;
   memset(&ret->rstate, 0, sizeof(ret->rstate));
   memset(&ret->palette_damage, 0, sizeof(ret->palette_damage));
   memset(&ret->palette, 0, sizeof(ret->palette));

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -923,23 +923,18 @@ init_banner(const notcurses* nc, fbuf* f){
     term_fg_palindex(nc, f, nc->tcache.caps.colors <= 256 ?
                      14 % nc->tcache.caps.colors : 0x2080e0);
     if(nc->tcache.cellpixy && nc->tcache.cellpixx){
-      fbuf_printf(f, "%d rows (%dpx) %d cols (%dpx) %dx%d %luB crend %u colors",
+      fbuf_printf(f, "%d rows (%dpx) %d cols (%dpx) %dx%d ",
                   nc->stdplane->leny, nc->tcache.cellpixy,
                   nc->stdplane->lenx, nc->tcache.cellpixx,
                   nc->stdplane->leny * nc->tcache.cellpixy,
-                  nc->stdplane->lenx * nc->tcache.cellpixx,
-                  (unsigned long)sizeof(struct crender),
-                  nc->tcache.caps.colors);
+                  nc->stdplane->lenx * nc->tcache.cellpixx);
     }else{
-      fbuf_printf(f, "%d rows %d cols (%sB) %luB crend %u colors",
+      fbuf_printf(f, "%d rows %d cols (%sB) ",
                   nc->stdplane->leny, nc->stdplane->lenx,
-                  bprefix(nc->stats.s.fbbytes, 1, prefixbuf, 0),
-                  (unsigned long)sizeof(struct crender),
-                  nc->tcache.caps.colors);
+                  bprefix(nc->stats.s.fbbytes, 1, prefixbuf, 0));
     }
     const char* setaf;
     if(nc->tcache.caps.rgb && (setaf = get_escape(&nc->tcache, ESCAPE_SETAF))){
-      fbuf_putc(f, '+');
       term_fg_rgb8(&nc->tcache, f, 0xe0, 0x60, 0x60);
       fbuf_putc(f, 'r');
       term_fg_rgb8(&nc->tcache, f, 0x60, 0xe0, 0x60);
@@ -948,8 +943,10 @@ init_banner(const notcurses* nc, fbuf* f){
       fbuf_putc(f, 'b');
       term_fg_palindex(nc, f, nc->tcache.caps.colors <= 256 ?
                        14 % nc->tcache.caps.colors : 0x2080e0);
+      fbuf_putc(f, '+');
     }
-    fbuf_printf(f, "\n%s%s, %zuB %s cells\nterminfo from %s zlib %s\n",
+    fbuf_printf(f, "%u colors\n%s%s (%s)\nterminfo from %s zlib %s\n",
+                nc->tcache.caps.colors,
 #ifdef __clang__
             "", // name is contained in __VERSION__
 #else
@@ -960,7 +957,6 @@ init_banner(const notcurses* nc, fbuf* f){
 #endif
 #endif
             __VERSION__,
-            sizeof(nccell),
 #ifdef __BYTE_ORDER__
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
             "LE",

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -1266,9 +1266,6 @@ raster_and_write(notcurses* nc, ncpile* p, fbuf* f){
   unblock_signals(&oldmask);
   rasterize_sprixels_post(nc, p);
 //fprintf(stderr, "%lu/%lu %lu/%lu %lu/%lu %d\n", nc->stats.defaultelisions, nc->stats.defaultemissions, nc->stats.fgelisions, nc->stats.fgemissions, nc->stats.bgelisions, nc->stats.bgemissions, ret);
-  if(nc->renderfp){
-    fprintf(nc->renderfp, "%s\n", (const char*)nc->rstate.f.buf);
-  }
   if(ret < 0){
     return ret;
   }

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -205,6 +205,7 @@ typedef struct tinfo {
   bool detected_cursor_inversion; // have we performed inversion testing?
   bool inverted_cursor;      // does the terminal return inverted coordinates?
   bool bce;                  // is the bce property advertised?
+  bool in_alt_screen;        // are we in the alternate screen?
 } tinfo;
 
 // retrieve the terminfo(5)-style escape 'e' from tdesc (NULL if undefined).
@@ -272,6 +273,92 @@ grow_esc_table(tinfo* ti, const char* tstr, escape_e esc,
   memcpy(ti->esctable + *tused, tstr, slen);
   ti->escindices[esc] = *tused + 1; // one-bias
   *tused += slen;
+  return 0;
+}
+
+static inline int
+ncfputs(const char* ext, FILE* out){
+  int r;
+#ifdef __USE_GNU
+  r = fputs_unlocked(ext, out);
+#else
+  r = fputs(ext, out);
+#endif
+  return r;
+}
+
+static inline int
+ncfputc(char c, FILE* out){
+#ifdef __USE_GNU
+  return putc_unlocked(c, out);
+#else
+  return putc(c, out);
+#endif
+}
+
+// reliably flush a FILE*...except you can't, so far as i can tell. at least
+// on glibc, a single fflush() error latches the FILE* error, but ceases to
+// perform any work (even following a clearerr()), despite returning 0 from
+// that point on. thus, after a fflush() error, even on EAGAIN and friends,
+// you can't use the stream any further. doesn't this make fflush() pretty
+// much useless? it sure would seem to, which is why we use an fbuf for
+// all our important I/O, which we then blit with blocking_write(). if you
+// care about your data, you'll do the same.
+static inline int
+ncflush(FILE* out){
+  if(ferror(out)){
+    logerror("Not attempting a flush following error\n");
+  }
+  if(fflush(out) == EOF){
+    logerror("Unrecoverable error flushing io (%s)\n", strerror(errno));
+    return -1;
+  }
+  return 0;
+}
+
+static inline int
+term_emit(const char* seq, FILE* out, bool flush){
+  if(!seq){
+    return -1;
+  }
+  if(ncfputs(seq, out) == EOF){
+    logerror("Error emitting %zub escape (%s)\n", strlen(seq), strerror(errno));
+    return -1;
+  }
+  return flush ? ncflush(out) : 0;
+}
+
+static inline int
+enter_alternate_screen(FILE* fp, tinfo* ti, bool flush){
+  if(ti->in_alt_screen){
+    return 0;
+  }
+  const char* smcup = get_escape(ti, ESCAPE_SMCUP);
+  if(smcup == NULL){
+    logerror("alternate screen is unavailable");
+    return -1;
+  }
+  if(term_emit(smcup, fp, flush)){
+    return -1;
+  }
+  ti->in_alt_screen = true;
+  return 0;
+}
+
+static inline int
+leave_alternate_screen(FILE* fp, tinfo* ti){
+  if(!ti->in_alt_screen){
+    return 0;
+  }
+  const char* rmcup = get_escape(ti, ESCAPE_RMCUP);
+  if(rmcup == NULL){
+    logerror("can't leave alternate screen");
+    return -1;
+  }
+  if(term_emit(rmcup, fp, true)){
+    return -1;
+  }
+  ti->in_alt_screen = false;
   return 0;
 }
 


### PR DESCRIPTION
`notcurses-demo` used direct mode and `ncdirect` to print its summary table on exit. Rewrite it all using CLI mode, proving it out further. Adds `notcurses_enter_alternate_screen()` and `notcurses_leave_alternate_screen()`. Closes #1836.