### PR TITLE
[ncls] implement -L option / symlink handling #2006

### DIFF
--- a/doc/man/man1/ncls.1.md
+++ b/doc/man/man1/ncls.1.md
@@ -21,7 +21,7 @@ ncls - List paths with rendering of multimedia
 
 **-l**: use a long listing format.
 
-**-L**: when showing file information for a symbolic link, show information for  the file the link references rather than for the link itself.
+**-L**: dereference symbolic links
 
 **-R**: list subdirectories recursively.
 

--- a/src/demo/demo.c
+++ b/src/demo/demo.c
@@ -166,7 +166,7 @@ usage(const char* exe, int status){
   ncplane_set_fg_rgb8(n, 0xff, 0xff, 0x80);
   ncplane_printf(n, " -p:");
   ncplane_set_fg_rgb8(n, 0xff, 0xff, 0xff);
-  ncplane_printf(n, " data file path (default: %s)\n", NOTCURSES_SHARE);
+  ncplane_printf(n, " data file path (default: %s)\n", notcurses_data_dir());
   ncplane_printf(n, "\nspecify demos via their first letter. repetitions are allowed.\n");
   ncplane_set_fg_rgb8(n, 0x80, 0xff, 0x80);
   ncplane_printf(n, " default spec: %s\n\n", DEFAULT_DEMO);

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -143,16 +143,9 @@ int handle_path(int dirfd, const std::string& pdir, const char* p, const lsConte
     return -1;
   }
 #else
-  if(ctx.dereflinks){
-    if(lstat(path_join(pdir, p).c_str(), &st)){
-      std::cerr << "Error running stat(" << p << "): " << strerror(errno) << std::endl;
-      return -1;
-    }
-  }else{
-    if(stat(path_join(pdir, p).c_str(), &st)){
-      std::cerr << "Error running stat(" << p << "): " << strerror(errno) << std::endl;
-      return -1;
-    }
+  if(stat(path_join(pdir, p).c_str(), &st)){
+    std::cerr << "Error running stat(" << p << "): " << strerror(errno) << std::endl;
+    return -1;
   }
 #endif
   if((st.st_mode & S_IFMT) == S_IFDIR){


### PR DESCRIPTION
Implement the `-L` option on all operating systems for `ncls`. Don't resolve symbolic links unless `-L` is provided. Closes #2006.