### PR TITLE
always define `AT_NO_AUTOMOUNT` if it is not defined

### DIFF
--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -14,8 +14,8 @@
 #include <sys/types.h>
 #include <compat/compat.h>
 #include <ncpp/Direct.hh>
-#ifndef __linux__
-#define AT_NO_AUTOMOUNT 0 // not defined on freebsd
+#ifndef AT_NO_AUTOMOUNT
+#define AT_NO_AUTOMOUNT 0x800
 #endif
 
 void usage(std::ostream& os, const char* name, int code){

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -15,7 +15,7 @@
 #include <compat/compat.h>
 #include <ncpp/Direct.hh>
 #ifndef AT_NO_AUTOMOUNT
-#define AT_NO_AUTOMOUNT 0x800
+#define AT_NO_AUTOMOUNT 0  // not defined on freebsd and some older linux kernels
 #endif
 
 void usage(std::ostream& os, const char* name, int code){


### PR DESCRIPTION
I have a linux system where this is not defined, leading to:

```
/workspace/srcdir/notcurses-3.0.0/src/ls/main.cpp: In function ‘int handle_path(int, const string&, const char*, const lsContext&, bool)’:
/workspace/srcdir/notcurses-3.0.0/src/ls/main.cpp:145:29: error: ‘AT_NO_AUTOMOUNT’ was not declared in this scope
   if(fstatat(dirfd, p, &st, AT_NO_AUTOMOUNT)){
                             ^~~~~~~~~~~~~~~
```

Also, instead of defining it to 0, it seems 0x800 is the value used in the kernel (https://docs.huihoo.com/doxygen/linux/kernel/3.7/include_2uapi_2linux_2fcntl_8h_source.html),  and I have also seen that used in other places (https://github.com/pengutronix/genimage/pull/92/files).