### PR TITLE
Move to bottom row when scrolling for child

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ If things break or seem otherwise lackluster, **please** consult the
 
 <details>
   <summary>Will there ever be Java wrappers?</summary>
-  I should hope not. If you want a Java solution, try Autumn Lamonte's
+  I should hope not. If you want a Java solution, try @klamonte's
   <a href="https://jexer.sourceforge.io/">Jexer</a>. Autumn's a good
   woman, and thorough. We seem to have neatly partitioned the language
   space.

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1855,6 +1855,7 @@ emit_scrolls(const tinfo* ti, int count, fbuf* f){
   if(ind == NULL){
     ind = "\v";
   }
+  // fell through if we had no indn
   while(count > 0){
     if(fbuf_emit(f, ind) < 0){
       return -1;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1673,6 +1673,7 @@ int ncplane_scrollup_child(ncplane* n, const ncplane* child){
     return 0;
   }
   int r = chend - parend; // how many rows we need scroll parent
+  ncplane_cursor_move_yx(n, ncplane_dim_y(n) - 1, 0);
   int ret = ncplane_scrollup(n, r);
   return ret;
 }


### PR DESCRIPTION
Closes #2378 for almost all cases. When we call `ncplane_scroll_throughchild()`, we need move to the bottom row before emitting our `indn` or vertical feeds. Use halfblocks when drawing palette in `ncneofetch`, when available.