### PR TITLE
Extract arguments from automaton in a post-match procedure

### DIFF
--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -113,7 +113,6 @@ esctrie_make_numeric(esctrie* e){
   for(int i = '0' ; i < '9' ; ++i){
     e->trie[i] = e;
   }
-  logdebug("made numeric: %p\n", e);
   return 0;
 }
 
@@ -130,7 +129,6 @@ esctrie_make_kleene(esctrie* e, unsigned follow, esctrie* term){
       e->trie[i] = e;
     }
   }
-  logdebug("made kleene: %p\n", e);
   return 0;
 }
 
@@ -146,7 +144,6 @@ esctrie_make_function(esctrie* e, triefunc fxn){
   }
   e->ntype = NODE_FUNCTION;
   e->fxn = fxn;
-  logdebug("made function %p: %p\n", fxn, e);
   return 0;
 }
 

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -55,7 +55,7 @@ uint32_t esctrie_id(const esctrie* e){
 static inline unsigned
 create_esctrie_node(automaton* a, int special){
   if(a->poolused == a->poolsize){
-    unsigned newsize = a->poolsize ? a->poolsize * 2 : 2048;
+    unsigned newsize = a->poolsize ? a->poolsize * 2 : 512;
     esctrie* tmp = realloc(a->nodepool, sizeof(*a->nodepool) * newsize);
     if(tmp == NULL){
       return 0;

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -21,7 +21,8 @@ typedef struct automaton {
   int used;                 // bytes consumed thus far
   int instring;             // are we in an ST-terminated string?
   struct esctrie* state;
-  unsigned stridx;          // bytes of accumulating string (includes NUL)
+  unsigned stridx;          // bytes of accumulating string (includes NUL) FIXME kill
+  const unsigned char* matchstart;   // beginning of active match
 } automaton;
 
 void input_free_esctrie(automaton *a);
@@ -41,7 +42,6 @@ uint32_t esctrie_id(const struct esctrie* e);
 const char* esctrie_string(const struct esctrie* e);
 // returns 128-way array of esctrie pointers
 struct esctrie** esctrie_trie(struct esctrie* e);
-int esctrie_numeric(const struct esctrie* e);
 
 #ifdef __cplusplus
 }

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -21,7 +21,6 @@ typedef struct automaton {
   int used;                 // bytes consumed thus far
   int instring;             // are we in an ST-terminated string?
   struct esctrie* state;
-  unsigned stridx;          // bytes of accumulating string (includes NUL) FIXME kill
   const unsigned char* matchstart;   // beginning of active match
 } automaton;
 
@@ -39,7 +38,6 @@ int walk_automaton(automaton* a, struct inputctx* ictx, unsigned candidate,
   __attribute__ ((nonnull (1, 2, 4)));
 
 uint32_t esctrie_id(const struct esctrie* e);
-const char* esctrie_string(const struct esctrie* e);
 // returns 128-way array of esctrie pointers
 struct esctrie** esctrie_trie(struct esctrie* e);
 

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -117,7 +117,6 @@ inc_input_errors(inputctx* ictx){
 // load all known special keys from terminfo, and build the input sequence trie
 static int
 prep_special_keys(inputctx* ictx){
-  /*
 #ifndef __MINGW64__
   static const struct {
     const char* tinfo;
@@ -289,7 +288,6 @@ prep_special_keys(inputctx* ictx){
     logdebug("support for terminfo's %s: %s\n", k->tinfo, seq);
   }
 #endif
-  */
   (void)ictx;
   return 0;
 }

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -358,10 +358,10 @@ amata_next_string(automaton* amata, const char* prefix){
 // SGR (1006) mouse encoding, so use the final character to determine release
 // ('M' for click, 'm' for release).
 static void
-mouse_click(inputctx* ictx, unsigned release){
+mouse_click(inputctx* ictx, unsigned release, char follow){
   unsigned mods = amata_next_numeric(&ictx->amata, "\x1b[<", ';');
   long x = amata_next_numeric(&ictx->amata, "", ';');
-  long y = amata_next_numeric(&ictx->amata, "", ';');
+  long y = amata_next_numeric(&ictx->amata, "", follow);
   x -= (1 + ictx->lmargin);
   y -= (1 + ictx->tmargin);
   // convert from 1- to 0-indexing, and account for margins
@@ -405,13 +405,13 @@ mouse_click(inputctx* ictx, unsigned release){
 
 static int
 mouse_press_cb(inputctx* ictx){
-  mouse_click(ictx, 0);
+  mouse_click(ictx, 0, 'M');
   return 2;
 }
 
 static int
 mouse_release_cb(inputctx* ictx){
-  mouse_click(ictx, 1);
+  mouse_click(ictx, 1, 'm');
   return 2;
 }
 

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -320,8 +320,9 @@ amata_next_numeric(automaton* amata, const char* prefix, char follow){
     ret += addend;
     ++amata->matchstart;
   }
-  if(*amata->matchstart++ != follow){
-    logerror("didn't see follow (%c)\n", follow);
+  char candidate = *amata->matchstart++;
+  if(candidate != follow){
+    logerror("didn't see follow (%c vs %c)\n", candidate, follow);
     return 0;
   }
   return ret;
@@ -659,7 +660,7 @@ kittygraph_cb(inputctx* ictx){
 
 static int
 decrpm_asu_cb(inputctx* ictx){
-  unsigned ps = amata_next_numeric(&ictx->amata, "\x1b[?2026;", 'y');
+  unsigned ps = amata_next_numeric(&ictx->amata, "\x1b[?2026;", '$');
   loginfo("received decrpm 2026 %u\n", ps);
   if(ps == 2){
     if(ictx->initdata){

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1225,7 +1225,7 @@ process_escape(inputctx* ictx, const unsigned char* buf, int buflen){
     if(candidate == NCKEY_ESC && !ictx->amata.instring){
       ictx->amata.matchstart = buf + ictx->amata.used - 1;
       ictx->amata.state = ictx->amata.escapes;
-      logtrace("initialized automaton to %p\n", ictx->amata.state);
+      logtrace("initialized automaton to %u\n", ictx->amata.state);
       ictx->amata.used = 1;
       if(used > 1){ // we got reset; replay as input
         return -(used - 1);
@@ -1236,11 +1236,8 @@ process_escape(inputctx* ictx, const unsigned char* buf, int buflen){
       // coming from a transition, where ictx->triepos->trie is checked below.
     }else{
       ncinput ni = {};
-      logtrace("triepos: %p in: %c instring%c special: 0x%08x\n", ictx->amata.state,
-               isprint(candidate) ? candidate : ' ', ictx->amata.instring ? '+' : '-',
-               ictx->amata.state ? esctrie_id(ictx->amata.state) : 0);
       int w = walk_automaton(&ictx->amata, ictx, candidate, &ni);
-      logdebug("walk result on %u (%c): %d %p\n", candidate,
+      logdebug("walk result on %u (%c): %d %u\n", candidate,
                isprint(candidate) ? candidate : ' ', w, ictx->amata.state);
       if(w > 0){
         if(ni.id){


### PR DESCRIPTION
There were aspects of the automaton that made storing parameter state in nodes a no-go. Instead, extract it in a post-pass, only after a full match. Ends up saving space due to fields removed from `trienode`s, and cuts all callbacks by about 1/3 of their code. Closes #2219.