### PR TITLE
Reimplement ncls in CLI mode

### DIFF
--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3211,7 +3211,7 @@ typedef struct ncvgeom {
   unsigned cdimy, cdimx;   // terminal cell geometry when this was calculated
   unsigned rpixy, rpixx;   // rendered pixel geometry (per visual_options)
   unsigned rcelly, rcellx; // rendered cell geometry (per visual_options)
-  unsigned scaley, scalex; // pixels per filled cell (scale == c for bitmaps)
+  unsigned scaley, scalex; // source pixels per filled cell
   unsigned begy, begx;     // upper-left corner of used region
   unsigned leny, lenx;     // geometry of used region
   unsigned maxpixely, maxpixelx; // only defined for NCBLIT_PIXEL

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -180,6 +180,7 @@ void ncls_thread(const lsContext* ctx) {
         vopts.scaling = ctx->scaling;
         ncp = ncvisual_blit(ctx->nc, ncv, &vopts);
       }
+      ncvisual_destroy(ncv);
       pthread_mutex_lock(&outmtx);
       ncplane_printf(stdn, "%s\n", j.p.c_str());
       if(ncp){
@@ -187,9 +188,7 @@ void ncls_thread(const lsContext* ctx) {
         ncplane_move_yx(ncp, ncplane_cursor_y(stdn), ncplane_cursor_x(stdn));
         ncplane_scrollup_child(stdn, ncp);
         notcurses_render(ctx->nc);
-        ncplane_destroy(ncp);
       }
-      ncvisual_destroy(ncv);
       pthread_mutex_unlock(&outmtx);
     }else if(!keep_working){
       pthread_mutex_unlock(&mtx);

--- a/src/ls/main.cpp
+++ b/src/ls/main.cpp
@@ -181,7 +181,7 @@ void ncls_thread(const lsContext* ctx) {
         ncp = ncvisual_blit(ctx->nc, ncv, &vopts);
       }
       pthread_mutex_lock(&outmtx);
-      std::cout << j.p << '\n';
+      ncplane_printf(stdn, "%s\n", j.p.c_str());
       if(ncp){
         ncplane_reparent(ncp, stdn);
         ncplane_move_yx(ncp, ncplane_cursor_y(stdn), ncplane_cursor_x(stdn));


### PR DESCRIPTION
Stop using Direct Mode for `ncls`, using CLI mode instead. Cuts the runtime of `ncls` pretty drastically. Closes #2026.

Stop using `NCSCALE_SCALE_HIRES` by default in `ncls`. Instead, use `NCSCALE_NONE` unless that exceeds the visual area, using `NCSCALE_SCALE_HIRES` in that case. If scaling is specified, use that all the time. Closes #2008.