### PR TITLE
[ncplane_put] subtle cursor verification fix

### DIFF
--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1733,16 +1733,17 @@ ncplane_put(ncplane* n, int y, int x, const char* egc, int cols,
   // line. if scrolling is enabled, move to the next line if so. if x or y are
   // specified, we must always try to print at exactly that location, and
   // there's no need to check the present location in that dimension.
-  //
-  // check x for all negatives; only -1 is valid, but our else clause is
-  // predicated on a non-negative x.
   if(x < 0){
-    if(n->x + cols - 1 >= n->lenx){
-      if(!n->scrolling){
-        logerror("target x %d [%.*s] > length %d\n", n->x, bytes, egc, n->lenx);
-        return -1;
+    // we checked x for all negatives, but only -1 is valid (our else clause is
+    // predicated on a non-negative x).
+    if(x == -1){
+      if(n->x + cols - 1 >= n->lenx){
+        if(!n->scrolling){
+          logerror("target x %d [%.*s] > length %d\n", n->x, bytes, egc, n->lenx);
+          return -1;
+        }
+        scroll_down(n);
       }
-      scroll_down(n);
     }
   }else{
     if((unsigned)x + cols - 1 >= n->lenx){

--- a/src/tests/fade.cpp
+++ b/src/tests/fade.cpp
@@ -41,7 +41,6 @@ TEST_CASE("Fade") {
   unsigned dimy, dimx;
   ncplane_dim_yx(n_, &dimy, &dimx);
   nccell c = NCCELL_CHAR_INITIALIZER('*');
-  nccell_set_fg_rgb8(&c, 0xff, 0xff, 0xff);
   unsigned rgb = 0xffffffu;
   CHECK(!ncplane_set_scrolling(n_, true));
   for(unsigned y = 0 ; y < dimy ; ++y){

--- a/src/tests/wide.cpp
+++ b/src/tests/wide.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Wide") {
     unsigned y, x;
     ncplane_cursor_yx(n_, &y, &x);
     CHECK(0 == y);
-    CHECK(dimx - 1 == x);
+    CHECK(0 == x);
     CHECK(0 == notcurses_render(nc_));
   }
 


### PR DESCRIPTION
We were checking for an off-plane cursor destination on the X axis when it was provided explicitly, but not when -1 was used to indicate the current position (contradicting the comment immediately above the test). We also want to do so when we're using the current position, though in this case scrolling must be taken into account. Also, we were placing the cursor on such a validation failure, despite not intending to write anything.

Not testing for a current x (the -1 case) usually worked because it was thrown out by ncplane_move_cursor_yx() below. That fails, however, when we're working with an EGC that's more than one column.

Delicate! I was hoping one or two of y'all could look at this and give it some more eyes.