### PR TITLE
allow users to set the stdplane's resizecb

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
-* 2.4.1 (not yet released)
+* 2.4.2 (not yet released)
+  * You can now set a resize callback on the standard plane.
+
+* 2.4.1 (2021-09-12)
   * `notcurses_check_pixel_support()` still returns 0 if there is no support
     for bitmap graphics, but now returns an `ncpixelimple_e` to differentiate
     the pixel backend otherwise. This result is strictly informative.

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -571,7 +571,6 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
 
 // create an ncplane of the specified dimensions, but do not yet place it in
 // the z-buffer. clear out all cells. this is for a wholly new context.
-// FIXME set up using resizecb rather than special-purpose from SIGWINCH
 static ncplane*
 create_initial_ncplane(notcurses* nc, int dimy, int dimx){
   ncplane_options nopts = {
@@ -580,7 +579,7 @@ create_initial_ncplane(notcurses* nc, int dimy, int dimx){
     .cols = dimx - (nc->margin_l + nc->margin_r),
     .userptr = NULL,
     .name = "std",
-    .resizecb = ncplane_resize_maximize,
+    .resizecb = NULL,
     .flags = 0,
   };
   return nc->stdplane = ncplane_new_internal(nc, NULL, &nopts);
@@ -2346,9 +2345,6 @@ ncplane* ncplane_boundlist(ncplane* n){
 }
 
 void ncplane_set_resizecb(ncplane* n, int(*resizecb)(ncplane*)){
-  if(n == notcurses_stdplane(ncplane_notcurses(n))){
-    return;
-  }
   n->resizecb = resizecb;
 }
 

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -56,6 +56,12 @@ notcurses_resize_internal(ncplane* pp, int* restrict rows, int* restrict cols){
   pile->dimx = *cols;
   int ret = 0;
 //notcurses_debug(n, stderr);
+  // if this pile contains the standard plane, it ought be resized to match
+  // the viewing area before invoking any other resize callbacks.
+  if(ncplane_pile(notcurses_stdplane(n)) == pile){
+    ncplane_resize_maximize(notcurses_stdplane(n));
+  }
+  // now, begin a resize callback cascade on the root planes of the pile.
   for(ncplane* rootn = pile->roots ; rootn ; rootn = rootn->bnext){
     if(rootn->resizecb){
       ret |= rootn->resizecb(rootn);


### PR DESCRIPTION
Hardcode a call to ncplane_resize_maximize() in notcurses_resize_internal() for the standard plane, when handling the standard pile. allow the user to set the standard plane's resize callback beyond that. closes #2163.