### PR TITLE
Initial kitty keyboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ Why use this non-standard library?
 * Portable support for bitmapped graphics, whether using Sixel, Kitty, the iTerm2
   protocol, or even the Linux framebuffer console.
 
+* Support for unambiguous [keyboard protocols](https://sw.kovidgoyal.net/kitty/keyboard-protocol/).
+
+* "TUI mode" facilitates high-performance, non-scrolling, full-screen
+  applications. "CLI mode" supports scrolling output for shell utilities,
+  but with the full power of Notcurses.
+
 * It's Apache2-licensed in its entirety, as opposed to the
   [drama in several acts](https://invisible-island.net/ncurses/ncurses-license.html)
   that is the NCURSES license (the latter is [summarized](https://invisible-island.net/ncurses/ncurses-license.html#issues_freer)

--- a/TERMINALS.md
+++ b/TERMINALS.md
@@ -116,6 +116,9 @@ https://github.com/dankamongmen/notcurses/issues/1117.
 Kitty is furthermore the only terminal I know to lack the `bce` (Background
 Color Erase) capability, but Notcurses never relies on `bce` behavior.
 
+Kitty has introduced an unambiguous [keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/).
+Notcurses supports this protocol when it is detected.
+
 ### WezTerm
 
 WezTerm [implements](https://wezfurlong.org/wezterm/escape-sequences.html) some

--- a/doc/man/man1/notcurses-input.1.md
+++ b/doc/man/man1/notcurses-input.1.md
@@ -8,7 +8,7 @@ notcurses-input - Read and display input events
 
 # SYNOPSIS
 
-**notcurses-input**
+**notcurses-input** [**-v**]
 
 # DESCRIPTION
 
@@ -16,6 +16,8 @@ notcurses-input - Read and display input events
 synthesized events and mouse events. To exit, generate EOF (usually Ctrl+'d').
 
 # OPTIONS
+
+**-v**: Increase verbosity.
 
 # NOTES
 

--- a/doc/man/man3/notcurses_input.3.md
+++ b/doc/man/man3/notcurses_input.3.md
@@ -150,6 +150,9 @@ descriptor returned by **notcurses_inputready_fd** to ensure compatibility with
 future versions of Notcurses (it is possible that future versions will process
 input in their own contexts).
 
+When support is detected, the Kitty keyboard disambiguation protocol will be
+requested. This eliminates most of the **BUGS** mentioned below.
+
 # BUGS
 
 Failed escape sequences are not yet played back in their entirety; only an
@@ -166,6 +169,9 @@ in the future.
 
 Ctrl pressed along with 'J' or 'M', whether Shift is pressed or not, currently
 registers as **NCKEY_ENTER**. This will likely change in the future.
+
+When the Kitty keyboard disambiguation protocol is used, most of these issues
+are resolved.
 
 # SEE ALSO
 

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -681,7 +681,7 @@ int main(int argc, char** argv){
     usage(argv[0], stderr);
   }else if(argc == 2){
     if(strcmp(argv[1], "-v") == 0){
-      opts.loglevel = NCLOGLEVEL_DEBUG;
+      opts.loglevel = NCLOGLEVEL_TRACE;
     }else{
       usage(argv[0], stderr);
     }

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -331,12 +331,30 @@ int input_demo(ncpp::NotCurses* nc) {
   return 0;
 }
 
-int main(void){
+static void
+usage(const char* arg0, FILE* fp){
+  fprintf(fp, "usage: %s [ -v ]\n", arg0);
+  if(fp == stderr){
+    exit(EXIT_FAILURE);
+  }
+  exit(EXIT_SUCCESS);
+}
+
+int main(int argc, char** argv){
   if(setlocale(LC_ALL, "") == nullptr){
     return EXIT_FAILURE;
   }
   notcurses_options nopts{};
   nopts.loglevel = NCLOGLEVEL_ERROR;
+  if(argc > 2){
+    usage(argv[0], stderr);
+  }else if(argc == 2){
+    if(strcmp(argv[1], "-v") == 0){
+      nopts.loglevel = NCLOGLEVEL_TRACE;
+    }else{
+      usage(argv[0], stderr);
+    }
+  }
   nopts.flags = NCOPTION_INHIBIT_SETLOCALE;
   NotCurses nc(nopts);
   nc.mouse_enable(); // might fail if no mouse is available

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -243,6 +243,21 @@ handle_csi(ncinputlayer* nc, ncinput* ni, int leftmargin, int topmargin){
   while(nc->inputbuf_occupied){
     int candidate = pop_input_keypress(nc);
     logdebug("candidate: %c (%d)\n", candidate, candidate);
+    if(candidate == 'u'){ // kitty keyboard protocol
+      if(state == PARAM3){
+        logwarn("triparam kitty message?\n");
+        break;
+      }else if(state == PARAM1){
+        param1 = param;
+        param = 1;
+      }
+      ni->id = param1;
+      ni->shift = !!((param - 1) & 0x1);
+      ni->alt = !!((param - 1) & 0x2);
+      ni->ctrl = !!((param - 1) & 0x4);
+      // FIXME decode remaining modifiers through 128
+      return param1;
+    }
     if(state == PARAM1){
       // if !mouse and candidate is '>', set mouse. otherwise it ought be a
       // digit or a semicolon.

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -183,7 +183,7 @@ static int
 ncinputlayer_add_input_escape(ncinputlayer* nc, const char* esc, uint32_t special,
                               unsigned shift, unsigned ctrl, unsigned alt){
   if(esc[0] != NCKEY_ESC || strlen(esc) < 2){ // assume ESC prefix + content
-    logerror("not an escape: %s (0x%x)\n", esc, special);
+    logerror("not an escape (0x%x)\n", special);
     return -1;
   }
   esctrie** cur = &nc->inputescapes;
@@ -720,10 +720,11 @@ prep_kitty_special_keys(ncinputlayer* nc){
     uint32_t key;
     bool shift, ctrl, alt;
   } keys[] = {
-    { .esc = "\e[P", .key = NCKEY_F01, },
-    { .esc = "\e[Q", .key = NCKEY_F02, },
-    { .esc = "\e[R", .key = NCKEY_F03, },
-    { .esc = "\e[S", .key = NCKEY_F04, },
+    { .esc = "\x1b[P", .key = NCKEY_F01, },
+    { .esc = "\x1b[Q", .key = NCKEY_F02, },
+    { .esc = "\x1b[R", .key = NCKEY_F03, },
+    { .esc = "\x1b[S", .key = NCKEY_F04, },
+    { .esc = NULL, .key = NCKEY_INVALID, },
   }, *k;
   for(k = keys ; k->esc ; ++k){
     if(ncinputlayer_add_input_escape(nc, k->esc, k->key, k->shift, k->ctrl, k->alt)){
@@ -745,32 +746,32 @@ prep_windows_special_keys(ncinputlayer* nc){
     uint32_t key;
     bool shift, ctrl, alt;
   } keys[] = {
-    { .esc = "\e[A", .key = NCKEY_UP, },
-    { .esc = "\e[B", .key = NCKEY_DOWN, },
-    { .esc = "\e[C", .key = NCKEY_RIGHT, },
-    { .esc = "\e[D", .key = NCKEY_LEFT, },
-    { .esc = "\e[1;5A", .key = NCKEY_UP, .ctrl = 1, },
-    { .esc = "\e[1;5B", .key = NCKEY_DOWN, .ctrl = 1, },
-    { .esc = "\e[1;5C", .key = NCKEY_RIGHT, .ctrl = 1, },
-    { .esc = "\e[1;5D", .key = NCKEY_LEFT, .ctrl = 1, },
-    { .esc = "\e[H", .key = NCKEY_HOME, },
-    { .esc = "\e[F", .key = NCKEY_END, },
-    { .esc = "\e[2~", .key = NCKEY_INS, },
-    { .esc = "\e[3~", .key = NCKEY_DEL, },
-    { .esc = "\e[5~", .key = NCKEY_PGUP, },
-    { .esc = "\e[6~", .key = NCKEY_PGDOWN, },
-    { .esc = "\eOP", .key = NCKEY_F01, },
-    { .esc = "\eOQ", .key = NCKEY_F02, },
-    { .esc = "\eOR", .key = NCKEY_F03, },
-    { .esc = "\eOS", .key = NCKEY_F04, },
-    { .esc = "\e[15~", .key = NCKEY_F05, },
-    { .esc = "\e[17~", .key = NCKEY_F06, },
-    { .esc = "\e[18~", .key = NCKEY_F07, },
-    { .esc = "\e[19~", .key = NCKEY_F08, },
-    { .esc = "\e[20~", .key = NCKEY_F09, },
-    { .esc = "\e[21~", .key = NCKEY_F10, },
-    { .esc = "\e[23~", .key = NCKEY_F11, },
-    { .esc = "\e[24~", .key = NCKEY_F12, },
+    { .esc = "\x1b[A", .key = NCKEY_UP, },
+    { .esc = "\x1b[B", .key = NCKEY_DOWN, },
+    { .esc = "\x1b[C", .key = NCKEY_RIGHT, },
+    { .esc = "\x1b[D", .key = NCKEY_LEFT, },
+    { .esc = "\x1b[1;5A", .key = NCKEY_UP, .ctrl = 1, },
+    { .esc = "\x1b[1;5B", .key = NCKEY_DOWN, .ctrl = 1, },
+    { .esc = "\x1b[1;5C", .key = NCKEY_RIGHT, .ctrl = 1, },
+    { .esc = "\x1b[1;5D", .key = NCKEY_LEFT, .ctrl = 1, },
+    { .esc = "\x1b[H", .key = NCKEY_HOME, },
+    { .esc = "\x1b[F", .key = NCKEY_END, },
+    { .esc = "\x1b[2~", .key = NCKEY_INS, },
+    { .esc = "\x1b[3~", .key = NCKEY_DEL, },
+    { .esc = "\x1b[5~", .key = NCKEY_PGUP, },
+    { .esc = "\x1b[6~", .key = NCKEY_PGDOWN, },
+    { .esc = "\x1bOP", .key = NCKEY_F01, },
+    { .esc = "\x1bOQ", .key = NCKEY_F02, },
+    { .esc = "\x1bOR", .key = NCKEY_F03, },
+    { .esc = "\x1bOS", .key = NCKEY_F04, },
+    { .esc = "\x1b[15~", .key = NCKEY_F05, },
+    { .esc = "\x1b[17~", .key = NCKEY_F06, },
+    { .esc = "\x1b[18~", .key = NCKEY_F07, },
+    { .esc = "\x1b[19~", .key = NCKEY_F08, },
+    { .esc = "\x1b[20~", .key = NCKEY_F09, },
+    { .esc = "\x1b[21~", .key = NCKEY_F10, },
+    { .esc = "\x1b[23~", .key = NCKEY_F11, },
+    { .esc = "\x1b[24~", .key = NCKEY_F12, },
     { .esc = NULL, .key = NCKEY_INVALID, },
   }, *k;
   for(k = keys ; k->esc ; ++k){
@@ -941,17 +942,17 @@ prep_special_keys(ncinputlayer* nc){
   for(k = keys ; k->tinfo ; ++k){
     char* seq = tigetstr(k->tinfo);
     if(seq == NULL || seq == (char*)-1){
-//fprintf(stderr, "no support for terminfo's %s\n", k->tinfo);
+      loginfo("no terminfo declaration for %s\n", k->tinfo);
       continue;
     }
-    if(seq[0] != NCKEY_ESC){
-      loginfo("%s is not an escape sequence\n", k->tinfo);
+    if(seq[0] != NCKEY_ESC || strlen(seq) < 2){ // assume ESC prefix + content
+      logwarn("invalid escape: %s (0x%x)\n", k->tinfo, k->key);
       continue;
     }
-    logdebug("support for terminfo's %s: %s\n", k->tinfo, seq);
     if(ncinputlayer_add_input_escape(nc, seq, k->key, k->shift, k->ctrl, k->alt)){
       return -1;
     }
+    logdebug("support for terminfo's %s: %s\n", k->tinfo, seq);
   }
   if(ncinputlayer_add_input_escape(nc, CSIPREFIX, NCKEY_CSI, 0, 0, 0)){
     return -1;

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -768,7 +768,7 @@ int interrogate_terminfo(tinfo* ti, const char* termtype, FILE* out, unsigned ut
     // if we already know our terminal (e.g. on the linux console), there's no
     // need to send the identification queries. the controls are sufficient.
     bool minimal = (ti->qterm != TERMINAL_UNKNOWN);
-    if(send_initial_queries(ti->ttyfd, minimal)){
+    if(send_initial_queries(ti->ttyfd, minimal, noaltscreen)){
       goto err;
     }
   }


### PR DESCRIPTION
Incomplete, but this introduces support for kitty's unambiguous keyboard protocol. Send a directive setting the support level to 1. Send a query checking for the support level. Lex the incoming sequences, and dispatch them. Add support for `-v` to `notcurses-input`, and update the man page. Add the necessary definitions to handle function keys under the protocol. Don't send any directives until after we've switched to the alternate screen, if we're going to be using the alternate screen (this might fix #2129). Always load the Windows-style special key sequences. Completes most of #2131.