### PR TITLE
extract out tiocgwinsz() #2141

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -48,6 +48,12 @@ int faccessat(int dirfd, const char *pathname, int mode, int flags);
 #define nl_langinfo(x) "UTF-8"
 #define ppoll(w, x, y, z) WSAPoll((w), (x), (y))
 pid_t waitpid(pid_t pid, int* ret, int flags);
+struct winsize {
+ unsigned short ws_row;
+ unsigned short ws_col;
+ unsigned short ws_xpixel;
+ unsigned short ws_ypixel;
+};
 #define WNOHANG 0
 #else
 #include <poll.h>

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -1079,6 +1079,25 @@ int locate_cursor(tinfo* ti, int* cursor_y, int* cursor_x){
   return 0;
 }
 
+int tiocgwinsz(int fd, struct winsize* ws){
+#ifndef __MINGW64__
+  int i = ioctl(fd, TIOCGWINSZ, ws);
+  if(i < 0){
+    logerror("TIOCGWINSZ failed on %d (%s)\n", fd, strerror(errno));
+    return -1;
+  }
+  if(ws->ws_row <= 0 || ws->ws_col <= 0){
+    logerror("Bogus return from TIOCGWINSZ on %d (%d/%d)\n",
+             fd, ws->ws_row, ws->ws_col);
+    return -1;
+  }
+#else
+  (void)fd;
+  (void)ws;
+#endif
+  return 0;
+}
+
 int cbreak_mode(tinfo* ti){
 #ifndef __MINGW64__
   int ttyfd = ti->ttyfd;

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -343,6 +343,9 @@ leave_alternate_screen(FILE* fp, tinfo* ti){
 
 int cbreak_mode(tinfo* ti);
 
+// execute termios's TIOCGWINSZ ioctl(). returns -1 on failure.
+int tiocgwinsz(int fd, struct winsize* ws);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/poc/grid.c
+++ b/src/poc/grid.c
@@ -25,15 +25,15 @@ draw_grid(struct ncplane* stdn){
         for(int x = 0 ; x < maxbx ; ++x){
           uint32_t* px = row + x;
           ncpixel_set_a(px, 255);
-          ncpixel_set_r(px, 255);
-          ncpixel_set_g(px, 255);
-          ncpixel_set_b(px, 255);
+          ncpixel_set_r(px, 0x39);
+          ncpixel_set_g(px, 0xff);
+          ncpixel_set_b(px, 0xa0);
           if((x += cellpxx - 1) < maxbx){
             px = row + x;
             ncpixel_set_a(px, 255);
-            ncpixel_set_r(px, 255);
-            ncpixel_set_g(px, 255);
-            ncpixel_set_b(px, 255);
+            ncpixel_set_r(px, 0x39);
+            ncpixel_set_g(px, 0xff);
+            ncpixel_set_b(px, 0xa0);
           }
         }
       }


### PR DESCRIPTION
Factor out a wrapper around the TIOCGWINSZ `ioctl()`, as we might want to use it elsewhere.