### PR TITLE
gpm: spawn thread, mask out unwanted events

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -336,6 +336,7 @@ int main(void){
     return EXIT_FAILURE;
   }
   notcurses_options nopts{};
+  nopts.loglevel = NCLOGLEVEL_ERROR;
   nopts.flags = NCOPTION_INHIBIT_SETLOCALE;
   NotCurses nc(nopts);
   nc.mouse_enable(); // might fail if no mouse is available

--- a/src/lib/gpm.c
+++ b/src/lib/gpm.c
@@ -16,7 +16,8 @@ gpmwatcher(void* vti){
       logerror("error reading from gpm daemon\n");
       continue;
     }
-    loginfo("got gpm event\n");
+    loginfo("got gpm event y=%hd x=%hd mod=%u butt=%u\n", gev.y, gev.x,
+            (unsigned)gev.modifiers, (unsigned)gev.buttons);
     // FIXME decode event and enqueue to input layer
   }
   return NULL;

--- a/src/lib/gpm.c
+++ b/src/lib/gpm.c
@@ -12,12 +12,12 @@ gpmwatcher(void* vti){
   (void)ti; // FIXME
   Gpm_Event gev;
   while(true){
-    if(Gpm_GetEvent(&gev)){
+    if(!Gpm_GetEvent(&gev)){
       logerror("error reading from gpm daemon\n");
-      break;
+      continue;
     }
     loginfo("got gpm event\n");
-    // FIXME
+    // FIXME decode event and enqueue to input layer
   }
   return NULL;
 }

--- a/src/lib/gpm.c
+++ b/src/lib/gpm.c
@@ -27,7 +27,7 @@ int gpm_connect(tinfo* ti){
   (void)ti;
   gpm_zerobased = 1;
   // get all of _MOVE, _DRAG, _DOWN, and _UP
-  gpmconn.eventMask = ~0;
+  gpmconn.eventMask = GPM_DRAG | GPM_DOWN | GPM_UP;
   gpmconn.defaultMask = 0;
   gpmconn.minMod = 0;
   gpmconn.maxMod = 0; // allow shift+drag to be used for direct copy+paste

--- a/src/lib/gpm.c
+++ b/src/lib/gpm.c
@@ -6,6 +6,22 @@
 
 static Gpm_Connect gpmconn;    // gpm server handle
 
+static void*
+gpmwatcher(void* vti){
+  tinfo* ti = vti;
+  (void)ti; // FIXME
+  Gpm_Event gev;
+  while(true){
+    if(Gpm_GetEvent(&gev)){
+      logerror("error reading from gpm daemon\n");
+      break;
+    }
+    loginfo("got gpm event\n");
+    // FIXME
+  }
+  return NULL;
+}
+
 int gpm_connect(tinfo* ti){
   (void)ti;
   gpm_zerobased = 1;
@@ -15,7 +31,13 @@ int gpm_connect(tinfo* ti){
   gpmconn.minMod = 0;
   gpmconn.maxMod = 0; // allow shift+drag to be used for direct copy+paste
   if(Gpm_Open(&gpmconn, 0) == -1){
-    logerror("couldn't connect to gpm");
+    logerror("couldn't connect to gpm\n");
+    return -1;
+  }
+  if(pthread_create(&ti->gpmthread, NULL, gpmwatcher, ti)){
+    logerror("couldn't spawn gpm thread\n");
+    Gpm_Close();
+    memset(&gpmconn, 0, sizeof(gpmconn));
     return -1;
   }
   loginfo("connected to gpm on %d\n", gpm_fd);
@@ -29,10 +51,20 @@ int gpm_read(tinfo* ti, ncinput* ni){
 }
 
 int gpm_close(tinfo* ti){
-  (void)ti;
+  if(pthread_cancel(ti->gpmthread)){
+    logerror("couldn't cancel gpm thread\n"); // daemon might have died
+  }
+  void* thrres;
+  if(pthread_join(ti->gpmthread, &thrres)){
+    logerror("error joining gpm thread\n");
+  }
   Gpm_Close();
   memset(&gpmconn, 0, sizeof(gpmconn));
   return 0;
+}
+
+const char* gpm_version(void){
+  return Gpm_GetLibVersion(NULL);
 }
 #else
 int gpm_connect(tinfo* ti){
@@ -49,5 +81,9 @@ int gpm_read(tinfo* ti, ncinput* ni){
 int gpm_close(tinfo* ti){
   (void)ti;
   return -1;
+}
+
+const char* gpm_version(void){
+  return "n/a";
 }
 #endif

--- a/src/lib/gpm.h
+++ b/src/lib/gpm.h
@@ -23,6 +23,9 @@ int gpm_read(struct tinfo* ti, struct ncinput* ni);
 
 int gpm_close(struct tinfo* ti);
 
+// Returns a library-owned pointer to the libgpm client version.
+const char* gpm_version(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -959,7 +959,7 @@ init_banner(const notcurses* nc, fbuf* f){
                        14 % nc->tcache.caps.colors : 0x2080e0);
       fbuf_putc(f, '+');
     }
-    fbuf_printf(f, "%u colors\n%s%s (%s)\nterminfo from %s zlib %s\n",
+    fbuf_printf(f, "%u colors\n%s%s (%s)\nterminfo from %s zlib %s GPM %s\n",
                 nc->tcache.caps.colors,
 #ifdef __clang__
             "", // name is contained in __VERSION__
@@ -980,7 +980,7 @@ init_banner(const notcurses* nc, fbuf* f){
 #else
 #error "No __BYTE_ORDER__ definition"
 #endif
-            curses_version(), zlibVersion());
+            curses_version(), zlibVersion(), gpm_version());
     ncvisual_printbanner(f);
     init_banner_warnings(nc, f);
     const char* esc;

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -199,6 +199,7 @@ typedef struct tinfo {
   int default_cols;          // COLUMNS environment var / cols terminfo / 80
 
   int gpmfd;                 // connection to GPM daemon
+  pthread_t gpmthread;       // thread handle for GPM watcher
 #ifdef __linux__
   int linux_fb_fd;           // linux framebuffer device fd
   char* linux_fb_dev;        // device corresponding to linux_fb_dev

--- a/src/poc/multiselect.c
+++ b/src/poc/multiselect.c
@@ -64,6 +64,7 @@ int main(void){
   }
   notcurses_options opts = {
     .flags = NCOPTION_INHIBIT_SETLOCALE,
+    .loglevel = NCLOGLEVEL_ERROR,
   };
   struct notcurses* nc = notcurses_init(&opts, NULL);
   if(nc == NULL){


### PR DESCRIPTION
Show the libgpm version in the init banner. Mask out `GPM_MOVE`; we only want `DOWN`, `UP`, and `DRAG` events. Launch a thread to handle GPM events; it will translate them and dump them into the inputlayer.