### PR TITLE
Duplicate linux framebuffer before changing font

### DIFF
--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -432,9 +432,6 @@ copy_and_close_linux_fb(tinfo* ti, struct framebuffer_copy* fbdup){
   fbdup->maplen = ti->linux_fb_len;
   ti->linux_fbuffer = NULL;
   ti->linux_fb_len = 0;
-  // FIXME can we get away without the fd close?
-  //close(ti->linux_fb_fd);
-  //ti->linux_fb_fd = -1;
   fbdup->pixely = ti->pixy;
   fbdup->pixelx = ti->pixx;
   return 0;

--- a/src/lib/linux.h
+++ b/src/lib/linux.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
 #include <stdbool.h>
 
 struct tinfo;
@@ -17,6 +18,11 @@ bool is_linux_console(int fd);
 // if the halfblocks are available, whether they required a reprogramming or
 // not. *|quadrants| will be true if the quadrants are available, whether that
 // required a reprogramming or not.
+// note that reprogramming the font drops any existing graphics from the
+// framebuffer. if ti has mapped the framebuffer, it will be copied and
+// unmapped before we reprogram. after reprogramming, it is remapped, and
+// the old contents are copied in, then freed. there will be an unavoidable
+// flicker while this happens.
 int reprogram_console_font(struct tinfo* ti, unsigned no_font_changes,
                            bool* halfblocks, bool* quadrants);
 

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -582,17 +582,17 @@ apply_term_heuristics(tinfo* ti, const char* termname, queried_terminals_e qterm
     if(uname(&un) == 0){
       ti->termversion = strdup(un.release);
     }
-    ti->caps.halfblocks = false;
-    ti->caps.braille = false; // no caps.braille, no caps.sextants in linux console
-    if(ti->ttyfd >= 0){
-      reprogram_console_font(ti, nonewfonts, &ti->caps.halfblocks,
-                             &ti->caps.quadrants);
-    }
     if(is_linux_framebuffer(ti)){
       termname = "Linux framebuffer";
       setup_fbcon_bitmaps(ti, ti->linux_fb_fd);
     }else{
       termname = "Linux console";
+    }
+    ti->caps.halfblocks = false;
+    ti->caps.braille = false; // no caps.braille, no caps.sextants in linux console
+    if(ti->ttyfd >= 0){
+      reprogram_console_font(ti, nonewfonts, &ti->caps.halfblocks,
+                             &ti->caps.quadrants);
     }
     // assume no useful unicode drawing unless we're positively sure
 #else

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -139,6 +139,28 @@ query_rgb(void){
   return rgb;
 }
 
+// we have to keep a copy of the linux framebuffer while we reprogram fonts
+struct framebuffer_copy {
+  void* map;
+  size_t mapsize;
+  int pixely, pixelx;
+};
+
+static int
+copy_and_close_linux_fb(tinfo* ti, struct framebuffer_copy* fbdup){
+  if((fbdup->map = memdup(ti->linux_fbuffer, ti->linux_fb_len)) == NULL){
+    return -1;
+  }
+  munmap(ti->linux_fbuffer, ti->linux_fb_len);
+  fbdup->mapsize = ti->linux_fb_len;
+  ti->linux_fbuffer = NULL;
+  ti->linux_fb_len = 0;
+  close(ti->linux_fb_fd);
+  ti->linux_fb_fd = -1;
+  // FIXME need pixelx/pixely!
+  return 0;
+}
+
 // we couldn't get a terminal from interrogation, so let's see if the TERM
 // matches any of our known terminals. this can only be as accurate as the
 // TERM setting is (and as up-to-date and complete as we are).

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -139,28 +139,6 @@ query_rgb(void){
   return rgb;
 }
 
-// we have to keep a copy of the linux framebuffer while we reprogram fonts
-struct framebuffer_copy {
-  void* map;
-  size_t mapsize;
-  int pixely, pixelx;
-};
-
-static int
-copy_and_close_linux_fb(tinfo* ti, struct framebuffer_copy* fbdup){
-  if((fbdup->map = memdup(ti->linux_fbuffer, ti->linux_fb_len)) == NULL){
-    return -1;
-  }
-  munmap(ti->linux_fbuffer, ti->linux_fb_len);
-  fbdup->mapsize = ti->linux_fb_len;
-  ti->linux_fbuffer = NULL;
-  ti->linux_fb_len = 0;
-  close(ti->linux_fb_fd);
-  ti->linux_fb_fd = -1;
-  // FIXME need pixelx/pixely!
-  return 0;
-}
-
 // we couldn't get a terminal from interrogation, so let's see if the TERM
 // matches any of our known terminals. this can only be as accurate as the
 // TERM setting is (and as up-to-date and complete as we are).
@@ -607,7 +585,8 @@ apply_term_heuristics(tinfo* ti, const char* termname, queried_terminals_e qterm
     ti->caps.halfblocks = false;
     ti->caps.braille = false; // no caps.braille, no caps.sextants in linux console
     if(ti->ttyfd >= 0){
-      reprogram_console_font(ti, nonewfonts, &ti->caps.halfblocks, &ti->caps.quadrants);
+      reprogram_console_font(ti, nonewfonts, &ti->caps.halfblocks,
+                             &ti->caps.quadrants);
     }
     if(is_linux_framebuffer(ti)){
       termname = "Linux framebuffer";


### PR DESCRIPTION
Reprogramming the Linux console font, as we do to add halfblocks, quadrants, and eighths, clears any existing graphics (for whatever reason). If we're going to perform a reprogram of the console fonts, "back up" the existing framebuffer into a copy from the `mmap`. Following the reprogramming, blit this copy back into a new map (you can't have a map open, or the reprogramming `ioctl()` will fail), assuming the size hasn't changed. Closes #2108.