### PR TITLE
Track and destroy widgets from notcurses_stop()

### DIFF
--- a/doc/man/man3/notcurses_menu.3.md
+++ b/doc/man/man3/notcurses_menu.3.md
@@ -60,7 +60,7 @@ typedef struct ncmenu_options {
 
 **bool ncmenu_offer_input(struct ncmenu* ***n***, const ncinput* ***nc***);**
 
-**int ncmenu_destroy(struct ncmenu* ***n***);**
+**void ncmenu_destroy(struct ncmenu* ***n***);**
 
 # DESCRIPTION
 

--- a/doc/man/man3/notcurses_selector.3.md
+++ b/doc/man/man3/notcurses_selector.3.md
@@ -55,7 +55,7 @@ typedef struct ncselector_options {
 
 **bool ncselector_offer_input(struct ncselector* ***n***, const ncinput* ***nc***);**
 
-**void ncselector_destroy(struct ncselector* ***n***, char\*\* ***item***);**
+**void ncselector_destroy(struct ncselector* ***n***);**
 
 # DESCRIPTION
 

--- a/include/ncpp/Selector.hh
+++ b/include/ncpp/Selector.hh
@@ -38,7 +38,7 @@ namespace ncpp
 		~Selector ()
 		{
 			if (!is_notcurses_stopped ())
-				ncselector_destroy (selector, nullptr);
+				ncselector_destroy (selector);
 		}
 
 		int additem (const ncselector_item *item) const NOEXCEPT_MAYBE

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3608,9 +3608,8 @@ API const char* ncselector_nextitem(struct ncselector* n)
 API bool ncselector_offer_input(struct ncselector* n, const ncinput* nc)
   __attribute__ ((nonnull (1, 2)));
 
-// Destroy the ncselector. If 'item' is not NULL, the last selected option will
-// be strdup()ed and assigned to '*item' (and must be free()d by the caller).
-API void ncselector_destroy(struct ncselector* n, char** item);
+// Destroy the ncselector.
+API void ncselector_destroy(struct ncselector* n);
 
 struct ncmselector_item {
   const char* option;
@@ -3825,7 +3824,7 @@ API bool ncmenu_offer_input(struct ncmenu* n, const ncinput* nc)
   __attribute__ ((nonnull (1, 2)));
 
 // Destroy a menu created with ncmenu_create().
-API int ncmenu_destroy(struct ncmenu* n);
+API void ncmenu_destroy(struct ncmenu* n);
 
 // Progress bars. They proceed linearly in any of four directions. The entirety
 // of the plane will be used -- any border should be provided by the caller on

--- a/src/demo/zoo.c
+++ b/src/demo/zoo.c
@@ -429,7 +429,7 @@ reader_demo(struct notcurses* nc){
   }
 
 done:
-  ncselector_destroy(selector, NULL);
+  ncselector_destroy(selector);
   ncmultiselector_destroy(mselector);
   ncplane_destroy(rp);
   return ret;

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -412,6 +412,7 @@ ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
       };
       ret->ncp = ncplane_create(n, &nopts);
       if(ret->ncp){
+        ncplane_set_widget(ret->ncp, ret, ncmenu_destroy);
         ret->unrolledsection = -1;
         ret->headerchannels = opts->headerchannels;
         ret->dissectchannels = opts->headerchannels;
@@ -769,7 +770,9 @@ int ncmenu_destroy(ncmenu* n){
   int ret = 0;
   if(n){
     free_menu_sections(n);
-    ncplane_destroy(n->ncp);
+    if(ncplane_set_widget(n->ncp, NULL, NULL) == 0){
+      ncplane_destroy(n->ncp);
+    }
     free(n);
   }
   return ret;

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -412,7 +412,7 @@ ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
       };
       ret->ncp = ncplane_create(n, &nopts);
       if(ret->ncp){
-        ncplane_set_widget(ret->ncp, ret, ncmenu_destroy);
+        ncplane_set_widget(ret->ncp, ret, (void(*)(void*))ncmenu_destroy);
         ret->unrolledsection = -1;
         ret->headerchannels = opts->headerchannels;
         ret->dissectchannels = opts->headerchannels;
@@ -766,8 +766,7 @@ ncplane* ncmenu_plane(ncmenu* menu){
   return menu->ncp;
 }
 
-int ncmenu_destroy(ncmenu* n){
-  int ret = 0;
+void ncmenu_destroy(ncmenu* n){
   if(n){
     free_menu_sections(n);
     if(ncplane_set_widget(n->ncp, NULL, NULL) == 0){
@@ -775,5 +774,4 @@ int ncmenu_destroy(ncmenu* n){
     }
     free(n);
   }
-  return ret;
 }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -346,6 +346,13 @@ ncpile_destroy(ncpile* pile){
 
 void free_plane(ncplane* p){
   if(p){
+    if(p->widget){
+      void* w = p->widget;
+      void (*wdestruct)(void*) = p->wdestruct;
+      p->widget = NULL;
+      p->wdestruct = NULL;
+      wdestruct(w);
+    }
     // ncdirect fakes an ncplane with no ->pile
     if(ncplane_pile(p)){
       notcurses* nc = ncplane_notcurses(p);
@@ -444,6 +451,8 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
   }
   p->scrolling = false;
   p->fixedbound = nopts->flags & NCPLANE_OPTION_FIXED;
+  p->widget = NULL;
+  p->wdestruct = NULL;
   if(nopts->flags & NCPLANE_OPTION_MARGINALIZED){
     p->margin_b = nopts->margin_b;
     p->margin_r = nopts->margin_r;

--- a/src/lib/plot.c
+++ b/src/lib/plot.c
@@ -531,6 +531,7 @@ create_##T(nc##X##plot* ncpp, ncplane* n, const ncplot_options* opts, const T mi
     } \
   } \
   redraw_plot_##T(ncpp); \
+  ncplane_set_widget(ncpp->plot.ncp, ncpp, (void(*)(void*))nc##X##plot_destroy); \
   return bset; \
 } \
 /* if x is less than the window, return -1, as the sample will be thrown away. \
@@ -606,7 +607,9 @@ CREATE(double, d)
 static void
 ncplot_destroy(ncplot* n){
   free(n->title);
-  ncplane_destroy(n->ncp);
+  if(ncplane_set_widget(n->ncp, NULL, NULL) == 0){
+    ncplane_destroy(n->ncp);
+  }
   ncplane_destroy(n->pixelp);
   free(n->channels);
 }

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -286,7 +286,6 @@ int ncreel_del(ncreel* nr, struct nctablet* t){
   if(t == NULL){
     return -1;
   }
-  nctablet_delete_internal(t);
   if(nr->tablets == t){
     if((nr->tablets = t->next) == t){
       nr->tablets = NULL;
@@ -297,6 +296,7 @@ int ncreel_del(ncreel* nr, struct nctablet* t){
   if(nr->vft == t){
     clean_reel(nr); // maybe just make nr->tablets the vft?
   }
+  nctablet_delete_internal(t);
   --nr->tabletcount;
   ncreel_redraw(nr);
   return 0;

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -531,7 +531,9 @@ trim_reel_overhang(ncreel* r, nctablet* top, nctablet* bottom){
   //fprintf(stderr, "bot: %dx%d @ %d, maxy: %d\n", ylen, xlen, y, maxy);
     if(maxy < y){
   //fprintf(stderr, "NUKING bottom!\n");
-      ncplane_destroy_family(bottom->p);
+      if(ncplane_set_widget(bottom->p, NULL, NULL) == 0){
+        ncplane_destroy_family(bottom->p);
+      }
       bottom->p = NULL;
       bottom->cbp = NULL;
       bottom = bottom->prev;
@@ -820,12 +822,16 @@ ncreel* ncreel_create(ncplane* n, const ncreel_options* ropts){
   memcpy(&nr->ropts, ropts, sizeof(*ropts));
   nr->p = n;
   nr->vft = NULL;
+  if(ncplane_set_widget(nr->p, nr, (void(*)(void*))ncreel_destroy)){
+    ncplane_destroy(nr->p);
+    free(nr);
+    return NULL;
+  }
   if(ncreel_redraw(nr)){
     ncplane_destroy(nr->p);
     free(nr);
     return NULL;
   }
-  ncplane_set_widget(nr->p, nr, (void(*)(void*))ncreel_destroy);
   return nr;
 }
 

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -781,6 +781,7 @@ ncreel* ncreel_create(ncplane* n, const ncreel_options* ropts){
     free(nr);
     return NULL;
   }
+  ncplane_set_widget(nr->p, nr, (void(*)(void*))ncreel_destroy);
   return nr;
 }
 
@@ -857,7 +858,9 @@ void ncreel_destroy(ncreel* nreel){
     while( (t = nreel->tablets) ){
       ncreel_del(nreel, t);
     }
-    ncplane_destroy(nreel->p);
+    if(ncplane_set_widget(nreel->p, NULL, NULL) == 0){
+      ncplane_destroy(nreel->p);
+    }
     free(nreel);
   }
 }

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -340,7 +340,7 @@ ncselector* ncselector_create(ncplane* n, const ncselector_options* opts){
     goto freeitems;
   }
   ncselector_draw(ns); // deal with error here?
-  ncplane_set_widget(ns->ncp, ns, ncselector_destroy);
+  ncplane_set_widget(ns->ncp, ns, (void(*)(void*))ncselector_destroy);
   return ns;
 
 freeitems:
@@ -549,12 +549,8 @@ bool ncselector_offer_input(ncselector* n, const ncinput* nc){
   return false;
 }
 
-void ncselector_destroy(ncselector* n, char** item){
+void ncselector_destroy(ncselector* n){
   if(n){
-    if(item){
-      *item = n->items[n->selected].option;
-      n->items[n->selected].option = NULL;
-    }
     while(n->itemcount--){
       free(n->items[n->itemcount].option);
       free(n->items[n->itemcount].desc);
@@ -948,7 +944,7 @@ ncmultiselector* ncmultiselector_create(ncplane* n, const ncmultiselector_option
     goto freeitems;
   }
   ncmultiselector_draw(ns); // deal with error here?
-  ncplane_set_widget(ns->ncp, ns, ncmultiselector_destroy);
+  ncplane_set_widget(ns->ncp, ns, (void(*)(void*))ncmultiselector_destroy);
   return ns;
 
 freeitems:

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -340,6 +340,7 @@ ncselector* ncselector_create(ncplane* n, const ncselector_options* opts){
     goto freeitems;
   }
   ncselector_draw(ns); // deal with error here?
+  ncplane_set_widget(ns->ncp, ns, ncselector_destroy);
   return ns;
 
 freeitems:
@@ -558,7 +559,9 @@ void ncselector_destroy(ncselector* n, char** item){
       free(n->items[n->itemcount].option);
       free(n->items[n->itemcount].desc);
     }
-    ncplane_destroy(n->ncp);
+    if(ncplane_set_widget(n->ncp, NULL, NULL) == 0){
+      ncplane_destroy(n->ncp);
+    }
     free(n->items);
     free(n->title);
     free(n->secondary);
@@ -945,6 +948,7 @@ ncmultiselector* ncmultiselector_create(ncplane* n, const ncmultiselector_option
     goto freeitems;
   }
   ncmultiselector_draw(ns); // deal with error here?
+  ncplane_set_widget(ns->ncp, ns, ncmultiselector_destroy);
   return ns;
 
 freeitems:
@@ -965,7 +969,9 @@ void ncmultiselector_destroy(ncmultiselector* n){
       free(n->items[n->itemcount].option);
       free(n->items[n->itemcount].desc);
     }
-    ncplane_destroy(n->ncp);
+    if(ncplane_set_widget(n->ncp, NULL, NULL) == 0){
+      ncplane_destroy(n->ncp);
+    }
     free(n->items);
     free(n->title);
     free(n->secondary);

--- a/src/lib/tabbed.c
+++ b/src/lib/tabbed.c
@@ -411,25 +411,25 @@ void nctabbed_destroy(nctabbed* nt){
   if(!nt){
     return;
   }
-  nctab* t = nt->leftmost;
-  nctab* tmp;
-  if(t){
-    t->prev->next = NULL;
-    if(t->next){
-      t->next->prev = NULL;
-    }
-  }
-  while(t){
-    tmp = t->next;
-    free(t->name);
-    free(t);
-    t = tmp;
-  }
   if(ncplane_set_widget(nt->ncp, NULL, NULL) == 0){
+    nctab* t = nt->leftmost;
+    nctab* tmp;
+    if(t){
+      t->prev->next = NULL;
+      if(t->next){
+        t->next->prev = NULL;
+      }
+    }
+    while(t){
+      tmp = t->next;
+      free(t->name);
+      free(t);
+      t = tmp;
+    }
     ncplane_destroy_family(nt->ncp);
+    free(nt->opts.separator);
+    free(nt);
   }
-  free(nt->opts.separator);
-  free(nt);
 }
 
 void nctabbed_set_hdrchan(nctabbed* nt, uint64_t chan){

--- a/src/lib/tabbed.c
+++ b/src/lib/tabbed.c
@@ -223,6 +223,7 @@ nctabbed* nctabbed_create(ncplane* n, const nctabbed_options* topts){
     }
   }
   nctabbed_redraw(nt);
+  ncplane_set_widget(nt->p, nt, (void(*)(void*))nctabbed_destroy);
   return nt;
 }
 
@@ -424,7 +425,9 @@ void nctabbed_destroy(nctabbed* nt){
     free(t);
     t = tmp;
   }
-  ncplane_destroy_family(nt->ncp);
+  if(ncplane_set_widget(nt->ncp, NULL, NULL) == 0){
+    ncplane_destroy_family(nt->ncp);
+  }
   free(nt->opts.separator);
   free(nt);
 }

--- a/src/lib/tree.c
+++ b/src/lib/tree.c
@@ -117,6 +117,7 @@ nctree_inner_create(ncplane* n, const nctree_options* opts){
     }
     ret->items.ncp = n;
     ret->items.curry = NULL;
+    ncplane_set_widget(n, ret, (void(*)(void*))nctree_destroy);
     nctree_redraw(ret);
   }
   return ret;
@@ -153,6 +154,9 @@ error:
 void nctree_destroy(nctree* n){
   if(n){
     free_tree_items(&n->items);
+    if(ncplane_set_widget(n->items.ncp, NULL, NULL) == 0){
+      ncplane_destroy(n->items.ncp);
+    }
     free(n->currentpath);
     free(n);
   }

--- a/src/lib/tree.c
+++ b/src/lib/tree.c
@@ -117,7 +117,6 @@ nctree_inner_create(ncplane* n, const nctree_options* opts){
     }
     ret->items.ncp = n;
     ret->items.curry = NULL;
-    ncplane_set_widget(n, ret, (void(*)(void*))nctree_destroy);
     nctree_redraw(ret);
   }
   return ret;
@@ -154,9 +153,6 @@ error:
 void nctree_destroy(nctree* n){
   if(n){
     free_tree_items(&n->items);
-    if(ncplane_set_widget(n->items.ncp, NULL, NULL) == 0){
-      ncplane_destroy(n->items.ncp);
-    }
     free(n->currentpath);
     free(n);
   }

--- a/src/poc/procroller.c
+++ b/src/poc/procroller.c
@@ -54,7 +54,8 @@ int main(int argc, char** argv){
   struct ncplane* std = notcurses_stdplane(nc);
   ncplane_set_scrolling(std, true);
   ncsubproc_options nopts = {};
-  struct ncsubproc* nsproc = ncsubproc_createvp(std, &nopts, *argv, argv, cb, eofcb);
+  struct ncsubproc* nsproc = ncsubproc_createvp(std, &nopts, *argv,
+                              (const char* const*)argv, cb, eofcb);
   if(nsproc == NULL){
     notcurses_stop(nc);
     return EXIT_FAILURE;

--- a/src/poc/selector.c
+++ b/src/poc/selector.c
@@ -39,8 +39,8 @@ run_selector(struct notcurses* nc, struct ncselector* ns){
         continue;
       }
       switch(keypress){
-        case NCKEY_ENTER: ncselector_destroy(ns, NULL); return;
-        case 'M': case 'J': if(ni.ctrl){ ncselector_destroy(ns, NULL); return; }
+        case NCKEY_ENTER: ncselector_destroy(ns); return;
+        case 'M': case 'J': if(ni.ctrl){ ncselector_destroy(ns); return; }
       }
       if(keypress == 'q'){
         break;
@@ -48,7 +48,7 @@ run_selector(struct notcurses* nc, struct ncselector* ns){
     }
     notcurses_render(nc);
   }
-  ncselector_destroy(ns, NULL);
+  ncselector_destroy(ns);
 }
 
 int main(void){

--- a/src/pocpp/reel.cpp
+++ b/src/pocpp/reel.cpp
@@ -214,7 +214,8 @@ int main(int argc, char** argv){
   auto nstd = notcurses_stddim_yx(nc, &dimy, &dimx);
   struct ncplane* n;
   if(ncplane_putstr_aligned(nstd, 0, NCALIGN_CENTER, "(a)dd (d)el (+/-) change lines (q)uit") <= 0){
-    return -1;
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
   }
   struct ncplane_options nopts = {
     .y = 1,
@@ -229,10 +230,12 @@ int main(int argc, char** argv){
   };
   n = ncplane_create(nstd, &nopts);
   if(!n){
-    return -1;
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
   }
   if(ncplane_set_fg_rgb8(n, 0xb1, 0x1b, 0xb1)){
-    return -1;
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
   }
   ncchannels_set_fg_rgb(&ropts.focusedchan, 0xffffff);
   ncchannels_set_bg_rgb(&ropts.focusedchan, 0x00c080);
@@ -240,9 +243,11 @@ int main(int argc, char** argv){
   auto nr = ncreel_create(n, &ropts);
   ncplane_set_userptr(n, nr);
   if(!nr){
-    return -1;
+    notcurses_stop(nc);
+    return EXIT_FAILURE;
   }
   int r = runreels(nc, nr);
+  ncreel_destroy(nr);
   if(notcurses_stop(nc)){
     return EXIT_FAILURE;
   }

--- a/src/tests/menu.cpp
+++ b/src/tests/menu.cpp
@@ -76,7 +76,7 @@ TEST_CASE("Menu") {
     ncmenu_destroy(ncm);
   }
 
-  // don't call ncmenu_destroy(), invoking destruction in notcurses_stop()
+  // don't call ncmenu_destroy(), invoking destruction in notcurses_stop().
   SUBCASE("MenuNoFree") {
     struct ncmenu_item file_items[] = {
       { .desc = "I would like a new file", .shortcut = ncinput(), },

--- a/src/tests/plane.cpp
+++ b/src/tests/plane.cpp
@@ -102,6 +102,17 @@ TEST_CASE("Plane") {
     CHECK(0 > ncplane_set_fg_rgb8(n_, 256, 256, 256));
   }
 
+  SUBCASE("StandardPlaneChild") {
+    struct ncplane_options nopts;
+    nopts.rows = ncplane_dim_y(n_);
+    nopts.cols = ncplane_dim_x(n_);
+    auto n = ncplane_create(n_, &nopts);
+    REQUIRE(nullptr != n);
+    CHECK(ncplane_dim_y(n) == ncplane_dim_y(n_));
+    CHECK(ncplane_dim_x(n) == ncplane_dim_x(n_));
+    CHECK(0 == ncplane_destroy(n));
+  }
+
   // Verify we can emit a NUL character, and it advances the cursor after
   // wiping out whatever we printed it atop.
   SUBCASE("EmitNULCell") {

--- a/src/tests/plane.cpp
+++ b/src/tests/plane.cpp
@@ -107,7 +107,9 @@ TEST_CASE("Plane") {
   SUBCASE("EmitNULCell") {
     nccell c = CELL_CHAR_INITIALIZER('a');
     CHECK(0 < ncplane_putc_yx(n_, 0, 0, &c));
-    CHECK(0 == strcmp("a", ncplane_at_yx(n_, 0, 0, nullptr, nullptr)));
+    auto egc = ncplane_at_yx(n_, 0, 0, nullptr, nullptr);
+    CHECK(0 == strcmp("a", egc));
+    free(egc);
     unsigned y, x;
     ncplane_cursor_yx(n_, &y, &x);
     CHECK(0 == y);
@@ -115,7 +117,9 @@ TEST_CASE("Plane") {
     CHECK(0 == notcurses_render(nc_));
     c = CELL_TRIVIAL_INITIALIZER;
     CHECK(0 < ncplane_putc_yx(n_, 0, 0, &c));
-    CHECK(0 == strcmp("", ncplane_at_yx(n_, 0, 0, nullptr, nullptr)));
+    egc = ncplane_at_yx(n_, 0, 0, nullptr, nullptr);
+    CHECK(0 == strcmp("", egc));
+    free(egc);
     ncplane_cursor_yx(n_, &y, &x);
     CHECK(0 == y);
     CHECK(1 == x);

--- a/src/tests/plot.cpp
+++ b/src/tests/plot.cpp
@@ -173,6 +173,7 @@ TEST_CASE("Plot") {
       // FIXME loop throughout plane, check all cells
       auto egc = ncplane_at_yx(ncp, 5, 49, &smask, &channels);
       CHECK(0 == strcmp(egc, "⣿"));
+      free(egc);
     }
     ncuplot_destroy(p);
   }

--- a/src/tests/reel.cpp
+++ b/src/tests/reel.cpp
@@ -139,12 +139,28 @@ TEST_CASE("Reels") {
   // attempt to bind a single plane to two different reels, ensuring that it is
   // refused by the second (and testing that error path). this ought result in
   // the shared plane (and thus the original widget) also being destroyed.
-  SUBCASE("RefuseBoundPlane") {
+  SUBCASE("RefuseBoundStandardPlane") {
     ncreel_options r = { };
     struct ncreel* nr = ncreel_create(n_, &r);
     REQUIRE(nr);
     CHECK(0 == notcurses_render(nc_));
     struct ncreel* fail = ncreel_create(n_, &r);
+    CHECK(nullptr == fail);
+    CHECK(0 == notcurses_render(nc_));
+  }
+
+  // now do the same, but with a plane we have created.
+  SUBCASE("RefuseBoundCreatedPlane") {
+    struct ncplane_options nopts{};
+    nopts.rows = ncplane_dim_y(n_);
+    nopts.cols = ncplane_dim_x(n_);
+    auto ncp = ncplane_create(n_, &nopts);
+    REQUIRE(nullptr != ncp);
+    ncreel_options r = { };
+    struct ncreel* nr = ncreel_create(ncp, &r);
+    REQUIRE(nr);
+    CHECK(0 == notcurses_render(nc_));
+    struct ncreel* fail = ncreel_create(ncp, &r);
     CHECK(nullptr == fail);
     CHECK(0 == notcurses_render(nc_));
   }

--- a/src/tests/reel.cpp
+++ b/src/tests/reel.cpp
@@ -127,6 +127,28 @@ TEST_CASE("Reels") {
   REQUIRE(n_);
   REQUIRE(0 == ncplane_cursor_move_yx(n_, 0, 0));
 
+  // create a reel, but don't explicitly destroy it, thus testing the
+  // context shutdown cleanup path
+  SUBCASE("ImplicitDestroy") {
+    ncreel_options r = { };
+    struct ncreel* nr = ncreel_create(n_, &r);
+    REQUIRE(nr);
+    CHECK(0 == notcurses_render(nc_));
+  }
+
+  // attempt to bind a single plane to two different reels, ensuring that it is
+  // refused by the second (and testing that error path). this ought result in
+  // the shared plane (and thus the original widget) also being destroyed.
+  SUBCASE("RefuseBoundPlane") {
+    ncreel_options r = { };
+    struct ncreel* nr = ncreel_create(n_, &r);
+    REQUIRE(nr);
+    CHECK(0 == notcurses_render(nc_));
+    struct ncreel* fail = ncreel_create(n_, &r);
+    CHECK(nullptr == fail);
+    CHECK(0 == notcurses_render(nc_));
+  }
+
   SUBCASE("InitLinear") {
     ncreel_options r = { };
     struct ncreel* nr = ncreel_create(n_, &r);

--- a/src/tests/selector.cpp
+++ b/src/tests/selector.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Selectors") {
     ncplane_dim_yx(ncsp, &dimy, &dimx);
     CHECK(4 == dimy);
     CHECK(5 == dimx);
-    ncselector_destroy(ncs, nullptr);
+    ncselector_destroy(ncs);
   }
 
   SUBCASE("TitledSelector") {
@@ -57,7 +57,7 @@ TEST_CASE("Selectors") {
     ncplane_dim_yx(ncsp, &dimy, &dimx);
     CHECK(6 == dimy);
     CHECK(strlen(opts.title) + 4 == dimx);
-    ncselector_destroy(ncs, nullptr);
+    ncselector_destroy(ncs);
   }
 
   SUBCASE("SecondarySelector") {
@@ -82,7 +82,7 @@ TEST_CASE("Selectors") {
     ncplane_dim_yx(ncsp, &dimy, &dimx);
     CHECK(4 == dimy);
     CHECK(strlen(opts.secondary) + 2 == dimx);
-    ncselector_destroy(ncs, nullptr);
+    ncselector_destroy(ncs);
   }
 
   SUBCASE("FooterSelector") {
@@ -107,7 +107,7 @@ TEST_CASE("Selectors") {
     ncplane_dim_yx(ncsp, &dimy, &dimx);
     CHECK(4 == dimy);
     CHECK(strlen(opts.footer) + 2 == dimx);
-    ncselector_destroy(ncs, nullptr);
+    ncselector_destroy(ncs);
   }
 
   SUBCASE("PopulatedSelector") {
@@ -137,7 +137,7 @@ TEST_CASE("Selectors") {
     ncplane_dim_yx(ncsp, &dimy, &dimx);
     CHECK(7 == dimy);
     CHECK(15 < dimx);
-    ncselector_destroy(ncs, nullptr);
+    ncselector_destroy(ncs);
   }
 
   SUBCASE("EmptySelectorMovement") {
@@ -162,7 +162,7 @@ TEST_CASE("Selectors") {
     sel = ncselector_previtem(ncs);
     REQUIRE(nullptr == sel);
     CHECK(0 == notcurses_render(nc_));
-    ncselector_destroy(ncs, nullptr);
+    ncselector_destroy(ncs);
   }
 
   SUBCASE("SelectorMovement") {
@@ -207,7 +207,7 @@ TEST_CASE("Selectors") {
     REQUIRE(nullptr != sel);
     CHECK(0 == strcmp(sel, items[0].option));
     CHECK(0 == notcurses_render(nc_));
-    ncselector_destroy(ncs, nullptr);
+    ncselector_destroy(ncs);
   }
 
   // Provide three items, limited to 1 shown at a time
@@ -259,7 +259,7 @@ TEST_CASE("Selectors") {
     unsigned dimy, dimx;
     ncplane_dim_yx(ncsp, &dimy, &dimx);
     CHECK(5 == dimy);
-    ncselector_destroy(ncs, nullptr);
+    ncselector_destroy(ncs);
   }
 
   // Provide three items, limited to 2 shown at a time
@@ -310,7 +310,7 @@ TEST_CASE("Selectors") {
     unsigned dimy, dimx;
     ncplane_dim_yx(ncsp, &dimy, &dimx);
     CHECK(6 == dimy);
-    ncselector_destroy(ncs, nullptr);
+    ncselector_destroy(ncs);
   }
 
   CHECK(0 == notcurses_stop(nc_));


### PR DESCRIPTION
`notcurses_stop()` ought release all resources associated with the Notcurses context. Widgets, however, were not being internally tracked, and we relied on the client explicitly freeing them up. This must of course remain supported, but we want to free them up ourselves as a last resort. Do so by associating a widget and a widget destructor with each `ncplane`. In the worst case, we waste 2 pointers (16B on 64-bit machines) per `ncplane`. All destructors were normalized to `void(*)(T *)` so they could be called through a generic pointer, bleh. Closes #2342.