### PR TITLE
Implement ncdirect_dump_cellplane with fbuf

### DIFF
--- a/.github/workflows/macos_test.yml
+++ b/.github/workflows/macos_test.yml
@@ -26,7 +26,6 @@ jobs:
             ffmpeg \
             libunistring \
             ncurses \
-            pandoc \
             readline
 
       - uses: actions/checkout@v2
@@ -35,7 +34,8 @@ jobs:
         run: |
           mkdir build && cd build
           cmake .. \
-            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_BUILD_TYPE=Release \
+            -DUSE_PANDOC=off
 
       - name: make
         run: |
@@ -45,7 +45,8 @@ jobs:
       - name: ctest
         run: |
           cd build
-          ctest --output-on-failure
+          make test
+          #ctest --output-on-failure
 
       - name: make install
         run: |

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1607,6 +1607,8 @@ ncdirect_bg_palindex_p(const ncdirect* nc){
   return ncchannels_bg_palindex_p(ncdirect_channels(nc));
 }
 
+int ncdirect_set_fg_rgb_f(ncdirect* nc, unsigned rgb, fbuf* f);
+int ncdirect_set_bg_rgb_f(ncdirect* nc, unsigned rgb, fbuf* f);
 int term_fg_rgb8(const tinfo* ti, fbuf* f, unsigned r, unsigned g, unsigned b);
 
 const struct blitset* lookup_blitset(const tinfo* tcache, ncblitter_e setid, bool may_degrade);


### PR DESCRIPTION
`ncdirect_dump_cellplane()` was using standard I/O, which is unreliable with large amounts of data plus flushes. Rewrite it to use `fbuf` and a final `write()`. Closes #2167, hopefully.