### PR TITLE
Deal with cell-pixel geometry changes, part 1 of 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,17 @@ If things break or seem otherwise lackluster, **please** consult the
   machines, and these writes aren't tracked by the standard statistics.
 </details>
 
+<details>
+  <summary>I just want to display a bitmap on my terminal. Your library is
+  complex and stupid. You are simple and stupid.</summary>
+  If you're willing to call a binary, use <tt>ncplayer</tt> to put an image,
+  with desired scaling, anywhere on the screen and call it a day. Otherwise,
+  call <tt>notcurses_init()</tt>, <tt>ncvisual_from_file()</tt>,
+  <tt>ncvisual_blit()</tt>, <tt>notcurses_render()</tt>, and
+  <tt>notcurses_stop()</tt>. It's not too tough. And thanks—your thoughtful
+  comments and appreciative tone are why I work on Free Software.
+</details>
+
 ## Useful links
 
 * [BiDi in Terminal Emulators](https://terminal-wg.pages.freedesktop.org/bidi/)

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1778,6 +1778,7 @@ API int ncplane_scrollup(struct ncplane* n, int r)
 // Scroll |n| up until |child| is no longer hidden beneath it. Returns an
 // error if |child| is not a child of |n|, or |n| is not scrolling, or |child|
 // is fixed. Returns the number of scrolling events otherwise (might be 0).
+// If the child plane is not fixed, it will likely scroll as well.
 API int ncplane_scrollup_child(struct ncplane* n, const struct ncplane* child)
   __attribute__ ((nonnull (1, 2)));
 

--- a/src/lib/banner.c
+++ b/src/lib/banner.c
@@ -38,13 +38,13 @@ int init_banner(const notcurses* nc, fbuf* f){
     free(osver);
     term_fg_palindex(nc, f, nc->tcache.caps.colors <= 256 ?
                      14 % nc->tcache.caps.colors : 0x2080e0);
-    if(nc->tcache.cellpixy && nc->tcache.cellpixx){
+    if(nc->tcache.cellpxy && nc->tcache.cellpxx){
       fbuf_printf(f, "%s%d rows (%dpx) %d cols (%dpx) %dx%d ",
                   clreol,
-                  nc->stdplane->leny, nc->tcache.cellpixy,
-                  nc->stdplane->lenx, nc->tcache.cellpixx,
-                  nc->stdplane->leny * nc->tcache.cellpixy,
-                  nc->stdplane->lenx * nc->tcache.cellpixx);
+                  nc->stdplane->leny, nc->tcache.cellpxy,
+                  nc->stdplane->lenx, nc->tcache.cellpxx,
+                  nc->stdplane->leny * nc->tcache.cellpxy,
+                  nc->stdplane->lenx * nc->tcache.cellpxx);
     }else{
       fbuf_printf(f, "%d rows %d cols ",
                   nc->stdplane->leny, nc->stdplane->lenx);

--- a/src/lib/blitset.h
+++ b/src/lib/blitset.h
@@ -9,7 +9,7 @@ extern "C" {
 static inline int
 encoding_y_scale(const tinfo* tcache, const struct blitset* bset) {
   if(bset->geom == NCBLIT_PIXEL){
-    return tcache->cellpixy;
+    return tcache->cellpxy;
   }
   return bset->height;
 }
@@ -18,7 +18,7 @@ encoding_y_scale(const tinfo* tcache, const struct blitset* bset) {
 static inline int
 encoding_x_scale(const tinfo* tcache, const struct blitset* bset) {
   if(bset->geom == NCBLIT_PIXEL){
-    return tcache->cellpixx;
+    return tcache->cellpxx;
   }
   return bset->width;
 }

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -654,8 +654,8 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
       disprows = dimy * encoding_y_scale(&n->tcache, bset) - 1;
       outy = disprows;
     }else{
-      dispcols = dimx * n->tcache.cellpixx;
-      disprows = dimy * n->tcache.cellpixy;
+      dispcols = dimx * n->tcache.cellpxx;
+      disprows = dimy * n->tcache.cellpxy;
       clamp_to_sixelmax(&n->tcache, &disprows, &dispcols, &outy, vopts->scaling);
     }
     if(vopts->scaling == NCSCALE_SCALE || vopts->scaling == NCSCALE_SCALE_HIRES){
@@ -675,7 +675,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
     }
   }
   if(bset->geom == NCBLIT_PIXEL){
-    while((outy + n->tcache.cellpixy - 1) / n->tcache.cellpixy > dimy){
+    while((outy + n->tcache.cellpxy - 1) / n->tcache.cellpxy > dimy){
       outy -= n->tcache.sprixel_scale_height;
       disprows = outy;
     }
@@ -693,8 +693,8 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
     .flags = 0,
   };
   if(bset->geom == NCBLIT_PIXEL){
-    nopts.rows = outy / n->tcache.cellpixy + !!(outy % n->tcache.cellpixy);
-    nopts.cols = dispcols / n->tcache.cellpixx + !!(dispcols % n->tcache.cellpixx);
+    nopts.rows = outy / n->tcache.cellpxy + !!(outy % n->tcache.cellpxy);
+    nopts.cols = dispcols / n->tcache.cellpxx + !!(dispcols % n->tcache.cellpxx);
   }
   if(ymax && nopts.rows > ymax){
     nopts.rows = ymax;
@@ -717,7 +717,9 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
   }
   if(bset->geom == NCBLIT_PIXEL){
     bargs.u.pixel.colorregs = n->tcache.color_registers;
-    if((bargs.u.pixel.spx = sprixel_alloc(&n->tcache, ncdv, nopts.rows, nopts.cols)) == NULL){
+    bargs.u.pixel.cellpxy = n->tcache.cellpxy;
+    bargs.u.pixel.cellpxx = n->tcache.cellpxx;
+    if((bargs.u.pixel.spx = sprixel_alloc(ncdv, nopts.rows, nopts.cols)) == NULL){
       free_plane(ncdv);
       return NULL;
     }

--- a/src/lib/plot.c
+++ b/src/lib/plot.c
@@ -59,11 +59,11 @@ create_pixelp(ncplot *p, ncplane* n){
 // we have some color gradient across the life of the plot (almost; it gets
 // recalculated if the cell-pixel geometry changes and we're using
 // NCBLIT_PIXEL). if we're using cell blitting, we only get one channel pair
-// per row, no matter what height we have. with pixels, we get cellpixy * rows.
+// per row, no matter what height we have. with pixels, we get cellpxy * rows.
 static int
 calculate_gradient_vector(ncplot* p, unsigned pixelp){
   const int dimy = ncplane_dim_y(p->ncp);
-  const unsigned states = dimy * (pixelp ? ncplane_notcurses(p->ncp)->tcache.cellpixy : 1);
+  const unsigned states = dimy * (pixelp ? ncplane_pile(p->ncp)->cellpxy : 1);
   if(states == p->chancount){ // no need to recalculate
     return 0;
   }
@@ -93,13 +93,13 @@ int redraw_pixelplot_##T(nc##X##plot* ncp){ \
   if(calculate_gradient_vector(&ncp->plot, 1)){ \
     return -1; \
   } \
-  const int scale = ncplane_notcurses_const(ncp->plot.ncp)->tcache.cellpixx; \
+  const int scale = ncplane_pile_const(ncp->plot.ncp)->cellpxx; \
   ncplane_erase(ncp->plot.ncp); \
   unsigned dimy, dimx; \
   ncplane_dim_yx(ncp->plot.ncp, &dimy, &dimx); \
   const unsigned scaleddim = dimx * scale; \
   /* each transition is worth this much change in value */ \
-  const size_t states = ncplane_notcurses_const(ncp->plot.ncp)->tcache.cellpixy; \
+  const size_t states = ncplane_pile_const(ncp->plot.ncp)->cellpxy; \
   /* FIXME can we not rid ourselves of this meddlesome double? either way, the \
      interval is one row's range (for linear plots), or the base \
      (base^slots == maxy-miny) of the range (for exponential plots). */ \
@@ -480,8 +480,8 @@ create_##T(nc##X##plot* ncpp, ncplane* n, const ncplot_options* opts, const T mi
   ncpp->plot.rangex = opts->rangex; \
   /* if we're sizing the plot based off the plane dimensions, scale it by the \
      plot geometry's width for all calculations */ \
-  const unsigned scaleddim = dimx * (bset->geom == NCBLIT_PIXEL ? ncplane_notcurses(n)->tcache.cellpixx : bset->width); \
-  const unsigned scaledprefixlen = NCPREFIXCOLUMNS * (bset->geom == NCBLIT_PIXEL ? ncplane_notcurses(n)->tcache.cellpixx : bset->width); \
+  const unsigned scaleddim = dimx * (bset->geom == NCBLIT_PIXEL ? ncplane_pile_const(n)->cellpxx : bset->width); \
+  const unsigned scaledprefixlen = NCPREFIXCOLUMNS * (bset->geom == NCBLIT_PIXEL ? ncplane_pile_const(n)->cellpxx : bset->width); \
   if((ncpp->plot.slotcount = ncpp->plot.rangex) == 0){ \
     ncpp->plot.slotcount = scaleddim; \
   } \

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -154,18 +154,6 @@ sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx){
 int sprixel_load(sprixel* spx, fbuf* f, unsigned pixy, unsigned pixx,
                  int parse_start, sprixel_e state){
   assert(spx->n);
-  /*
-  if(spx->cellpxy > 0){ // don't explode on ncdirect case
-    if((pixy + spx->cellpxy - 1) / spx->cellpxy > spx->dimy){
-      logerror("bad pixy %d (cellpxy %d dimy %d)\n", pixy, spx->cellpxy, spx->dimy);
-      return -1;
-    }
-    if((pixx + spx->cellpxx - 1) / spx->cellpxx > spx->dimx){
-      logerror("bad pixx %d (cellpxx %d dimx %d)\n", pixx, spx->cellpxx, spx->dimx);
-      return -1;
-    }
-  }
-  */
   if(&spx->glyph != f){
     fbuf_free(&spx->glyph);
     memcpy(&spx->glyph, f, sizeof(*f));
@@ -180,6 +168,7 @@ int sprixel_load(sprixel* spx, fbuf* f, unsigned pixy, unsigned pixx,
 // returns 1 if already annihilated, 0 if we successfully annihilated the cell,
 // or -1 if we could not annihilate the cell (i.e. we're sixel).
 int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
+  assert(s->n);
   int idx = s->dimx * ycell + xcell;
   if(s->n->tam[idx].state == SPRIXCELL_TRANSPARENT){
     // need to make a transparent auxvec, because a reload will force us to

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -56,7 +56,7 @@ sprixel* sprixel_recycle(ncplane* n){
     int dimy = hides->dimy;
     int dimx = hides->dimx;
     sprixel_hide(hides);
-    return sprixel_alloc(&nc->tcache, n, dimy, dimx);
+    return sprixel_alloc(n, dimy, dimx);
   }
   sixelmap_free(n->sprite->smap);
   n->sprite->smap = NULL;
@@ -114,7 +114,7 @@ void sprixel_invalidate(sprixel* s, int y, int x){
   }
 }
 
-sprixel* sprixel_alloc(const tinfo* ti, ncplane* n, int dimy, int dimx){
+sprixel* sprixel_alloc(ncplane* n, int dimy, int dimx){
   sprixel* ret = malloc(sizeof(sprixel));
   if(ret == NULL){
     return NULL;
@@ -134,8 +134,6 @@ sprixel* sprixel_alloc(const tinfo* ti, ncplane* n, int dimy, int dimx){
     sprixelid_nonce = 1;
   }
 //fprintf(stderr, "LOOKING AT %p (p->n = %p)\n", ret, ret->n);
-  ret->cellpxy = ti->cellpixy;
-  ret->cellpxx = ti->cellpixx;
   if(ncplane_pile(ret->n)){ // rendered mode
     ncpile* np = ncplane_pile(ret->n);
     if( (ret->next = np->sprixelcache) ){
@@ -156,6 +154,7 @@ sprixel* sprixel_alloc(const tinfo* ti, ncplane* n, int dimy, int dimx){
 int sprixel_load(sprixel* spx, fbuf* f, unsigned pixy, unsigned pixx,
                  int parse_start, sprixel_e state){
   assert(spx->n);
+  /*
   if(spx->cellpxy > 0){ // don't explode on ncdirect case
     if((pixy + spx->cellpxy - 1) / spx->cellpxy > spx->dimy){
       logerror("bad pixy %d (cellpxy %d dimy %d)\n", pixy, spx->cellpxy, spx->dimy);
@@ -166,6 +165,7 @@ int sprixel_load(sprixel* spx, fbuf* f, unsigned pixy, unsigned pixx,
       return -1;
     }
   }
+  */
   if(&spx->glyph != f){
     fbuf_free(&spx->glyph);
     memcpy(&spx->glyph, f, sizeof(*f));
@@ -187,7 +187,7 @@ int sprite_wipe(const notcurses* nc, sprixel* s, int ycell, int xcell){
     // be entirely 0s coming from pixel_trans_auxvec().
     if(s->n->tam[idx].auxvector == NULL){
       if(nc->tcache.pixel_trans_auxvec){
-        s->n->tam[idx].auxvector = nc->tcache.pixel_trans_auxvec(&nc->tcache);
+        s->n->tam[idx].auxvector = nc->tcache.pixel_trans_auxvec(ncplane_pile(s->n));
         if(s->n->tam[idx].auxvector == NULL){
           return -1;
         }

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -143,7 +143,6 @@ typedef struct sprixel {
   struct sprixel* prev;
   unsigned dimy, dimx;  // cell geometry
   int pixy, pixx;       // pixel geometry (might be smaller than cell geo)
-  int cellpxy, cellpxx; // cell-pixel geometry at time of creation
   // each tacache entry is one of 0 (standard opaque cell), 1 (cell with
   // some transparency), 2 (annihilated, excised)
   int movedfromy;       // for SPRIXEL_MOVED, the starting absolute position,
@@ -196,8 +195,8 @@ int kitty_remove(int id, fbuf* f);
 int kitty_clear_all(fbuf* f);
 int sixel_init(int fd);
 int sixel_init_inverted(int fd);
-uint8_t* sixel_trans_auxvec(const struct tinfo* ti);
-uint8_t* kitty_trans_auxvec(const struct tinfo* ti);
+uint8_t* sixel_trans_auxvec(const struct ncpile* p);
+uint8_t* kitty_trans_auxvec(const struct ncpile* p);
 int kitty_commit(fbuf* f, sprixel* s, unsigned noscroll);
 int sixel_blit(struct ncplane* nc, int linesize, const void* data,
                int leny, int lenx, const struct blitterargs* bargs);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -1078,8 +1078,8 @@ int interrogate_terminfo(tinfo* ti, FILE* out, unsigned utf8,
       ti->pixx = iresp->pixx;
     }
     if(ti->default_rows && ti->default_cols){
-      ti->cellpixy = ti->pixy / ti->default_rows;
-      ti->cellpixx = ti->pixx / ti->default_cols;
+      ti->cellpxy = ti->pixy / ti->default_rows;
+      ti->cellpxx = ti->pixx / ti->default_cols;
     }
     if(iresp->got_bg){
       // reset the 0xfe000000 we loaded during initialization. if we're

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -110,8 +110,8 @@ typedef struct tinfo {
   unsigned pixx;                   // total pixel geometry, width
   // we use the cell's size in pixels for pixel blitting. this information can
   // be acquired on all terminals with pixel support.
-  unsigned cellpixy;               // cell pixel height, might be 0
-  unsigned cellpixx;               // cell pixel width, might be 0
+  unsigned cellpxy;                // cell pixel height, might be 0
+  unsigned cellpxx;                // cell pixel width, might be 0
   unsigned dimy, dimx;             // most recent cell geometry
 
   unsigned supported_styles; // bitmask over NCSTYLE_* driven via sgr/ncv
@@ -149,7 +149,7 @@ typedef struct tinfo {
   int (*pixel_commit)(fbuf* f, struct sprixel* s, unsigned noscroll);
   // scroll all graphics up. only used with fbcon.
   void (*pixel_scroll)(const struct ncpile* p, struct tinfo*, int rows);
-  uint8_t* (*pixel_trans_auxvec)(const struct tinfo* ti); // create tranparent auxvec
+  uint8_t* (*pixel_trans_auxvec)(const struct ncpile* p); // create tranparent auxvec
   // sprixel parameters. there are several different sprixel protocols, of
   // which we support sixel and kitty. the kitty protocol is used based
   // on TERM heuristics. otherwise, we attempt to detect sixel support, and

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -173,7 +173,9 @@ struct ncplane* ffmpeg_subtitle(ncplane* parent, const ncvisual* ncv){
         continue;
       }
       struct notcurses* nc = ncplane_notcurses(parent);
-      if(nc->tcache.cellpixy <= 0 || nc->tcache.cellpixx <= 0){
+      const unsigned cellpxy = ncplane_pile_const(parent)->cellpxy;
+      const unsigned cellpxx = ncplane_pile_const(parent)->cellpxx;
+      if(cellpxy <= 0 || cellpxx <= 0){
         continue;
       }
       struct ncvisual* v = ncvisual_from_palidx(rect->data[0], rect->h,
@@ -182,10 +184,10 @@ struct ncplane* ffmpeg_subtitle(ncplane* parent, const ncvisual* ncv){
       if(v == NULL){
         return NULL;
       }
-      int rows = (rect->h + nc->tcache.cellpixy - 1) / nc->tcache.cellpixy;
+      int rows = (rect->h + cellpxx - 1) / cellpxy;
       struct ncplane_options nopts = {
         .rows = rows,
-        .cols = (rect->w + nc->tcache.cellpixx - 1) / nc->tcache.cellpixx,
+        .cols = (rect->w + cellpxx - 1) / cellpxx,
         .y = ncplane_dim_y(parent) - rows - 1,
         .name = "t1st",
       };

--- a/src/tests/bitmap.cpp
+++ b/src/tests/bitmap.cpp
@@ -14,8 +14,8 @@ TEST_CASE("Bitmaps") {
   }
 
   SUBCASE("SprixelTermValues") {
-    CHECK(0 < nc_->tcache.cellpixy);
-    CHECK(0 < nc_->tcache.cellpixx);
+    CHECK(0 < nc_->tcache.cellpxy);
+    CHECK(0 < nc_->tcache.cellpxx);
     if(!nc_->tcache.pixel_draw_late){
       CHECK(nc_->tcache.pixel_draw);
     }
@@ -66,8 +66,8 @@ TEST_CASE("Bitmaps") {
 
   // a sprixel requires a plane large enough to hold it
   SUBCASE("SprixelTooTall") {
-    auto y = nc_->tcache.cellpixy + 6;
-    auto x = nc_->tcache.cellpixx;
+    auto y = nc_->tcache.cellpxy + 6;
+    auto x = nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xe61c28ff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -89,8 +89,8 @@ TEST_CASE("Bitmaps") {
   }
 
   SUBCASE("SprixelTooWide") {
-    auto y = nc_->tcache.cellpixy;
-    auto x = nc_->tcache.cellpixx + 1;
+    auto y = nc_->tcache.cellpxy;
+    auto x = nc_->tcache.cellpxx + 1;
     std::vector<uint32_t> v(x * y, htole(0xe61c28ff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -114,8 +114,8 @@ TEST_CASE("Bitmaps") {
 
   // should not be able to emit glyphs to a sprixelated plane
   SUBCASE("SprixelNoGlyphs") {
-    auto y = nc_->tcache.cellpixy;
-    auto x = nc_->tcache.cellpixx;
+    auto y = nc_->tcache.cellpxy;
+    auto x = nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xe61c28ff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -139,8 +139,8 @@ TEST_CASE("Bitmaps") {
   }
 
   SUBCASE("BitmapStack") {
-    auto y = nc_->tcache.cellpixy * 10;
-    auto x = nc_->tcache.cellpixx * 10;
+    auto y = nc_->tcache.cellpxy * 10;
+    auto x = nc_->tcache.cellpxx * 10;
     std::vector<uint32_t> v(x * y, htole(0xe61c28ff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -152,8 +152,8 @@ TEST_CASE("Bitmaps") {
     REQUIRE(nullptr != botn);
     // should just have a red plane
     CHECK(0 == notcurses_render(nc_));
-    y = nc_->tcache.cellpixy * 5;
-    x = nc_->tcache.cellpixx * 5;
+    y = nc_->tcache.cellpxy * 5;
+    x = nc_->tcache.cellpxx * 5;
     std::vector<uint32_t> v2(x * y, htole(0x8142f1ff));
     auto ncv2 = ncvisual_from_rgba(v2.data(), y, sizeof(decltype(v2)::value_type) * x, x);
     REQUIRE(nullptr != ncv2);
@@ -198,8 +198,8 @@ TEST_CASE("Bitmaps") {
 
   SUBCASE("BitmapStretch") {
     // first, assemble a visual equivalent to 1 cell
-    auto y = nc_->tcache.cellpixy;
-    auto x = nc_->tcache.cellpixx;
+    auto y = nc_->tcache.cellpxy;
+    auto x = nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xffffffff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -211,8 +211,8 @@ TEST_CASE("Bitmaps") {
     REQUIRE(nullptr != n);
     auto s = n->sprite;
     REQUIRE(nullptr != s);
-    CHECK(nc_->tcache.cellpixy == ncv->pixy);
-    CHECK(nc_->tcache.cellpixx == ncv->pixx);
+    CHECK(nc_->tcache.cellpxy == ncv->pixy);
+    CHECK(nc_->tcache.cellpxx == ncv->pixx);
     CHECK(0 == notcurses_render(nc_));
     struct ncplane_options nopts = {
       .y = 1,
@@ -232,8 +232,8 @@ TEST_CASE("Bitmaps") {
     CHECK(vopts.n == ncvisual_blit(nc_, ncv, &vopts));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncvisual_resize_noninterpolative(ncv, ncv->pixy * 4, ncv->pixx * 4));
-    CHECK(4 * nc_->tcache.cellpixy == ncv->pixy);
-    CHECK(4 * nc_->tcache.cellpixx == ncv->pixx);
+    CHECK(4 * nc_->tcache.cellpxy == ncv->pixy);
+    CHECK(4 * nc_->tcache.cellpxx == ncv->pixx);
     vopts.y = 1;
     vopts.x = 6;
     vopts.n = n_;
@@ -242,7 +242,7 @@ TEST_CASE("Bitmaps") {
     auto infn = ncvisual_blit(nc_, ncv, &vopts);
     REQUIRE(infn);
     if(nc_->tcache.sprixel_scale_height == 6){
-      if(4 * nc_->tcache.cellpixy % 6){
+      if(4 * nc_->tcache.cellpxy % 6){
         CHECK(5 == ncplane_dim_y(infn));
       }else{
         CHECK(4 == ncplane_dim_y(infn));
@@ -259,8 +259,8 @@ TEST_CASE("Bitmaps") {
     vopts.x = 11;
     auto resizen = ncvisual_blit(nc_, ncv, &vopts);
     REQUIRE(resizen);
-    CHECK((8 + nc_->tcache.cellpixy - 1) / nc_->tcache.cellpixy == ncplane_dim_y(resizen));
-    CHECK((8 + nc_->tcache.cellpixx - 1) / nc_->tcache.cellpixx == ncplane_dim_x(resizen));
+    CHECK((8 + nc_->tcache.cellpxy - 1) / nc_->tcache.cellpxy == ncplane_dim_y(resizen));
+    CHECK((8 + nc_->tcache.cellpxx - 1) / nc_->tcache.cellpxx == ncplane_dim_x(resizen));
     CHECK(0 == notcurses_render(nc_));
     CHECK(0 == ncplane_destroy(bigp));
     CHECK(0 == ncplane_destroy(resizen));
@@ -274,8 +274,8 @@ TEST_CASE("Bitmaps") {
   // resulting geometries for (rough) equality
   SUBCASE("InflateVsScale") {
     // first, assemble a visual equivalent to 1 cell
-    auto y = nc_->tcache.cellpixy;
-    auto x = nc_->tcache.cellpixx;
+    auto y = nc_->tcache.cellpxy;
+    auto x = nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xff7799dd));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -355,8 +355,8 @@ TEST_CASE("Bitmaps") {
       .transcolor = 0,
       .pxoffy = 0, .pxoffx = 0,
     };
-    auto y = nc_->tcache.cellpixy * 6;
-    auto x = nc_->tcache.cellpixx;
+    auto y = nc_->tcache.cellpxy * 6;
+    auto x = nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xffffffff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -399,8 +399,8 @@ TEST_CASE("Bitmaps") {
       .transcolor = 0,
       .pxoffy = 0, .pxoffx = 0,
     };
-    auto y = nc_->tcache.cellpixy * 6;
-    auto x = nc_->tcache.cellpixx;
+    auto y = nc_->tcache.cellpxy * 6;
+    auto x = nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xffffffff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -417,8 +417,8 @@ TEST_CASE("Bitmaps") {
 
   SUBCASE("PixelCellWipe") {
     // first, assemble a visual equivalent to 4 cells
-    auto y = 2 * nc_->tcache.cellpixy;
-    auto x = 2 * nc_->tcache.cellpixx;
+    auto y = 2 * nc_->tcache.cellpxy;
+    auto x = 2 * nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xffffffff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -446,8 +446,8 @@ TEST_CASE("Bitmaps") {
 
   SUBCASE("PixelCellWipePolychromatic") {
     // first, assemble a visual equivalent to 4 cells
-    auto y = 2 * nc_->tcache.cellpixy;
-    auto x = 2 * nc_->tcache.cellpixx;
+    auto y = 2 * nc_->tcache.cellpxy;
+    auto x = 2 * nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xffffffff));
     for(auto& e : v){
       e -= htole(rand() % 0x1000000);
@@ -478,8 +478,8 @@ TEST_CASE("Bitmaps") {
 
   SUBCASE("PixelBigCellWipePolychromatic") {
     // first, assemble a visual equivalent to 100 cells
-    auto y = 10 * nc_->tcache.cellpixy;
-    auto x = 10 * nc_->tcache.cellpixx;
+    auto y = 10 * nc_->tcache.cellpxy;
+    auto x = 10 * nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xffffffff));
     for(auto& e : v){
       e -= htole(rand() % 0x1000000);
@@ -513,14 +513,14 @@ TEST_CASE("Bitmaps") {
     // first, assemble a visual equivalent to 54 cells
     auto dimy = 6;
     auto dimx = 9;
-    auto y = dimy * nc_->tcache.cellpixy;
-    auto x = dimx * nc_->tcache.cellpixx;
+    auto y = dimy * nc_->tcache.cellpxy;
+    auto x = dimx * nc_->tcache.cellpxx;
     std::vector<uint32_t> v(x * y, htole(0xffffffff));
     // every other cell, set some pixels transparent
     for(int i = 0 ; i < dimy * dimx ; ++i){
       if(i % 2){
-        int py = (i / dimx) * nc_->tcache.cellpixy;
-        int px = (i % dimx) * nc_->tcache.cellpixx;
+        int py = (i / dimx) * nc_->tcache.cellpxy;
+        int px = (i % dimx) * nc_->tcache.cellpxx;
         ncpixel_set_a(&v[py * x + px], 0);
       }
     }
@@ -540,8 +540,8 @@ TEST_CASE("Bitmaps") {
     CHECK(s->dimx == dimx);
     const auto tam = n->tam;
     for(unsigned i = 0 ; i < s->dimy * s->dimx ; ++i){
-      int py = (i / dimx) * nc_->tcache.cellpixy;
-      int px = (i % dimx) * nc_->tcache.cellpixx;
+      int py = (i / dimx) * nc_->tcache.cellpxy;
+      int px = (i % dimx) * nc_->tcache.cellpxx;
       // cells with a transparent pixel ought be SPRIXCELL_MIXED;
       // cells without one ought be SPRIXCELL_OPAQUE.
       sprixcell_e state = tam[(i / dimx) + (i % dimx)].state;
@@ -613,8 +613,8 @@ TEST_CASE("Bitmaps") {
 
   SUBCASE("BitmapMoveOffscreenLeft") {
     // first, assemble a visual equivalent to 2x2 cells
-    auto y = nc_->tcache.cellpixy * 2;
-    auto x = nc_->tcache.cellpixx * 2;
+    auto y = nc_->tcache.cellpxy * 2;
+    auto x = nc_->tcache.cellpxx * 2;
     std::vector<uint32_t> v(x * y * 4, htole(0xffccccff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -634,8 +634,8 @@ TEST_CASE("Bitmaps") {
 
   SUBCASE("BitmapMoveOffscreenRight") {
     // first, assemble a visual equivalent to 2x2 cells
-    auto y = nc_->tcache.cellpixy * 2;
-    auto x = nc_->tcache.cellpixx * 2;
+    auto y = nc_->tcache.cellpxy * 2;
+    auto x = nc_->tcache.cellpxx * 2;
     std::vector<uint32_t> v(x * y * 4, htole(0xffccccff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -656,8 +656,8 @@ TEST_CASE("Bitmaps") {
 
   SUBCASE("BitmapMoveOffscreenDown") {
     // first, assemble a visual equivalent to 2x2 cells
-    auto y = nc_->tcache.cellpixy * 2;
-    auto x = nc_->tcache.cellpixx * 2;
+    auto y = nc_->tcache.cellpxy * 2;
+    auto x = nc_->tcache.cellpxx * 2;
     std::vector<uint32_t> v(x * y * 4, htole(0xffccccff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -677,8 +677,8 @@ TEST_CASE("Bitmaps") {
 
   SUBCASE("BitmapMoveOffscreenUp") {
     // first, assemble a visual equivalent to 2x2 cells
-    auto y = nc_->tcache.cellpixy * 2;
-    auto x = nc_->tcache.cellpixx * 2;
+    auto y = nc_->tcache.cellpxy * 2;
+    auto x = nc_->tcache.cellpxx * 2;
     std::vector<uint32_t> v(x * y * 4, htole(0xffccccff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -700,8 +700,8 @@ TEST_CASE("Bitmaps") {
   // smoothly move a bitmap diagonally across the screen
   SUBCASE("BitmapSmoothMove") {
     // first, assemble a visual equivalent to 2x2 cells
-    auto y = nc_->tcache.cellpixy * 2;
-    auto x = nc_->tcache.cellpixx * 2;
+    auto y = nc_->tcache.cellpxy * 2;
+    auto x = nc_->tcache.cellpxx * 2;
     std::vector<uint32_t> v(x * y * 4, htole(0xffccccff));
     auto ncv = ncvisual_from_rgba(v.data(), y, sizeof(decltype(v)::value_type) * x, x);
     REQUIRE(nullptr != ncv);
@@ -711,15 +711,15 @@ TEST_CASE("Bitmaps") {
     vopts.flags = NCVISUAL_OPTION_NODEGRADE | NCVISUAL_OPTION_CHILDPLANE;
     auto n = ncvisual_blit(nc_, ncv, &vopts);
     REQUIRE(nullptr != n);
-    auto xpx = (ncplane_dim_x(n_) - 2) * nc_->tcache.cellpixx;
-    auto ypx = (ncplane_dim_y(n_) - 2) * nc_->tcache.cellpixy;
+    auto xpx = (ncplane_dim_x(n_) - 2) * nc_->tcache.cellpxx;
+    auto ypx = (ncplane_dim_y(n_) - 2) * nc_->tcache.cellpxy;
     double xyrat = (double)ypx / xpx;
     for(unsigned xat = 0 ; xat < xpx ; ++xat){
-      vopts.x = xat / nc_->tcache.cellpixx;
-      vopts.pxoffx = xat % nc_->tcache.cellpixx;
+      vopts.x = xat / nc_->tcache.cellpxx;
+      vopts.pxoffx = xat % nc_->tcache.cellpxx;
       int yat = xat * xyrat;
-      vopts.y = yat / nc_->tcache.cellpixy;
-      vopts.pxoffy = yat % nc_->tcache.cellpixy;
+      vopts.y = yat / nc_->tcache.cellpxy;
+      vopts.pxoffy = yat % nc_->tcache.cellpxy;
       CHECK(0 == ncplane_destroy(n));
       n = ncvisual_blit(nc_, ncv, &vopts);
       REQUIRE(nullptr != n);

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -7,8 +7,8 @@
 void default_visual_extrinsics(const notcurses* nc, const ncvgeom& g) {
   CHECK(0 == g.pixy);
   CHECK(0 == g.pixx);
-  CHECK(nc->tcache.cellpixy == g.cdimy);
-  CHECK(nc->tcache.cellpixx == g.cdimx);
+  CHECK(nc->tcache.cellpxy == g.cdimy);
+  CHECK(nc->tcache.cellpxx == g.cdimx);
   CHECK(1 <= g.scaley);
   CHECK(1 <= g.scalex);
   CHECK(0 == g.rpixy);
@@ -91,8 +91,8 @@ TEST_CASE("Visual") {
     CHECK(0 == ncvisual_geom(nc_, nullptr, &vopts, &g));
     CHECK(0 == g.pixy);
     CHECK(0 == g.pixx);
-    CHECK(nc_->tcache.cellpixy == g.cdimy);
-    CHECK(nc_->tcache.cellpixx == g.cdimx);
+    CHECK(nc_->tcache.cellpxy == g.cdimy);
+    CHECK(nc_->tcache.cellpxx == g.cdimx);
     if(notcurses_canpixel(nc_)){
       CHECK(g.cdimy == g.scaley);
       CHECK(g.cdimx == g.scalex);


### PR DESCRIPTION
Finally address #1687. Remove cell-pixel geometry from `sprixel` objects. Add it to `ncpile`s. All sprixels within a pile will use the same cell-pixel geometry, though this is not yet enforced or implemented (that's part 2). This leaves us in the same exact place, except the cell-pixel geometry is stored in the `ncpile`, and that's used everywhere that's relevant (as opposed to the cell-pixel geometry in the `terminfo` object). The `terminfo` has the most up-to-date cell-pixel geometry, but that's irrelevant to an `ncpile` until said pile is rendered. At that time, we'll update to any new cell-pixel geometry, transmogrifying all affected sprixels in the pile.