### PR TITLE
Replay invalid control sequences as text

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -198,7 +198,7 @@ void Tick(ncpp::NotCurses* nc, uint64_t sec) {
 
 void Ticker(ncpp::NotCurses* nc) {
   do{
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    std::this_thread::sleep_for(std::chrono::milliseconds{1000});
     const uint64_t sec = (timenow_to_ns() - start) / NANOSECS_IN_SEC;
     Tick(nc, sec);
   }while(!done);
@@ -308,6 +308,11 @@ int input_demo(ncpp::NotCurses* nc) {
         n->set_fg_rgb8(64, 128, 250);
         n->printf("Unicode: [0x%08x] '%lc'", r, (wchar_t)r);
       }
+    }
+    int x;
+    n->get_cursor_yx(nullptr, &x);
+    for(int i = x ; i < n->get_dim_x() ; ++i){
+      n->putc(' ');
     }
     if(!dim_rows(n)){
       break;

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -198,7 +198,7 @@ void Tick(ncpp::NotCurses* nc, uint64_t sec) {
 
 void Ticker(ncpp::NotCurses* nc) {
   do{
-    std::this_thread::sleep_for(std::chrono::milliseconds{1000});
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
     const uint64_t sec = (timenow_to_ns() - start) / NANOSECS_IN_SEC;
     Tick(nc, sec);
   }while(!done);

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1459,6 +1459,7 @@ pump_control_read(inputctx* ictx, unsigned char c){
           ictx->numeric = 0;
         }
         ictx->state = STATE_NULL;
+        return 2;
       }else if(c >= 0x40 && c <= 0x7E){
         ictx->state = STATE_NULL;
         if(c == 'c'){

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1709,7 +1709,6 @@ process_input(const unsigned char* buf, int buflen, ncinput* ni){
 // sticks that into the bulk queue.
 static int
 process_ncinput(inputctx* ictx, const unsigned char* buf, int buflen){
-fprintf(stderr, "PROCESSING UP TO %d BUF!\n", buflen);
   pthread_mutex_lock(&ictx->ilock);
   if(ictx->ivalid == ictx->isize){
     pthread_mutex_unlock(&ictx->ilock);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -785,7 +785,8 @@ int interrogate_terminfo(tinfo* ti, const char* termtype, FILE* out, unsigned ut
   // machines, but they'll use the terminfo installed thereon (putty, etc.).
   int termerr;
   if(setupterm(termtype, ti->ttyfd, &termerr)){
-    logpanic("Terminfo error %d for %s (see terminfo(3ncurses))\n", termerr, termtype);
+    logpanic("Terminfo error %d for [%s] (see terminfo(3ncurses))\n",
+             termerr, termtype ? termtype : "");
     goto err;
   }
   tname = termname(); // longname() is also available

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -212,7 +212,7 @@ int interrogate_terminfo(tinfo* ti, const char* termtype, FILE* out,
                          unsigned nonewfonts, int* cursor_y, int* cursor_x,
                          struct ncsharedstats* stats, int lmargin, int tmargin,
                          unsigned draininput)
-  __attribute__ ((nonnull (1, 2, 3, 10)));
+  __attribute__ ((nonnull (1, 3, 10)));
 
 void free_terminfo_cache(tinfo* ti);
 

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -86,6 +86,7 @@ reset_terminal(){
       tios.c_lflag |= ISIG | ICANON | ECHO;
       tcsetattr(fd, TCSADRAIN, &tios);
     }
+    printf("\x1b[<u"); // pop any kitty keyboard state we set
     char* str = tigetstr("sgr0");
     if(str != (char*)-1){
       printf("%s", str);

--- a/tools/interactive-tester.sh
+++ b/tools/interactive-tester.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+# interactive tester for Notcurses. runs a variety of programs, which the
+# user must inspect for correct output -- i.e. these do not check their
+# own output for correctness =[. it ought be run from a notcurses build
+# directory, with all binaries built.
+
+DATA=../data # FIXME
+OUT=$(basename 0).log # FIXME
+rm -f "$OUT"
+
+[ -d "$DATA" ] || { echo "$DATA was not a directory" >&2 ; exit 1 ; }
+
+# this ought process the entire file, then allow the user to exit with ^D
+./notcurses-input -v < ../src/lib/in.c 2>>"$OUT"
+
+# goes through a series of self-described bitmap frames
+./bitmapstates 2>>"$OUT"
+
+./statepixel "$DATA"/worldmap.jpg 2>>"$OUT"
+
+./ncneofetch -v 2>>"$OUT"


### PR DESCRIPTION
When `stdin` is connected to a terminal, we get control sequences and bulk input interleaved on that single source. We use `process_melange()` to deal with this unsavory situation, though even `process_escapes()` (which operates on the terminal exclusively when `stdin` is redirected) must be aware of it.

Amend `process_escape()` to only try and handle a single escape at a time. When it runs out of text without a sequence, or when it processes a definitely invalid sequence, return the negative number of bytes processed. If we were at the end of the input buffer, we'll go ahead and try reading again, but in a nonblocking fashion. Otherwise, we consider any leftover text to be an invalid sequence. Either way, once decided, play it from the `tbuf` into the `ibuf` in `process_escapes()`. In `process_melange()`, meanwhile, the same rules apply, but on determination of invalidity, just slide it direct to `process_input()`.

`process_input()` has furthermore been strengthened against invalid UTF8, which will be thrown away, and the `input_errors` stat is primed and ready to go once more.

Closes #2100.