### PR TITLE
add image to [trans] demo's end

### DIFF
--- a/src/demo/hud.c
+++ b/src/demo/hud.c
@@ -652,9 +652,9 @@ int fpsgraph_init(struct notcurses* nc){
   uint32_t style = 0;
   uint64_t channels = 0;
   ncchannels_set_fg_alpha(&channels, NCALPHA_BLEND);
-  ncchannels_set_fg_rgb(&channels, 0x201020);
+  ncchannels_set_fg_rgb(&channels, 0x201040);
   ncchannels_set_bg_alpha(&channels, NCALPHA_BLEND);
-  ncchannels_set_bg_rgb(&channels, 0x201020);
+  ncchannels_set_bg_rgb(&channels, 0x201040);
   ncplane_set_base(newp, "", style, channels);
   ncplot_options opts;
   memset(&opts, 0, sizeof(opts));
@@ -666,10 +666,10 @@ int fpsgraph_init(struct notcurses* nc){
   opts.legendstyle = NCSTYLE_ITALIC | NCSTYLE_BOLD;
   opts.title = "frames per second";
   ncchannels_set_fg_rgb8(&opts.minchannels, 0x80, 0x80, 0xff);
-  ncchannels_set_bg_rgb(&opts.minchannels, 0x201020);
+  ncchannels_set_bg_rgb(&opts.minchannels, 0x201040);
   ncchannels_set_bg_alpha(&opts.minchannels, NCALPHA_BLEND);
   ncchannels_set_fg_rgb8(&opts.maxchannels, 0x80, 0xff, 0x80);
-  ncchannels_set_bg_rgb(&opts.maxchannels, 0x201020);
+  ncchannels_set_bg_rgb(&opts.maxchannels, 0x201040);
   ncchannels_set_bg_alpha(&opts.maxchannels, NCALPHA_BLEND);
   // takes ownership of newp on all paths
   struct ncuplot* fpsplot = ncuplot_create(newp, &opts, 0, 0);

--- a/src/demo/trans.c
+++ b/src/demo/trans.c
@@ -241,7 +241,6 @@ slidepanel(struct notcurses* nc, struct ncplane* stdn){
   }
   ncplane_destroy(l);
 
-  clock_gettime(CLOCK_MONOTONIC, &cur);
   char* logop = find_data("notcurses.png");
   struct ncvisual* ncv = ncvisual_from_file(logop);
   if(ncv == NULL){
@@ -259,6 +258,7 @@ slidepanel(struct notcurses* nc, struct ncplane* stdn){
     return err;
   }
   ncvisual_destroy(ncv);
+  clock_gettime(CLOCK_MONOTONIC, &cur);
   l = legend(nc, "partially-transparent image");
   deadlinens = timespec_to_ns(&cur) + timespec_to_ns(&demodelay);
   if( (err = slideitslideit(nc, n, deadlinens, &vely, &velx)) ){


### PR DESCRIPTION
The `[trans]` demo bounces a rectangular block around the screen with various alpha and glyph settings. This adds an image to the end. Closes #2275.