### PR TITLE
[kitty] multiframe annihilation transitivity

### DIFF
--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -23,11 +23,7 @@ void sprixel_debug(const sprixel* s, FILE* out){
       for(int x = 0 ; x < s->dimx ; ++x){
         if(s->n->tam[idx].state == SPRIXCELL_ANNIHILATED){
           if(s->n->tam[idx].auxvector){
-            fprintf(out, "%03d] ", idx);
-            for(int p = 0 ; p < s->cellpxx * s->cellpxy ; ++p){
-              fprintf(out, "%02x ", s->n->tam[idx].auxvector[p]);
-            }
-            fprintf(out, "\n");
+            fprintf(out, "%03d] %p\n", idx, s->n->tam[idx].auxvector);
           }else{
             fprintf(out, "%03d] missing!\n", idx);
           }


### PR DESCRIPTION
When using the reflexive composition extension to the
Kitty graphics protocol, we refer to the previously-
blitted image to rebuild cells, and thus don't have to
keep a copy of the image ourselves. We just blit null-
alpha cells to wipe, and then execute a reflective
composition to rebuild. The auxvector is a single word,
holding the state we were in before the wipe, since we
don't have a copy of the image to look at to determine
the state afresh (and caching it is more efficient
anyway). Good, good.

Except. When we reload the plane, we want to carry over
those wipe cells, yes? I.e. if there was a plane above
the graphic before, and we replace the graphic, that
plane still better be above it. And that means editing
the cell out of the new graphic that we blit up, on the
fly. Which we were doing. Problem is, if we later need
to rebuild that cell, and we reflexively compose using
this new image, *we reflexively compose the edited-out
cell*, and thus remain wiped (our RGB values get set
properly, but we have all 0 alphas). No good!

So instead, in KITTY_SELFREF (the most advanced kitty
implementation, corresponding to reflexive composition),
do a pass at the end and send AAAAA wipes for any
ANNIHILATED{_TRANS} sprixcells. We don't present until
both have hit (since we're using a new image ID), so
there's no flicker, though there is some bandwidth cost.

That handles rebuilding. Problem is, if we then need to
wipe these same sprixcells *again*, our auxvecs were
set to ANNIHILATED{_TRANS}, and thus no wipe takes place.
Rather than blindly propagating the auxvec across the
frames, properly reset the auxvec according to the new
blit. This handles wiping post rebuild, closing the cycle.

Kitty 0.22.0+ now runs the bitmapstates PoC perfectly.
Closes #2143.  woo-hah!