### PR TITLE
Unify control sequence automata #2183

### DIFF
--- a/doc/man/man3/notcurses_stats.3.md
+++ b/doc/man/man3/notcurses_stats.3.md
@@ -42,7 +42,7 @@ typedef struct ncstats {
   uint64_t sprixelelisions;  // sprixel elision count
   uint64_t sprixelbytes;     // sprixel bytes emitted
   uint64_t appsync_updates;  // application-synchronized updates
-  uint64_t input_events;     // EGC inputs received or synthesized
+  uint64_t input_events;     // inputs received or synthesized
   uint64_t input_errors;     // errors processing input
 
   // current state -- these can decrease

--- a/src/info/main.c
+++ b/src/info/main.c
@@ -414,6 +414,7 @@ tinfo_debug_styles(const notcurses* nc, struct ncplane* n, const char* indent){
   tinfo_debug_cap(n, "vid", notcurses_canopen_videos(nc));
   tinfo_debug_cap(n, "indn", get_escape(ti, ESCAPE_INDN));
   tinfo_debug_cap(n, "gpm", ti->gpmfd >= 0);
+  tinfo_debug_cap(n, "kbd", ti->kbdlevel > 0);
   finish_line(n);
 }
 

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -102,6 +102,21 @@ esctrie_make_numeric(esctrie* e){
 }
 
 static int
+esctrie_make_kleene(esctrie* e){
+  if(e->ntype != NODE_SPECIAL){
+    logerror("can't make node type %d string\n", e->ntype);
+    return -1;
+  }
+  for(int i = 0 ; i < 0x80 ; ++i){
+    if(e->trie[i] == NULL){
+      e->trie[i] = e;
+    }
+  }
+  logdebug("made kleene: %p\n", e);
+  return 0;
+}
+
+static int
 esctrie_make_string(esctrie* e){
   if(e->ntype != NODE_SPECIAL){
     logerror("can't make node type %d string\n", e->ntype);
@@ -208,6 +223,12 @@ int inputctx_add_cflow(automaton* a, const char* csi, triefunc fxn){
         }
       }else if(c == 'S'){
         if(esctrie_make_string(eptr)){
+          return -1;
+        }
+      }else if(c == 'H'){
+        // FIXME
+      }else if(c == 'D'){ // drain (kleene closure)
+        if(esctrie_make_kleene(eptr)){
           return -1;
         }
       }else{

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -83,6 +83,9 @@ void input_free_esctrie(automaton* a){
 
 static int
 esctrie_make_numeric(esctrie* e){
+  if(e->ntype == NODE_NUMERIC){
+    return 0;
+  }
   if(e->ntype != NODE_SPECIAL){
     logerror("can't make node type %d numeric\n", e->ntype);
     return -1;
@@ -118,6 +121,9 @@ esctrie_make_kleene(esctrie* e){
 
 static int
 esctrie_make_string(esctrie* e){
+  if(e->ntype == NODE_STRING){
+    return 0;
+  }
   if(e->ntype != NODE_SPECIAL){
     logerror("can't make node type %d string\n", e->ntype);
     return -1;
@@ -198,13 +204,6 @@ int inputctx_add_cflow(automaton* a, const char* csi, triefunc fxn){
   }
   esctrie* eptr = a->escapes;
   logdebug("ESCAPE START: %p\n", eptr);
-  if(eptr->trie['['] == NULL){
-    if((eptr->trie['['] = create_esctrie_node(0)) == NULL){
-      return -1;
-    }
-  }
-  eptr = eptr->trie['['];
-  logdebug("CSI START: %p\n", eptr);
   bool inescape = false;
   unsigned char c;
   while( (c = *csi++) ){

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -236,6 +236,18 @@ link_kleene(esctrie* e){
   return targ;
 }
 
+static void
+fill_in_numerics(esctrie* e, esctrie* targ){
+  // fill in all NULL numeric links with the new target
+  for(int i = '0' ; i <= '9' ; ++i){
+    if(e->trie[i] == NULL){
+      e->trie[i] = targ;
+    }else if(e->trie[i] != e){
+      fill_in_numerics(e->trie[i], targ);
+    }
+  }
+}
+
 // accept any digit and transition to a numeric node.
 static esctrie*
 link_numeric(esctrie* e){
@@ -256,14 +268,7 @@ link_numeric(esctrie* e){
       }
     }
   }
-  // fill in all NULL numeric links with the new target
-  for(int i = '0' ; i <= '9' ; ++i){
-    if(e->trie[i] == NULL){
-      e->trie[i] = targ;
-    }else{
-      // FIXME travel to the ends and link targ there
-    }
-  }
+  fill_in_numerics(e, targ);
   return targ;
 }
 

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -343,6 +343,29 @@ int inputctx_add_input_escape(automaton* a, const char* esc, uint32_t special,
 }
 
 static int
+ruts_hex(int* numeric, unsigned char c){
+  if(!isxdigit(c)){
+    return -1;
+  }
+  int digit;
+  if(isdigit(c)){
+    digit = c - '0';
+  }else if(islower(c)){
+    digit = c - 'a' + 10;
+  }else if(isupper(c)){
+    digit = c - 'A' + 10;
+  }else{
+    return -1; // should be impossible to reach
+  }
+  if(INT_MAX / 10 - digit < *numeric){ // would overflow
+    return -1;
+  }
+  *numeric *= 16;
+  *numeric += digit;
+  return 0;
+}
+
+static int
 growstring(automaton* a, esctrie* e, unsigned candidate){
   if(!isprint(candidate)){
     logerror("unexpected char %u in string\n", candidate);

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -50,8 +50,10 @@ create_esctrie_node(int special){
         memset(e->trie, 0, tsize);
         return e;
       }
+      free(e);
+      return NULL;
     }
-    free(e);
+    return e;
   }
   return e;
 }
@@ -164,11 +166,19 @@ esctrie_make_string(esctrie* e, triefunc fxn){
     }
     e->trie[i] = e;
   }
-  e->trie[0x1b] = create_esctrie_node(0);
+  if((e->trie[0x1b] = create_esctrie_node(0)) == NULL){
+    return -1;
+  }
   e = e->trie[0x1b];
-  e->trie['\\'] = create_esctrie_node(0);
+  if((e->trie['\\'] = create_esctrie_node(NCKEY_INVALID)) == NULL){
+    return -1;
+  }
   e = e->trie['\\'];
-  esctrie_make_function(e, fxn);
+  e->ni.id = 0;
+  e->ntype = NODE_SPECIAL;
+  if(esctrie_make_function(e, fxn)){
+    return -1;
+  }
   logdebug("made string: %p\n", e);
   return 0;
 }

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -23,6 +23,10 @@ uint32_t esctrie_id(const esctrie* e){
   return e->ni.id;
 }
 
+const char* esctrie_string(const esctrie* e){
+  return e->str;
+}
+
 esctrie** esctrie_trie(esctrie* e){
   return e->trie;
 }
@@ -357,13 +361,13 @@ int walk_automaton(automaton* a, struct inputctx* ictx, unsigned candidate,
     case NODE_NUMERIC:
       e->number = candidate - '0';
       break;
-    case NODE_STRING:{
+    case NODE_STRING:
       a->stridx = 1;
       if(growstring(a, e, candidate)){
         return -1;
       }
       break;
-    }case NODE_SPECIAL:
+    case NODE_SPECIAL:
       if(e->ni.id){
         memcpy(ni, &e->ni, sizeof(*ni));
         a->state = NULL; // FIXME?
@@ -372,10 +376,11 @@ int walk_automaton(automaton* a, struct inputctx* ictx, unsigned candidate,
       break;
     case NODE_FUNCTION:
       a->state = NULL; // FIXME?
-      if(e->fxn(ictx)){
-        return -1;
+      if(e->fxn == NULL){
+        return 2;
       }
-      return 1;
+      return e->fxn(ictx);
+      break;
   }
   return 0;
 }

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -214,6 +214,28 @@ esctrie_make_string(esctrie* e, triefunc fxn){
   return 0;
 }
 
+static esctrie*
+link_kleene(esctrie* e){
+  esctrie* targ = NULL;
+  if(targ == NULL){
+    if( (targ = create_esctrie_node(0)) ){
+      if(esctrie_make_kleene(targ)){
+        free_trienode(&targ);
+        return NULL;
+      }
+    }
+  }
+  // fill in all NULL numeric links with the new target
+  for(int i = 0 ; i < 0x80 ; ++i){
+    if(e->trie[i] == NULL){
+      e->trie[i] = targ;
+    }else{
+      // FIXME travel to the ends and link targ there
+    }
+  }
+  return targ;
+}
+
 // accept any digit and transition to a numeric node.
 static esctrie*
 link_numeric(esctrie* e){
@@ -276,7 +298,8 @@ int inputctx_add_cflow(automaton* a, const char* csi, triefunc fxn){
       }else if(c == 'H'){
         // FIXME
       }else if(c == 'D'){ // drain (kleene closure)
-        if(esctrie_make_kleene(eptr)){
+        eptr = link_kleene(eptr);
+        if(eptr == NULL){
           return -1;
         }
       }else{

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -328,8 +328,6 @@ int inputctx_add_cflow(automaton* a, const char* csi, triefunc fxn){
           return -1;
         }
         return 0;
-      }else if(c == 'H'){
-        // FIXME
       }else if(c == 'D'){ // drain (kleene closure)
         // a kleene must be followed by some terminator
         if(!*csi){
@@ -424,29 +422,6 @@ int inputctx_add_input_escape(automaton* a, const char* esc, uint32_t special,
     cur->ni.ctrl = ctrl;
     cur->ni.alt = alt;
   }
-  return 0;
-}
-
-static int
-ruts_hex(int* numeric, unsigned char c){
-  if(!isxdigit(c)){
-    return -1;
-  }
-  int digit;
-  if(isdigit(c)){
-    digit = c - '0';
-  }else if(islower(c)){
-    digit = c - 'a' + 10;
-  }else if(isupper(c)){
-    digit = c - 'A' + 10;
-  }else{
-    return -1; // should be impossible to reach
-  }
-  if(INT_MAX / 10 - digit < *numeric){ // would overflow
-    return -1;
-  }
-  *numeric *= 16;
-  *numeric += digit;
   return 0;
 }
 

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -1,0 +1,94 @@
+#include "internal.h"
+
+// we assumed escapes can only be composed of 7-bit chars
+typedef struct esctrie {
+  struct esctrie** trie;  // if non-NULL, next level of radix-128 trie
+  ncinput ni;             // composed key terminating here
+} esctrie;
+
+uint32_t esctrie_id(const esctrie* e){
+  return e->ni.id;
+}
+
+void esctrie_ni(const esctrie* e, ncinput* ni){
+  memcpy(ni, &e->ni, sizeof(*ni));
+}
+
+esctrie** esctrie_trie(esctrie* e){
+  return e->trie;
+}
+
+esctrie* create_esctrie_node(int special){
+  esctrie* e = malloc(sizeof(*e));
+  if(e){
+    memset(e, 0, sizeof(*e));
+    e->ni.id = special;
+  }
+  return e;
+}
+
+void input_free_esctrie(esctrie** eptr){
+  esctrie* e;
+  if( (e = *eptr) ){
+    if(e->trie){
+      int z;
+      for(z = 0 ; z < 0x80 ; ++z){
+        if(e->trie[z]){
+          input_free_esctrie(&e->trie[z]);
+        }
+      }
+      free(e->trie);
+    }
+    free(e);
+  }
+}
+
+// multiple input escapes might map to the same input
+int inputctx_add_input_escape(esctrie** eptr, const char* esc, uint32_t special,
+                              unsigned shift, unsigned ctrl, unsigned alt){
+  if(esc[0] != NCKEY_ESC || strlen(esc) < 2){ // assume ESC prefix + content
+    logerror("not an escape (0x%x)\n", special);
+    return -1;
+  }
+  if(*eptr == NULL){
+    if((*eptr = create_esctrie_node(NCKEY_INVALID)) == NULL){
+      return -1;
+    }
+  }
+  esctrie* cur = *eptr;
+  ++esc; // don't encode initial escape as a transition
+  do{
+    int valid = *esc;
+    if(valid <= 0 || valid >= 0x80 || valid == NCKEY_ESC){
+      logerror("invalid character %d in escape\n", valid);
+      return -1;
+    }
+    if(cur->trie == NULL){
+      const size_t tsize = sizeof(cur->trie) * 0x80;
+      if((cur->trie = malloc(tsize)) == NULL){
+        return -1;
+      }
+      memset(cur->trie, 0, tsize);
+    }
+    if(cur->trie[valid] == NULL){
+      if((cur->trie[valid] = create_esctrie_node(NCKEY_INVALID)) == NULL){
+        return -1;
+      }
+    }
+    cur = cur->trie[valid];
+    ++esc;
+  }while(*esc);
+  // it appears that multiple keys can be mapped to the same escape string. as
+  // an example, see "kend" and "kc1" in st ("simple term" from suckless) :/.
+  if(cur->ni.id != NCKEY_INVALID){ // already had one here!
+    if(cur->ni.id != special){
+      logwarn("already added escape (got 0x%x, wanted 0x%x)\n", cur->ni.id, special);
+    }
+  }else{
+    cur->ni.id = special;
+    cur->ni.shift = shift;
+    cur->ni.ctrl = ctrl;
+    cur->ni.alt = alt;
+  }
+  return 0;
+}

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -38,6 +38,7 @@ int walk_automaton(automaton* a, struct inputctx* ictx, unsigned candidate,
   __attribute__ ((nonnull (1, 2, 4)));
 
 uint32_t esctrie_id(const struct esctrie* e);
+const char* esctrie_string(const struct esctrie* e);
 // returns 128-way array of esctrie pointers
 struct esctrie** esctrie_trie(struct esctrie* e);
 int esctrie_numeric(const struct esctrie* e);

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -1,0 +1,30 @@
+#ifndef NOTCURSES_AUTOMATON
+#define NOTCURSES_AUTOMATON
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+struct ncinput;
+struct esctrie;
+
+struct esctrie* create_esctrie_node(int special);
+
+void input_free_esctrie(struct esctrie** eptr);
+
+int inputctx_add_input_escape(struct esctrie** eptr, const char* esc,
+                              uint32_t special, unsigned shift,
+                              unsigned ctrl, unsigned alt);
+
+uint32_t esctrie_id(const struct esctrie* e);
+void esctrie_ni(const struct esctrie* e, struct ncinput* ni);
+// returns 128-way array of esctrie pointers
+struct esctrie** esctrie_trie(struct esctrie* e);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -9,13 +9,14 @@ extern "C" {
 
 struct ncinput;
 struct esctrie;
+struct inputctx;
 
 // the state necessary for matching input against our automaton of control
 // sequences. we *do not* match the bulk UTF-8 input. we match online (i.e.
 // we can be passed a byte at a time).
 typedef struct automaton {
   struct esctrie* escapes;  // head Esc node of trie
-  unsigned used;            // bytes consumed thus far
+  int used;                 // bytes consumed thus far
   // FIXME need an array to track the path
   struct esctrie* state;
   unsigned stridx;          // bytes of accumulating string (includes NUL)
@@ -27,8 +28,11 @@ int inputctx_add_input_escape(automaton* a, const char* esc,
                               uint32_t special, unsigned shift,
                               unsigned ctrl, unsigned alt);
 
+int walk_automaton(automaton* a, struct inputctx* ictx, unsigned candidate,
+                   struct ncinput* ni)
+  __attribute__ ((nonnull (1, 2, 4)));
+
 uint32_t esctrie_id(const struct esctrie* e);
-void esctrie_ni(const struct esctrie* e, struct ncinput* ni);
 // returns 128-way array of esctrie pointers
 struct esctrie** esctrie_trie(struct esctrie* e);
 

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -10,8 +10,6 @@ extern "C" {
 struct ncinput;
 struct esctrie;
 
-struct esctrie* create_esctrie_node(int special);
-
 void input_free_esctrie(struct esctrie** eptr);
 
 int inputctx_add_input_escape(struct esctrie** eptr, const char* esc,

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -19,7 +19,7 @@ typedef int (*triefunc)(struct inputctx*);
 typedef struct automaton {
   struct esctrie* escapes;  // head Esc node of trie
   int used;                 // bytes consumed thus far
-  // FIXME need an array to track the path
+  int instring;             // are we in an ST-terminated string?
   struct esctrie* state;
   unsigned stridx;          // bytes of accumulating string (includes NUL)
 } automaton;

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -10,9 +10,20 @@ extern "C" {
 struct ncinput;
 struct esctrie;
 
-void input_free_esctrie(struct esctrie** eptr);
+// the state necessary for matching input against our automaton of control
+// sequences. we *do not* match the bulk UTF-8 input. we match online (i.e.
+// we can be passed a byte at a time).
+typedef struct automaton {
+  struct esctrie* escapes;  // head Esc node of trie
+  unsigned used;            // bytes consumed thus far
+  // FIXME need an array to track the path
+  struct esctrie* state;
+  unsigned stridx;          // bytes of accumulating string (includes NUL)
+} automaton;
 
-int inputctx_add_input_escape(struct esctrie** eptr, const char* esc,
+void input_free_esctrie(automaton *a);
+
+int inputctx_add_input_escape(automaton* a, const char* esc,
                               uint32_t special, unsigned shift,
                               unsigned ctrl, unsigned alt);
 

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -11,6 +11,8 @@ struct ncinput;
 struct esctrie;
 struct inputctx;
 
+typedef void(*triefunc)(struct inputctx*);
+
 // the state necessary for matching input against our automaton of control
 // sequences. we *do not* match the bulk UTF-8 input. we match online (i.e.
 // we can be passed a byte at a time).
@@ -27,6 +29,9 @@ void input_free_esctrie(automaton *a);
 int inputctx_add_input_escape(automaton* a, const char* esc,
                               uint32_t special, unsigned shift,
                               unsigned ctrl, unsigned alt);
+
+int inputctx_add_cflow(automaton* a, const char* csi, triefunc fxn)
+  __attribute__ ((nonnull (1, 2, 3)));
 
 int walk_automaton(automaton* a, struct inputctx* ictx, unsigned candidate,
                    struct ncinput* ni)

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -37,6 +37,8 @@ int walk_automaton(automaton* a, struct inputctx* ictx, unsigned candidate,
                    struct ncinput* ni)
   __attribute__ ((nonnull (1, 2, 4)));
 
+int dump_automaton(const automaton* a) __attribute__ ((nonnull (1)));
+
 uint32_t esctrie_id(const struct esctrie* e);
 const char* esctrie_string(const struct esctrie* e);
 // returns 128-way array of esctrie pointers

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -11,7 +11,7 @@ struct ncinput;
 struct esctrie;
 struct inputctx;
 
-typedef void(*triefunc)(struct inputctx*);
+typedef int (*triefunc)(struct inputctx*);
 
 // the state necessary for matching input against our automaton of control
 // sequences. we *do not* match the bulk UTF-8 input. we match online (i.e.
@@ -40,6 +40,7 @@ int walk_automaton(automaton* a, struct inputctx* ictx, unsigned candidate,
 uint32_t esctrie_id(const struct esctrie* e);
 // returns 128-way array of esctrie pointers
 struct esctrie** esctrie_trie(struct esctrie* e);
+int esctrie_numeric(const struct esctrie* e);
 
 #ifdef __cplusplus
 }

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -37,8 +37,6 @@ int walk_automaton(automaton* a, struct inputctx* ictx, unsigned candidate,
                    struct ncinput* ni)
   __attribute__ ((nonnull (1, 2, 4)));
 
-int dump_automaton(const automaton* a) __attribute__ ((nonnull (1)));
-
 uint32_t esctrie_id(const struct esctrie* e);
 const char* esctrie_string(const struct esctrie* e);
 // returns 128-way array of esctrie pointers

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -181,12 +181,9 @@ int ncdirect_cursor_disable(ncdirect* nc){
 }
 
 static int
-cursor_yx_get(ncdirect* n, int ttyfd, const char* u7, int* y, int* x){
+cursor_yx_get(ncdirect* n, const char* u7, int* y, int* x){
   struct inputctx* ictx = n->tcache.ictx;
   if(ncdirect_flush(n)){
-    return -1;
-  }
-  if(tty_emit(u7, ttyfd)){
     return -1;
   }
   int fakey, fakex;
@@ -196,7 +193,7 @@ cursor_yx_get(ncdirect* n, int ttyfd, const char* u7, int* y, int* x){
   if(x == NULL){
     x = &fakex;
   }
-  get_cursor_location(ictx, y, x);
+  get_cursor_location(ictx, u7, y, x);
   loginfo("cursor at y=%d x=%d\n", *y, *x);
   return 0;
 }
@@ -214,7 +211,7 @@ int ncdirect_cursor_move_yx(ncdirect* n, int y, int x){
     if(hpa){
       return term_emit(tiparm(hpa, x), n->ttyfp, false);
     }else if(n->tcache.ttyfd >= 0 && u7){
-      if(cursor_yx_get(n, n->tcache.ttyfd, u7, &y, NULL)){
+      if(cursor_yx_get(n, u7, &y, NULL)){
         return -1;
       }
     }else{
@@ -224,7 +221,7 @@ int ncdirect_cursor_move_yx(ncdirect* n, int y, int x){
     if(!vpa){
       return term_emit(tiparm(vpa, y), n->ttyfp, false);
     }else if(n->tcache.ttyfd >= 0 && u7){
-      if(cursor_yx_get(n, n->tcache.ttyfd, u7, NULL, &x)){
+      if(cursor_yx_get(n, u7, NULL, &x)){
         return -1;
       }
     }else{
@@ -394,7 +391,7 @@ int ncdirect_cursor_yx(ncdirect* n, int* y, int* x){
   if(!x){
     x = &xval;
   }
-  ret = cursor_yx_get(n, n->tcache.ttyfd, u7, y, x);
+  ret = cursor_yx_get(n, u7, y, x);
   if(tcsetattr(n->tcache.ttyfd, TCSANOW, &oldtermios)){
     fprintf(stderr, "Couldn't restore terminal mode on %d (%s)\n",
             n->tcache.ttyfd, strerror(errno)); // don't return error for this
@@ -967,7 +964,7 @@ char* ncdirect_readline(ncdirect* n, const char* prompt){
   }
   // FIXME what if we're reading from redirected input, not a terminal?
   int y, xstart;
-  if(cursor_yx_get(n, n->tcache.ttyfd, u7, &y, &xstart)){
+  if(cursor_yx_get(n, u7, &y, &xstart)){
     return NULL;
   }
   int tline = y;
@@ -1016,7 +1013,7 @@ char* ncdirect_readline(ncdirect* n, const char* prompt){
       str[wused - 1] = L'\0';
       // FIXME check modifiers
       int x;
-      if(cursor_yx_get(n, n->tcache.ttyfd, u7, &y, &x)){
+      if(cursor_yx_get(n, u7, &y, &x)){
         break;
       }
       if(x < oldx){

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -859,6 +859,11 @@ ncdirect* ncdirect_core_init(const char* termtype, FILE* outfp, uint64_t flags){
   if(flags > (NCDIRECT_OPTION_DRAIN_INPUT << 1)){ // allow them through with warning
     logwarn("Passed unsupported flags 0x%016jx\n", (uintmax_t)flags);
   }
+  if(termtype){
+    if(putenv_term(termtype)){
+      return NULL;
+    }
+  }
   ncdirect* ret = malloc(sizeof(ncdirect));
   if(ret == NULL){
     return ret;

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -841,7 +841,11 @@ ncdirect_stop_minimal(void* vnc){
     ret |= fbuf_finalize(&f, stdout);
   }
   if(nc->tcache.ttyfd >= 0){
-    ret |= tty_emit("\x1b[<u", nc->tcache.ttyfd);
+    if(nc->tcache.kbdlevel){
+      if(tty_emit(KKEYBOARD_POP, nc->tcache.ttyfd)){
+        ret = -1;
+      }
+    }
     const char* cnorm = get_escape(&nc->tcache, ESCAPE_CNORM);
     if(cnorm && tty_emit(cnorm, nc->tcache.ttyfd)){
       ret = -1;

--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -64,7 +64,8 @@ egcpool_grow(egcpool* pool, size_t len){
 
 // get the expected length of the encoded codepoint from the first byte of a
 // utf-8 character. if the byte is illegal as a first byte, 1 is returned.
-// Table 3.1B, Legal UTF8 Byte Sequences, Corrigendum #1: UTF-8 Shortest Form
+// Table 3.1B, Legal UTF8 Byte Sequences, Corrigendum #1: UTF-8 Shortest Form.
+// subsequent ("continuation") bytes must start with the bit pattern 10.
 static inline size_t
 utf8_codepoint_length(unsigned char c){
   if(c <= 0x7f){        // 0x000000...0x00007f

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -861,15 +861,16 @@ build_cflow_automaton(inputctx* ictx){
     { "[\\Nu", kitty_cb_simple, },
     { "[\\N;\\Nu", kitty_cb, },
     { "[?\\Nu", kitty_keyboard_cb, },
-    { "[?1;2c", da1_cb, }, // CSI ? 1 ; 2 c  ("VT100 with Advanced Video Option")
-    { "[?1;0c", da1_cb, }, // CSI ? 1 ; 0 c  ("VT101 with No Options")
-    { "[?4;6c", da1_cb, }, // CSI ? 4 ; 6 c  ("VT132 with Advanced Video and Graphics")
-    { "[?6c", da1_cb, },   // CSI ? 6 c  ("VT102")
-    { "[?7c", da1_cb, },   // CSI ? 7 c  ("VT131")
-    { "[?12;\\Dc", da1_cb, }, // CSI ? 1 2 ; Ps c  ("VT125")
-    { "[?62;\\Dc", da1_cb, }, // CSI ? 6 2 ; Ps c  ("VT220")
-    { "[?63;\\Dc", da1_cb, }, // CSI ? 6 3 ; Ps c  ("VT320")
-    { "[?64;\\Dc", da1_cb, }, // CSI ? 6 4 ; Ps c  ("VT420")
+    { "[?1;2c", da1_cb, }, // CSI ? 1 ; 2 c ("VT100 with Advanced Video Option")
+    { "[?1;0c", da1_cb, }, // CSI ? 1 ; 0 c ("VT101 with No Options")
+    { "[?4;6c", da1_cb, }, // CSI ? 4 ; 6 c ("VT132 with Advanced Video and Graphics")
+    { "[?6c", da1_cb, },   // CSI ? 6 c ("VT102")
+    { "[?7c", da1_cb, },   // CSI ? 7 c ("VT131")
+    { "[?12;\\Dc", da1_cb, }, // CSI ? 1 2 ; Ps c ("VT125")
+    { "[?62;\\Dc", da1_cb, }, // CSI ? 6 2 ; Ps c ("VT220")
+    { "[?63;\\Dc", da1_cb, }, // CSI ? 6 3 ; Ps c ("VT320")
+    { "[?64;\\Dc", da1_cb, }, // CSI ? 6 4 ; Ps c ("VT420")
+    { "[?65;\\Dc", da1_cb, }, // CSI ? 6 5 ; Ps c (WezTerm)
     { "[?1;2S", NULL, }, // negative cregs XTSMGRAPHICS
     { "[?2;2S", NULL, }, // negative pixels XTSMGRAPHICS
     { "[?1;0;\\NS", xtsmgraphics_cregs_cb, },

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -333,6 +333,13 @@ csi_node(automaton *amata){
   return esctrie_trie(e)['['];
 }
 
+// get the DCS node from the trie
+static inline struct esctrie*
+dcs_node(automaton *amata){
+  struct esctrie* e = amata->escapes;
+  return esctrie_trie(e)['P'];
+}
+
 // ictx->numeric, ictx->p3, and ictx->p2 have the two parameters. we're using
 // SGR (1006) mouse encoding, so use the final character to determine release
 // ('M' for click, 'm' for release).
@@ -675,8 +682,7 @@ bgdef_cb(inputctx* ictx){
 
 static int
 xtversion_cb(inputctx* ictx){
-  struct esctrie* e = ictx->amata.escapes;
-  e = esctrie_trie(e)['P'];
+  struct esctrie* e = dcs_node(&ictx->amata);
   e = esctrie_trie(e)['>'];
   e = esctrie_trie(e)['|'];
   e = esctrie_trie(e)['a'];
@@ -723,8 +729,7 @@ xtversion_cb(inputctx* ictx){
 
 static int
 tcap_cb(inputctx* ictx){
-  struct esctrie* e = ictx->amata.escapes;
-  e = esctrie_trie(e)['P'];
+  struct esctrie* e = dcs_node(&ictx->amata);
   e = esctrie_trie(e)['1'];
   e = esctrie_trie(e)['+'];
   e = esctrie_trie(e)['r'];
@@ -749,8 +754,7 @@ tcap_cb(inputctx* ictx){
 
 static int
 tda_cb(inputctx* ictx){
-  struct esctrie* e = ictx->amata.escapes;
-  e = esctrie_trie(e)['P'];
+  struct esctrie* e = dcs_node(&ictx->amata);
   e = esctrie_trie(e)['!'];
   e = esctrie_trie(e)['|'];
   const char* str = esctrie_string(e);

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1535,7 +1535,8 @@ static void
 process_melange(inputctx* ictx, const unsigned char* buf, int* bufused){
   int offset = 0;
   while(*bufused){
-    logdebug("input %d/%d [0x%02x]\n", offset, *bufused, buf[offset]);
+    logdebug("input %d/%d [0x%02x] (%c)\n", offset, *bufused, buf[offset],
+             isprint(*bufused) ? *bufused : ' ');
     int consumed = 0;
     if(buf[offset] == '\x1b'){
       consumed = process_escape(ictx, buf + offset, *bufused);

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -390,6 +390,10 @@ cursor_location_cb(inputctx* ictx){
   e = esctrie_trie(e)[';'];
   e = esctrie_trie(e)['0'];
   int x = esctrie_numeric(e) - 1;
+  if(ictx->initdata){
+    ictx->initdata->cursory = y;
+    ictx->initdata->cursorx = x;
+  }
   pthread_mutex_lock(&ictx->clock);
   if(ictx->cvalid == ictx->csize){
     pthread_mutex_unlock(&ictx->clock);

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -771,6 +771,7 @@ tda_cb(inputctx* ictx){
   struct esctrie* e = dcs_node(&ictx->amata);
   e = esctrie_trie(e)['!'];
   e = esctrie_trie(e)['|'];
+  e = esctrie_trie(e)['a'];
   const char* str = esctrie_string(e);
   if(str == NULL){
     logwarn("empty ternary device attribute\n");

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -612,24 +612,36 @@ decrpm_cb(inputctx* ictx){
 
 static int
 bgdef_cb(inputctx* ictx){
-  if(ictx->initdata == NULL){
-    return 2;
-  }
-  /*
-      case STATE_BG1:{
+  if(ictx->initdata){
+      struct esctrie* e = ictx->amata.escapes;
+      e = esctrie_trie(e)[']'];
+      e = esctrie_trie(e)['1'];
+      e = esctrie_trie(e)['1'];
+      e = esctrie_trie(e)[';'];
+      e = esctrie_trie(e)['r'];
+      e = esctrie_trie(e)['g'];
+      e = esctrie_trie(e)['b'];
+      e = esctrie_trie(e)[':'];
+      e = esctrie_trie(e)['a'];
+      const char* str = esctrie_string(e);
+      if(str == NULL){
+        logerror("empty bg string\n");
+      }else{
         int r, g, b;
-        if(sscanf(ictx->runstring, "rgb:%02x/%02x/%02x", &r, &g, &b) == 3){
+        if(sscanf(str, "%02x/%02x/%02x", &r, &g, &b) == 3){
           // great! =]
-        }else if(sscanf(ictx->runstring, "rgb:%04x/%04x/%04x", &r, &g, &b) == 3){
+        }else if(sscanf(str, "%04x/%04x/%04x", &r, &g, &b) == 3){
           r /= 256;
           g /= 256;
           b /= 256;
         }else{
-          break;
+          logerror("couldn't extract rgb from %s\n", str);
+          r = g = b = 0;
         }
-        inits->bg = (r << 16u) | (g << 8u) | b;
-        break;
-        */
+        ictx->initdata->bg = (r << 16u) | (g << 8u) | b;
+        loginfo("default background 0x%02x%02x%02x\n", r, g, b);
+      }
+  }
   return 2;
 }
 
@@ -825,7 +837,7 @@ build_cflow_automaton(inputctx* ictx){
     // OSC (\e_...ST)
     { "_G\\S", kittygraph_cb, },
     // a mystery to everyone!
-    { "]11;\\S", bgdef_cb, },
+    { "]11;rgb:\\S", bgdef_cb, },
     { NULL, NULL, },
   }, *csi;
   for(csi = csis ; csi->cflow ; ++csi){

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -825,7 +825,7 @@ build_cflow_automaton(inputctx* ictx){
     // OSC (\e_...ST)
     { "_G\\S", kittygraph_cb, },
     // a mystery to everyone!
-    { "11;\\S", bgdef_cb, },
+    { "]11;\\S", bgdef_cb, },
     { NULL, NULL, },
   }, *csi;
   for(csi = csis ; csi->cflow ; ++csi){

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -562,9 +562,23 @@ handoff_initial_responses(inputctx* ictx){
 
 static int
 da1_cb(inputctx* ictx){
-  loginfo("read device attributes\n");
+  loginfo("read primary device attributes\n");
   if(ictx->initdata){
     handoff_initial_responses(ictx);
+  }
+  return 2;
+}
+
+static int
+da2_cb(inputctx* ictx){
+  loginfo("read secondary device attributes\n");
+  if(ictx->initdata){
+    // SDA yields up Alacritty's crate version, but it doesn't unambiguously
+    // identify Alacritty. If we've got any other version information, don't
+    // use this. use the second parameter (Pv).
+    if(ictx->initdata->qterm == 0 && ictx->initdata->version == NULL){
+      // FIXME alacritty handle
+    }
   }
   return 2;
 }
@@ -791,6 +805,17 @@ build_cflow_automaton(inputctx* ictx){
     { "[?64;\\Dc", da1_cb, }, // CSI ? 6 4 ; Ps c  ("VT420")
     { "[?1;0;\\NS", xtsmgraphics_cregs_cb, },
     { "[?2;0;\\N;\\NS", xtsmgraphics_sixel_cb, },
+    { "[>0;\\N;\\Nc", da2_cb, }, // "VT100"
+    { "[>1;\\N;\\Nc", da2_cb, }, // "VT220"
+    { "[>2;\\N;\\Nc", da2_cb, }, // "VT240" or "VT241"
+    { "[>18;\\N;\\Nc", da2_cb, }, // "VT330"
+    { "[>19;\\N;\\Nc", da2_cb, }, // "VT340"
+    { "[>24;\\N;\\Nc", da2_cb, }, // "VT320"
+    { "[>32;\\N;\\Nc", da2_cb, }, // "VT382"
+    { "[>41;\\N;\\Nc", da2_cb, }, // "VT420"
+    { "[>61;\\N;\\Nc", da2_cb, }, // "VT510"
+    { "[>64;\\N;\\Nc", da2_cb, }, // "VT520"
+    { "[>65;\\N;\\Nc", da2_cb, }, // "VT525"
     { "[?\\N;\\N$y", decrpm_cb, },
     // DCS (\eP...ST)
     { "P1+r\\H=\\H", tcap_cb, }, // positive XTGETTCAP

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -881,7 +881,9 @@ build_cflow_automaton(inputctx* ictx){
     { "[?64;\\Dc", da1_cb, }, // CSI ? 6 4 ; Ps c ("VT420")
     { "[?65;\\Dc", da1_cb, }, // CSI ? 6 5 ; Ps c (WezTerm)
     { "[?1;2S", NULL, }, // negative cregs XTSMGRAPHICS
+    { "[?1;3;0S", NULL, }, // negative cregs XTSMGRAPHICS
     { "[?2;2S", NULL, }, // negative pixels XTSMGRAPHICS
+    { "[?2;3;0S", NULL, }, // negative pixels XTSMGRAPHICS
     { "[?1;0;\\NS", xtsmgraphics_cregs_cb, },
     { "[?2;0;\\N;\\NS", xtsmgraphics_sixel_cb, },
     { "[?2026;\\N$y", decrpm_asu_cb, },

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -380,11 +380,13 @@ cursor_location_cb(inputctx* ictx){
   e = esctrie_trie(e)['0'];
   int y = esctrie_numeric(e) - 1;
   e = esctrie_trie(e)[';'];
-  e = esctrie_trie(e)['0'];
+  e = esctrie_trie(e)['9'];
   int x = esctrie_numeric(e) - 1;
+  // the first one doesn't go onto the queue; consume it here
   if(ictx->initdata){
     ictx->initdata->cursory = y;
     ictx->initdata->cursorx = x;
+    return 2;
   }
   pthread_mutex_lock(&ictx->clock);
   if(ictx->cvalid == ictx->csize){
@@ -1770,7 +1772,7 @@ uint32_t ncdirect_getc(ncdirect* nc, const struct timespec *ts,
 int get_cursor_location(inputctx* ictx, const char* u7, int* y, int* x){
   pthread_mutex_lock(&ictx->clock);
   while(ictx->cvalid == 0){
-    if(tty_emit(u7, ictx->termfd)){
+    if(tty_emit(u7, ictx->ti->ttyfd)){
       return -1;
     }
     pthread_cond_wait(&ictx->ccond, &ictx->clock);

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -761,13 +761,12 @@ tcap_cb(inputctx* ictx){
   e = esctrie_trie(e)['1'];
   e = esctrie_trie(e)['+'];
   e = esctrie_trie(e)['r'];
-  e = esctrie_trie(e)['0'];
-  int cap = esctrie_numeric(e);
-  e = esctrie_trie(e)['='];
-  int val = esctrie_numeric(e);
+  e = esctrie_trie(e)['a'];
+  const char* str = esctrie_string(e);
+  loginfo("TCAP: %s\n", str);
+    /* FIXME
   if(cap == 0x544e){ // 'TN' terminal name
     loginfo("got TN capability %d\n", val);
-    /* FIXME
         if(strcmp(ictx->runstring, "xterm-kitty") == 0){
           inits->qterm = TERMINAL_KITTY;
         }else if(strcmp(ictx->runstring, "mlterm") == 0){
@@ -776,7 +775,6 @@ tcap_cb(inputctx* ictx){
         }
         break;
         */
-  }
   return 2;
 }
 
@@ -808,8 +806,8 @@ tda_cb(inputctx* ictx){
 static int
 build_cflow_automaton(inputctx* ictx){
   // syntax: literals are matched. \N is a numeric. \D is a drain (Kleene
-  // closure). \S is a ST-terminated string. \H is a hex-encoded string.
-  // this working is very dependent on order, and very delicate! hands off!
+  // closure). \S is a ST-terminated string. this working is very dependent on
+  // order, and very delicate! hands off!
   const struct {
     const char* cflow;
     triefunc fxn;
@@ -847,8 +845,8 @@ build_cflow_automaton(inputctx* ictx){
     { "[>64;\\N;\\Nc", da2_cb, }, // "VT520"
     { "[>65;\\N;\\Nc", da2_cb, }, // "VT525"
     // DCS (\eP...ST)
-    { "P1+r\\H=\\H", tcap_cb, }, // positive XTGETTCAP
-    { "P0+r\\H", NULL, },        // negative XTGETTCAP
+    { "P1+r\\S", tcap_cb, }, // positive XTGETTCAP
+    { "P0+r\\S", NULL, },    // negative XTGETTCAP
     { "P!|\\S", tda_cb, },
     { "P>|\\S", xtversion_cb, },
     // OSC (\e_...ST)

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -325,7 +325,7 @@ prep_special_keys(inputctx* ictx){
     { .tinfo = "kUP5",  .key = NCKEY_UP, .ctrl = 1, },
     { .tinfo = "kUP6",  .key = NCKEY_UP, .ctrl = 1, .shift = 1, },
     { .tinfo = "kUP7",  .key = NCKEY_UP, .alt = 1, .ctrl = 1, },
-    { .tinfo = NULL,    .key = NCKEY_INVALID, }
+    { .tinfo = NULL,    .key = 0, }
   }, *k;
   for(k = keys ; k->tinfo ; ++k){
     char* seq = tigetstr(k->tinfo);
@@ -456,7 +456,7 @@ prep_kitty_special_keys(inputctx* ictx){
     { .esc = "\x1b[127;2u", .key = NCKEY_BACKSPACE, .shift = 1, },
     { .esc = "\x1b[127;3u", .key = NCKEY_BACKSPACE, .alt = 1, },
     { .esc = "\x1b[127;5u", .key = NCKEY_BACKSPACE, .ctrl = 1, },
-    { .esc = NULL, .key = NCKEY_INVALID, },
+    { .esc = NULL, .key = 0, },
   }, *k;
   for(k = keys ; k->esc ; ++k){
     if(inputctx_add_input_escape(&ictx->inputescapes, k->esc, k->key,
@@ -505,7 +505,7 @@ prep_windows_special_keys(inputctx* ictx){
     { .esc = "\x1b[21~", .key = NCKEY_F10, },
     { .esc = "\x1b[23~", .key = NCKEY_F11, },
     { .esc = "\x1b[24~", .key = NCKEY_F12, },
-    { .esc = NULL, .key = NCKEY_INVALID, },
+    { .esc = NULL, .key = 0, },
   }, *k;
   for(k = keys ; k->esc ; ++k){
     if(inputctx_add_input_escape(&ictx->inputescapes, k->esc, k->key,
@@ -849,7 +849,7 @@ alt_key(inputctx* ictx, unsigned id){
 static void
 special_key(inputctx* ictx){
   assert(ictx->triepos);
-  assert(NCKEY_INVALID != ictx->triepos->special);
+  assert(0 != ictx->triepos->special);
   pthread_mutex_lock(&ictx->ilock);
   if(ictx->ivalid == ictx->isize){
     pthread_mutex_unlock(&ictx->ilock);
@@ -1452,6 +1452,7 @@ pump_control_read(inputctx* ictx, unsigned char c){
       logerror("Reached invalid init state %d\n", ictx->state);
       return -1;
   }
+  logdebug("leaving with state %d\n", ictx->state);
   return 0;
 }
 
@@ -1528,7 +1529,7 @@ process_escape(inputctx* ictx, const unsigned char* buf, int buflen){
       ictx->triepos = esctrie_trie(ictx->triepos)[candidate];
       logtrace("triepos: %p in: %u special: 0x%08x\n", ictx->triepos,
                candidate, esctrie_id(ictx->triepos));
-      if(esctrie_id(ictx->triepos) != NCKEY_INVALID){ // match! mark and reset
+      if(esctrie_id(ictx->triepos)){ // match! mark and reset
         special_key(ictx);
         ictx->triepos = ictx->inputescapes;
         return used;

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -635,6 +635,15 @@ da2_cb(inputctx* ictx){
   return 2;
 }
 
+// weird form of Ternary Device Attributes used only by WezTerm
+static int
+da3_cb(inputctx* ictx){
+  if(ictx->initdata){
+    loginfo("read ternary device attributes\n");
+  }
+  return 2;
+}
+
 static int
 kittygraph_cb(inputctx* ictx){
   loginfo("kitty graphics message\n");
@@ -887,10 +896,11 @@ build_cflow_automaton(inputctx* ictx){
     { "[>61;\\N;\\Nc", da2_cb, }, // "VT510"
     { "[>64;\\N;\\Nc", da2_cb, }, // "VT520"
     { "[>65;\\N;\\Nc", da2_cb, }, // "VT525"
+    { "[=\\Sc", da3_cb, }, // CSI da3 form as issued by WezTerm
     // DCS (\eP...ST)
     { "P1+r\\S", tcap_cb, }, // positive XTGETTCAP
     { "P0+r\\S", NULL, },    // negative XTGETTCAP
-    { "P!|\\S", tda_cb, },
+    { "P!|\\S", tda_cb, }, // DCS da3 form used by XTerm
     { "P>|\\S", xtversion_cb, },
     // OSC (\e_...ST)
     { "_G\\S", kittygraph_cb, },

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1359,7 +1359,7 @@ logdebug("state now: %p\n", ictx->amata.state);
       return -(used - 1);
     }
     // an escape always resets the trie, as does a NULL transition
-    if(candidate == NCKEY_ESC){
+    if(candidate == NCKEY_ESC && !ictx->amata.instring){
       ictx->amata.state = ictx->amata.escapes;
       ictx->amata.used = 1;
       if(used > 1){ // we got reset; replay as input

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1744,9 +1744,12 @@ uint32_t ncdirect_getc(ncdirect* nc, const struct timespec *ts,
   return ncdirect_get(nc, ts, ni);
 }
 
-int get_cursor_location(struct inputctx* ictx, int* y, int* x){
+int get_cursor_location(inputctx* ictx, const char* u7, int* y, int* x){
   pthread_mutex_lock(&ictx->clock);
   while(ictx->cvalid == 0){
+    if(tty_emit(u7, ictx->termfd)){
+      return -1;
+    }
     pthread_cond_wait(&ictx->ccond, &ictx->clock);
   }
   const cursorloc* cloc = &ictx->csrs[ictx->cread];

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -517,13 +517,11 @@ kitty_cb(inputctx* ictx){
   return 2;
 }
 
-// FIXME broken: we don't always come through the 0; usually in fact we get
-// 1, which is masked by [?1;2c, added earlier
 static int
 kitty_keyboard_cb(inputctx* ictx){
   struct esctrie* e = csi_node(&ictx->amata);
   e = esctrie_trie(e)['?'];
-  e = esctrie_trie(e)['0'];
+  e = esctrie_trie(e)['1'];
   int val = esctrie_numeric(e);
   if(ictx->initdata){
     ictx->initdata->kbdlevel = val;

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -835,6 +835,8 @@ build_cflow_automaton(inputctx* ictx){
     { "[?62;\\Dc", da1_cb, }, // CSI ? 6 2 ; Ps c  ("VT220")
     { "[?63;\\Dc", da1_cb, }, // CSI ? 6 3 ; Ps c  ("VT320")
     { "[?64;\\Dc", da1_cb, }, // CSI ? 6 4 ; Ps c  ("VT420")
+    { "[?1;2S", NULL, }, // negative cregs XTSMGRAPHICS
+    { "[?2;2S", NULL, }, // negative pixels XTSMGRAPHICS
     { "[?1;0;\\NS", xtsmgraphics_cregs_cb, },
     { "[?2;0;\\N;\\NS", xtsmgraphics_sixel_cb, },
     { "[?2026;\\N$y", decrpm_asu_cb, },

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -605,16 +605,18 @@ kittygraph_cb(inputctx* ictx){
 }
 
 static int
-decrpm_cb(inputctx* ictx){
+decrpm_asu_cb(inputctx* ictx){
   struct esctrie* e = csi_node(&ictx->amata);
   e = esctrie_trie(e)['?'];
+  e = esctrie_trie(e)['2'];
   e = esctrie_trie(e)['0'];
-  int pd = esctrie_numeric(e); // expect 2 for color registers
+  e = esctrie_trie(e)['2'];
+  e = esctrie_trie(e)['6'];
   e = esctrie_trie(e)[';'];
   e = esctrie_trie(e)['0'];
   int ps = esctrie_numeric(e);
-  loginfo("received decrpm %d %d\n", pd, ps);
-  if(pd == 2026 && ps == 2){
+  loginfo("received decrpm 2026 %d\n", ps);
+  if(ps == 2){
     if(ictx->initdata){
       ictx->initdata->appsync_supported = 1;
     }
@@ -807,6 +809,7 @@ static int
 build_cflow_automaton(inputctx* ictx){
   // syntax: literals are matched. \N is a numeric. \D is a drain (Kleene
   // closure). \S is a ST-terminated string. \H is a hex-encoded string.
+  // this working is very dependent on order, and very delicate! hands off!
   const struct {
     const char* cflow;
     triefunc fxn;
@@ -819,6 +822,7 @@ build_cflow_automaton(inputctx* ictx){
     { "[\\N;\\N;\\Nt", geom_cb, },
     { "[\\Nu", kitty_cb_simple, },
     { "[\\N;\\Nu", kitty_cb, },
+    { "[?\\Nu", kitty_keyboard_cb, },
     { "[?1;2c", da1_cb, }, // CSI ? 1 ; 2 c  ("VT100 with Advanced Video Option")
     { "[?1;0c", da1_cb, }, // CSI ? 1 ; 0 c  ("VT101 with No Options")
     { "[?4;6c", da1_cb, }, // CSI ? 4 ; 6 c  ("VT132 with Advanced Video and Graphics")
@@ -830,8 +834,7 @@ build_cflow_automaton(inputctx* ictx){
     { "[?64;\\Dc", da1_cb, }, // CSI ? 6 4 ; Ps c  ("VT420")
     { "[?1;0;\\NS", xtsmgraphics_cregs_cb, },
     { "[?2;0;\\N;\\NS", xtsmgraphics_sixel_cb, },
-    { "[?\\Nu", kitty_keyboard_cb, },
-    { "[?\\N;\\N$y", decrpm_cb, },
+    { "[?2026;\\N$y", decrpm_asu_cb, },
     { "[>0;\\N;\\Nc", da2_cb, }, // "VT100"
     { "[>1;\\N;\\Nc", da2_cb, }, // "VT220"
     { "[>2;\\N;\\Nc", da2_cb, }, // "VT240" or "VT241"

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -583,7 +583,7 @@ da1_cb(inputctx* ictx){
   if(ictx->initdata){
     handoff_initial_responses(ictx);
   }
-  return 2;
+  return 1;
 }
 
 static int
@@ -769,7 +769,7 @@ xtversion_cb(inputctx* ictx){
     return 2; // don't replay as input
   }
   if(ictx->initdata == NULL){
-    return 1;
+    return 2;
   }
   static const struct {
     const char* prefix;

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -361,10 +361,10 @@ mouse_click(inputctx* ictx, unsigned release){
   const int mods = esctrie_numeric(e);
   e = esctrie_trie(e)[';'];
   e = esctrie_trie(e)['0'];
-  const int y = esctrie_numeric(e) - 1;
+  const int x = esctrie_numeric(e) - 1 - ictx->lmargin;
   e = esctrie_trie(e)[';'];
   e = esctrie_trie(e)['0'];
-  const int x = esctrie_numeric(e) - 1;
+  const int y = esctrie_numeric(e) - 1 - ictx->tmargin;
   // convert from 1- to 0-indexing, and account for margins
   if(x < 0 || y < 0){ // click was in margins, drop it
     logwarn("dropping click in margins %d/%d\n", y, x);

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -525,7 +525,10 @@ kitty_keyboard_cb(inputctx* ictx){
   e = esctrie_trie(e)['?'];
   e = esctrie_trie(e)['0'];
   int val = esctrie_numeric(e);
-  loginfo("kitty keyboard protocol level %u\n", val);
+  if(ictx->initdata){
+    ictx->initdata->kbdlevel = val;
+    loginfo("kitty keyboard protocol level %u\n", ictx->initdata->kbdlevel);
+  }
   return 2;
 }
 

--- a/src/lib/in.h
+++ b/src/lib/in.h
@@ -75,8 +75,8 @@ struct initial_responses {
 struct initial_responses* inputlayer_get_responses(struct inputctx* ictx)
   __attribute__ ((nonnull (1)));
 
-int get_cursor_location(struct inputctx* ictx, int* y, int* x)
-  __attribute__ ((nonnull (1)));
+int get_cursor_location(struct inputctx* ictx, const char* u7, int* y, int* x)
+  __attribute__ ((nonnull (1, 2)));
 
 #ifdef __cplusplus
 }

--- a/src/lib/in.h
+++ b/src/lib/in.h
@@ -68,6 +68,7 @@ struct initial_responses {
   int sixely;                  // maximum sixel height
   int sixelx;                  // maximum sixel width
   char* version;               // version string, heap-allocated
+  unsigned kbdlevel;           // kitty keyboard protocol level
 };
 
 // Blocking call. Waits until the input thread has processed all responses to

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1783,6 +1783,9 @@ emit_scrolls(const tinfo* ti, int count, fbuf* f){
   return 0;
 }
 
+// replace or populate the TERM environment variable with 'termname'
+int putenv_term(const char* termname) __attribute__ ((nonnull (1)));
+
 #undef ALLOC
 #undef API
 

--- a/src/lib/logging.h
+++ b/src/lib/logging.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void nclog(const char* fmt, ...);
+void nclog(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 // logging
 extern int loglevel;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -100,8 +100,10 @@ notcurses_stop_minimal(void* vnc){
     if(nc->tcache.tpreserved){
       ret |= tcsetattr(nc->tcache.ttyfd, TCSAFLUSH, nc->tcache.tpreserved);
     }
-    if(tty_emit(KKEYBOARD_POP, nc->tcache.ttyfd)){
-      ret = -1;
+    if(nc->tcache.kbdlevel){
+      if(tty_emit(KKEYBOARD_POP, nc->tcache.ttyfd)){
+        ret = -1;
+      }
     }
     if((esc = get_escape(&nc->tcache, ESCAPE_RMCUP))){
       if(sprite_clear_all(&nc->tcache, f)){ // send this to f

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -985,6 +985,11 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
   if(opts->flags >= (NCOPTION_DRAIN_INPUT << 1u)){
     fprintf(stderr, "Warning: unknown Notcurses options %016" PRIu64 "\n", opts->flags);
   }
+  if(opts->termtype){
+    if(putenv_term(opts->termtype)){
+      return NULL;
+    }
+  }
   notcurses* ret = malloc(sizeof(*ret));
   if(ret == NULL){
     return ret;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1121,12 +1121,11 @@ notcurses* notcurses_core_init(const notcurses_options* opts, FILE* outfp){
     goto err;
   }
   init_banner(ret, &ret->rstate.f);
-  fwrite(ret->rstate.f.buf, ret->rstate.f.used, 1, ret->ttyfp);
-  fbuf_reset(&ret->rstate.f);
-  if(ncflush(ret->ttyfp)){
+  if(blocking_write(fileno(ret->ttyfp), ret->rstate.f.buf, ret->rstate.f.used)){
     free_plane(ret->stdplane);
     goto err;
   }
+  fbuf_reset(&ret->rstate.f);
   if(ret->rstate.logendy >= 0){ // if either is set, both are
     if(!ret->suppress_banner && ret->tcache.ttyfd >= 0){
       if(locate_cursor(&ret->tcache, &ret->rstate.logendy, &ret->rstate.logendx)){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -100,7 +100,7 @@ notcurses_stop_minimal(void* vnc){
     if(nc->tcache.tpreserved){
       ret |= tcsetattr(nc->tcache.ttyfd, TCSAFLUSH, nc->tcache.tpreserved);
     }
-    if(tty_emit("\x1b[<u", nc->tcache.ttyfd)){
+    if(tty_emit(KKEYBOARD_POP, nc->tcache.ttyfd)){
       ret = -1;
     }
     if((esc = get_escape(&nc->tcache, ESCAPE_RMCUP))){

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -731,7 +731,7 @@ int ncplane_resize_internal(ncplane* n, int keepy, int keepx, int keepleny,
     logerror("Can't keep %d@%d cols from %d\n", keeplenx, keepx, cols);
     return -1;
   }
-  loginfo("%dx%d @ %d/%d → %d/%d @ %d/%d (keeping %dx%d from %d/%d)\n", rows, cols, n->absy, n->absx, ylen, xlen, n->absy + keepy + yoff, n->absx + keepx + xoff, keepleny, keeplenx, keepy, keepx);
+  loginfo("%dx%d @ %d/%d → %d/%d @ %d/%d (want %dx%d from %d/%d)\n", rows, cols, n->absy, n->absx, ylen, xlen, n->absy + keepy + yoff, n->absx + keepx + xoff, keepleny, keeplenx, keepy, keepx);
   if(n->absy == n->absy + keepy && n->absx == n->absx + keepx &&
       rows == ylen && cols == xlen){
     return 0;

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -321,7 +321,8 @@ init_terminfo_esc(tinfo* ti, const char* name, escape_e idx,
 #define KBDSUPPORT "\x1b[>u\x1b[=1u"
 
 // the kitty keyboard protocol allows unambiguous, complete identification of
-// input events. this queries for the level of support.
+// input events. this queries for the level of support. we want to do this
+// because the "keyboard pop" control code is mishandled by kitty < 0.20.0.
 #define KBDQUERY "\x1b[?u"
 
 // these queries (terminated with a Primary Device Attributes, to which
@@ -928,6 +929,7 @@ int interrogate_terminfo(tinfo* ti, const char* termtype, FILE* out, unsigned ut
         goto err;
       }
     }
+    ti->kbdlevel = iresp->kbdlevel;
     if(iresp->qterm != TERMINAL_UNKNOWN){
       ti->qterm = iresp->qterm;
     }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -978,7 +978,7 @@ int interrogate_terminfo(tinfo* ti, const char* termtype, FILE* out, unsigned ut
   build_supported_styles(ti);
   if(ti->pixel_draw == NULL && ti->pixel_draw_late == NULL){
     if(kitty_graphics){
-      setup_kitty_bitmaps(ti, ti->ttyfd, NCPIXEL_KITTY_ANIMATED);
+      setup_kitty_bitmaps(ti, ti->ttyfd, NCPIXEL_KITTY_STATIC);
     }
     // our current sixel quantization algorithm requires at least 64 color
     // registers. we make use of no more than 256. this needs to happen
@@ -1054,7 +1054,9 @@ int locate_cursor(tinfo* ti, int* cursor_y, int* cursor_x){
     return -1;
   }
   int fd = ti->ttyfd;
-  get_cursor_location(ti->ictx, u7, cursor_y, cursor_x);
+  if(get_cursor_location(ti->ictx, u7, cursor_y, cursor_x)){
+    return -1;
+  }
   loginfo("got a report from %d %d/%d\n", fd, *cursor_y, *cursor_x);
   return 0;
 }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -1012,6 +1012,7 @@ int interrogate_terminfo(tinfo* ti, const char* termtype, FILE* out, unsigned ut
 err:
   // FIXME need to leave alternate screen if we entered it
   if(ti->tpreserved){
+    tty_emit("\x1b[<u", ti->ttyfd);
     (void)tcsetattr(ti->ttyfd, TCSANOW, ti->tpreserved);
     free(ti->tpreserved);
     ti->tpreserved = NULL;

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -1075,10 +1075,7 @@ int locate_cursor(tinfo* ti, int* cursor_y, int* cursor_x){
     return -1;
   }
   int fd = ti->ttyfd;
-  if(tty_emit(u7, fd)){
-    return -1;
-  }
-  get_cursor_location(ti->ictx, cursor_y, cursor_x);
+  get_cursor_location(ti->ictx, u7, cursor_y, cursor_x);
   loginfo("got a report from %d %d/%d\n", fd, *cursor_y, *cursor_x);
   return 0;
 }

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -387,6 +387,7 @@ init_terminfo_esc(tinfo* ti, const char* name, escape_e idx,
 // terminfo, but everyone who supports it supports it the same way, and we
 // need to send it before our other directives if we're going to use it.
 #define SMCUP "\x1b[?1049h"
+#define RMCUP "\x1b[?1049l"
 
 // we send an XTSMGRAPHICS to set up 256 color registers (the most we can
 // currently take advantage of; we need at least 64 to use sixel at all).
@@ -1010,9 +1011,11 @@ int interrogate_terminfo(tinfo* ti, const char* termtype, FILE* out, unsigned ut
   return 0;
 
 err:
-  // FIXME need to leave alternate screen if we entered it
+  if(ti->ttyfd >= 0){
+    tty_emit(KKEYBOARD_POP, ti->ttyfd);
+    tty_emit(RMCUP, ti->ttyfd);
+  }
   if(ti->tpreserved){
-    tty_emit("\x1b[<u", ti->ttyfd);
     (void)tcsetattr(ti->ttyfd, TCSANOW, ti->tpreserved);
     free(ti->tpreserved);
     ti->tpreserved = NULL;

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -16,6 +16,8 @@ extern "C" {
 #include "fbuf.h"
 #include "in.h"
 
+#define KKEYBOARD_POP "\x1b[<u"
+
 struct ncpile;
 struct sprixel;
 struct notcurses;

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -183,6 +183,7 @@ typedef struct tinfo {
   HANDLE outhandle;
 #endif
 
+  unsigned kbdlevel;         // kitty keyboard support level
   bool bce;                  // is the bce property advertised?
   bool in_alt_screen;        // are we in the alternate screen?
 } tinfo;

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -59,7 +59,7 @@ git pull
 TARBALL=v$VERSION.tar.gz
 wget https://github.com/dankamongmen/notcurses/archive/$TARBALL
 gpg --sign --armor --detach-sign $TARBALL
-rm v$VERSION.tar.gz
+rm $TARBALL
 
 echo "Cut $VERSION, signed to $TARBALL.asc"
 echo "Now uploadling the sig to https://github.com/dankamongmen/notcurses/releases"


### PR DESCRIPTION
Combine our two control sequence automata into one. This greatly simplifies our runtime at the cost of greatly complicating our initialization. We must build a DFA that recognizes the union over various regular languages, some known at compile time, some only discovered at runtime, with many sharing prefixes. I'm still perfecting this, but the vast majority of work is done. Closes #2183.