### PR TITLE
make Lmcons.h lowercase

### DIFF
--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -25,7 +25,7 @@ path_separator(void){
   return '\\';
 }
 #define NL "\r\n"
-#include <Lmcons.h>
+#include <lmcons.h>
 #include <winsock2.h>
 #define tcgetattr(x, y) (0)
 #define tcsetattr(x, y, z) (0)


### PR DESCRIPTION
This is the actual name of the file (https://github.com/tpn/winsdk-10/blob/master/Include/10.0.14393.0/shared/lmcons.h) which matters on case-sensitive systems.

For context, I am cross-compiling notcurses to windows from a linux system and without this I got:

```
[13:38:45] In file included from /workspace/srcdir/notcurses-3.0.0/src/lib/internal.h:10:0,
[13:38:45]                  from /workspace/srcdir/notcurses-3.0.0/src/lib/banner.c:1:
[13:38:45] /workspace/srcdir/notcurses-3.0.0/src/compat/compat.h:28:10: fatal error: Lmcons.h: No such file or directory
[13:38:45]  #include <Lmcons.h>
[13:38:45]           ^~~~~~~~~~
[13:38:45] compilation terminated.
...
```

The full build still doesn't go through with this but it makes the build go further at least.

