### PR TITLE
Normalize geometry arguments across all functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@ rearrangements of Notcurses.
     deprecated functionality, ABI3 ought require small changes, if any.
 
 * 2.4.9 (not yet released)
+  * The handling of geometry and distance has been normalized across all
+    functions. Lengths are now `unsigned` as opposed to `int`. Where -1 was
+    being used to indicate "everything", 0 is now required. This affects
+    `ncplane_as_rgba()`, `ncplane_contents()`, and `ncvisual_from_plane()`,
+    which all used -1.
   * `ncvisual_geom()` has been introduced, using the `ncvgeom` struct
     introduced for direct mode. This allows complete statement of geometry
     for an `ncvisual`. It replaces `ncvisual_blitter_geom()`, which has been

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,9 @@ rearrangements of Notcurses.
     functions. Lengths are now `unsigned` as opposed to `int`. Where -1 was
     being used to indicate "everything", 0 is now required. This affects
     `ncplane_as_rgba()`, `ncplane_contents()`, and `ncvisual_from_plane()`,
-    which all used -1.
+    which all used -1. A length of zero passed to line-drawing functions is
+    now an error. Several line-drawing functions now reliably return errors
+    as opposed to short successes.
   * `ncvisual_geom()` has been introduced, using the `ncvgeom` struct
     introduced for direct mode. This allows complete statement of geometry
     for an `ncvisual`. It replaces `ncvisual_blitter_geom()`, which has been

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,8 @@ rearrangements of Notcurses.
     `ncplane_as_rgba()`, `ncplane_contents()`, and `ncvisual_from_plane()`,
     which all used -1. A length of zero passed to line-drawing functions is
     now an error. Several line-drawing functions now reliably return errors
-    as opposed to short successes.
+    as opposed to short successes. Dimensions of 0 to `ncplane_mergedown()`
+    now mean "everything".
   * `ncvisual_geom()` has been introduced, using the `ncvgeom` struct
     introduced for direct mode. This allows complete statement of geometry
     for an `ncvisual`. It replaces `ncvisual_blitter_geom()`, which has been

--- a/USAGE.md
+++ b/USAGE.md
@@ -918,12 +918,18 @@ struct ncplane* ncplane_dup(struct ncplane* n, void* opaque);
 
 // Merge the ncplane 'src' down onto the ncplane 'dst'. This is most rigorously
 // defined as "write to 'dst' the frame that would be rendered were the entire
-// stack made up only of 'src' and, below it, 'dst', and 'dst' was the entire
-// rendering region." Merging is independent of the position of 'src' viz 'dst'
-// on the z-axis. If 'src' does not intersect with 'dst', 'dst' will not be
-// changed, but it is not an error. The source plane still exists following
-// this operation. Do not supply the same plane for both 'src' and 'dst'.
-int ncplane_mergedown(struct ncplane* restrict src, struct ncplane* restrict dst);
+// stack made up only of the specified subregion of 'src' and, below it, the
+// subregion of 'dst' having the specified origin. Merging is independent of
+// the position of 'src' viz 'dst' on the z-axis. It is an error to define a
+// subregion that is not entirely contained within 'src'. It is an error to
+// define a target origin such that the projected subregion is not entirely
+// contained within 'dst'.  Behavior is undefined if 'src' and 'dst' are
+// equivalent. 'dst' is modified, but 'src' remains unchanged. Neither 'src'
+// nor 'dst' may have sprixels. Lengths of 0 mean "everything left".
+int ncplane_mergedown(struct ncplane* restrict src, struct ncplane* restrict dst,
+                      unsigned begsrcy, unsigned begsrcx,
+                      unsigned leny, unsigned lenx,
+                      unsigned dsty, unsigned dstx);
 
 // Merge the entirety of 'src' down onto the ncplane 'dst'. If 'src' does not
 // intersect with 'dst', 'dst' will not be changed, but it is not an error.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1214,16 +1214,19 @@ int ncplane_at_yx_cell(struct ncplane* n, int y, int x, nccell* c);
 // Create an RGBA flat array from the selected region of the ncplane 'nc'.
 // Start at the plane's 'begy'x'begx' coordinate (which must lie on the
 // plane), continuing for 'leny'x'lenx' cells. Either or both of 'leny' and
-// 'lenx' can be specified as -1 to go through the boundary of the plane.
+// 'lenx' can be specified as 0 to go through the boundary of the plane.
 // Only glyphs from the specified blitset may be present. If 'pxdimy' and/or
 // 'pxdimx' are non-NULL, they will be filled in with the pixel geometry.
 uint32_t* ncplane_as_rgba(const struct ncplane* n, ncblitter_e blit,
-                          int begy, int begx, int leny, int lenx,
-                          int* pxdimy, int* pxdimx);
+                          unsigned begy, unsigned begx, unsigned leny,
+                          unsigned lenx, unsigned* pxdimy, unsigned* pxdimx);
 
-// return a nul-terminated, heap copy of the current (UTF-8) contents.
-char* ncplane_contents(const struct ncplane* nc, int begy, int begx,
-                           int leny, int lenx);
+// Create a flat string from the EGCs of the selected region of the ncplane
+// 'n'. Start at the plane's 'begy'x'begx' coordinate (which must lie on the
+// plane), continuing for 'leny'x'lenx' cells. Either or both of 'leny' and
+// 'lenx' can be specified as 0 to go through the boundary of the plane.
+char* ncplane_contents(const struct ncplane* nc, unsigned begy, unsigned begx,
+                       unsigned leny, unsigned lenx);
 
 // Manipulate the opaque user pointer associated with this plane.
 // ncplane_set_userptr() returns the previous userptr after replacing
@@ -3291,8 +3294,11 @@ struct ncvisual* ncvisual_from_palidx(const void* data, int rows,
 // glyph will result in a NULL being returned. This function exists so that
 // planes can be subjected to ncvisual transformations. If possible, it's
 // better to create the ncvisual from memory using ncvisual_from_rgba().
-struct ncvisual* ncvisual_from_plane(const struct ncplane* n, ncblitter_e blit,
-                                     int begy, int begx, int leny, int lenx);
+// Lengths of 0 are interpreted to mean "all available remaining area".
+struct ncvisual* ncvisual_from_plane(const struct ncplane* n,
+                                     ncblitter_e blit,
+                                     unsigned begy, unsigned begx,
+                                     unsigned leny, unsigned lenx);
 ```
 
 Various transformations can be applied to an `ncvisual`, regardless of how

--- a/USAGE.md
+++ b/USAGE.md
@@ -526,10 +526,11 @@ int ncdirect_putegc(struct ncdirect* nc, uint64_t channels,
 // horizontal line, |len| cannot exceed the screen width minus the cursor's
 // offset. For a vertical line, it may be as long as you'd like; the screen
 // will scroll as necessary. All lines start at the current cursor position.
-int ncdirect_hline_interp(struct ncdirect* n, const char* egc, int len,
-                          uint64_t h1, uint64_t h2);
-int ncdirect_vline_interp(struct ncdirect* n, const char* egc, int len,
-                          uint64_t h1, uint64_t h2);
+// A length of 0 is an error, resulting in a return of -1.
+int ncdirect_hline_interp(struct ncdirect* n, const char* egc,
+                          unsigned len, uint64_t h1, uint64_t h2);
+int ncdirect_vline_interp(struct ncdirect* n, const char* egc,
+                          unsigned len, uint64_t h1, uint64_t h2);
 
 // Draw a box with its upper-left corner at the current cursor position, having
 // dimensions |ylen|x|xlen|. See ncplane_box() for more information. The
@@ -1499,21 +1500,20 @@ on both sides. Boxes allow fairly detailed specification of how they're drawn.
 // current cursor position. The cursor will end at the cell following the last
 // cell output (even, perhaps counter-intuitively, when drawing vertical
 // lines), just as if ncplane_putc() was called at that spot. Return the
-// number of cells drawn on success. On error, return the negative number of
-// cells drawn.
-int ncplane_hline_interp(struct ncplane* n, const nccell* c, int len,
-                         uint64_t c1, uint64_t c2);
+// number of cells drawn on success. A length of 0 is an error.
+int ncplane_hline_interp(struct ncplane* n, const nccell* c,
+                         unsigned len, uint64_t c1, uint64_t c2);
 
 static inline int
-ncplane_hline(struct ncplane* n, const nccell* c, int len){
+ncplane_hline(struct ncplane* n, const nccell* c, unsigned len){
   return ncplane_hline_interp(n, c, len, c->channels, c->channels);
 }
 
-int ncplane_vline_interp(struct ncplane* n, const nccell* c, int len,
-                         uint64_t c1, uint64_t c2);
+int ncplane_vline_interp(struct ncplane* n, const nccell* c,
+                         unsigned len, uint64_t c1, uint64_t c2);
 
 static inline int
-ncplane_vline(struct ncplane* n, const nccell* c, int len){
+ncplane_vline(struct ncplane* n, const nccell* c, unsigned len){
   return ncplane_vline_interp(n, c, len, c->channels, c->channels);
 }
 

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -78,9 +78,9 @@ notcurses_direct - minimal notcurses instances for styling text
 
 **const char* ncdirect_detected_terminal(const struct ncdirect* ***n***);**
 
-**int ncdirect_hline_interp(struct ncdirect* ***n***, const char* ***egc***, int ***len***, uint64_t ***h1***, uint64_t ***h2***);**
+**int ncdirect_hline_interp(struct ncdirect* ***n***, const char* ***egc***, unsigned ***len***, uint64_t ***h1***, uint64_t ***h2***);**
 
-**int ncdirect_vline_interp(struct ncdirect* ***n***, const char* ***egc***, int ***len***, uint64_t ***h1***, uint64_t ***h2***);**
+**int ncdirect_vline_interp(struct ncdirect* ***n***, const char* ***egc***, unsigned ***len***, uint64_t ***h1***, uint64_t ***h2***);**
 
 **int ncdirect_box(struct ncdirect* ***n***, uint64_t ***ul***, uint64_t ***ur***, uint64_t ***ll***, uint64_t ***lr***, const wchar_t* ***wchars***, int ***ylen***, int ***xlen***, unsigned ***ctlword***);**
 

--- a/doc/man/man3/notcurses_direct.3.md
+++ b/doc/man/man3/notcurses_direct.3.md
@@ -232,8 +232,11 @@ space as is necessary". It is an error to pass a negative number for either.
 points to a valid **struct ncdirect**, which can be used until it is provided
 to **ncdirect_stop**.
 
-**ncdirect_putstr** and **ncdirect_printf_aligned** return the number of bytes
-written on success. On failure, they return some negative number.
+**ncdirect_printf_aligned** returns the number of bytes written on success. On
+failure, it returns some negative number.
+
+**ncdirect_putstr** returns a nonnegative number on success, and **EOF**
+on failure.
 
 **ncdirect_putegc** returns the number of columns consumed on success, or -1
 on failure. If ***sbytes*** is not **NULL**, the number of bytes consumed

--- a/doc/man/man3/notcurses_lines.3.md
+++ b/doc/man/man3/notcurses_lines.3.md
@@ -10,13 +10,13 @@ notcurses_lines - operations on lines and boxes
 
 **#include <notcurses/notcurses.h>**
 
-**int ncplane_hline_interp(struct ncplane* ***n***, const nccell* ***c***, int ***len***, uint64_t ***c1***, uint64_t ***c2***);**
+**int ncplane_hline_interp(struct ncplane* ***n***, const nccell* ***c***, unsigned ***len***, uint64_t ***c1***, uint64_t ***c2***);**
 
-**static inline int ncplane_hline(struct ncplane* ***n***, const nccell* ***c***, int ***len***);**
+**static inline int ncplane_hline(struct ncplane* ***n***, const nccell* ***c***, unsigned ***len***);**
 
-**int ncplane_vline_interp(struct ncplane* ***n***, const nccell* ***c***, int ***len***, uint64_t ***c1***, uint64_t ***c2***);**
+**int ncplane_vline_interp(struct ncplane* ***n***, const nccell* ***c***, unsigned ***len***, uint64_t ***c1***, uint64_t ***c2***);**
 
-**static inline int ncplane_vline(struct ncplane* ***n***, const nccell* ***c***, int ***len***);**
+**static inline int ncplane_vline(struct ncplane* ***n***, const nccell* ***c***, unsigned ***len***);**
 
 ```c
 #define NCBOXMASK_TOP    0x0001
@@ -77,6 +77,10 @@ Box- and line-drawing is unaffected by a plane's scrolling status.
 
 **ncplane_format** returns -1 if either **ystop** or **xstop** is less than the
 current equivalent position, otherwise 0.
+
+**ncplane_hline_interp**, **ncplane_hline**, **ncplane_vline_interp**, and
+**ncplane_vline** all return the number of glyphs drawn on success, or -1
+on failure. Passing a length of 0 is an error.
 
 # SEE ALSO
 

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -123,9 +123,9 @@ typedef struct ncplane_options {
 
 **int ncplane_at_yx_cell(struct ncplane* ***n***, int ***y***, int ***x***, nccell* ***c***);**
 
-**uint32_t* ncplane_as_rgba(const struct ncplane* ***nc***, ncblitter_e ***blit***, int ***begy***, int ***begx***, int ***leny***, int ***lenx***, int* ***pxdimy***, int* ***pxdimx***);**
+**uint32_t* ncplane_as_rgba(const struct ncplane* ***nc***, ncblitter_e ***blit***, unsigned ***begy***, unsigned ***begx***, unsigned ***leny***, unsigned ***lenx***, unsigned* ***pxdimy***, unsigned* ***pxdimx***);**
 
-**char* ncplane_contents(const struct ncplane* ***nc***, int ***begy***, int ***begx***, int ***leny***, int ***lenx***);**
+**char* ncplane_contents(const struct ncplane* ***nc***, unsigned ***begy***, unsigned ***begx***, unsigned ***leny***, unsigned ***lenx***);**
 
 **void* ncplane_set_userptr(struct ncplane* ***n***, void* ***opaque***);**
 

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -205,7 +205,7 @@ typedef struct ncplane_options {
 
 **void notcurses_drop_planes(struct notcurses* ***nc***);**
 
-**int ncplane_mergedown(struct ncplane* ***src***, struct ncplane* ***dst***, int ***begsrcy***, int ***begsrcx***, int ***leny***, int ***lenx***, int ***dsty***, int ***dstx***);**
+**int ncplane_mergedown(struct ncplane* ***src***, struct ncplane* ***dst***, unsigned ***begsrcy***, unsigned ***begsrcx***, unsigned ***leny***, unsigned ***lenx***, unsigned ***dsty***, unsigned ***dstx***);**
 
 **int ncplane_mergedown_simple(struct ncplane* restrict ***src***, struct ncplane* restrict ***dst***);**
 

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -77,7 +77,7 @@ typedef struct ncvgeom {
 
 **struct ncvisual* ncvisual_from_palidx(const void* ***data***, int ***rows***, int ***rowstride***, int ***cols***, int ***palsize***, int ***pstride***, const uint32_t* ***palette***);**
 
-**struct ncvisual* ncvisual_from_plane(struct ncplane* ***n***, ncblitter_e ***blit***, int ***begy***, int ***begx***, int ***leny***, int ***lenx***);**
+**struct ncvisual* ncvisual_from_plane(struct ncplane* ***n***, ncblitter_e ***blit***, unsigned ***begy***, unsigned ***begx***, unsigned ***leny***, unsigned ***lenx***);**
 
 **int ncvisual_geom(const struct notcurses* ***nc***, const struct ncvisual* ***n***, const struct ncvisual_options* ***vopts***, ncvgeom* ***geom***);**
 

--- a/include/ncpp/Direct.hh
+++ b/include/ncpp/Direct.hh
@@ -177,12 +177,12 @@ namespace ncpp
 
 		// TODO: ncdirect_printf_aligned (will need a version which takes vargs)
 
-		int hline_interp (const char* egc, int len, uint64_t h1, uint64_t h2) const noexcept
+		int hline_interp (const char* egc, unsigned len, uint64_t h1, uint64_t h2) const noexcept
 		{
 			return ncdirect_hline_interp (direct, egc, len, h1, h2);
 		}
 
-		int vline_interp (const char* egc, int len, uint64_t h1, uint64_t h2) const noexcept
+		int vline_interp (const char* egc, unsigned len, uint64_t h1, uint64_t h2) const noexcept
 		{
 			return ncdirect_vline_interp (direct, egc, len, h1, h2);
 		}

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -699,22 +699,22 @@ namespace ncpp
 			return error_guard<int> (ncplane_vprintf_aligned (plane, y, static_cast<ncalign_e>(align), format, ap), -1);
 		}
 
-		int hline (const Cell &c, int len) const NOEXCEPT_MAYBE
+		int hline (const Cell &c, unsigned len) const NOEXCEPT_MAYBE
 		{
 			return error_guard<int> (ncplane_hline (plane, c, len), -1);
 		}
 
-		int hline (const Cell &c, int len, uint64_t c1, uint64_t c2) const NOEXCEPT_MAYBE
+		int hline (const Cell &c, unsigned len, uint64_t c1, uint64_t c2) const NOEXCEPT_MAYBE
 		{
 			return error_guard<int> (ncplane_hline_interp (plane, c, len, c1, c2), -1);
 		}
 
-		int vline (const Cell &c, int len) const NOEXCEPT_MAYBE
+		int vline (const Cell &c, unsigned len) const NOEXCEPT_MAYBE
 		{
 			return error_guard<int> (ncplane_vline (plane, c, len), -1);
 		}
 
-		int vline (const Cell &c, int len, uint64_t c1, uint64_t c2) const NOEXCEPT_MAYBE
+		int vline (const Cell &c, unsigned len, uint64_t c1, uint64_t c2) const NOEXCEPT_MAYBE
 		{
 			return error_guard<int> (ncplane_vline_interp (plane, c, len, c1, c2), -1);
 		}
@@ -803,12 +803,12 @@ namespace ncpp
 			return error_guard<int> (ncplane_polyfill_yx (plane, y, x, c), -1);
 		}
 
-		uint32_t* rgba(ncblitter_e blit, int begy, int begx, int leny, int lenx) const noexcept
+		uint32_t* rgba(ncblitter_e blit, unsigned begy, unsigned begx, unsigned leny, unsigned lenx) const noexcept
 		{
 			return ncplane_as_rgba (plane, blit, begy, begx, leny, lenx, nullptr, nullptr);
 		}
 
-		char* content(int begy, int begx, int leny, int lenx) const noexcept
+		char* content(unsigned begy, unsigned begx, unsigned leny, unsigned lenx) const noexcept
 		{
 			return ncplane_contents (plane, begy, begx, leny, lenx);
 		}

--- a/include/ncpp/Plane.hh
+++ b/include/ncpp/Plane.hh
@@ -452,17 +452,17 @@ namespace ncpp
 			return move_above (*above);
 		}
 
-		bool mergedown (Plane &dst, int begsrcy, int begsrcx, int leny, int lenx, int dsty, int dstx) const
+		bool mergedown (Plane &dst, unsigned begsrcy, unsigned begsrcx, unsigned leny, unsigned lenx, unsigned dsty, unsigned dstx) const
 		{
 			return mergedown (&dst, begsrcy, begsrcx, leny, lenx, dsty, dstx);
 		}
 
-		bool mergedown (Plane *dst, int begsrcy, int begsrcx, int leny, int lenx, int dsty, int dstx) const
+		bool mergedown (Plane *dst, unsigned begsrcy, unsigned begsrcx, unsigned leny, unsigned lenx, unsigned dsty, unsigned dstx) const
 		{
-			if (dst != nullptr && plane == dst->plane)
+			if (plane == dst->plane)
 				throw invalid_argument ("'dst' must refer to a different plane than the one this method is called on");
 
-			return error_guard (ncplane_mergedown (plane, dst != nullptr ? dst->plane : nullptr, begsrcy, begsrcx, leny, lenx, dsty, dstx), -1);
+			return error_guard (ncplane_mergedown (plane, dst->plane, begsrcy, begsrcx, leny, lenx, dsty, dstx), -1);
 		}
 
 		bool mergedown_simple (Plane &dst) const
@@ -472,7 +472,7 @@ namespace ncpp
 
 		bool mergedown_simple (Plane *dst) const
 		{
-			if (dst == nullptr || plane == dst->plane)
+			if (plane == dst->plane)
 				throw invalid_argument ("'dst' must refer to a different plane than the one this method is called on");
 
 			return error_guard (ncplane_mergedown_simple (plane, dst->plane), -1);

--- a/include/ncpp/Visual.hh
+++ b/include/ncpp/Visual.hh
@@ -32,7 +32,7 @@ namespace ncpp
 				throw init_error ("Notcurses failed to create a new visual");
 		}
 
-		explicit Visual (const Plane& p, ncblitter_e blit, int begy, int begx, int leny, int lenx)
+		explicit Visual (const Plane& p, ncblitter_e blit, unsigned begy, unsigned begx, unsigned leny, unsigned lenx)
 			: Root (NotCurses::get_instance ())
 		{
 			visual = ncvisual_from_plane (p, blit, begy, begx, leny, lenx);

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -116,7 +116,7 @@ API unsigned ncdirect_palette_size(const struct ncdirect* nc)
 
 // Output the string |utf8| according to the channels |channels|. Note that
 // ncdirect_putstr() does not explicitly flush output buffers, so it will not
-// necessarily be immediately visible.
+// necessarily be immediately visible. Returns EOF on error.
 API int ncdirect_putstr(struct ncdirect* nc, uint64_t channels, const char* utf8)
   __attribute__ ((nonnull (1, 3)));
 

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -277,40 +277,40 @@ API int ncdirect_vline_interp(struct ncdirect* n, const char* egc,
 // array of 6 wide characters: UL, UR, LL, LR, HL, VL.
 API int ncdirect_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                      uint64_t ll, uint64_t lr, const wchar_t* wchars,
-                     int ylen, int xlen, unsigned ctlword)
+                     unsigned ylen, unsigned xlen, unsigned ctlword)
   __attribute__ ((nonnull (1, 6)));
 
 __attribute__ ((nonnull (1))) static inline int
 ncdirect_light_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                    uint64_t ll, uint64_t lr,
-                   int ylen, int xlen, unsigned ctlword){
+                   unsigned ylen, unsigned xlen, unsigned ctlword){
   return ncdirect_box(n, ul, ur, ll, lr, NCBOXLIGHTW, ylen, xlen, ctlword);
 }
 
 __attribute__ ((nonnull (1))) static inline int
 ncdirect_heavy_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                    uint64_t ll, uint64_t lr,
-                   int ylen, int xlen, unsigned ctlword){
+                   unsigned ylen, unsigned xlen, unsigned ctlword){
   return ncdirect_box(n, ul, ur, ll, lr, NCBOXHEAVYW, ylen, xlen, ctlword);
 }
 
 __attribute__ ((nonnull (1))) static inline int
 ncdirect_ascii_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                    uint64_t ll, uint64_t lr,
-                   int ylen, int xlen, unsigned ctlword){
+                   unsigned ylen, unsigned xlen, unsigned ctlword){
   return ncdirect_box(n, ul, ur, ll, lr, NCBOXASCIIW, ylen, xlen, ctlword);
 }
 
 // ncdirect_box() with the rounded box-drawing characters
 API int ncdirect_rounded_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                              uint64_t ll, uint64_t lr,
-                             int ylen, int xlen, unsigned ctlword)
+                             unsigned ylen, unsigned xlen, unsigned ctlword)
   __attribute__ ((nonnull (1)));
 
 // ncdirect_box() with the double box-drawing characters
 API int ncdirect_double_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                             uint64_t ll, uint64_t lr,
-                            int ylen, int xlen, unsigned ctlword)
+                            unsigned ylen, unsigned xlen, unsigned ctlword)
   __attribute__ ((nonnull (1)));
 
 // Provide a NULL 'ts' to block at length, a 'ts' of 0 for non-blocking

--- a/include/notcurses/direct.h
+++ b/include/notcurses/direct.h
@@ -263,13 +263,13 @@ API const nccapabilities* ncdirect_capabilities(const struct ncdirect* n)
 // horizontal line, |len| cannot exceed the screen width minus the cursor's
 // offset. For a vertical line, it may be as long as you'd like; the screen
 // will scroll as necessary. All lines start at the current cursor position.
-API int ncdirect_hline_interp(struct ncdirect* n, const char* egc, int len,
-                              uint64_t h1, uint64_t h2)
-  __attribute__ ((nonnull (1)));
+API int ncdirect_hline_interp(struct ncdirect* n, const char* egc,
+                              unsigned len, uint64_t h1, uint64_t h2)
+  __attribute__ ((nonnull (1, 2)));
 
-API int ncdirect_vline_interp(struct ncdirect* n, const char* egc, int len,
-                              uint64_t h1, uint64_t h2)
-  __attribute__ ((nonnull (1)));
+API int ncdirect_vline_interp(struct ncdirect* n, const char* egc,
+                              unsigned len, uint64_t h1, uint64_t h2)
+  __attribute__ ((nonnull (1, 2)));
 
 // Draw a box with its upper-left corner at the current cursor position, having
 // dimensions |ylen|x|xlen|. See ncplane_box() for more information. The
@@ -278,7 +278,7 @@ API int ncdirect_vline_interp(struct ncdirect* n, const char* egc, int len,
 API int ncdirect_box(struct ncdirect* n, uint64_t ul, uint64_t ur,
                      uint64_t ll, uint64_t lr, const wchar_t* wchars,
                      int ylen, int xlen, unsigned ctlword)
-  __attribute__ ((nonnull (1)));
+  __attribute__ ((nonnull (1, 6)));
 
 __attribute__ ((nonnull (1))) static inline int
 ncdirect_light_box(struct ncdirect* n, uint64_t ul, uint64_t ur,

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1763,9 +1763,9 @@ API int ncplane_at_yx_cell(struct ncplane* n, int y, int x, nccell* c);
 // Create a flat string from the EGCs of the selected region of the ncplane
 // 'n'. Start at the plane's 'begy'x'begx' coordinate (which must lie on the
 // plane), continuing for 'leny'x'lenx' cells. Either or both of 'leny' and
-// 'lenx' can be specified as -1 to go through the boundary of the plane.
-API char* ncplane_contents(struct ncplane* n, int begy, int begx,
-                           int leny, int lenx);
+// 'lenx' can be specified as 0 to go through the boundary of the plane.
+API char* ncplane_contents(struct ncplane* n, unsigned begy, unsigned begx,
+                           unsigned leny, unsigned lenx);
 
 // Manipulate the opaque user pointer associated with this plane.
 // ncplane_set_userptr() returns the previous userptr after replacing
@@ -1783,12 +1783,13 @@ API void ncplane_center_abs(const struct ncplane* n, int* RESTRICT y,
 // Create an RGBA flat array from the selected region of the ncplane 'nc'.
 // Start at the plane's 'begy'x'begx' coordinate (which must lie on the
 // plane), continuing for 'leny'x'lenx' cells. Either or both of 'leny' and
-// 'lenx' can be specified as -1 to go through the boundary of the plane.
+// 'lenx' can be specified as 0 to go through the boundary of the plane.
 // Only glyphs from the specified ncblitset may be present. If 'pxdimy' and/or
-// 'pxdimx' are non-NULL, they will be filled in with the pixel geometry.
+// 'pxdimx' are non-NULL, they will be filled in with the total pixel geometry.
 API ALLOC uint32_t* ncplane_as_rgba(const struct ncplane* n, ncblitter_e blit,
-                                    int begy, int begx, int leny, int lenx,
-                                    int* pxdimy, int* pxdimx)
+                                    unsigned begy, unsigned begx,
+                                    unsigned leny, unsigned lenx,
+                                    unsigned* pxdimy, unsigned* pxdimx)
   __attribute__ ((nonnull (1)));
 
 // Return the offset into 'availu' at which 'u' ought be output given the
@@ -2832,10 +2833,12 @@ API ALLOC struct ncvisual* ncvisual_from_palidx(const void* data, int rows,
 // glyph will result in a NULL being returned. This function exists so that
 // planes can be subjected to ncvisual transformations. If possible, it's
 // better to create the ncvisual from memory using ncvisual_from_rgba().
+// Lengths of 0 are interpreted to mean "all available remaining area".
 API ALLOC struct ncvisual* ncvisual_from_plane(const struct ncplane* n,
                                                ncblitter_e blit,
-                                               int begy, int begx,
-                                               int leny, int lenx);
+                                               unsigned begy, unsigned begx,
+                                               unsigned leny, unsigned lenx)
+  __attribute__ ((nonnull (1)));
 
 #define NCVISUAL_OPTION_NODEGRADE     0x0001ull // fail rather than degrade
 #define NCVISUAL_OPTION_BLEND         0x0002ull // use NCALPHA_BLEND with visual

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2302,28 +2302,32 @@ API int ncplane_stain(struct ncplane* n, int ystop, int xstop, uint64_t ul,
 // Merge the entirety of 'src' down onto the ncplane 'dst'. If 'src' does not
 // intersect with 'dst', 'dst' will not be changed, but it is not an error.
 API int ncplane_mergedown_simple(struct ncplane* RESTRICT src,
-                                 struct ncplane* RESTRICT dst);
+                                 struct ncplane* RESTRICT dst)
+  __attribute__ ((nonnull (1, 2)));
 
 // Merge the ncplane 'src' down onto the ncplane 'dst'. This is most rigorously
 // defined as "write to 'dst' the frame that would be rendered were the entire
 // stack made up only of the specified subregion of 'src' and, below it, the
 // subregion of 'dst' having the specified origin. Merging is independent of
 // the position of 'src' viz 'dst' on the z-axis. It is an error to define a
-// subregion of zero area, or that is not entirely contained within 'src'. It
-// is an error to define a target origin such that the projected subregion is
-// not entirely contained within 'dst'.  Behavior is undefined if 'src' and
-// 'dst' are equivalent. 'dst' is modified, but 'src' remains unchanged.
-// neither 'src' nor 'dst' may have sprixels.
+// subregion that is not entirely contained within 'src'. It is an error to
+// define a target origin such that the projected subregion is not entirely
+// contained within 'dst'.  Behavior is undefined if 'src' and 'dst' are
+// equivalent. 'dst' is modified, but 'src' remains unchanged. Neither 'src'
+// nor 'dst' may have sprixels. Lengths of 0 mean "everything left".
 API int ncplane_mergedown(struct ncplane* RESTRICT src,
                           struct ncplane* RESTRICT dst,
-                          int begsrcy, int begsrcx, int leny, int lenx,
-                          int dsty, int dstx);
+                          unsigned begsrcy, unsigned begsrcx,
+                          unsigned leny, unsigned lenx,
+                          unsigned dsty, unsigned dstx)
+  __attribute__ ((nonnull (1, 2)));
 
 // Erase every cell in the ncplane (each cell is initialized to the null glyph
 // and the default channels/styles). All cells associated with this ncplane are
 // invalidated, and must not be used after the call, *excluding* the base cell.
 // The cursor is homed. The plane's active attributes are unaffected.
-API void ncplane_erase(struct ncplane* n);
+API void ncplane_erase(struct ncplane* n)
+  __attribute__ ((nonnull (1)));
 
 // Erase every cell in the region starting at {ystart, xstart} and having size
 // {|ylen|x|xlen|} for non-zero lengths. If ystart and/or xstart are -1, the current

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -2156,20 +2156,22 @@ API int ncplane_puttext(struct ncplane* n, int y, ncalign_e align,
 // cell output (even, perhaps counter-intuitively, when drawing vertical
 // lines), just as if ncplane_putc() was called at that spot. Return the
 // number of cells drawn on success. On error, return the negative number of
-// cells drawn.
-API int ncplane_hline_interp(struct ncplane* n, const nccell* c, int len,
-                             uint64_t c1, uint64_t c2);
+// cells drawn. A length of 0 is an error, resulting in a return of -1.
+API int ncplane_hline_interp(struct ncplane* n, const nccell* c,
+                             unsigned len, uint64_t c1, uint64_t c2)
+  __attribute__ ((nonnull (1, 2)));
 
-static inline int
-ncplane_hline(struct ncplane* n, const nccell* c, int len){
+__attribute__ ((nonnull (1, 2))) static inline int
+ncplane_hline(struct ncplane* n, const nccell* c, unsigned len){
   return ncplane_hline_interp(n, c, len, c->channels, c->channels);
 }
 
-API int ncplane_vline_interp(struct ncplane* n, const nccell* c, int len,
-                             uint64_t c1, uint64_t c2);
+API int ncplane_vline_interp(struct ncplane* n, const nccell* c,
+                             unsigned len, uint64_t c1, uint64_t c2)
+  __attribute__ ((nonnull (1, 2)));
 
-static inline int
-ncplane_vline(struct ncplane* n, const nccell* c, int len){
+__attribute__ ((nonnull (1, 2))) static inline int
+ncplane_vline(struct ncplane* n, const nccell* c, unsigned len){
   return ncplane_vline_interp(n, c, len, c->channels, c->channels);
 }
 

--- a/python/notcurses/plane.c
+++ b/python/notcurses/plane.c
@@ -199,7 +199,10 @@ NcPlane_set_scrolling(NcPlaneObject *self, PyObject *args)
 static PyObject *
 NcPlane_resize(NcPlaneObject *self, PyObject *args, PyObject *kwds)
 {
-    int keepy = 0, keepx = 0, keepleny = 0, keeplenx = 0, yoff = 0, xoff = 0, ylen = 0, xlen = 0;
+    int keepy = 0, keepx = 0;
+    unsigned keepleny = 0, keeplenx = 0;
+    int yoff = 0, xoff = 0;
+    unsigned ylen = 0, xlen = 0;
 
     char *keywords[] = {"keepy", "keepx",
                         "keepleny", "keeplenx",
@@ -207,7 +210,7 @@ NcPlane_resize(NcPlaneObject *self, PyObject *args, PyObject *kwds)
                         "ylen", "xlen",
                         NULL};
 
-    GNU_PY_CHECK_BOOL(PyArg_ParseTupleAndKeywords(args, kwds, "iiiiiiii", keywords,
+    GNU_PY_CHECK_BOOL(PyArg_ParseTupleAndKeywords(args, kwds, "iiIIiiII", keywords,
                                                   &keepy, &keepx,
                                                   &keepleny, &keeplenx,
                                                   &yoff, &xoff,
@@ -221,9 +224,9 @@ NcPlane_resize(NcPlaneObject *self, PyObject *args, PyObject *kwds)
 static PyObject *
 NcPlane_resize_simple(NcPlaneObject *self, PyObject *args)
 {
-    int ylen = 0, xlen = 0;
+    unsigned ylen = 0, xlen = 0;
 
-    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "ii", &ylen, &xlen));
+    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "II", &ylen, &xlen));
 
     CHECK_NOTCURSES(ncplane_resize_simple(self->ncplane_ptr, ylen, xlen));
 
@@ -474,11 +477,11 @@ NcPlane_at_yx_cell(NcPlaneObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
 static PyObject *
 NcPlane_contents(NcPlaneObject *self, PyObject *args, PyObject *kwds)
 {
-    int beg_y = 0, beg_x = 0, len_y = -1, len_x = -1;
+    unsigned beg_y = 0, beg_x = 0, len_y = 0, len_x = 0;
 
     char *keywords[] = {"begy", "begx", "leny", "lenx", NULL};
 
-    GNU_PY_CHECK_BOOL(PyArg_ParseTupleAndKeywords(args, kwds, "ii|ii", keywords,
+    GNU_PY_CHECK_BOOL(PyArg_ParseTupleAndKeywords(args, kwds, "II|II", keywords,
                                                   &beg_y, &beg_x,
                                                   &len_y, &len_x));
 
@@ -960,14 +963,7 @@ NcPlane_mergedown_simple(NcPlaneObject *self, PyObject *args)
 
     GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "|O!", &NcPlane_Type, &dst_obj));
 
-    if (NULL != dst_obj)
-    {
-        CHECK_NOTCURSES(ncplane_mergedown_simple(self->ncplane_ptr, dst_obj->ncplane_ptr));
-    }
-    else
-    {
-        CHECK_NOTCURSES(ncplane_mergedown_simple(self->ncplane_ptr, NULL));
-    }
+    CHECK_NOTCURSES(ncplane_mergedown_simple(self->ncplane_ptr, dst_obj->ncplane_ptr));
 
     Py_RETURN_NONE;
 }
@@ -976,14 +972,14 @@ static PyObject *
 NcPlane_mergedown(NcPlaneObject *self, PyObject *args, PyObject *kwds)
 {
     NcPlaneObject *dst_obj = NULL;
-    int begsrcy = 0, begsrcx = 0, leny = 0, lenx = 0;
-    int dsty = 0, dstx = 0;
+    unsigned begsrcy = 0, begsrcx = 0, leny = 0, lenx = 0;
+    unsigned dsty = 0, dstx = 0;
 
     char *keywords[] = {"dst",
                         "begsrcy", "begsrcx", "leny", "lenx",
                         "dsty", "dstx",
                         NULL};
-    GNU_PY_CHECK_BOOL(PyArg_ParseTupleAndKeywords(args, kwds, "O!iiiiii", keywords,
+    GNU_PY_CHECK_BOOL(PyArg_ParseTupleAndKeywords(args, kwds, "O!IIIIII", keywords,
                                                   &NcPlane_Type, &dst_obj,
                                                   &begsrcy, &begsrcx, &leny, &lenx,
                                                   &dsty, &dstx));

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1318,6 +1318,7 @@ int ncdirect_hline_interp(ncdirect* n, const char* egc, unsigned len,
       ncdirect_set_bg_rgb8(n, br, bg, bb);
     }
     if(fprintf(n->ttyfp, "%s", egc) < 0){
+      logerror("error emitting egc [%s]\n", egc);
       return -1;
     }
   }
@@ -1399,11 +1400,13 @@ int ncdirect_box(ncdirect* n, uint64_t ul, uint64_t ur,
   char vl[MB_LEN_MAX + 1];
   unsigned edges;
   edges = !(ctlword & NCBOXMASK_TOP) + !(ctlword & NCBOXMASK_LEFT);
+  // FIXME rewrite all fprintfs as ncdirect_putstr()!
   if(edges >= box_corner_needs(ctlword)){
     if(activate_channels(n, ul)){
       return -1;
     }
     if(fprintf(n->ttyfp, "%lc", wchars[0]) < 0){
+      logerror("error emitting %lc\n", wchars[0]);
       return -1;
     }
   }else{
@@ -1412,11 +1415,13 @@ int ncdirect_box(ncdirect* n, uint64_t ul, uint64_t ur,
   mbstate_t ps = {};
   size_t bytes;
   if((bytes = wcrtomb(hl, wchars[4], &ps)) == (size_t)-1){
+    logerror("error converting %lc\n", wchars[4]);
     return -1;
   }
   hl[bytes] = '\0';
   memset(&ps, 0, sizeof(ps));
   if((bytes = wcrtomb(vl, wchars[5], &ps)) == (size_t)-1){
+    logerror("error converting %lc\n", wchars[5]);
     return -1;
   }
   vl[bytes] = '\0';

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1376,7 +1376,7 @@ int ncdirect_vline_interp(ncdirect* n, const char* egc, unsigned len,
     if(!bgdef){
       ncchannels_set_bg_rgb8(&channels, br1, bg1, bb1);
     }
-    if(ncdirect_putstr(n, channels, egc) <= 0){
+    if(ncdirect_putstr(n, channels, egc) == EOF){
       return -1;
     }
     if(len - ret > 1){

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1466,8 +1466,8 @@ int ncdirect_box(ncdirect* n, uint64_t ul, uint64_t ur,
     }else{
       ncdirect_cursor_left(n, xlen - 1);
     }
+    ncdirect_cursor_down(n, 1);
   }
-  ncdirect_cursor_down(n, 1);
   // bottom line
   edges = !(ctlword & NCBOXMASK_BOTTOM) + !(ctlword & NCBOXMASK_LEFT);
   if(edges >= box_corner_needs(ctlword)){

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1263,8 +1263,11 @@ int ncdirect_set_bg_default(ncdirect* nc){
   return 0;
 }
 
-int ncdirect_hline_interp(ncdirect* n, const char* egc, int len,
+int ncdirect_hline_interp(ncdirect* n, const char* egc, unsigned len,
                           uint64_t c1, uint64_t c2){
+  if(len == 0){
+    return -1;
+  }
   unsigned ur, ug, ub;
   int r1, g1, b1, r2, g2, b2;
   int br1, bg1, bb1, br2, bg2, bb2;
@@ -1282,7 +1285,7 @@ int ncdirect_hline_interp(ncdirect* n, const char* egc, int len,
   int deltbr = br2 - br1;
   int deltbg = bg2 - bg1;
   int deltbb = bb2 - bb1;
-  int ret;
+  unsigned ret;
   bool fgdef = false, bgdef = false;
   if(ncchannels_fg_default_p(c1) && ncchannels_fg_default_p(c2)){
     if(ncdirect_set_fg_default(n)){
@@ -1297,12 +1300,12 @@ int ncdirect_hline_interp(ncdirect* n, const char* egc, int len,
     bgdef = true;
   }
   for(ret = 0 ; ret < len ; ++ret){
-    int r = (deltr * ret) / len + r1;
-    int g = (deltg * ret) / len + g1;
-    int b = (deltb * ret) / len + b1;
-    int br = (deltbr * ret) / len + br1;
-    int bg = (deltbg * ret) / len + bg1;
-    int bb = (deltbb * ret) / len + bb1;
+    int r = (deltr * (int)ret) / (int)len + r1;
+    int g = (deltg * (int)ret) / (int)len + g1;
+    int b = (deltb * (int)ret) / (int)len + b1;
+    int br = (deltbr * (int)ret) / (int)len + br1;
+    int bg = (deltbg * (int)ret) / (int)len + bg1;
+    int bb = (deltbb * (int)ret) / (int)len + bb1;
     if(!fgdef){
       ncdirect_set_fg_rgb8(n, r, g, b);
     }
@@ -1310,14 +1313,17 @@ int ncdirect_hline_interp(ncdirect* n, const char* egc, int len,
       ncdirect_set_bg_rgb8(n, br, bg, bb);
     }
     if(fprintf(n->ttyfp, "%s", egc) < 0){
-      break;
+      return -1;
     }
   }
   return ret;
 }
 
-int ncdirect_vline_interp(ncdirect* n, const char* egc, int len,
+int ncdirect_vline_interp(ncdirect* n, const char* egc, unsigned len,
                           uint64_t c1, uint64_t c2){
+  if(len == 0){
+    return -1;
+  }
   unsigned ur, ug, ub;
   int r1, g1, b1, r2, g2, b2;
   int br1, bg1, bb1, br2, bg2, bb2;
@@ -1329,13 +1335,13 @@ int ncdirect_vline_interp(ncdirect* n, const char* egc, int len,
   br1 = ur; bg1 = ug; bb1 = ub;
   ncchannels_bg_rgb8(c2, &ur, &ug, &ub);
   br2 = ur; bg2 = ug; bb2 = ub;
-  int deltr = (r2 - r1) / (len + 1);
-  int deltg = (g2 - g1) / (len + 1);
-  int deltb = (b2 - b1) / (len + 1);
-  int deltbr = (br2 - br1) / (len + 1);
-  int deltbg = (bg2 - bg1) / (len + 1);
-  int deltbb = (bb2 - bb1) / (len + 1);
-  int ret;
+  int deltr = (r2 - r1) / ((int)len + 1);
+  int deltg = (g2 - g1) / ((int)len + 1);
+  int deltb = (b2 - b1) / ((int)len + 1);
+  int deltbr = (br2 - br1) / ((int)len + 1);
+  int deltbg = (bg2 - bg1) / ((int)len + 1);
+  int deltbb = (bb2 - bb1) / ((int)len + 1);
+  unsigned ret;
   bool fgdef = false, bgdef = false;
   if(ncchannels_fg_default_p(c1) && ncchannels_fg_default_p(c2)){
     if(ncdirect_set_fg_default(n)){
@@ -1364,11 +1370,11 @@ int ncdirect_vline_interp(ncdirect* n, const char* egc, int len,
       ncchannels_set_bg_rgb8(&channels, br1, bg1, bb1);
     }
     if(ncdirect_putstr(n, channels, egc) <= 0){
-      break;
+      return -1;
     }
     if(len - ret > 1){
       if(ncdirect_cursor_down(n, 1) || ncdirect_cursor_left(n, 1)){
-        break;
+        return -1;
       }
     }
   }

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -66,6 +66,7 @@ int ncdirect_putegc(ncdirect* nc, uint64_t channels, const char* utf8,
 
 int ncdirect_cursor_up(ncdirect* nc, int num){
   if(num < 0){
+    logerror("requested negative move %d\n", num);
     return -1;
   }
   if(num == 0){
@@ -80,6 +81,7 @@ int ncdirect_cursor_up(ncdirect* nc, int num){
 
 int ncdirect_cursor_left(ncdirect* nc, int num){
   if(num < 0){
+    logerror("requested negative move %d\n", num);
     return -1;
   }
   if(num == 0){
@@ -94,6 +96,7 @@ int ncdirect_cursor_left(ncdirect* nc, int num){
 
 int ncdirect_cursor_right(ncdirect* nc, int num){
   if(num < 0){
+    logerror("requested negative move %d\n", num);
     return -1;
   }
   if(num == 0){
@@ -112,6 +115,7 @@ int ncdirect_cursor_right(ncdirect* nc, int num){
 // necessary but performing no carriage return -- a pure line feed.
 int ncdirect_cursor_down(ncdirect* nc, int num){
   if(num < 0){
+    logerror("requested negative move %d\n", num);
     return -1;
   }
   if(num == 0){
@@ -1266,6 +1270,7 @@ int ncdirect_set_bg_default(ncdirect* nc){
 int ncdirect_hline_interp(ncdirect* n, const char* egc, unsigned len,
                           uint64_t c1, uint64_t c2){
   if(len == 0){
+    logerror("passed zero length\n");
     return -1;
   }
   unsigned ur, ug, ub;
@@ -1322,6 +1327,7 @@ int ncdirect_hline_interp(ncdirect* n, const char* egc, unsigned len,
 int ncdirect_vline_interp(ncdirect* n, const char* egc, unsigned len,
                           uint64_t c1, uint64_t c2){
   if(len == 0){
+    logerror("passed zero length\n");
     return -1;
   }
   unsigned ur, ug, ub;

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -1392,7 +1392,7 @@ int ncdirect_vline_interp(ncdirect* n, const char* egc, unsigned len,
 //  they cannot be complex EGCs, but only a single wchar_t, alas.
 int ncdirect_box(ncdirect* n, uint64_t ul, uint64_t ur,
                  uint64_t ll, uint64_t lr, const wchar_t* wchars,
-                 int ylen, int xlen, unsigned ctlword){
+                 unsigned ylen, unsigned xlen, unsigned ctlword){
   if(xlen < 2 || ylen < 2){
     return -1;
   }
@@ -1503,13 +1503,13 @@ int ncdirect_box(ncdirect* n, uint64_t ul, uint64_t ur,
 
 int ncdirect_rounded_box(ncdirect* n, uint64_t ul, uint64_t ur,
                          uint64_t ll, uint64_t lr,
-                         int ylen, int xlen, unsigned ctlword){
+                         unsigned ylen, unsigned xlen, unsigned ctlword){
   return ncdirect_box(n, ul, ur, ll, lr, NCBOXROUNDW, ylen, xlen, ctlword);
 }
 
 int ncdirect_double_box(ncdirect* n, uint64_t ul, uint64_t ur,
-                         uint64_t ll, uint64_t lr,
-                         int ylen, int xlen, unsigned ctlword){
+                        uint64_t ll, uint64_t lr,
+                        unsigned ylen, unsigned xlen, unsigned ctlword){
   return ncdirect_box(n, ul, ur, ll, lr, NCBOXDOUBLEW, ylen, xlen, ctlword);
 }
 

--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -131,7 +131,9 @@ utf8_egc_len(const char* gcluster, int* colcount){
         }
       }
     }
-    *colcount += cols;
+    if(*colcount == 0){
+      *colcount += cols;
+    }
     ret += r;
     gcluster += r;
     prevw = wc;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -865,8 +865,9 @@ cell_duplicate_far(egcpool* tpool, nccell* targ, const ncplane* splane, const nc
 }
 
 int ncplane_resize_internal(ncplane* n, int keepy, int keepx,
-                            int keepleny, int keeplenx, int yoff, int xoff,
-                            int ylen, int xlen);
+                            unsigned keepleny, unsigned keeplenx,
+                            int yoff, int xoff,
+                            unsigned ylen, unsigned xlen);
 
 int update_term_dimensions(int* rows, int* cols, tinfo* tcache, int margin_b);
 

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1877,8 +1877,12 @@ int ncplane_vprintf_stained(struct ncplane* n, const char* format, va_list ap){
   return ret;
 }
 
-int ncplane_hline_interp(ncplane* n, const nccell* c, int len,
+int ncplane_hline_interp(ncplane* n, const nccell* c, unsigned len,
                          uint64_t c1, uint64_t c2){
+  if(len <= 0){
+    logerror("passed invalid length %u\n", len);
+    return -1;
+  }
   unsigned ur, ug, ub;
   int r1, g1, b1, r2, g2, b2;
   int br1, bg1, bb1, br2, bg2, bb2;
@@ -1896,7 +1900,7 @@ int ncplane_hline_interp(ncplane* n, const nccell* c, int len,
   int deltbr = br2 - br1;
   int deltbg = bg2 - bg1;
   int deltbb = bb2 - bb1;
-  int ret;
+  unsigned ret;
   nccell dupc = CELL_TRIVIAL_INITIALIZER;
   if(nccell_duplicate(n, &dupc, c) < 0){
     return -1;
@@ -1909,12 +1913,12 @@ int ncplane_hline_interp(ncplane* n, const nccell* c, int len,
     bgdef = true;
   }
   for(ret = 0 ; ret < len ; ++ret){
-    int r = (deltr * ret) / len + r1;
-    int g = (deltg * ret) / len + g1;
-    int b = (deltb * ret) / len + b1;
-    int br = (deltbr * ret) / len + br1;
-    int bg = (deltbg * ret) / len + bg1;
-    int bb = (deltbb * ret) / len + bb1;
+    int r = (deltr * (int)ret) / (int)len + r1;
+    int g = (deltg * (int)ret) / (int)len + g1;
+    int b = (deltb * (int)ret) / (int)len + b1;
+    int br = (deltbr * (int)ret) / (int)len + br1;
+    int bg = (deltbg * (int)ret) / (int)len + bg1;
+    int bb = (deltbb * (int)ret) / (int)len + bb1;
     if(!fgdef){
       nccell_set_fg_rgb8(&dupc, r, g, b);
     }
@@ -1922,15 +1926,19 @@ int ncplane_hline_interp(ncplane* n, const nccell* c, int len,
       nccell_set_bg_rgb8(&dupc, br, bg, bb);
     }
     if(ncplane_putc(n, &dupc) <= 0){
-      break;
+      return -1;
     }
   }
   nccell_release(n, &dupc);
   return ret;
 }
 
-int ncplane_vline_interp(ncplane* n, const nccell* c, int len,
+int ncplane_vline_interp(ncplane* n, const nccell* c, unsigned len,
                          uint64_t c1, uint64_t c2){
+  if(len <= 0){
+    logerror("passed invalid length %u\n", len);
+    return -1;
+  }
   unsigned ur, ug, ub;
   int r1, g1, b1, r2, g2, b2;
   int br1, bg1, bb1, br2, bg2, bb2;
@@ -1942,13 +1950,14 @@ int ncplane_vline_interp(ncplane* n, const nccell* c, int len,
   br1 = ur; bg1 = ug; bb1 = ub;
   ncchannels_bg_rgb8(c2, &ur, &ug, &ub);
   br2 = ur; bg2 = ug; bb2 = ub;
-  int deltr = (r2 - r1) / (len + 1);
-  int deltg = (g2 - g1) / (len + 1);
-  int deltb = (b2 - b1) / (len + 1);
-  int deltbr = (br2 - br1) / (len + 1);
-  int deltbg = (bg2 - bg1) / (len + 1);
-  int deltbb = (bb2 - bb1) / (len + 1);
-  int ret, ypos, xpos;
+  int deltr = (r2 - r1) / ((int)len + 1);
+  int deltg = (g2 - g1) / ((int)len + 1);
+  int deltb = (b2 - b1) / ((int)len + 1);
+  int deltbr = (br2 - br1) / ((int)len + 1);
+  int deltbg = (bg2 - bg1) / ((int)len + 1);
+  int deltbb = (bb2 - bb1) / ((int)len + 1);
+  int ypos, xpos;
+  unsigned ret;
   ncplane_cursor_yx(n, &ypos, &xpos);
   nccell dupc = CELL_TRIVIAL_INITIALIZER;
   if(nccell_duplicate(n, &dupc, c) < 0){
@@ -1978,7 +1987,7 @@ int ncplane_vline_interp(ncplane* n, const nccell* c, int len,
       nccell_set_bg_rgb8(&dupc, br1, bg1, bb1);
     }
     if(ncplane_putc(n, &dupc) <= 0){
-      break;
+      return -1;
     }
   }
   nccell_release(n, &dupc);

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -381,7 +381,7 @@ bool ncreader_offer_input(ncreader* n, const ncinput* ni){
 }
 
 char* ncreader_contents(const ncreader* n){
-  return ncplane_contents(n->ncp, 0, 0, -1, -1);
+  return ncplane_contents(n->ncp, 0, 0, 0, 0);
 }
 
 void ncreader_destroy(ncreader* n, char** contents){

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -1190,9 +1190,10 @@ ncplane* ncvisual_render(notcurses* nc, ncvisual* ncv, const struct ncvisual_opt
   return ncvisual_blit(nc, ncv, vopts);
 }
 
-ncvisual* ncvisual_from_plane(const ncplane* n, ncblitter_e blit, int begy, int begx,
-                              int leny, int lenx){
-  int py, px;
+ncvisual* ncvisual_from_plane(const ncplane* n, ncblitter_e blit,
+                              unsigned begy, unsigned begx,
+                              unsigned leny, unsigned lenx){
+  unsigned py, px;
   uint32_t* rgba = ncplane_as_rgba(n, blit, begy, begx, leny, lenx, &py, &px);
 //fprintf(stderr, "snarg: %d/%d @ %d/%d (%p)\n", leny, lenx, begy, begx, rgba);
   if(rgba == NULL){

--- a/src/tests/Ncpp.cpp
+++ b/src/tests/Ncpp.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Ncpp"
       REQUIRE(n);
       // FIXME load it into visual, erase plane, render visual, check for equivalence...
       {
-        Visual v = Visual(*n, NCBLIT_1x1, 0, 0, -1, -1);
+        Visual v = Visual(*n, NCBLIT_1x1, 0, 0, 0, 0);
       }
     }
     CHECK(nc.stop());

--- a/src/tests/blit.cpp
+++ b/src/tests/blit.cpp
@@ -166,8 +166,8 @@ TEST_CASE("Blit") {
     CHECK(0 == notcurses_render(nc_));
     CHECK(1 == ncplane_dim_y(p));
     CHECK(2 == ncplane_dim_x(p));
-    int pxdimy, pxdimx;
-    auto edata = ncplane_as_rgba(p, vopts.blitter, 0, 0, -1, -1, &pxdimy, &pxdimx);
+    unsigned pxdimy, pxdimx;
+    auto edata = ncplane_as_rgba(p, vopts.blitter, 0, 0, 0, 0, &pxdimy, &pxdimx);
     REQUIRE(nullptr != edata);
     CHECK(0 == memcmp(data, edata, sizeof(data)));
     free(edata);
@@ -193,8 +193,8 @@ TEST_CASE("Blit") {
       REQUIRE(nullptr != p);
       CHECK(1 == ncplane_dim_y(p));
       CHECK(4 == ncplane_dim_x(p));
-      int pxdimy, pxdimx;
-      auto edata = ncplane_as_rgba(p, vopts.blitter, 0, 0, -1, -1, &pxdimy, &pxdimx);
+      unsigned pxdimy, pxdimx;
+      auto edata = ncplane_as_rgba(p, vopts.blitter, 0, 0, 0, 0, &pxdimy, &pxdimx);
       REQUIRE(nullptr != edata);
       for(size_t i = 0 ; i < sizeof(data) / sizeof(*data) ; ++i){
         CHECK(edata[i] == data[i]);
@@ -238,8 +238,8 @@ TEST_CASE("Blit") {
       REQUIRE(nullptr != p);
       CHECK(1 == ncplane_dim_y(p));
       CHECK(16 == ncplane_dim_x(p));
-      int pxdimy, pxdimx;
-      auto edata = ncplane_as_rgba(p, vopts.blitter, 0, 0, -1, -1, &pxdimy, &pxdimx);
+      unsigned pxdimy, pxdimx;
+      auto edata = ncplane_as_rgba(p, vopts.blitter, 0, 0, 0, 0, &pxdimy, &pxdimx);
       REQUIRE(nullptr != edata);
       for(size_t i = 0 ; i < sizeof(data) / sizeof(*data) ; ++i){
         CHECK(edata[i] == data[i]);

--- a/src/tests/cell.cpp
+++ b/src/tests/cell.cpp
@@ -22,14 +22,14 @@ TEST_CASE("Cell") {
     CHECK(1 == nccell_cols(&c));
     CHECK(4 == nccell_load(n_, &c, " ி"));
     cols = nccell_cols(&c);
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__APPLE__)
     CHECK(2 == cols);
 #else
     CHECK(1 == cols);
 #endif
     CHECK(4 == nccell_load(n_, &c, " ि"));
     cols = nccell_cols(&c);
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__APPLE__)
     CHECK(2 == cols);
 #else
     CHECK(1 == cols);

--- a/src/tests/cell.cpp
+++ b/src/tests/cell.cpp
@@ -22,18 +22,10 @@ TEST_CASE("Cell") {
     CHECK(1 == nccell_cols(&c));
     CHECK(4 == nccell_load(n_, &c, " ி"));
     cols = nccell_cols(&c);
-#if defined(__APPLE__)
-    CHECK(2 == cols);
-#else
     CHECK(1 == cols);
-#endif
     CHECK(4 == nccell_load(n_, &c, " ि"));
     cols = nccell_cols(&c);
-#if defined(__APPLE__)
-    CHECK(2 == cols);
-#else
     CHECK(1 == cols);
-#endif
     // musl+s390x (alpine) is reporting these EGCs to be 0 columns wide (they
     // ought be 1). not sure whether i've got a bug (s390x is big-endian), or
     // whether it does. just relaxed the tests for now FIXME.

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -68,7 +68,10 @@ TEST_CASE("Direct") {
     ncchannels_set_bg_default(&chans);
     ncdirect_set_bg_rgb8(nc_, 0x88, 0x88, 0x88);
     printf("test background\n");
-    CHECK(0 == ncdirect_ascii_box(nc_, chans, chans, chans, chans, 8, 8, 0));
+    for(unsigned r = 2 ; r < 8 ; ++r){
+      CHECK(0 == ncdirect_ascii_box(nc_, chans, chans, chans, chans, r, r, 0));
+      printf("\n");
+    }
   }
 
 #ifndef NOTCURSES_USE_MULTIMEDIA

--- a/src/tests/palette.cpp
+++ b/src/tests/palette.cpp
@@ -91,7 +91,9 @@ TEST_CASE("Palette256") {
     nccell_release(n_, &c);
     CHECK(0 == notcurses_render(nc_));
     nccell r = CELL_TRIVIAL_INITIALIZER;
-    CHECK(nullptr != notcurses_at_yx(nc_, 0, 0, &r.stylemask, &r.channels));
+    auto egc = notcurses_at_yx(nc_, 0, 0, &r.stylemask, &r.channels);
+    CHECK(nullptr != egc);
+    free(egc);
     CHECK(nccell_fg_palindex_p(&r));
     CHECK(nccell_bg_palindex_p(&r));
     CHECK(NCALPHA_OPAQUE == nccell_fg_alpha(&r));

--- a/src/tests/rotate.cpp
+++ b/src/tests/rotate.cpp
@@ -175,9 +175,9 @@ TEST_CASE("Rotate") {
     opts.flags = NCVISUAL_OPTION_CHILDPLANE;
     auto rendered = ncvisual_blit(nc_, ncv, &opts);
     REQUIRE(rendered);
-    int pxdimy, pxdimx;
+    unsigned pxdimy, pxdimx;
     uint32_t* rgbaret = ncplane_as_rgba(rendered, NCBLIT_2x1,
-                                        0, 0, -1, -1, &pxdimy, &pxdimx);
+                                        0, 0, 0, 0, &pxdimy, &pxdimx);
     REQUIRE(rgbaret);
     if(height % 2){
       ++height;
@@ -237,9 +237,9 @@ TEST_CASE("Rotate") {
     opts.flags = NCVISUAL_OPTION_CHILDPLANE;
     auto rendered = ncvisual_blit(nc_, ncv, &opts);
     REQUIRE(rendered);
-    int pxdimy, pxdimx;
+    unsigned pxdimy, pxdimx;
     uint32_t* rgbaret = ncplane_as_rgba(rendered, NCBLIT_2x1,
-                                        0, 0, -1, -1, &pxdimy, &pxdimx);
+                                        0, 0, 0, 0, &pxdimy, &pxdimx);
     REQUIRE(rgbaret);
     if(height % 2){
       ++height;

--- a/src/tests/selector.cpp
+++ b/src/tests/selector.cpp
@@ -37,7 +37,8 @@ TEST_CASE("Selectors") {
 
   SUBCASE("TitledSelector") {
     struct ncselector_options opts{};
-    opts.title = strdup("hey hey whaddya say");
+    auto title = strdup("hey hey whaddya say");
+    opts.title = title;
     struct ncplane_options nopts = {
       .y = 0,
       .x = 0,
@@ -57,11 +58,13 @@ TEST_CASE("Selectors") {
     CHECK(6 == dimy);
     CHECK(strlen(opts.title) + 4 == dimx);
     ncselector_destroy(ncs, nullptr);
+    free(title);
   }
 
   SUBCASE("SecondarySelector") {
     struct ncselector_options opts{};
-    opts.secondary = strdup("this is not a title, but it's not *not* a title");
+    auto secondary = strdup("this is not a title, but it's not *not* a title");
+    opts.secondary = secondary;
     struct ncplane_options nopts = {
       .y = 0,
       .x = 0,
@@ -81,11 +84,13 @@ TEST_CASE("Selectors") {
     CHECK(4 == dimy);
     CHECK(strlen(opts.secondary) + 2 == dimx);
     ncselector_destroy(ncs, nullptr);
+    free(secondary);
   }
 
   SUBCASE("FooterSelector") {
     struct ncselector_options opts{};
-    opts.footer = strdup("i am a lone footer, little old footer");
+    auto foot = strdup("i am a lone footer, little old footer");
+    opts.footer = foot;
     struct ncplane_options nopts = {
       .y = 0,
       .x = 0,
@@ -105,6 +110,7 @@ TEST_CASE("Selectors") {
     CHECK(4 == dimy);
     CHECK(strlen(opts.footer) + 2 == dimx);
     ncselector_destroy(ncs, nullptr);
+    free(foot);
   }
 
   SUBCASE("PopulatedSelector") {

--- a/src/tests/textlayout.cpp
+++ b/src/tests/textlayout.cpp
@@ -105,7 +105,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "my nuclear arms"));
     free(line);
@@ -132,7 +132,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "my grasping arms"));
     free(line);
@@ -159,7 +159,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "abcde")); // FIXME should have newlines
     free(line);
@@ -186,7 +186,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "abcdefgh"));
     free(line);
@@ -214,7 +214,7 @@ TEST_CASE("TextLayout") {
       CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, boundstr, &bytes));
       CHECK(0 == notcurses_render(nc_));
       CHECK(bytes == strlen(boundstr));
-      char* line = ncplane_contents(sp, 0, 0, -1, -1);
+      char* line = ncplane_contents(sp, 0, 0, 0, 0);
       REQUIRE(line);
       CHECK(0 == strcmp(line, boundstr));
       free(line);
@@ -243,7 +243,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "my thermonuclear arms"));
     free(line);
@@ -272,7 +272,7 @@ TEST_CASE("TextLayout") {
       CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, boundstr, &bytes));
       CHECK(0 == notcurses_render(nc_));
       CHECK(bytes == strlen(boundstr));
-      char* line = ncplane_contents(sp, 0, 0, -1, -1);
+      char* line = ncplane_contents(sp, 0, 0, 0, 0);
       REQUIRE(line);
       CHECK(0 == strcmp(line, "1 我能吞下玻璃"));
       free(line);
@@ -299,7 +299,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_CENTER, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "    my thermonuclear arms"));
     free(line);
@@ -326,7 +326,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "quarkgluonfart "));
     free(line);
@@ -353,7 +353,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "quark gluon fart "));
     free(line);
@@ -380,7 +380,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "quantum balls"));
     free(line);
@@ -407,7 +407,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "quantum balls scratchy no?! "));
     free(line);
@@ -434,7 +434,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "0123456789AB"));
     free(line);
@@ -462,7 +462,7 @@ TEST_CASE("TextLayout") {
       CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
       CHECK(0 == notcurses_render(nc_));
       CHECK(bytes == strlen(boundstr));
-      char* line = ncplane_contents(sp, 0, 0, -1, -1);
+      char* line = ncplane_contents(sp, 0, 0, 0, 0);
       REQUIRE(line);
       CHECK(0 == strcmp(line, "我能吞 下玻璃 "));
       free(line);
@@ -492,7 +492,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 > res);
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes < strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "quantum balls scratchy no?! "));
     free(line);
@@ -519,7 +519,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, boundstr, &bytes));
     CHECK(0 == notcurses_render(nc_));
     CHECK(bytes == strlen(boundstr));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "scratchy?! true! arrrrp"));
     free(line);
@@ -553,7 +553,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, text, &bytes));
     CHECK(bytes == strlen(text));
     CHECK(0 == notcurses_render(nc_));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ornare neque ac ipsum viverra, vestibulum hendrerit leo consequat. Integer velit, pharetra sed nisl quis, porttitor ornare purus. Cras ac sollicitudin dolor, eget elementum dolor. Quisque lobortis sagittis."));
     free(line);
@@ -589,7 +589,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, text, &bytes));
     CHECK(bytes == strlen(text));
     CHECK(0 == notcurses_render(nc_));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "to be selected from a list of n items. NCFdplane streams a file descriptor, while NCSubproc spawns a subprocess and streams its output. A variety of plots are supported, and menus can be placed along the top and/or bottom of any plane.Widgets can be controlled with the keyboard and/or mouse. They are implemented atop ncplanes, and these planes can be manipulated like all others."));
     free(line);
@@ -626,7 +626,7 @@ TEST_CASE("TextLayout") {
     CHECK(0 < ncplane_puttext(sp, 0, NCALIGN_LEFT, text, &bytes));
     CHECK(bytes == strlen(text));
     CHECK(0 == notcurses_render(nc_));
-    char* line = ncplane_contents(sp, 0, 0, -1, -1);
+    char* line = ncplane_contents(sp, 0, 0, 0, 0);
     REQUIRE(line);
     CHECK(0 == strcmp(line, "Notcurses provides several widgets to quickly build vivid TUIs.This NCReader widget facilitates free-form text entry complete with readline-style bindings. NCSelector allows a single option to be selected from a list. NCMultiselector allows 0..n options to be selected from a list of n items. NCFdplane streams a file descriptor, while NCSubproc spawns a subprocess and streams its output. A variety of plots are supported, and menus can be placed along the top and/or bottom of any plane.Widgets can be controlled with the keyboard and/or mouse. They are implemented atop ncplanes, and these planes can be manipulated like all others."));
     free(line);

--- a/src/tetris/background.h
+++ b/src/tetris/background.h
@@ -18,7 +18,7 @@ void DrawBoard() { // draw all fixed components of the game
   stdplane_->get_dim(&y, &x);
   board_top_y_ = y - (BOARD_HEIGHT + 2);
   board_ = std::make_unique<ncpp::Plane>(BOARD_HEIGHT, BOARD_WIDTH * 2,
-                                          board_top_y_, x / 2 - (BOARD_WIDTH + 1));
+                                         board_top_y_, x / 2 - (BOARD_WIDTH + 1));
   uint64_t channels = 0;
   ncchannels_set_fg_rgb(&channels, 0x00b040);
   ncchannels_set_bg_alpha(&channels, NCALPHA_TRANSPARENT);


### PR DESCRIPTION
We take geometries in more than a dozen functions as parameters. We were handling them differently in different places: sometimes -1 meant "all available", sometimes 0 did (and negatives were all errors), for some any non-positive number was an error. All geometries and lenghts are now passed as `unsigned`, and 0 means "everything" where that is appropriate. Closes #1696.