### PR TITLE
add missing `cinttypes` include in `player/play.cpp`

### DIFF
--- a/src/player/play.cpp
+++ b/src/player/play.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <memory>
+#include <cinttypes>
 #include <cstring>
 #include <cstdlib>
 #include <clocale>


### PR DESCRIPTION
Without this I am hitting:

```
/workspace/srcdir/notcurses-3.0.0/src/player/play.cpp: In function ‘int perframe(ncvisual*, ncvisual_options*, const timespec*, void*)’:
/workspace/srcdir/notcurses-3.0.0/src/player/play.cpp:85:43: error: expected ‘)’ before ‘PRId64’
     stdn->printf(0, NCAlign::Right, "%02" PRId64 ":%02" PRId64 ":%02" PRId64 ".%04" PRId64,
                                           ^~~~~~
/workspace/srcdir/notcurses-3.0.0/src/player/play.cpp:86:39: warning: conversion lacks type at end of format [-Wformat=]
                  h, m, s, ns / 1000000);
                                       ^
/workspace/srcdir/notcurses-3.0.0/src/player/play.cpp:86:39: warning: too many arguments for format [-Wformat-extra-args]
```

