### PR TITLE
Fix for ncpp throwing heap allocated exceptions

### DIFF
--- a/include/ncpp/Subproc.hh
+++ b/include/ncpp/Subproc.hh
@@ -89,7 +89,7 @@ namespace ncpp
 			}
 
 			if (subproc == nullptr)
-				throw new init_error ("Notcurses failed to create ncsubproc instance");
+				throw init_error ("Notcurses failed to create ncsubproc instance");
 		}
 
 	private:

--- a/src/libcpp/NotCurses.cc
+++ b/src/libcpp/NotCurses.cc
@@ -36,7 +36,7 @@ NotCurses::NotCurses (const notcurses_options &nc_opts, FILE *fp)
 
 	nc = notcurses_init (&nc_opts, fp);
 	if (nc == nullptr)
-		throw new init_error ("notcurses failed to initialize");
+		throw init_error ("notcurses failed to initialize");
 	if (_instance == nullptr)
 		_instance = this;
 }

--- a/src/libcpp/Root.cc
+++ b/src/libcpp/Root.cc
@@ -13,7 +13,7 @@ notcurses* Root::get_notcurses () const
 		ret = NotCurses::get_instance ();
 
 	if (ret == nullptr)
-		throw new invalid_state_error (ncpp_invalid_state_message);
+		throw invalid_state_error (ncpp_invalid_state_message);
 	return ret;
 }
 


### PR DESCRIPTION
This addresses #2209 with removal of the `new` keyword such that exceptions are no longer heap-allocated.

I'm not fully aware of the inner workings of ncpp so I'm not sure if there's a semantic or logical requirement for the exceptions to be thrown heap-allocated but alas this pull request is here in case the desire for heap-allocation was erroneous.

`ncpp_build` and `ncpp_build_exceptions` both seem to run fine too. 