### PR TITLE
[notcurses_init] factor out notcurses_early_init()

### DIFF
--- a/doc/man/man3/notcurses_init.3.md
+++ b/doc/man/man3/notcurses_init.3.md
@@ -87,7 +87,9 @@ strong opinions regarding the alternate screen, so it's often useful to expose
 this via a command-line option. When the alternate screen is not used, the
 contents of the terminal at startup remain visible until obliterated, on a
 cell-by-cell basis (see **notcurses_plane(3)** for details on clearing the
-screen at startup without using the alternate screen).
+screen at startup without using the alternate screen). If the alternate screen
+is not available, the display will still be cleared without
+**NCOPTION_NO_ALTERNATE_SCREEN**.
 
 notcurses hides the cursor by default. It can be dynamically enabled, moved, or
 disabled during execution via **notcurses_cursor_enable** and

--- a/src/lib/banner.c
+++ b/src/lib/banner.c
@@ -27,7 +27,7 @@ int init_banner(const notcurses* nc, fbuf* f){
   if(clreol == NULL){
     clreol = "";
   }
-  if(!nc->suppress_banner){
+  if(!(nc->flags & NCOPTION_SUPPRESS_BANNERS)){
     term_fg_palindex(nc, f, 50 % nc->tcache.caps.colors);
     char* osver = notcurses_osversion();
     fbuf_printf(f, "%snotcurses %s on %s %s%s(%s)" NL,

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -334,7 +334,6 @@ typedef struct notcurses {
   FILE* ttyfp;    // FILE* for writing rasterized data
   tinfo tcache;   // terminfo cache
   pthread_mutex_t pilelock; // guards pile list, locks resize in render
-  bool suppress_banner; // from notcurses_options
 
   // desired margins (best-effort only), copied in from notcurses_options
   int margin_t, margin_b, margin_r, margin_l;

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -822,7 +822,6 @@ int interrogate_terminfo(tinfo* ti, FILE* out, unsigned utf8,
     cursor_y = &foolcursor_y;
   }
   *cursor_x = *cursor_y = -1;
-  memset(ti, 0, sizeof(*ti));
   ti->bg_collides_default = 0xfe000000;
   ti->kbdlevel = UINT_MAX; // see comment in tinfo definition
   ti->qterm = TERMINAL_UNKNOWN;

--- a/src/poc/cli.c
+++ b/src/poc/cli.c
@@ -1,17 +1,22 @@
 #include <notcurses/notcurses.h>
 
 int main(void){
-  struct notcurses_options opts = {
-    .flags = NCOPTION_NO_ALTERNATE_SCREEN |
-             NCOPTION_PRESERVE_CURSOR |
+  struct notcurses_options nopts = {
+    .flags = NCOPTION_PRESERVE_CURSOR |
              NCOPTION_NO_CLEAR_BITMAPS |
-             NCOPTION_DRAIN_INPUT |
-             NCOPTION_SUPPRESS_BANNERS,
+             NCOPTION_NO_ALTERNATE_SCREEN,
   };
-  struct notcurses* nc = notcurses_init(&opts, NULL);
+  struct notcurses* nc = notcurses_init(&nopts, NULL);
   if(nc == NULL){
     return EXIT_FAILURE;
   }
+  struct ncplane* stdn = notcurses_stdplane(nc);
+  ncplane_putstr(stdn, "press any key");
+  notcurses_render(nc);
+  ncinput ni;
+  do{
+    notcurses_get_blocking(nc, &ni);
+  }while(ni.evtype == NCTYPE_RELEASE);
   notcurses_stop(nc);
   return EXIT_SUCCESS;
 }

--- a/src/poc/cli2.c
+++ b/src/poc/cli2.c
@@ -1,0 +1,17 @@
+#include <notcurses/notcurses.h>
+
+int main(void){                                                                                                                     
+  struct notcurses_options opts = {                                                                                                 
+    .flags = NCOPTION_NO_ALTERNATE_SCREEN |                                                                                         
+             NCOPTION_PRESERVE_CURSOR |                                                                                             
+             NCOPTION_NO_CLEAR_BITMAPS |                                                                                            
+             NCOPTION_DRAIN_INPUT,                                                                                                  
+  };                                                                                                                                
+  struct notcurses* nc = notcurses_init(&opts, NULL);                                                                               
+  if(nc == NULL){                                                                                                                   
+    return EXIT_FAILURE;                                                                                                            
+  }                                                                                                                                 
+  notcurses_render(nc);
+  notcurses_stop(nc);                                                                                                               
+  return EXIT_SUCCESS;                                                                                                              
+}


### PR DESCRIPTION
* Eliminate `suppress_banners` field from `struct notcurses` -- we have this from `flags`
* Factor `notcurses_early_init()` out of `notcurses_core_init()`
* Lift fake `notcurses_options` out of `notcurses_core_init()`
* Correct a few uses of logging before it's set up

This ought be a no-op of a change, but I'd like to get some eyes on it, given how delicate and critical this code is.