### PR TITLE
Deal with cell-pixel geometry changes, part 2 of 2

### DIFF
--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1305,7 +1305,6 @@ API int ncplane_resize_realign(struct ncplane* n);
 // move the plane such that it is entirely within its parent, if possible.
 // no resizing is performed.
 API int ncplane_resize_placewithin(struct ncplane* n);
-///////////////////////////////////////////////////////////////////////////////
 
 // Replace the ncplane's existing resizecb with 'resizecb' (which may be NULL).
 // The standard plane's resizecb may not be changed.

--- a/src/demo/input.c
+++ b/src/demo/input.c
@@ -84,11 +84,7 @@ uint32_t demo_getc(struct notcurses* nc, const struct timespec* ts, ncinput* ni)
     if(!menu_or_hud_key(nc, &q->ni)){
       if(nckey_mouse_p(q->ni.id)){
         if(!handle_mouse(&q->ni)){
-          if(id == 'L' && q->ni.ctrl){
-            notcurses_refresh(nc, NULL, NULL);
-          }else{
-            handoff = true;
-          }
+          handoff = true;
         }
       }else{
         if(id == 'L' && q->ni.ctrl){

--- a/src/demo/xray.c
+++ b/src/demo/xray.c
@@ -3,8 +3,8 @@
 #include <stdatomic.h>
 
 // this can take a long time, especially in large terminals; we cap execution
-// at twenty seconds, and drop frames when behind.
-#define MAX_SECONDS 20
+// at fifteen seconds (the true intended runtime), and drop frames when behind.
+#define MAX_SECONDS 15
 
 // issue #2390 adds ncvisual_frame_count(). until then...FIXME
 #define VIDEO_FRAMES 862
@@ -114,7 +114,7 @@ get_next_frame(struct marsh* m, struct ncvisual_options* vopts){
   }
   uint64_t ns = clock_getns(CLOCK_MONOTONIC);
   int ret = m->next_frame;
-  uint64_t deadline = m->startns + (m->next_frame + 1) * 20 * (NANOSECS_IN_SEC / VIDEO_FRAMES);
+  uint64_t deadline = m->startns + (m->next_frame + 1) * MAX_SECONDS * (NANOSECS_IN_SEC / VIDEO_FRAMES);
   // if we've missed the deadline, drop the frame 95% of the time (you've still
   // got to draw now and again, or else there's just the initial frame hanging
   // there for ~900 frames of crap).

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -219,11 +219,11 @@ dim_rows(const Plane* n){
 
 void Tick(ncpp::NotCurses* nc, uint64_t sec) {
   const std::lock_guard<std::mutex> lock(mtx);
-  if(ncuplot_add_sample(plot, sec, 0)){
-    throw std::runtime_error("couldn't register timetick");
-  }
-  if(!nc->render()){
-    throw std::runtime_error("error rendering");
+  // might fail on various geometry changes
+  if(ncuplot_add_sample(plot, sec, 0) == 0){
+    if(!nc->render()){
+      throw std::runtime_error("error rendering");
+    }
   }
 }
 

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -755,6 +755,12 @@ legacy_functional(uint32_t id){
 }
 
 static int
+simple_cb_begin(inputctx* ictx){
+  kitty_kbd(ictx, NCKEY_BEGIN, 0, 0);
+  return 2;
+}
+
+static int
 kitty_cb_functional(inputctx* ictx){
   unsigned val = amata_next_numeric(&ictx->amata, "\x1b[", ';');
   unsigned mods = amata_next_numeric(&ictx->amata, "", ':');
@@ -1380,6 +1386,7 @@ build_cflow_automaton(inputctx* ictx){
     triefunc fxn;
   } csis[] = {
     // CSI (\e[)
+    { "[E", simple_cb_begin, },
     { "[<\\N;\\N;\\NM", mouse_press_cb, },
     { "[<\\N;\\N;\\Nm", mouse_release_cb, },
     // technically these must begin with "4" or "8"; enforce in callbacks

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -2113,12 +2113,12 @@ block_on_input(inputctx* ictx, unsigned* rtfd, unsigned* rifd){
   struct timespec* pts = nonblock ? &ts : NULL;
   while((events = ppoll(pfds, pfdcount, pts, &smask)) < 0){
 #endif
-    if(errno != EAGAIN && errno != EBUSY && errno != EWOULDBLOCK){
-      logerror("error polling (%s)\n", strerror(errno));
-      return -1;
-    }else if(errno == EINTR){
+    if(errno == EINTR){
       loginfo("interrupted by signal\n");
       return resize_seen;
+    }else if(errno != EAGAIN && errno != EBUSY && errno != EWOULDBLOCK){
+      logerror("error polling (%s)\n", strerror(errno));
+      return -1;
     }
   }
   loginfo("poll returned %d\n", events);

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -30,6 +30,7 @@ static sig_atomic_t resize_seen;
 void sigwinch_handler(int signo){
   if(signo == SIGWINCH){
     resize_seen = signo;
+    sigcont_seen_for_render = 1;
   }else if(signo == SIGCONT){
     cont_seen = signo;
     sigcont_seen_for_render = 1;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -798,6 +798,8 @@ sprite_rebuild(const notcurses* nc, sprixel* s, int ycell, int xcell){
       free(auxvec);
       s->n->tam[idx].auxvector = NULL;
     }
+  }else{
+    return 0;
   }
   // don't upset SPRIXEL_MOVED
   if(s->invalidated == SPRIXEL_QUIESCENT){

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -164,8 +164,8 @@ int fbcon_rebuild(sprixel* s, int ycell, int xcell, uint8_t* auxvec){
 int fbcon_draw(const tinfo* ti, sprixel* s, int y, int x){
   logdebug("id %" PRIu32 " dest %d/%d\n", s->id, y, x);
   int wrote = 0;
-  const int cellpxy = ncplane_pile(s->n)->cellpxy;
-  const int cellpxx = ncplane_pile(s->n)->cellpxx;
+  const int cellpxy = ncplane_pile(s->n) ? ncplane_pile(s->n)->cellpxy : ti->cellpxy;
+  const int cellpxx = ncplane_pile(s->n) ? ncplane_pile(s->n)->cellpxx : ti->cellpxx;
   for(unsigned l = 0 ; l < (unsigned)s->pixy && l + y * cellpxy < ti->pixy ; ++l){
     // FIXME pixel size isn't necessarily 4B, line isn't necessarily psize*pixx
     size_t offset = ((l + y * cellpxy) * ti->pixx + x * cellpxx) * 4;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -285,9 +285,13 @@ int update_term_dimensions(unsigned* rows, unsigned* cols, tinfo* tcache,
   }
   *rows = ws.ws_row;
   *cols = ws.ws_col;
+  unsigned cpixy;
+  unsigned cpixx;
 #ifdef __linux__
   if(tcache->linux_fb_fd >= 0){
     get_linux_fb_pixelgeom(tcache, &tcache->pixy, &tcache->pixx);
+    cpixy = tcache->pixy / *rows;
+    cpixx = tcache->pixx / *cols;
   }else{
 #else
   {
@@ -301,19 +305,19 @@ int update_term_dimensions(unsigned* rows, unsigned* cols, tinfo* tcache,
     }
     // update even if we didn't get values just now, because we need set
     // cellpx{y,x} up from an initial CSI14n, which set only pix{y,x}.
-    unsigned cpixy = ws.ws_row ? tcache->pixy / ws.ws_row : 0;
-    unsigned cpixx = ws.ws_col ? tcache->pixx / ws.ws_col : 0;
-    if(tcache->cellpxy != cpixy){
-      tcache->cellpxy = cpixy;
-      *pgeo_changed = 1;
-    }
-    if(tcache->cellpxx != cpixx){
-      tcache->cellpxx = cpixx;
-      *pgeo_changed = 1;
-    }
-    if(tcache->cellpxy == 0 || tcache->cellpxx == 0){
-      tcache->pixel_draw = NULL; // disable support
-    }
+    cpixy = ws.ws_row ? tcache->pixy / ws.ws_row : 0;
+    cpixx = ws.ws_col ? tcache->pixx / ws.ws_col : 0;
+  }
+  if(tcache->cellpxy != cpixy){
+    tcache->cellpxy = cpixy;
+    *pgeo_changed = 1;
+  }
+  if(tcache->cellpxx != cpixx){
+    tcache->cellpxx = cpixx;
+    *pgeo_changed = 1;
+  }
+  if(tcache->cellpxy == 0 || tcache->cellpxx == 0){
+    tcache->pixel_draw = NULL; // disable support
   }
 #else
   CONSOLE_SCREEN_BUFFER_INFO csbi;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2690,8 +2690,10 @@ splice_zaxis_recursive(ncplane* n, ncpile* p, unsigned ocellpxy, unsigned ocellp
     n->boundto->above = n;
   }
   if(n->sprite){
-    sprixel_rescale(n->sprite, ocellpxy, ocellpxx, ncellpxy, ncellpxx);
-    // FIXME do what on error?
+    if(ocellpxy != ncellpxy || ocellpxx != ncellpxx){
+      sprixel_rescale(n->sprite, ncellpxy, ncellpxx);
+      // FIXME do what on error?
+    }
   }
   for(ncplane* child = n->blist ; child ; child = child->bnext){
     splice_zaxis_recursive(child, p, ocellpxy, ocellpxx, ncellpxy, ncellpxx);

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -249,6 +249,10 @@ void ncplane_dim_yx(const ncplane* n, unsigned* rows, unsigned* cols){
 
 // anyone calling this needs ensure the ncplane's framebuffer is updated
 // to reflect changes in geometry. also called at startup for standard plane.
+// sets |cgeo_changed| high iff the cell geometry changed (will happen on a
+//  resize, and on a font resize if the pixel geometry does not change).
+// sets |pgeo_changed| high iff the cell-pixel geometry changed (will happen
+//  on a font resize).
 int update_term_dimensions(unsigned* rows, unsigned* cols, tinfo* tcache,
                            int margin_b, unsigned* cgeo_changed, unsigned* pgeo_changed){
   *pgeo_changed = 0;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2689,6 +2689,10 @@ splice_zaxis_recursive(ncplane* n, ncpile* p, unsigned ocellpxy, unsigned ocellp
     n->below = n->boundto;
     n->boundto->above = n;
   }
+  if(n->sprite){
+    sprixel_rescale(n->sprite, ocellpxy, ocellpxx, ncellpxy, ncellpxx);
+    // FIXME do what on error?
+  }
   for(ncplane* child = n->blist ; child ; child = child->bnext){
     splice_zaxis_recursive(child, p, ocellpxy, ocellpxx, ncellpxy, ncellpxx);
   }

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -222,8 +222,22 @@ int sprite_init(const tinfo* t, int fd){
   return t->pixel_init(fd);
 }
 
-int sprixel_rescale(sprixel* spx, unsigned ocellpixy, unsigned ocellpixx,
-                    unsigned ncellpixy, unsigned ncellpixx){
-  // FIXME
+int sprixel_rescale(sprixel* spx, unsigned ocellpxy, unsigned ocellpxx,
+                    unsigned ncellpxy, unsigned ncellpxx){
+  assert(spx->n);
+  if(ocellpxy == ncellpxy && ocellpxx == ncellpxx){ // no change
+    return 0;
+  }
+  // FIXME need adjust for sixel (scale_height)
+  int nrows = (spx->pixy + (ncellpxy - 1)) / ncellpxy;
+  int ncols = (spx->pixx + (ncellpxx - 1)) / ncellpxx;
+  tament* ntam = create_tam(nrows, ncols);
+  if(ntam == NULL){
+    return -1;
+  }
+  // FIXME rebuild all annihilated cells
+  // FIXME prepare new tam entries
+  destroy_tam(spx->n);
+  spx->n->tam = ntam;
   return 0;
 }

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -232,6 +232,11 @@ int sprixel_rescale(sprixel* spx, unsigned ncellpxy, unsigned ncellpxx){
   if(ntam == NULL){
     return -1;
   }
+  for(unsigned y = 0 ; y < spx->dimy ; ++y){
+    for(unsigned x = 0 ; x < spx->dimx ; ++x){
+      sprite_rebuild(ncplane_notcurses(spx->n), spx, y, x);
+    }
+  }
   // FIXME rebuild all annihilated cells
   // FIXME prepare new tam entries
   ncplane* ncopy = spx->n;

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -221,3 +221,9 @@ int sprite_init(const tinfo* t, int fd){
   }
   return t->pixel_init(fd);
 }
+
+int sprixel_rescale(sprixel* spx, unsigned ocellpixy, unsigned ocellpixx,
+                    unsigned ncellpixy, unsigned ncellpixx){
+  // FIXME
+  return 0;
+}

--- a/src/lib/sprite.c
+++ b/src/lib/sprite.c
@@ -222,12 +222,9 @@ int sprite_init(const tinfo* t, int fd){
   return t->pixel_init(fd);
 }
 
-int sprixel_rescale(sprixel* spx, unsigned ocellpxy, unsigned ocellpxx,
-                    unsigned ncellpxy, unsigned ncellpxx){
+int sprixel_rescale(sprixel* spx, unsigned ncellpxy, unsigned ncellpxx){
   assert(spx->n);
-  if(ocellpxy == ncellpxy && ocellpxx == ncellpxx){ // no change
-    return 0;
-  }
+  loginfo("rescaling -> %ux%u\n", ncellpxy, ncellpxx);
   // FIXME need adjust for sixel (scale_height)
   int nrows = (spx->pixy + (ncellpxy - 1)) / ncellpxy;
   int ncols = (spx->pixx + (ncellpxx - 1)) / ncellpxx;
@@ -237,7 +234,14 @@ int sprixel_rescale(sprixel* spx, unsigned ocellpxy, unsigned ocellpxx,
   }
   // FIXME rebuild all annihilated cells
   // FIXME prepare new tam entries
+  ncplane* ncopy = spx->n;
   destroy_tam(spx->n);
+  // spx->n->tam has been reset, so it will not be resized herein
+  ncplane_resize_simple(spx->n, nrows, ncols);
+  spx->n = ncopy;
+  spx->n->sprite = spx;
   spx->n->tam = ntam;
+  spx->dimy = nrows;
+  spx->dimx = ncols;
   return 0;
 }

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -216,10 +216,8 @@ void sixel_refresh(const struct ncpile* p, sprixel* s);
 int sprixel_load(sprixel* spx, fbuf* f, unsigned pixy, unsigned pixx,
                  int parse_start, sprixel_e state);
 
-// called when a sprixel's cell-pixel geometry needs to change from
-// |ocellpxy,ocellpxx| to |ncellpxy,ncellpxx|.
-int sprixel_rescale(sprixel* spx, unsigned ocellpixy, unsigned ocellpixx,
-                    unsigned ncellpixy, unsigned ncellpixx);
+// called when a sprixel's cell-pixel geometry needs to change to |ncellpxy,ncellpxx|.
+int sprixel_rescale(sprixel* spx, unsigned ncellpixy, unsigned ncellpixx);
 
 #ifdef __cplusplus
 }

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -216,6 +216,11 @@ void sixel_refresh(const struct ncpile* p, sprixel* s);
 int sprixel_load(sprixel* spx, fbuf* f, unsigned pixy, unsigned pixx,
                  int parse_start, sprixel_e state);
 
+// called when a sprixel's cell-pixel geometry needs to change from
+// |ocellpxy,ocellpxx| to |ncellpxy,ncellpxx|.
+int sprixel_rescale(sprixel* spx, unsigned ocellpixy, unsigned ocellpixx,
+                    unsigned ncellpixy, unsigned ncellpixx);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Call into `sprixel_rescale()` from `ncplane_reparent_family()` and `paint_sprixel()`. Pass `pgeo_changed` down from `ncpile_render()` all the way to `paint_sprixel()`. Implement `sprixel_rescale()`. Closes #1687.