### PR TITLE
Eliminate unnecessary signedness conversions in header

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1884,8 +1884,8 @@ void ncplane_set_fg_default(struct ncplane* n);
 void ncplane_set_bg_default(struct ncplane* n);
 
 // Provide a palette index on [0..255].
-int ncplane_set_fg_palindex(struct ncplane* n, int idx);
-int ncplane_set_bg_palindex(struct ncplane* n, int idx);
+int ncplane_set_fg_palindex(struct ncplane* n, unsigned idx);
+int ncplane_set_bg_palindex(struct ncplane* n, unsigned idx);
 ```
 
 ## Cells

--- a/doc/man/man3/notcurses_cell.3.md
+++ b/doc/man/man3/notcurses_cell.3.md
@@ -114,9 +114,9 @@ typedef struct nccell {
 
 **bool nccell_bg_default_p(const nccell* ***c***);**
 
-**int nccell_set_fg_palindex(nccell* ***cl***, int ***idx***);**
+**int nccell_set_fg_palindex(nccell* ***cl***, unsigned ***idx***);**
 
-**int nccell_set_bg_palindex(nccell* ***cl***, int ***idx***);**
+**int nccell_set_bg_palindex(nccell* ***cl***, unsigned ***idx***);**
 
 **uint32_t nccell_fg_palindex(const nccell* ***cl***);**
 

--- a/doc/man/man3/notcurses_channels.3.md
+++ b/doc/man/man3/notcurses_channels.3.md
@@ -79,15 +79,15 @@ notcurses_channels - operations on notcurses channels
 
 **bool ncchannel_palindex_p(uint32_t ***channel***);**
 
-**int ncchannel_set_palindex(uint32_t* ***channel***, int ***idx***);**
+**int ncchannel_set_palindex(uint32_t* ***channel***, unsigned ***idx***);**
 
 **unsigned ncchannels_fg_palindex(uint64_t ***channels***);**
 
 **unsigned ncchannels_bg_palindex(uint64_t ***channels***);**
 
-**int ncchannels_set_fg_palindex(uint64_t* ***channels***, int ***idx***);**
+**int ncchannels_set_fg_palindex(uint64_t* ***channels***, unsigned ***idx***);**
 
-**int ncchannels_set_bg_palindex(uint64_t* ***channels***, int ***idx***);**
+**int ncchannels_set_bg_palindex(uint64_t* ***channels***, unsigned ***idx***);**
 
 **uint64_t ncchannels_combine(uint32_t ***fchan***, uint32_t ***bchan***);**
 

--- a/doc/man/man3/notcurses_plane.3.md
+++ b/doc/man/man3/notcurses_plane.3.md
@@ -183,9 +183,9 @@ typedef struct ncplane_options {
 
 **int ncplane_set_bg_alpha(struct ncplane* ***n***, unsigned ***alpha***);**
 
-**int ncplane_set_fg_palindex(struct ncplane* ***n***, int ***idx***);**
+**int ncplane_set_fg_palindex(struct ncplane* ***n***, unsigned ***idx***);**
 
-**int ncplane_set_bg_palindex(struct ncplane* ***n***, int ***idx***);**
+**int ncplane_set_bg_palindex(struct ncplane* ***n***, unsigned ***idx***);**
 
 **uint16_t ncplane_styles(const struct ncplane* ***n***);**
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -182,10 +182,10 @@ ncchannel_palindex(uint32_t channel){
 }
 
 // Mark the channel as using the specified palette color. It is an error if
-// the index is negative, or greater than NCPALETTESIZE. Alpha is set opaque.
+// the index is greater than NCPALETTESIZE. Alpha is set opaque.
 static inline int
-ncchannel_set_palindex(uint32_t* channel, int idx){
-  if(idx < 0 || idx >= NCPALETTESIZE){
+ncchannel_set_palindex(uint32_t* channel, unsigned idx){
+  if(idx >= NCPALETTESIZE){
     return -1;
   }
   ncchannel_set_alpha(channel, NCALPHA_OPAQUE);
@@ -453,7 +453,7 @@ ncchannels_set_fg_rgb8_clipped(uint64_t* channels, int r, int g, int b){
 }
 
 static inline int
-ncchannels_set_fg_palindex(uint64_t* channels, int idx){
+ncchannels_set_fg_palindex(uint64_t* channels, unsigned idx){
   uint32_t channel = ncchannels_fchannel(*channels);
   if(ncchannel_set_palindex(&channel, idx) < 0){
     return -1;
@@ -496,7 +496,7 @@ ncchannels_set_bg_rgb8_clipped(uint64_t* channels, int r, int g, int b){
 // Set the cell's background palette index, set the background palette index
 // bit, set it background-opaque, and clear the background default color bit.
 static inline int
-ncchannels_set_bg_palindex(uint64_t* channels, int idx){
+ncchannels_set_bg_palindex(uint64_t* channels, unsigned idx){
   uint32_t channel = ncchannels_bchannel(*channels);
   if(ncchannel_set_palindex(&channel, idx) < 0){
     return -1;
@@ -2679,7 +2679,7 @@ nccell_set_fg_rgb(nccell* c, uint32_t channel){
 // Set the cell's foreground palette index, set the foreground palette index
 // bit, set it foreground-opaque, and clear the foreground default color bit.
 static inline int
-nccell_set_fg_palindex(nccell* cl, int idx){
+nccell_set_fg_palindex(nccell* cl, unsigned idx){
   return ncchannels_set_fg_palindex(&cl->channels, idx);
 }
 
@@ -2843,8 +2843,8 @@ API void ncplane_set_bg_default(struct ncplane* n);
 
 // Set the ncplane's foreground palette index, set the foreground palette index
 // bit, set it foreground-opaque, and clear the foreground default color bit.
-API int ncplane_set_fg_palindex(struct ncplane* n, int idx);
-API int ncplane_set_bg_palindex(struct ncplane* n, int idx);
+API int ncplane_set_fg_palindex(struct ncplane* n, unsigned idx);
+API int ncplane_set_bg_palindex(struct ncplane* n, unsigned idx);
 
 // Set the alpha parameters for ncplane 'n'.
 API int ncplane_set_fg_alpha(struct ncplane* n, int alpha);
@@ -3468,16 +3468,13 @@ ncpixel_set_b(uint32_t* pixel, unsigned b){
 
 // Construct a libav-compatible ABGR pixel, clipping at [0, 255).
 static inline uint32_t
-ncpixel(int r, int g, int b){
+ncpixel(unsigned r, unsigned g, unsigned b){
   uint32_t pixel = 0;
   ncpixel_set_a(&pixel, 0xff);
-  if(r < 0) r = 0;
   if(r > 255) r = 255;
   ncpixel_set_r(&pixel, r);
-  if(g < 0) g = 0;
   if(g > 255) g = 255;
   ncpixel_set_g(&pixel, g);
-  if(b < 0) b = 0;
   if(b > 255) b = 255;
   ncpixel_set_b(&pixel, b);
   return pixel;

--- a/python/notcurses/channels.c
+++ b/python/notcurses/channels.c
@@ -166,9 +166,9 @@ static PyObject *
 python_ncchannel_set_palindex(PyObject *Py_UNUSED(self), PyObject *args)
 {
     unsigned long ncchannel = {0};
-    int idx = {0};
+    unsigned int idx = {0};
 
-    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "ki", &ncchannel, &idx));
+    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "kI", &ncchannel, &idx));
 
     uint32_t ncchannel_fixed_size = (uint32_t)ncchannel;
 
@@ -398,9 +398,9 @@ static PyObject *
 python_ncchannels_set_fg_palindex(PyObject *Py_UNUSED(self), PyObject *args)
 {
     unsigned long long ncchannels = {0};
-    int idx = {0};
+    unsigned int idx = {0};
 
-    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "Ki", &ncchannels, &idx));
+    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "KI", &ncchannels, &idx));
 
     uint64_t ncchannels_fixed_size = (uint64_t)ncchannels;
 
@@ -473,9 +473,9 @@ static PyObject *
 python_ncchannels_set_bg_palindex(PyObject *Py_UNUSED(self), PyObject *args)
 {
     unsigned long long ncchannels = {0};
-    int idx = {0};
+    unsigned int idx = {0};
 
-    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "Ki", &ncchannels, &idx));
+    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "KI", &ncchannels, &idx));
 
     uint64_t ncchannels_fixed_size = (uint64_t)ncchannels;
 

--- a/python/notcurses/plane.c
+++ b/python/notcurses/plane.c
@@ -1174,8 +1174,8 @@ NcPlane_set_bg_default(NcPlaneObject *self, PyObject *Py_UNUSED(args))
 static PyObject *
 NcPlane_set_fg_palindex(NcPlaneObject *self, PyObject *args)
 {
-    int idx = 0;
-    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "i", &idx));
+    unsigned idx = 0;
+    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "I", &idx));
     ncplane_set_fg_palindex(self->ncplane_ptr, idx);
 
     Py_RETURN_NONE;
@@ -1184,8 +1184,8 @@ NcPlane_set_fg_palindex(NcPlaneObject *self, PyObject *args)
 static PyObject *
 NcPlane_set_bg_palindex(NcPlaneObject *self, PyObject *args)
 {
-    int idx = 0;
-    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "i", &idx));
+    unsigned idx = 0;
+    GNU_PY_CHECK_BOOL(PyArg_ParseTuple(args, "I", &idx));
     ncplane_set_bg_palindex(self->ncplane_ptr, idx);
 
     Py_RETURN_NONE;

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1496,11 +1496,11 @@ int ncplane_set_bg_alpha(ncplane *n, int alpha){
   return ncchannels_set_bg_alpha(&n->channels, alpha);
 }
 
-int ncplane_set_fg_palindex(ncplane* n, int idx){
+int ncplane_set_fg_palindex(ncplane* n, unsigned idx){
   return ncchannels_set_fg_palindex(&n->channels, idx);
 }
 
-int ncplane_set_bg_palindex(ncplane* n, int idx){
+int ncplane_set_bg_palindex(ncplane* n, unsigned idx){
   return ncchannels_set_bg_palindex(&n->channels, idx);
 }
 


### PR DESCRIPTION
The macOS build was complaining about some of these conversions. Tighten them up.