### PR TITLE
Added: pacman -S ... mingw-w64-ucrt-x86_64-ninja

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,7 +38,7 @@ Currently, building on Windows requires [MSYS2](https://www.msys2.org/) in its
 64-bit Universal C Runtime (UCRT) incarnation. This builds native Windows DLLs
 and EXEs, though it does not use Visual Studio. Install build dependencies:
 
-`pacman -S mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-doctest mingw-w64-ucrt-x86_64-ffmpeg mingw-w64-ucrt-x86_64-libunistring mingw-w64-ucrt-x86_64-ncurses mingw-w64-ucrt-x86_64-toolchain`
+`pacman -S mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-doctest mingw-w64-ucrt-x86_64-ffmpeg mingw-w64-ucrt-x86_64-libunistring mingw-w64-ucrt-x86_64-ncurses mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86_64-ninja`
 
 If you only intend to build core Notcurses (without multimedia support), you
 can omit `mingw-w64-ucrt-x86_64-ffmpeg`.


### PR DESCRIPTION
I had the above error:
```
CMake Error: CMake was unable to find a build program corresponding to "Ninja".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
See also "C:/Users/gxous/Desktop/notcurses-master/build/CMakeFiles/CMakeOutput.log".
```
It was solved by installing `mingw-w64-ucrt-x86_64-ninja`