### PR TITLE
tfman work

### DIFF
--- a/doc/man/man1/tfman.1.md
+++ b/doc/man/man1/tfman.1.md
@@ -8,7 +8,7 @@ tfman - Swank manual page browser
 
 # SYNOPSIS
 
-**tfman** [**-h**] [**-V**] files
+**tfman** [**-h**] [**-V**] [**-q**] files
 
 # DESCRIPTION
 
@@ -20,6 +20,8 @@ tfman - Swank manual page browser
 **-V**: Print the program name and version, and exit with success.
 
 **-h**: Print help information, and exit with success.
+
+**-q**: Don't wait for any input, and don't use the alternate screen.
 
 files: Files to render.
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -561,7 +561,8 @@ ncchannels_set_bg_default(uint64_t* channels){
 // returned, and the number of valid bytes and columns will be written into
 // *|validbytes| and *|validwidth| (assuming them non-NULL). If the entire
 // string is valid, *|validbytes| and *|validwidth| reflect the entire string.
-API int ncstrwidth(const char* egcs, int* validbytes, int* validwidth);
+API int ncstrwidth(const char* egcs, int* validbytes, int* validwidth)
+  __attribute__ ((nonnull (1)));
 
 // input functions like notcurses_get() return ucs32-encoded uint32_t. convert
 // a series of uint32_t to utf8. result must be at least 4 bytes per input
@@ -569,7 +570,8 @@ API int ncstrwidth(const char* egcs, int* validbytes, int* validwidth);
 // the number of bytes used is returned, or -1 if passed illegal ucs32, or too
 // small of a buffer.
 API int notcurses_ucs32_to_utf8(const uint32_t* ucs32, unsigned ucs32count,
-                                unsigned char* resultbuf, size_t buflen);
+                                unsigned char* resultbuf, size_t buflen)
+  __attribute__ ((nonnull (1, 3)));
 
 // An nccell corresponds to a single character cell on some plane, which can be
 // occupied by a single grapheme cluster (some root spacing glyph, along with
@@ -2019,7 +2021,8 @@ API int ncplane_putchar_stained(struct ncplane* n, char c)
 // On failure, -1 is returned. The number of bytes converted from gclust is
 // written to 'sbytes' if non-NULL.
 API int ncplane_putegc_yx(struct ncplane* n, int y, int x, const char* gclust,
-                          size_t* sbytes);
+                          size_t* sbytes)
+  __attribute__ ((nonnull (1, 4)));
 
 // Call ncplane_putegc_yx() at the current cursor location.
 static inline int

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -289,7 +289,7 @@ handle_opts(int argc, char** argv, notcurses_options* opts, FILE** json_output){
         opts->flags |= NCOPTION_NO_ALTERNATE_SCREEN;
         break;
       case 'p':
-        datadir = optarg;
+        datadir = strdup(optarg);
         break;
       case 'd':{
         float f;
@@ -595,6 +595,7 @@ int main(int argc, char** argv){
   if(json && summary_json(json, spec, dimy, dimx)){
     return EXIT_FAILURE;
   }
+  free(datadir);
   return r ? EXIT_FAILURE : EXIT_SUCCESS;
 
 err:

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -317,6 +317,9 @@ handle_opts(int argc, char** argv, notcurses_options* opts, FILE** json_output){
     fprintf(stderr, "Extra argument: %s\n", argv[optind + 1]);
     usage(*argv, EXIT_FAILURE);
   }
+  if(datadir == NULL){
+    datadir = notcurses_data_dir();
+  }
   const char* spec = argv[optind];
   return spec;
 }

--- a/src/man/main.c
+++ b/src/man/main.c
@@ -351,11 +351,13 @@ draw_domnode(struct ncplane* p, const pagedom* dom, const pagenode* n,
           putpara(p, n->text);
         }
       }else{
-        ncplane_set_styles(p, NCSTYLE_BOLD | NCSTYLE_ITALIC);
-        ncplane_set_fg_rgb(p, 0xff6a00);
-        ncplane_putstr_aligned(p, -1, NCALIGN_CENTER, n->text);
-        ncplane_set_fg_default(p);
-        ncplane_set_styles(p, NCSTYLE_NONE);
+        if(n->text){
+          ncplane_set_styles(p, NCSTYLE_BOLD | NCSTYLE_ITALIC);
+          ncplane_set_fg_rgb(p, 0xff6a00);
+          ncplane_putstr_aligned(p, -1, NCALIGN_CENTER, n->text);
+          ncplane_set_fg_default(p);
+          ncplane_set_styles(p, NCSTYLE_NONE);
+        }
       }
       *wrotetext = true;
       break;

--- a/src/man/parse.c
+++ b/src/man/parse.c
@@ -104,7 +104,7 @@ const trofftype* get_type(const struct troffnode* trie, const unsigned char** ws
   ++*ws;
   --len;
   while(len && !isspace(**ws) && **ws){
-    if(**ws > sizeof(trie->next) / sizeof(*trie->next)){ // illegal command
+    if(**ws >= sizeof(trie->next) / sizeof(*trie->next)){ // illegal command
       return NULL;
     }
     if((trie = trie->next[**ws]) == NULL){

--- a/src/man/parse.h
+++ b/src/man/parse.h
@@ -1,5 +1,5 @@
 #ifndef NOTCURSES_MAN_PARSE
-#define NOTCURSES_MAN_PRASE
+#define NOTCURSES_MAN_PARSE
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
* Add `-q` argument to `tfman` so it exits immediately rather than waiting for user input.
* Fix two problems found fuzzing `tfman` overnight (closes #2475).
* Reorder `crender` members to eliminate unnecessary padding for alignment; save 16% of render-specific allocation