### PR TITLE
sixel: damage necessary glyphs when redrawing bitmaps

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -192,7 +192,6 @@ void Tick(ncpp::NotCurses* nc, uint64_t sec) {
   if(!nc->render()){
     throw std::runtime_error("error rendering");
   }
-notcurses_debug(*nc, stderr);
 }
 
 void Ticker(ncpp::NotCurses* nc) {

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -192,6 +192,7 @@ void Tick(ncpp::NotCurses* nc, uint64_t sec) {
   if(!nc->render()){
     throw std::runtime_error("error rendering");
   }
+notcurses_debug(*nc, stderr);
 }
 
 void Ticker(ncpp::NotCurses* nc) {

--- a/src/lib/input.c
+++ b/src/lib/input.c
@@ -253,11 +253,16 @@ handle_csi(ncinputlayer* nc, ncinput* ni, int leftmargin, int topmargin){
         param1 = param;
         param = 1;
       }
-      ni->id = param1;
       ni->shift = !!((param - 1) & 0x1);
       ni->alt = !!((param - 1) & 0x2);
       ni->ctrl = !!((param - 1) & 0x4);
       // FIXME decode remaining modifiers through 128
+      // standard keyboard protocol reports ctrl+ascii as the capital form,
+      // so (for now) conform with kitty protocol...
+      if(param1 < 128 && islower(param1) && ni->ctrl){
+        param1 = toupper(param1);
+      }
+      ni->id = param1;
       return param1;
     }
     if(state == PARAM1){

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1377,8 +1377,8 @@ egc_rtl(const char* egc, int* bytes){
 // new, purpose-specific plane. |leny| and |lenx| are output geometry in pixels.
 static inline int
 plane_blit_sixel(sprixel* spx, fbuf* f, int leny, int lenx,
-                 int parse_start, tament* tam){
-  if(sprixel_load(spx, f, leny, lenx, parse_start)){
+                 int parse_start, tament* tam, sprixel_e state){
+  if(sprixel_load(spx, f, leny, lenx, parse_start, state)){
     return -1;
   }
   ncplane* n = spx->n;

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -1055,7 +1055,7 @@ kitty_blit_core(ncplane* n, int linesize, const void* data, int leny, int lenx,
     s->animating = false;
   }
   // take ownership of |buf| and |tam| on success.
-  if(plane_blit_sixel(s, &s->glyph, leny, lenx, parse_start, tam) < 0){
+  if(plane_blit_sixel(s, &s->glyph, leny, lenx, parse_start, tam, SPRIXEL_UNSEEN) < 0){
     goto error;
   }
   return 1;

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -104,7 +104,7 @@ int fbcon_blit(struct ncplane* n, int linesize, const void* data,
     }
   }
   scrub_tam_boundaries(tam, leny, lenx, cdimy, cdimx);
-  if(plane_blit_sixel(s, &s->glyph, leny, lenx, 0, tam) < 0){
+  if(plane_blit_sixel(s, &s->glyph, leny, lenx, 0, tam, SPRIXEL_INVALIDATED) < 0){
     goto error;
   }
   return 1;

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -383,14 +383,24 @@ void sixel_refresh(const ncpile* p, sprixel* s){
   s->needs_refresh = NULL;
 }
 
+// when we first cross into a new cell, we check its old state, and if it
+// was transparent, set the rmatrix low. otherwise, set it high.
+// FIXME when we check the *last* pixel, if the finished cell is opaque,
+// set rmatrix low. we're not currently being called for that case. it would
+// suffice to know we're on the last row...
 static inline void
 update_rmatrix(unsigned char* rmatrix, int txyidx, int lasttxyidx,
                const tament* tam){
+  (void)lasttxyidx;
   if(rmatrix == NULL){
     return;
   }
-  rmatrix[txyidx] = 1;
-  // FIXME finish out logic here
+  sprixcell_e state = tam[txyidx].state;
+  if(state == SPRIXCELL_TRANSPARENT || state > SPRIXCELL_ANNIHILATED){
+    rmatrix[txyidx] = 0;
+  }else{
+    rmatrix[txyidx] = 1;
+  }
 }
 
 // no mattter the input palette, we can always get a maximum of 64 colors if we

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -110,11 +110,11 @@ typedef enum {
 // ANNIHILATED cells which are no longer ANNIHILATED), or at blittime for
 // a new RGBA frame.
 typedef enum {
+  SPRIXCELL_TRANSPARENT,       // all pixels are naturally transparent
   SPRIXCELL_OPAQUE_SIXEL,      // no transparent pixels in this cell
   SPRIXCELL_OPAQUE_KITTY,
   SPRIXCELL_MIXED_SIXEL,       // this cell has both opaque and transparent pixels
   SPRIXCELL_MIXED_KITTY,
-  SPRIXCELL_TRANSPARENT,       // all pixels are naturally transparent
   SPRIXCELL_ANNIHILATED,       // this cell has been wiped (all trans)
   SPRIXCELL_ANNIHILATED_TRANS, // this transparent cell is covered
 } sprixcell_e;
@@ -151,6 +151,7 @@ typedef struct sprixel {
   // only used for kitty-based sprixels
   int parse_start;      // where to start parsing for cell wipes
   // only used for sixel-based sprixels
+  unsigned char* needs_refresh; // one per cell, whether new frame needs damage
   struct sixelmap* smap;  // copy of palette indices + transparency bits
   bool wipes_outstanding; // do we need rebuild the sixel next render?
   bool animating;        // do we have an active animation?
@@ -201,8 +202,11 @@ int fbcon_blit(struct ncplane* nc, int linesize, const void* data,
                int leny, int lenx, const struct blitterargs* bargs);
 int fbcon_draw(const tinfo* ti, sprixel* s, int y, int x);
 void fbcon_scroll(const struct ncpile* p, tinfo* ti, int rows);
-int sprixel_load(sprixel* spx, fbuf* f, int pixy, int pixx,
-                 int parse_start);
+void sixel_refresh(const struct ncpile* p, sprixel* s);
+
+// takes ownership of s on success.
+int sprixel_load(sprixel* spx, fbuf* f, int pixy, int pixx, int parse_start,
+                 sprixel_e state);
 
 typedef enum {
   // C=1 (disabling scrolling) was only introduced in 0.20.0, at the same

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -55,6 +55,7 @@ setup_sixel_bitmaps(tinfo* ti, int fd, bool invert80){
   ti->pixel_scrub = sixel_scrub;
   ti->pixel_remove = NULL;
   ti->pixel_draw = sixel_draw;
+  ti->pixel_refresh = sixel_refresh;
   ti->pixel_draw_late = NULL;
   ti->pixel_commit = NULL;
   ti->pixel_move = NULL;
@@ -78,6 +79,7 @@ setup_kitty_bitmaps(tinfo* ti, int fd, kitty_graphics_e level){
   ti->pixel_remove = kitty_remove;
   ti->pixel_draw = kitty_draw;
   ti->pixel_draw_late = NULL;
+  ti->pixel_refresh = NULL;
   ti->pixel_commit = kitty_commit;
   ti->pixel_move = kitty_move;
   ti->pixel_scroll = NULL;
@@ -113,6 +115,7 @@ setup_fbcon_bitmaps(tinfo* ti, int fd){
   ti->pixel_draw = NULL;
   ti->pixel_draw_late = fbcon_draw;
   ti->pixel_commit = NULL;
+  ti->pixel_refresh = NULL;
   ti->pixel_move = NULL;
   ti->pixel_scroll = fbcon_scroll;
   ti->pixel_shutdown = NULL;

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -157,6 +157,10 @@ typedef struct tinfo {
   int (*pixel_wipe)(struct sprixel* s, int y, int x);
   // perform the inverse of pixel_wipe, restoring an annihilated sprixcell.
   int (*pixel_rebuild)(struct sprixel* s, int y, int x, uint8_t* auxvec);
+  // called in phase 1 when INVALIDATED; this damages cells that have been
+  // redrawn in a sixel (when old was not transparent, and new is not opaque).
+  // it leaves the sprixel in INVALIDATED so that it's drawn in phase 2.
+  void (*pixel_refresh)(const struct ncpile* p, struct sprixel* s);
   int (*pixel_remove)(int id, fbuf* f); // kitty only, issue actual delete command
   int (*pixel_init)(const struct tinfo*, int fd); // called when support is detected
   int (*pixel_draw)(const struct tinfo*, const struct ncpile* p,


### PR DESCRIPTION
It was noticed that `notcurses-input` on XTerm using pixel plots never "went down"; once you had hit some level, all subsequent samples showed that level. Pressing Ctrl+L to refresh showed the correct graph. What was going on was that we weren't damaging the glyphs of a redraw, and pixel plots use redraws, and you need a damage whenever:

* the original one is NOT transparent, and
* the new one is NOT opaque

Pixel plots hit this exact case. To resolve it, I've added a `needs_refresh` field to `sprixel`, used only by Sixel. When redrawing the image, we follow the rule above, and build up this `needs_refresh` matrix. When we are in phase 1, we now run the new `pixel_refresh()`, defined only for Sixel. It runs through `needs_refresh`, damages the appropriate glyphs, and frees the matrix. We then draw in phase 2. In between, the first text phase has gone through and obliterated the old bitmap cells. This is only done for `SPRIXEL_INVALIDATED` in `clean_sprixels()`.

It's an awful lot of complexity to add at the last minute, but it's the only way I could see to solve this very real and very fundamental problem.

`notcurses-input` now works properly on XTerm, along with Kitty, Alacritty, and Contour.