### PR TITLE
fix `Secur32` library to be lowercase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ find_package(Threads)
 set_package_properties(Threads PROPERTIES TYPE REQUIRED)
 # platform-specific logics
 if(WIN32)
-  set(LIBRT wsock32 ws2_32 Secur32)
+  set(LIBRT wsock32 ws2_32 secur32)
 elseif(NOT APPLE)
   find_library(LIBM m REQUIRED)
   find_library(LIBRT rt REQUIRED)


### PR DESCRIPTION
Similar to https://github.com/dankamongmen/notcurses/pull/2468.

Otherwise one hits:

```
[18:05:06] /opt/x86_64-w64-mingw32/bin/ld: cannot find -lSecur32
[18:05:06] collect2: error: ld returned 1 exit status
```

on a case-sensitive system (e.g. when cross-compiling from Linux).