### PR TITLE
Factor out ncexecvpe()

### DIFF
--- a/src/compat/compat.c
+++ b/src/compat/compat.c
@@ -24,6 +24,12 @@ int set_fd_nonblocking(int fd, unsigned state, unsigned* oldstate){ // FIXME
   (void)oldstate;
   return 0;
 }
+int set_fd_cloexec(int fd, unsigned state, unsigned* oldstate){ // FIXME
+  (void)fd;
+  (void)state;
+  (void)oldstate;
+  return 0;
+}
 pid_t waitpid(pid_t pid, int* state, int options){ // FIXME
   (void)options;
   (void)pid;
@@ -44,7 +50,7 @@ pid_t waitpid(pid_t pid, int* state, int options){ // FIXME
 #include <unistd.h>
 #include <fcntl.h>
 int set_fd_nonblocking(int fd, unsigned state, unsigned* oldstate){
-  int flags = fcntl(fd, F_GETFL, 0);
+  int flags = fcntl(fd, F_GETFL);
   if(flags < 0){
     return -1;
   }
@@ -63,6 +69,31 @@ int set_fd_nonblocking(int fd, unsigned state, unsigned* oldstate){
     flags &= ~O_NONBLOCK;
   }
   if(fcntl(fd, F_SETFL, flags)){
+    return -1;
+  }
+  return 0;
+}
+
+int set_fd_cloexec(int fd, unsigned state, unsigned* oldstate){
+  int flags = fcntl(fd, F_GETFD);
+  if(flags < 0){
+    return -1;
+  }
+  if(oldstate){
+    *oldstate = flags & O_CLOEXEC;
+  }
+  if(state){
+    if(flags & O_CLOEXEC){
+      return 0;
+    }
+    flags |= O_CLOEXEC;
+  }else{
+    if(!(flags & O_CLOEXEC)){
+      return 0;
+    }
+    flags &= ~O_CLOEXEC;
+  }
+  if(fcntl(fd, F_SETFD, flags)){
     return -1;
   }
   return 0;

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -59,6 +59,7 @@ pid_t waitpid(pid_t pid, int* ret, int flags);
 #endif
 
 int set_fd_nonblocking(int fd, unsigned state, unsigned* oldstate);
+int set_fd_cloexec(int fd, unsigned state, unsigned* oldstate);
 
 static inline uint64_t
 timespec_to_ns(const struct timespec* ts){

--- a/src/tests/fds.cpp
+++ b/src/tests/fds.cpp
@@ -158,7 +158,6 @@ TEST_CASE("FdsAndSubprocs"
     opts.curry = &outofline_cancelled;
     auto ncsubp = ncsubproc_createvp(n_, &opts, argv[0], argv, testfdcb, testfdeof);
     REQUIRE(ncsubp);
-    // FIXME ought be CHECK, breaking in drone
     WARN(0 != ncsubproc_destroy(ncsubp));
     CHECK(0 == notcurses_render(nc_));
   }


### PR DESCRIPTION
Setting the stage for a move to `posix_spawn()`, factor `ncexecvpe()` out from the various subproc entry points, and rewrite all three of them as trivial wrappers of this new function. Kill off a FIXME by manually setting pipes `O_CLOEXEC` on BSD, where we don't have LInux's `pipe2()`.