### PR TITLE
Honor newlines when autogrowing

### DIFF
--- a/doc/man/man3/notcurses.3.md
+++ b/doc/man/man3/notcurses.3.md
@@ -109,20 +109,20 @@ is assumed to be 80x24 cells). Further ncplanes can be created with
 and new ncplanes are placed at the top of the z-buffer. Ncplanes can be larger,
 smaller, or the same size as the physical screen, and can be placed anywhere
 relative to it (including entirely off-screen). Ncplanes are made up of
-`nccell`s (see [NcCells][] below). Information on ncplanes is available at
+**nccell**s (see [NcCells][] below). Information on ncplanes is available at
 **notcurses_plane(3)**.
 
 ## NcCells
 
-`nccell`s make up the framebuffers backing each ncplane, one cell per
+**nccell**s make up the framebuffers backing each ncplane, one cell per
 coordinate, one extended grapheme cluster (see **unicode(7)**) per cell. An
-`nccell` consists of a gcluster (either a directly-encoded 7-bit ASCII
+**nccell** consists of a gcluster (either a directly-encoded 7-bit ASCII
 character (see **ascii(7)**), or a 25-bit index into the ncplane's egcpool), a
 set of attributes, and two channels (one for the foreground, and one for the
 background—see **notcurses_channels(3)**). Information on cells is available at
 **notcurses_cell(3)**.
 
-It is not usually necessary for users to interact directly with `nccell`s. They
+It is not usually necessary for users to interact directly with **nccell**s. They
 are typically encountered when retrieving data from ncplanes or the rendered
 scene (see e.g. **ncplane_at_yx(3)**), or to achieve peak performance when a
 particular EGC is heavily reused within a plane.

--- a/doc/man/man3/notcurses_channels.3.md
+++ b/doc/man/man3/notcurses_channels.3.md
@@ -102,9 +102,9 @@ foreground channel and ***bchan*** as the background channel.
 
 # RETURN VALUES
 
-Functions returning `int` return -1 on failure, or 0 on success. Failure is
-always due to invalid inputs. Functions returning `bool` are predicates, and
-return the requested value. Functions returning `unsigned` forms return the
+Functions returning **int** return -1 on failure, or 0 on success. Failure is
+always due to invalid inputs. Functions returning **bool** are predicates, and
+return the requested value. Functions returning **unsigned** forms return the
 input, modified as requested.
 
 **ncchannels_reverse** inverts the color components of the two channels,

--- a/doc/man/man3/notcurses_output.3.md
+++ b/doc/man/man3/notcurses_output.3.md
@@ -106,7 +106,7 @@ broken by cluster breaks, terminated by the appropriate NUL terminator.
 Control characters are rejected, except for a newline when the output plane
 is in scrolling mode. A newline outside of scrolling mode will be rejected.
 
-These functions output to the `ncplane`'s current cursor location. Aside from
+These functions output to the **ncplane**'s current cursor location. Aside from
 **ncplane_puttext()**, they *do not* move to the next line upon reaching the
 right extreme of the containing plane. If the entirety of the content cannot be
 output, they will output as much as possible.

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1646,6 +1646,7 @@ void scroll_down(ncplane* n){
   if(n->y == n->leny - 1){
     if(n->autogrow){
       ncplane_resize_simple(n, n->leny + 1, n->lenx);
+      ncplane_cursor_move_yx(n, n->leny - 1, 0);
       return;
     }
     if(n == notcurses_stdplane(ncplane_notcurses(n))){

--- a/src/man/main.c
+++ b/src/man/main.c
@@ -636,6 +636,8 @@ putpara(struct ncplane* p, const char* text){
           } macros[] = {
             { "aq]", "'", },
             { "dq]", "\"", },
+            { "rg]", "®", },
+            { "rs]", "\\", },
             { NULL, NULL, }
           };
           ++curend;
@@ -915,6 +917,7 @@ manloop(struct notcurses* nc, const char* arg){
           ncplane_move_rel(page, 1, 0);
         }
         break;
+      // we can move down iff our last line is beyond the visible area
       case 'j': case NCKEY_DOWN:
         if(ncplane_y(page) + ncplane_dim_y(page) > ncplane_dim_y(stdn)){
           ncplane_move_rel(page, -1, 0);

--- a/src/man/main.c
+++ b/src/man/main.c
@@ -691,7 +691,7 @@ draw_domnode(struct ncplane* p, const pagedom* dom, const pagenode* n,
       if(strcmp(n->text, "NAME")){
         ncplane_puttext(p, -1, NCALIGN_LEFT, "\n\n", &b);
         ncplane_set_styles(p, NCSTYLE_BOLD);
-        ncplane_putstr(p, n->text);
+        ncplane_putstr_aligned(p, -1, NCALIGN_CENTER, n->text);
         ncplane_set_styles(p, NCSTYLE_NONE);
         ncplane_cursor_move_yx(p, -1, 0);
         *wrotetext = true;
@@ -700,7 +700,7 @@ draw_domnode(struct ncplane* p, const pagedom* dom, const pagenode* n,
     case LINE_SS: // subsection heading
       ncplane_puttext(p, -1, NCALIGN_LEFT, "\n\n", &b);
       ncplane_set_styles(p, NCSTYLE_ITALIC);
-      ncplane_printf(p, "    %s", n->text);
+      ncplane_putstr_aligned(p, -1, NCALIGN_CENTER, n->text);
       ncplane_set_styles(p, NCSTYLE_NONE);
       ncplane_cursor_move_yx(p, -1, 0);
       *wrotetext = true;
@@ -714,7 +714,10 @@ draw_domnode(struct ncplane* p, const pagedom* dom, const pagenode* n,
         }
       }else{
         ncplane_set_styles(p, NCSTYLE_BOLD | NCSTYLE_ITALIC | NCSTYLE_UNDERLINE);
-        putpara(p, n->text);
+        ncplane_set_fg_rgb(p, 0xff6a00);
+        ncplane_putstr_aligned(p, -1, NCALIGN_CENTER, n->text);
+        ncplane_set_fg_default(p);
+        ncplane_set_styles(p, NCSTYLE_NONE);
       }
       *wrotetext = true;
       break;

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -18,7 +18,9 @@ auto testing_notcurses() -> struct notcurses* {
   // get loglevel from command line. enabling it by default leads to
   // more confusion than useful information, so leave it off by default.
   nopts.loglevel = cliloglevel;
-  nopts.flags = NCOPTION_SUPPRESS_BANNERS | NCOPTION_NO_ALTERNATE_SCREEN;
+  nopts.flags = NCOPTION_SUPPRESS_BANNERS
+                | NCOPTION_NO_ALTERNATE_SCREEN
+                | NCOPTION_DRAIN_INPUT;
   auto nc = notcurses_init(&nopts, nullptr);
   return nc;
 }

--- a/src/tests/textlayout.cpp
+++ b/src/tests/textlayout.cpp
@@ -653,6 +653,44 @@ TEST_CASE("TextLayout") {
     CHECK(0 == ncplane_destroy(sp));
   }
 
+  // test that multiple new lines are treated as such, both on the plane
+  // originally, and in any autogrown region.
+  SUBCASE("MultipleNewlines") {
+    struct ncplane_options nopts{};
+    nopts.rows = 3;
+    nopts.cols = 10;
+    nopts.flags = NCPLANE_OPTION_VSCROLL | NCPLANE_OPTION_AUTOGROW;
+    auto nn = ncplane_create(n_, &nopts);
+    REQUIRE(nn);
+    size_t b;
+    CHECK(0 == ncplane_puttext(nn, -1, NCALIGN_LEFT, "\n\n", &b));
+    unsigned y, x;
+    ncplane_cursor_yx(nn, &y, &x);
+    CHECK(2 == y);
+    CHECK(0 == x);
+    CHECK(3 == ncplane_puttext(nn, -1, NCALIGN_LEFT, "erp", &b));
+    ncplane_cursor_yx(nn, &y, &x);
+    CHECK(2 == y);
+    CHECK(3 == x);
+    CHECK(0 == notcurses_render(nc_));
+    CHECK(0 == ncplane_puttext(nn, -1, NCALIGN_LEFT, "\n", &b));
+    ncplane_cursor_yx(nn, &y, &x);
+    CHECK(3 == y);
+    CHECK(0 == x);
+    CHECK(0 == notcurses_render(nc_));
+    CHECK(0 == ncplane_puttext(nn, -1, NCALIGN_LEFT, "\n\n", &b));
+    ncplane_cursor_yx(nn, &y, &x);
+    CHECK(5 == y);
+    CHECK(0 == x);
+    CHECK(0 == notcurses_render(nc_));
+    CHECK(3 == ncplane_puttext(nn, -1, NCALIGN_LEFT, "erp\n", &b));
+    ncplane_cursor_yx(nn, &y, &x);
+    CHECK(6 == y);
+    CHECK(0 == x);
+    CHECK(0 == notcurses_render(nc_));
+    CHECK(0 == ncplane_destroy(nn));
+  }
+
   CHECK(0 == notcurses_stop(nc_));
 
 }


### PR DESCRIPTION
When autogrowing, move the cursor to reflect newlines in the output stream. Unit test this. Closes #2446.

Fix some man page syntax.