### PR TITLE
Prescroll in direct mode before blitting images

### DIFF
--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -525,12 +525,11 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np, int xoff){
     if(fbuf_init(&f)){
       return -1;
     }
-    // FIXME figure out how tall it is, and ensure we have sufficient room via scrolling
     if(cursor_yx_get(n->tcache.ttyfd, u7, &y, NULL)){
       return -1;
     }
     if(toty - dimy < y){
-      int scrolls = y;
+      int scrolls = y - 1;
       y = toty - dimy;
       if(y < 0){
         y = 0;
@@ -567,6 +566,13 @@ ncdirect_dump_plane(ncdirect* n, const ncplane* np, int xoff){
       if(n->tcache.pixel_draw_late(&n->tcache, np->sprite, y, xoff) < 0){
         return -1;
       }
+    }
+    int targy = y + dimy;
+    if(targy > toty){
+      targy = toty;
+    }
+    if(ncdirect_cursor_move_yx(n, targy, xoff)){
+      return -1;
     }
     return 0;
   }


### PR DESCRIPTION
With the Linux framebuffer console, graphics don't scroll along with text. When we're going to blit an image, check how far away from the bottom we are. If there's insufficient room to display it, manually scroll up however many lines (up to the top), making room for the image. This fixes `ncls` in the console, which was otherwise piling up all graphics at the bottom of one screen, with no scrolling happening. Closes #2059.