### PR TITLE
use an explicit zero in initializers

### DIFF
--- a/src/demo/box.c
+++ b/src/demo/box.c
@@ -237,7 +237,7 @@ int box_demo(struct notcurses* nc, uint64_t startns){
   struct timespec iterdelay;
   ns_to_timespec(timespec_to_ns(&demodelay) * 3 / iters, &iterdelay);
   int bitmaps = notcurses_canopen_images(nc) && notcurses_check_pixel_support(nc);
-  struct ship ships[3] = {};
+  struct ship ships[3] = {0};
   if(bitmaps > 0){
     if(get_ships(nc, ships, sizeof(ships) / sizeof(*ships))){
       return -1;

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -509,7 +509,7 @@ int main(int argc, char** argv){
 #endif
   const char* spec;
   FILE* json = NULL; // emit JSON summary to this file? (-J)
-  notcurses_options nopts = {};
+  notcurses_options nopts = {0};
   if((spec = handle_opts(argc, argv, &nopts, &json)) == NULL){
     if(argv[optind] != NULL){
       usage(*argv, EXIT_FAILURE);

--- a/src/demo/mojibake.c
+++ b/src/demo/mojibake.c
@@ -3611,7 +3611,7 @@ unicode14(struct ncplane* title, int y){
 
 struct ncplane*
 makegroup(struct ncplane* title, int y, const char* emoji, const char* name){
-  mbstate_t mbs = {};
+  mbstate_t mbs = {0};
   size_t count = mbsrtowcs(NULL, &emoji, 0, &mbs);
   if(count == (size_t)-1){
     fprintf(stderr, "couldn't convert %s\n", emoji);

--- a/src/fetch/main.c
+++ b/src/fetch/main.c
@@ -141,7 +141,7 @@ fetch_bsd_cpuinfo(fetched_info* fi){
 static int
 fetch_windows_cpuinfo(fetched_info* fi){
 #ifdef __MINGW64__
-  SYSTEM_INFO info = {};
+  SYSTEM_INFO info = {0};
   GetSystemInfo(&info);
   switch(info.wProcessorArchitecture){
     case PROCESSOR_ARCHITECTURE_AMD64:
@@ -763,7 +763,7 @@ display_thread(void* vmarshal){
 
 static int
 ncneofetch(struct notcurses* nc){
-  fetched_info fi = {};
+  fetched_info fi = {0};
   ncneo_kernel_e kern = get_kernel(&fi);
   switch(kern){
     case NCNEO_LINUX:

--- a/src/lib/direct.c
+++ b/src/lib/direct.c
@@ -632,7 +632,7 @@ int ncdirect_raster_frame(ncdirect* n, ncdirectv* ncdv, ncalign_e align){
 static ncdirectv*
 ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
                        const struct ncvisual_options* vopts){
-  struct ncvisual_options defvopts = {};
+  struct ncvisual_options defvopts = {0};
   if(!vopts){
     vopts = &defvopts;
   }
@@ -711,7 +711,7 @@ ncdirect_render_visual(ncdirect* n, ncvisual* ncv,
     free_plane(ncdv);
     return NULL;
   }
-  blitterargs bargs = {};
+  blitterargs bargs = {0};
   bargs.flags = vopts->flags;
   if(vopts->flags & NCVISUAL_OPTION_ADDALPHA){
     bargs.transcolor = vopts->transcolor | 0x1000000ull;
@@ -743,7 +743,7 @@ ncdirectv* ncdirect_render_frame(ncdirect* n, const char* file,
   if(ncv == NULL){
     return NULL;
   }
-  struct ncvisual_options vopts = {};
+  struct ncvisual_options vopts = {0};
   const struct blitset* bset = rgba_blitter_low(&n->tcache, scale, true, blitfxn);
   if(!bset){
     return NULL;
@@ -832,7 +832,7 @@ static int
 ncdirect_stop_minimal(void* vnc){
   ncdirect* nc = vnc;
   int ret = drop_signals(nc);
-  fbuf f = {};
+  fbuf f = {0};
   if(fbuf_init_small(&f) == 0){
     ret |= reset_term_attributes(&nc->tcache, &f);
     ret |= fbuf_finalize(&f, stdout);
@@ -1148,7 +1148,7 @@ int ncdirect_on_styles(ncdirect* n, unsigned stylebits){
     return -1;
   }
   uint32_t stylemask = n->stylemask | stylebits;
-  fbuf f = {};
+  fbuf f = {0};
   if(fbuf_init_small(&f)){
     return -1;
   }
@@ -1169,7 +1169,7 @@ uint16_t ncdirect_styles(const ncdirect* n){
 // turn off any specified stylebits
 int ncdirect_off_styles(ncdirect* n, unsigned stylebits){
   uint32_t stylemask = n->stylemask & ~stylebits;
-  fbuf f = {};
+  fbuf f = {0};
   if(fbuf_init_small(&f)){
     return -1;
   }
@@ -1189,7 +1189,7 @@ int ncdirect_set_styles(ncdirect* n, unsigned stylebits){
     return -1;
   }
   uint32_t stylemask = stylebits;
-  fbuf f = {};
+  fbuf f = {0};
   if(fbuf_init_small(&f)){
     return -1;
   }
@@ -1398,7 +1398,7 @@ int ncdirect_box(ncdirect* n, uint64_t ul, uint64_t ur,
   }else{
     ncdirect_cursor_right(n, 1);
   }
-  mbstate_t ps = {};
+  mbstate_t ps = {0};
   size_t bytes;
   if((bytes = wcrtomb(hl, wchars[4], &ps)) == (size_t)-1){
     logerror("error converting %lc\n", wchars[4]);
@@ -1552,7 +1552,7 @@ int ncdirect_stream(ncdirect* n, const char* filename, ncstreamcb streamer,
     }
     if(lastid > -1){
       if(n->tcache.pixel_remove){
-        fbuf f = {};
+        fbuf f = {0};
         fbuf_init_small(&f);
         if(n->tcache.pixel_remove(lastid, &f)){
           fbuf_free(&f);

--- a/src/lib/fd.c
+++ b/src/lib/fd.c
@@ -119,7 +119,7 @@ ncfdplane_create_internal(ncplane* n, const ncfdplane_options* opts, int fd,
 
 ncfdplane* ncfdplane_create(ncplane* n, const ncfdplane_options* opts, int fd,
                             ncfdplane_callback cbfxn, ncfdplane_done_cb donecbfxn){
-  ncfdplane_options zeroed = {};
+  ncfdplane_options zeroed = {0};
   if(!opts){
     opts = &zeroed;
   }
@@ -339,7 +339,7 @@ static ncsubproc*
 ncexecvpe(ncplane* n, const ncsubproc_options* opts, unsigned usepath,
           const char* bin,  char* const arg[], char* const env[],
           ncfdplane_callback cbfxn, ncfdplane_done_cb donecbfxn){
-  ncsubproc_options zeroed = {};
+  ncsubproc_options zeroed = {0};
   if(!opts){
     opts = &zeroed;
   }

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1866,7 +1866,7 @@ process_escape(inputctx* ictx, const unsigned char* buf, int buflen){
       // off the initial node, which definitely has a valid ->trie, or we're
       // coming from a transition, where ictx->triepos->trie is checked below.
     }else{
-      ncinput ni = {};
+      ncinput ni = {0};
       int w = walk_automaton(&ictx->amata, ictx, candidate, &ni);
       logdebug("walk result on %u (%c): %d %u\n", candidate,
                isprint(candidate) ? candidate : ' ', w, ictx->amata.state);
@@ -1969,7 +1969,7 @@ process_input(inputctx* ictx, const unsigned char* buf, int buflen, ncinput* ni)
     return 0; // need read more data; we don't have the complete character
   }
   wchar_t w;
-  mbstate_t mbstate = {};
+  mbstate_t mbstate = {0};
 //fprintf(stderr, "CANDIDATE: %d cpointlen: %zu cpoint: %d\n", candidate, cpointlen, cpoint[cpointlen]);
   // FIXME how the hell does this work with 16-bit wchar_t?
   size_t r = mbrtowc(&w, (const char*)buf, cpointlen, &mbstate);

--- a/src/lib/layout.c
+++ b/src/lib/layout.c
@@ -61,7 +61,7 @@ puttext_line(ncplane* n, ncalign_e align, const char* text, size_t* bytes){
   bytes_leading_ws = cols_leading_ws = 0;
   bytes_leading_break = cols_leading_break = 0;
   while(cols <= avail){    // we can print everything we've read, if desired
-    mbstate_t mbstate = {};
+    mbstate_t mbstate = {0};
     wchar_t w;
     const size_t consumed = mbrtowc(&w, text + b, MB_CUR_MAX, &mbstate);
     if(consumed == (size_t)-2 || consumed == (size_t)-1){

--- a/src/lib/linux.c
+++ b/src/lib/linux.c
@@ -694,7 +694,7 @@ int reprogram_console_font(tinfo* ti, unsigned no_font_changes,
     logwarn("error acquiring %zub for font descriptors (%s)\n", totsize, strerror(errno));
     return -1;
   }
-  struct unimapdesc map = {};
+  struct unimapdesc map = {0};
   map.entry_ct = USHRT_MAX;
   totsize = map.entry_ct * sizeof(struct unipair);
   map.entries = malloc(totsize);
@@ -734,7 +734,7 @@ int get_linux_fb_pixelgeom(tinfo* ti, unsigned* ypix, unsigned *xpix){
   if(xpix == NULL){
     xpix = &fakex;
   }
-  struct fb_var_screeninfo fbi = {};
+  struct fb_var_screeninfo fbi = {0};
   if(ioctl(ti->linux_fb_fd, FBIOGET_VSCREENINFO, &fbi)){
     logerror("no framebuffer info from %s %d (%s?)\n", ti->linux_fb_dev,
              ti->linux_fb_fd, strerror(errno));

--- a/src/lib/menu.c
+++ b/src/lib/menu.c
@@ -375,7 +375,7 @@ resize_menu(ncplane* n){
 }
 
 ncmenu* ncmenu_create(ncplane* n, const ncmenu_options* opts){
-  ncmenu_options zeroed = {};
+  ncmenu_options zeroed = {0};
   if(!opts){
     opts = &zeroed;
   }

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -2996,7 +2996,7 @@ int ncdirect_inputready_fd(ncdirect* n){
 static int
 get_blitter_egc_idx(const struct blitset* bset, const char* egc){
   wchar_t wc;
-  mbstate_t mbs = {};
+  mbstate_t mbs = {0};
   size_t sret = mbrtowc(&wc, egc, strlen(egc), &mbs);
   if(sret == (size_t)-1 || sret == (size_t)-2){
     return -1;
@@ -3178,7 +3178,7 @@ void nclog(const char* fmt, ...){
 }
 
 int ncplane_putwstr_stained(ncplane* n, const wchar_t* gclustarr){
-  mbstate_t ps = {};
+  mbstate_t ps = {0};
   const wchar_t** wset = &gclustarr;
   size_t mbytes = wcsrtombs(NULL, wset, 0, &ps);
   if(mbytes == (size_t)-1){

--- a/src/lib/plot.c
+++ b/src/lib/plot.c
@@ -436,7 +436,7 @@ create_##T(nc##X##plot* ncpp, ncplane* n, const ncplot_options* opts, const T mi
   if(ncplane_set_widget(ncpp->plot.ncp, ncpp, (void(*)(void*))nc##X##plot_destroy)){ \
     return NULL; \
   } \
-  ncplot_options zeroed = {}; \
+  ncplot_options zeroed = {0}; \
   if(!opts){ \
     opts = &zeroed; \
   } \

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -24,7 +24,7 @@ void ncreader_destroy(ncreader* n, char** contents){
 }
 
 ncreader* ncreader_create(ncplane* n, const ncreader_options* opts){
-  ncreader_options zeroed = {};
+  ncreader_options zeroed = {0};
   if(!opts){
     opts = &zeroed;
   }

--- a/src/lib/reel.c
+++ b/src/lib/reel.c
@@ -805,7 +805,7 @@ ncplane* ncreel_plane(ncreel* nr){
 }
 
 ncreel* ncreel_create(ncplane* n, const ncreel_options* ropts){
-  ncreel_options zeroed = {};
+  ncreel_options zeroed = {0};
   ncreel* nr;
   if(!ropts){
     ropts = &zeroed;

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -404,7 +404,7 @@ paint(ncplane* p, struct crender* rvec, int dstleny, int dstlenx,
 // we need NCALPHA_TRANSPARENT
 static inline void
 init_rvec(struct crender* rvec, int totalcells){
-  struct crender c = {};
+  struct crender c = {0};
   nccell_set_fg_alpha(&c.c, NCALPHA_TRANSPARENT);
   nccell_set_bg_alpha(&c.c, NCALPHA_TRANSPARENT);
   for(int t = 0 ; t < totalcells ; ++t){
@@ -1423,7 +1423,7 @@ int notcurses_refresh(notcurses* nc, unsigned* restrict dimy, unsigned* restrict
   if(nc->lfdimx == 0 || nc->lfdimy == 0){
     return 0;
   }
-  ncpile p = {};
+  ncpile p = {0};
   p.dimy = nc->lfdimy;
   p.dimx = nc->lfdimx;
   const int count = p.dimy * p.dimx;
@@ -1450,7 +1450,7 @@ int ncpile_render_to_file(ncplane* n, FILE* fp){
   if(nc->lfdimx == 0 || nc->lfdimy == 0){
     return 0;
   }
-  fbuf f = {};
+  fbuf f = {0};
   if(fbuf_init(&f)){
     return -1;
   }
@@ -1659,7 +1659,7 @@ int ncdirect_set_bg_rgb_f(ncdirect* nc, unsigned rgb, fbuf* f){
 }
 
 int ncdirect_set_bg_rgb(ncdirect* nc, unsigned rgb){
-  fbuf f = {};
+  fbuf f = {0};
   if(fbuf_init_small(&f)){
     return -1;
   }
@@ -1689,7 +1689,7 @@ int ncdirect_set_fg_rgb_f(ncdirect* nc, unsigned rgb, fbuf* f){
 }
 
 int ncdirect_set_fg_rgb(ncdirect* nc, unsigned rgb){
-  fbuf f = {};
+  fbuf f = {0};
   if(fbuf_init_small(&f)){
     return -1;
   }
@@ -1739,7 +1739,7 @@ int notcurses_cursor_enable(notcurses* nc, int y, int x){
   if(nc->cursory == y && nc->cursorx == x){
     return 0;
   }
-  fbuf f = {};
+  fbuf f = {0};
   if(fbuf_init_small(&f)){
     return -1;
   }

--- a/src/lib/selector.c
+++ b/src/lib/selector.c
@@ -282,7 +282,7 @@ ncselector* ncselector_create(ncplane* n, const ncselector_options* opts){
     logerror("won't use the standard plane\n"); // would fail later on resize
     return NULL;
   }
-  ncselector_options zeroed = {};
+  ncselector_options zeroed = {0};
   if(!opts){
     opts = &zeroed;
   }
@@ -887,7 +887,7 @@ ncmultiselector* ncmultiselector_create(ncplane* n, const ncmultiselector_option
     logerror("won't use the standard plane\n"); // would fail later on resize
     return NULL;
   }
-  ncmultiselector_options zeroed = {};
+  ncmultiselector_options zeroed = {0};
   if(!opts){
     opts = &zeroed;
   }

--- a/src/lib/tabbed.c
+++ b/src/lib/tabbed.c
@@ -146,8 +146,8 @@ nctab* nctab_prev(nctab* t){
 }
 
 nctabbed* nctabbed_create(ncplane* n, const nctabbed_options* topts){
-  nctabbed_options zeroed = {};
-  ncplane_options nopts = {};
+  nctabbed_options zeroed = {0};
+  ncplane_options nopts = {0};
   unsigned nrows, ncols;
   nctabbed* nt = NULL;
   if(!topts){

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -14,7 +14,7 @@
 // set this pointer. all this machination exists to support building notcurses
 // (and running notcurses programs) without the need of heavy media engines.
 
-static ncvisual_implementation null_visual_implementation = {};
+static ncvisual_implementation null_visual_implementation = {0};
 
 ncvisual_implementation* visual_implementation = &null_visual_implementation;
 

--- a/src/man/main.c
+++ b/src/man/main.c
@@ -78,7 +78,7 @@ map_gzipped_data(unsigned char* buf, size_t* len, unsigned char* ubuf, uint32_t 
 #include <zlib.h>
 static unsigned char*
 map_gzipped_data(unsigned char* buf, size_t* len, unsigned char* ubuf, uint32_t ulen){
-  z_stream z = {};
+  z_stream z = {0};
   int r = inflateInit2(&z, 15 | 16);
   if(r != Z_OK){
     fprintf(stderr, "error getting zlib inflator (%d)\n", r);
@@ -344,7 +344,7 @@ dom_get_title(const pagedom* dom){
 // heap-copies the utf8 to *token on success.
 static int
 lex_next_token(const char* s, char** token){
-  mbstate_t ps = {};
+  mbstate_t ps = {0};
   wchar_t w;
   size_t b, cur;
   cur = 0;
@@ -923,7 +923,7 @@ manloop(struct notcurses* nc, const char* arg){
   int ret = -1;
   struct ncplane* page = NULL;
   struct ncplane* bar = NULL;
-  pagedom dom = {};
+  pagedom dom = {0};
   size_t len;
   unsigned char* buf = get_troff_data(arg, &len);
   if(buf == NULL){

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -617,7 +617,7 @@ ffmpeg_resize_internal(const ncvisual* ncv, int rows, int* stride, int cols,
 // resize frame, converting to RGBA (if necessary) along the way
 static int
 ffmpeg_resize(ncvisual* n, unsigned rows, unsigned cols){
-  struct blitterargs bargs = {};
+  struct blitterargs bargs = {0};
   int stride;
   void* data = ffmpeg_resize_internal(n, rows, &stride, cols, &bargs);
   if(data == n->data){ // no change, return

--- a/src/poc/direct-input.c
+++ b/src/poc/direct-input.c
@@ -11,7 +11,7 @@ int main(void){
   ncinput ni;
   uint32_t i;
   while((i = ncdirect_get_blocking(n, &ni)) != (uint32_t)-1){
-    unsigned char utf8[5] = {};
+    unsigned char utf8[5] = {0};
     notcurses_ucs32_to_utf8(&i, 1, utf8, sizeof(utf8));
     printf("Read input: [%c%c%c] %s\n", ni.ctrl ? 'C' : 'c',
            ni.alt ? 'A' : 'a', ni.shift ? 'S' : 's', utf8);

--- a/src/poc/fileroller.c
+++ b/src/poc/fileroller.c
@@ -56,7 +56,7 @@ int main(int argc, char** argv){
       fprintf(stderr, "Couldn't open %s (%s)\n", *argv, strerror(errno));
       goto done;
     }
-    ncfdplane_options nopts = {};
+    ncfdplane_options nopts = {0};
     struct ncfdplane* ncfp = ncfdplane_create(n, &nopts, fd, cb, eofcb);
     pthread_mutex_lock(&lock);
     while(!fddone){

--- a/src/poc/linuxconjammer.c
+++ b/src/poc/linuxconjammer.c
@@ -161,7 +161,7 @@ fprintf(stderr, "\n");
 // positions in |*upper| and |*lower|.
 static int
 jam_linux_consolefont(int fd, unsigned showglyphs, unsigned* upper, unsigned* lower){
-  struct console_font_op cfo = {};
+  struct console_font_op cfo = {0};
   cfo.op = KD_FONT_OP_GET;
   cfo.charcount = 512;
   cfo.data = malloc(128 * cfo.charcount);
@@ -221,7 +221,7 @@ fprintf(stderr, "Bper: %zu %d at %p\n", Bper(&cfo), i + o, g[o]);
 
 static int
 jam_linux_consolemap(int fd, unsigned upper, unsigned lower){
-  struct unimapdesc map = {};
+  struct unimapdesc map = {0};
   map.entry_ct = USHRT_MAX;
   map.entries = malloc(map.entry_ct * sizeof(struct unipair));
   if(ioctl(fd, GIO_UNIMAP, &map)){

--- a/src/poc/linuxconsole.c
+++ b/src/poc/linuxconsole.c
@@ -85,7 +85,7 @@ explode_glyph_row(unsigned char** row, unsigned width){
 
 static int
 get_linux_consolefont(int fd, unsigned showglyphs){
-  struct console_font_op cfo = {};
+  struct console_font_op cfo = {0};
   cfo.op = KD_FONT_OP_GET;
   cfo.charcount = 512;
   cfo.width = 32;
@@ -130,7 +130,7 @@ get_linux_consolefont(int fd, unsigned showglyphs){
 
 static int
 get_linux_consolemap(int fd){
-  struct unimapdesc map = {};
+  struct unimapdesc map = {0};
   map.entry_ct = USHRT_MAX;
   map.entries = malloc(map.entry_ct * sizeof(struct unipair));
   if(ioctl(fd, GIO_UNIMAP, &map)){

--- a/src/poc/ncwidth.c
+++ b/src/poc/ncwidth.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv){
     int i = 0;
     used = 0;
     while(*arg){
-      mbstate_t mbs = {};
+      mbstate_t mbs = {0};
       wchar_t w;
       size_t conv = mbrtowc(&w, arg, strlen(arg), &mbs);
       if(conv == (size_t)-1 || conv == (size_t)-2){

--- a/src/poc/procroller.c
+++ b/src/poc/procroller.c
@@ -53,7 +53,7 @@ int main(int argc, char** argv){
   ++argv;
   struct ncplane* std = notcurses_stdplane(nc);
   ncplane_set_scrolling(std, true);
-  ncsubproc_options nopts = {};
+  ncsubproc_options nopts = {0};
   struct ncsubproc* nsproc = ncsubproc_createvp(std, &nopts, *argv,
                               (const char* const*)argv, cb, eofcb);
   if(nsproc == NULL){

--- a/src/poc/rotate.c
+++ b/src/poc/rotate.c
@@ -20,7 +20,7 @@ int main(int argc, char** argv){
   }else if(argc == 2){
     file = argv[1];
   }
-  notcurses_options opts = {};
+  notcurses_options opts = {0};
   //opts.loglevel = NCLOGLEVEL_TRACE;
   opts.flags = NCOPTION_INHIBIT_SETLOCALE
                 | NCOPTION_NO_ALTERNATE_SCREEN
@@ -35,7 +35,7 @@ int main(int argc, char** argv){
     notcurses_stop(nc);
     return EXIT_FAILURE;
   }
-  struct ncvisual_options vopts = {};
+  struct ncvisual_options vopts = {0};
   bool failed = false;
   struct ncvisual* ncv = ncvisual_from_file(file);
   if(!ncv){


### PR DESCRIPTION
Empty initializers are a GNU extension but are not allowed by the C-standard (see e.g. https://stackoverflow.com/a/17589839/10447964).

This could otherwise fail with:

```
[13:37:16] /workspace/srcdir/notcurses-3.0.0/src/lib/direct.c: In function ‘ncdirect_box’:
[13:37:16] /workspace/srcdir/notcurses-3.0.0/src/lib/direct.c:1396:18: error: empty scalar initializer
[13:37:16]    mbstate_t ps = {};
```