### PR TITLE
Use libdeflate instead of zlib

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: debian-unstable
 
 steps:
 - name: debian-build
-  image: dankamongmen/unstable_builder:2021-11-06a
+  image: dankamongmen/unstable_builder:2021-11-14a
   commands:
     - export LANG=en_US.UTF-8
     - export TERM=xterm
@@ -28,7 +28,7 @@ name: fedora-rawhide
 
 steps:
 - name: fedora-rawhide
-  image: dankamongmen/rawhide:2021-07-15a
+  image: dankamongmen/rawhide:2021-11-14a
   commands:
     - export LANG=en_US.UTF-8
     - export TERM=xterm
@@ -52,7 +52,7 @@ name: ubuntu-impish
 
 steps:
 - name: ubuntu-build
-  image: dankamongmen/impish:2021-08-19a
+  image: dankamongmen/impish:2021-11-14b
   commands:
     - export LANG=es_ES.UTF-8
     - export TERM=xterm
@@ -74,7 +74,7 @@ name: alpine-edge
 
 steps:
 - name: alpine-edge
-  image: dankamongmen/edge_builder:2021-11-08a
+  image: dankamongmen/edge_builder:2021-11-14a
   commands:
     - export LANG=en_US.UTF-8
     - export TERM=vt100

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,30 +21,31 @@ steps:
     - LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
     - env LD_LIBRARY_PATH=/usr/local/lib ./notcurses-pydemo > /dev/null
     - env LD_LIBRARY_PATH=/usr/local/lib ./ncdirect-pydemo > /dev/null
----
-kind: pipeline
-type: docker
-name: fedora-rawhide
-
-steps:
-- name: fedora-rawhide
-  image: dankamongmen/rawhide:2021-11-14a
-  commands:
-    - export LANG=en_US.UTF-8
-    - export TERM=xterm
-    - mkdir build
-    - cd build
-    - cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MULTIMEDIA=oiio -DUSE_QRCODEGEN=on ..
-    - make -j2
-    - ctest --output-on-failure
-    - make install
-    - ldconfig
-    - cd ../cffi
-    - LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
-    - cd ../python
-    - LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
-    - env LD_LIBRARY_PATH=/usr/local/lib ./notcurses-pydemo > /dev/null
-    - env LD_LIBRARY_PATH=/usr/local/lib ./ncdirect-pydemo > /dev/null
+# gone until we package libdeflate
+#---
+#kind: pipeline
+#type: docker
+#name: fedora-rawhide
+#
+#steps:
+#- name: fedora-rawhide
+#  image: dankamongmen/rawhide:2021-11-14a
+#  commands:
+#    - export LANG=en_US.UTF-8
+#    - export TERM=xterm
+#    - mkdir build
+#    - cd build
+#    - cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MULTIMEDIA=oiio -DUSE_QRCODEGEN=on ..
+#    - make -j2
+#    - ctest --output-on-failure
+#    - make install
+#    - ldconfig
+#    - cd ../cffi
+#    - LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
+#    - cd ../python
+#    - LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
+#    - env LD_LIBRARY_PATH=/usr/local/lib ./notcurses-pydemo > /dev/null
+#    - env LD_LIBRARY_PATH=/usr/local/lib ./ncdirect-pydemo > /dev/null
 ---
 kind: pipeline
 type: docker

--- a/.github/workflows/macos_test.yml
+++ b/.github/workflows/macos_test.yml
@@ -24,6 +24,7 @@ jobs:
             coreutils \
             doctest \
             ffmpeg \
+            libdeflate \
             libunistring \
             ncurses
 

--- a/.github/workflows/ubuntu_test.yml
+++ b/.github/workflows/ubuntu_test.yml
@@ -29,6 +29,7 @@ jobs:
             libavcodec-dev \
             libavformat-dev \
             libavutil-dev \
+            libdeflate-dev \
             libncurses-dev \
             libqrcodegen-dev \
             libswscale-dev \

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -31,6 +31,7 @@ jobs:
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-doctest
             mingw-w64-ucrt-x86_64-ffmpeg
+            mingw-w64-ucrt-x86_64-libdeflate
             mingw-w64-ucrt-x86_64-libunistring
             mingw-w64-ucrt-x86_64-ncurses
             mingw-w64-ucrt-x86_64-toolchain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,6 @@ endif()
 # feature_summary + set_package_properties to fail in one fell swoop.
 find_package(Threads)
 set_package_properties(Threads PROPERTIES TYPE REQUIRED)
-find_package(ZLIB)
-set_package_properties(ZLIB PROPERTIES TYPE REQUIRED)
 # platform-specific logics
 if(WIN32)
   set(LIBRT_LIBRARIES wsock32 ws2_32 Secur32)
@@ -168,6 +166,14 @@ endif()
 find_library(unistring unistring REQUIRED)
 set_property(GLOBAL APPEND PROPERTY PACKAGES_FOUND libunistring)
 set_package_properties(libunistring PROPERTIES TYPE REQUIRED)
+unset(HAVE_DEFLATE_H CACHE)
+check_include_file("libdeflate.h" HAVE_DEFLATE_H)
+if(NOT "${HAVE_DEFLATE_H}")
+  message(FATAL_ERROR "Couldn't find libdeflate.h")
+endif()
+find_library(libdeflate deflate REQUIRED)
+set_property(GLOBAL APPEND PROPERTY PACKAGES_FOUND libdeflate)
+set_package_properties(libdeflate PROPERTIES TYPE REQUIRED)
 if(${USE_GPM}) # no pkgconfig from gpm
 unset(HAVE_GPM_H CACHE)
 check_include_file("gpm.h" HAVE_GPM_H)
@@ -231,7 +237,7 @@ target_include_directories(notcurses-core
     "${CMAKE_REQUIRED_INCLUDES}"
     "${PROJECT_BINARY_DIR}/include"
     "${TERMINFO_INCLUDE_DIRS}"
-    "${ZLIB_INCLUDE_DIRS}"
+    "${libdeflate_INCLUDE_DIRS}"
 )
 target_include_directories(notcurses-core-static
   BEFORE
@@ -241,11 +247,11 @@ target_include_directories(notcurses-core-static
     "${CMAKE_REQUIRED_INCLUDES}"
     "${PROJECT_BINARY_DIR}/include"
     "${TERMINFO_STATIC_INCLUDE_DIRS}"
-    "${ZLIB_STATIC_INCLUDE_DIRS}"
+    "${libdeflate_STATIC_INCLUDE_DIRS}"
 )
 target_link_libraries(notcurses-core
   PRIVATE
-    "${ZLIB_LIBRARIES}"
+    "${libdeflate}"
     "${TERMINFO_LIBRARIES}"
     "${LIBM}"
     "${unistring}"
@@ -256,7 +262,7 @@ target_link_libraries(notcurses-core
 )
 target_link_libraries(notcurses-core-static
   PRIVATE
-    "${ZLIB_STATIC_LIBRARIES}"
+    "${libdeflate_STATIC_LIBRARIES}"
     "${TERMINFO_STATIC_LIBRARIES}"
     "${LIBM}"
     "${unistring}"
@@ -268,12 +274,12 @@ target_link_libraries(notcurses-core-static
 target_link_directories(notcurses-core
   PRIVATE
     "${TERMINFO_LIBRARY_DIRS}"
-    "${ZLIB_LIBRARY_DIRS}"
+    "${libdeflate_LIBRARY_DIRS}"
 )
 target_link_directories(notcurses-core-static
   PRIVATE
     "${TERMINFO_STATIC_LIBRARY_DIRS}"
-    "${ZLIB_STATIC_LIBRARY_DIRS}"
+    "${libdeflate_STATIC_LIBRARY_DIRS}"
 )
 if(${USE_QRCODEGEN})
 target_link_libraries(notcurses-core PRIVATE qrcodegen)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,11 +2,15 @@
 
 You are generally recommended to use your distro's package manager to install
 Notcurses; it is [available](https://repology.org/project/notcurses/versions)
-prepackaged on many distributions. Otherwise, acquire the current source via
+prepackaged on many distributions. If you wish to build from source, read on.
+
+## Prerequisites for building
+
+Acquire the current source via
 
 `git clone https://github.com/dankamongmen/notcurses.git`
 
-## Prerequisites
+There are no submodules. Dependencies are fairly minimal.
 
 ### APT
 
@@ -31,6 +35,12 @@ Install build dependencies:
 If you only intend to build core Notcurses (without multimedia support), you
 can omit `OpenImageIO-devel`. If you're building outside Fedora Core (e.g. with
 RPM Fusion), you might want to use FFmpeg rather than OpenImageIO.
+
+### FreeBSD / DragonFly BSD
+
+Install build dependencies:
+
+`pkg install devel/ncurses multimedia/ffmpeg graphics/qr-code-generator devel/libunistring`
 
 ### Microsoft Windows
 

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -6,14 +6,15 @@
 #include <locale.h>
 #include <strings.h>
 #include <pthread.h>
-#include <langinfo.h>
 #include <semaphore.h>
 #include <sys/param.h>
 #include <sys/types.h>
 #if defined(__linux__) || defined(__gnu_hurd__)
+#include <langinfo.h>
 #include <sys/utsname.h>
 #include <sys/sysinfo.h>
 #elif !defined(__MINGW64__)
+#include <langinfo.h>
 #include <sys/sysctl.h>
 #include <sys/utsname.h>
 #else

--- a/src/lib/banner.c
+++ b/src/lib/banner.c
@@ -1,4 +1,4 @@
-#include <zlib.h>
+#include <libdeflate.h>
 #include "internal.h"
 
 // only invoked without suppress banners flag. prints various warnings based on
@@ -61,7 +61,7 @@ int init_banner(const notcurses* nc, fbuf* f){
     const char* ncursesver = curses_version();
     const char* ncver = strchr(ncursesver, ' ');
     ncver = ncver ? ncver + 1 : ncursesver;
-    fbuf_printf(f, "%u colors" NL "%s%s%s (%s)" NL "%sterminfo %s zlib %s GPM %s" NL,
+    fbuf_printf(f, "%u colors" NL "%s%s%s (%s)" NL "%sterminfo %s libdeflate %s GPM %s" NL,
                 nc->tcache.caps.colors, clreol,
 #ifdef __clang__
             "", // name is contained in __VERSION__
@@ -82,7 +82,7 @@ int init_banner(const notcurses* nc, fbuf* f){
 #else
 #error "No __BYTE_ORDER__ definition"
 #endif
-            clreol, ncver, zlibVersion(), gpm_version());
+            clreol, ncver, LIBDEFLATE_VERSION_STRING, gpm_version());
     fbuf_puts(f, clreol); // for ncvisual banner
     ncvisual_printbanner(f);
     init_banner_warnings(nc, f, clreol);

--- a/src/lib/kitty.c
+++ b/src/lib/kitty.c
@@ -647,7 +647,7 @@ deflate_buf(void* buf, fbuf* f, int dimy, int dimx){
   if(0 == clen){ // wasn't enough room; compressed data is larger than original
     ret = encode_and_chunkify(f, buf, blen, 0);
   }else{
-    loginfo("deflated %juB to %juB\n", (uintmax_t)blen, (uintmax_t)clen);
+    loginfo("deflated %" PRIuPTR "B to %" PRIuPTR "B\n", blen, clen);
     ret = encode_and_chunkify(f, cbuf, clen, 1);
   }
   free(cbuf);


### PR DESCRIPTION
Libdeflate appears to reduce size by about 10% compared to zlib, and to do some in the same amount of time. On networked connections, this ought lead directly to savings. libdeflate is present on all supported platforms, so it doesn't add much cost. Closes #2314.