### PR TITLE
Fix up inputreadyfd for new input system #2216

### DIFF
--- a/src/demo/input.c
+++ b/src/demo/input.c
@@ -10,8 +10,8 @@ typedef struct nciqueue {
 } nciqueue;
 
 // a pipe on which we write upon receipt of input, so that demos
-// can reliably multiplex against other fds. freebsd doesn't have
-// eventfd, alas.
+// can reliably multiplex against other fds. osx doesn't have
+// eventfd, alas (freebsd added it in 13.0).
 static int input_pipefds[2] = {-1, -1};
 
 static pthread_t tid;

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -439,8 +439,12 @@ prep_special_keys(inputctx* ictx){
 
 static void
 endpipes(int pipes[static 2]){
-  close(pipes[0]);
-  close(pipes[1]);
+  if(pipes[0] >= 0){
+    close(pipes[0]);
+  }
+  if(pipes[1] >= 0){
+    close(pipes[1]);
+  }
 }
 
 static void
@@ -454,6 +458,7 @@ mark_pipe_ready(int pipes[static 2]){
 // only linux and freebsd13+ have eventfd(), so we'll fall back to pipes sigh.
 static int
 getpipes(int pipes[static 2]){
+#ifndef __MINGW64__
 #ifndef __APPLE__
   if(pipe2(pipes, O_CLOEXEC | O_NONBLOCK)){
     logerror("couldn't get pipes (%s)\n", strerror(errno));
@@ -475,6 +480,9 @@ getpipes(int pipes[static 2]){
     return -1;
   }
   // FIXME what to do on windows?
+#endif
+#else // windows
+  pipes[0] = pipes[1] = -1;
 #endif
   return 0;
 }

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -2093,6 +2093,12 @@ internal_get(inputctx* ictx, const struct timespec* ts, ncinput* ni){
   bool sendsignal = false;
   if(ictx->ivalid-- == ictx->isize){
     sendsignal = true;
+  }else if(ictx->ivalid){
+    logtrace("draining event readiness pipe\n");
+    char c;
+    while(read(ictx->readypipes[0], &c, sizeof(c)) == 1){
+      // FIXME accelerate;
+    }
   }
   pthread_mutex_unlock(&ictx->ilock);
   if(sendsignal){


### PR DESCRIPTION
With the new input system, the actual standard in fd is unsuitable for polling. Instead, create a FIFO ("pipe"), and write to it when we publish to the input buffer. On the other wise, when we empty the input buffer, drain the FIFO. Hand the read size of the pipe out through `notcurses_inputready_fd()`. Closes #2216.

This was the simplest, most naive implementation I could knock out before passing out. It cuts our total read processing bandwidth in Kitty by about 25%, so we'll want to punch this up. It ought suffice to restore reliability to the inputready fd.