### PR TITLE
Octrees for Victory

### DIFF
--- a/src/lib/fbuf.h
+++ b/src/lib/fbuf.h
@@ -182,10 +182,24 @@ fbuf_puts(fbuf* f, const char* s){
 
 static inline int
 fbuf_putint(fbuf* f, int n){
-  if(fbuf_grow(f, 10)){ // 32-bit int might require up to 10 digits
+  if(fbuf_grow(f, 20)){ // 64-bit int might require up to 20 digits
     return -1;
   }
   uint64_t r = snprintf(f->buf + f->used, f->size - f->used, "%d", n);
+  if(r > f->size - f->used){
+    assert(r <= f->size - f->used);
+    return -1; // FIXME grow?
+  }
+  f->used += r;
+  return r;
+}
+
+static inline int
+fbuf_putuint(fbuf* f, int n){
+  if(fbuf_grow(f, 20)){ // 64-bit int might require up to 20 digits
+    return -1;
+  }
+  uint64_t r = snprintf(f->buf + f->used, f->size - f->used, "%u", n);
   if(r > f->size - f->used){
     assert(r <= f->size - f->used);
     return -1; // FIXME grow?

--- a/src/lib/sixel.h
+++ b/src/lib/sixel.h
@@ -1,5 +1,5 @@
-#ifndef NOTCURSES_SIXEL
-#define NOTCURSES_SIXEL
+#ifndef NOTCURSES_LIB_SIXEL
+#define NOTCURSES_LIB_SIXEL
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -1362,10 +1362,13 @@ int interrogate_terminfo(tinfo* ti, FILE* out, unsigned utf8,
   }
   build_supported_styles(ti);
   if(ti->pixel_draw == NULL && ti->pixel_draw_late == NULL){
+    // color_registers was only assigned if kitty_graphics were unavailable
+    if(ti->color_registers > 0){
+      setup_sixel_bitmaps(ti, ti->ttyfd, invertsixel);
+    }
     if(kitty_graphics){
       setup_kitty_bitmaps(ti, ti->ttyfd, NCPIXEL_KITTY_STATIC);
     }
-    setup_sixel_bitmaps(ti, ti->ttyfd, invertsixel);
   }
   return 0;
 

--- a/src/poc/quantanal.c
+++ b/src/poc/quantanal.c
@@ -37,6 +37,9 @@ compare(const struct ncvisual* n1, const struct ncvisual* n2,
         fprintf(stderr, "error getting pixel at %u/%u (%u/%u)\n", y, x, ly, lx);
         return -1;
       }
+      if(ncpixel_a(p0) < 192 || ncpixel_a(p1) < 192){
+        continue;
+      }
       co0 = count_colors(p0, cbuf0, co0);
       co1 = count_colors(p1, cbuf1, co1);
       // three component differences for current pixel

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -74,6 +74,7 @@ TEST_CASE("Direct") {
     }
   }
 
+  /*
 #ifndef NOTCURSES_USE_MULTIMEDIA
   SUBCASE("VisualDisabled"){
     CHECK(!ncdirect_canopen_images(nc_));
@@ -171,6 +172,7 @@ TEST_CASE("Direct") {
     }
   }
 #endif
+  */
 
   CHECK(0 == ncdirect_stop(nc_));
 

--- a/src/tests/direct.cpp
+++ b/src/tests/direct.cpp
@@ -74,7 +74,6 @@ TEST_CASE("Direct") {
     }
   }
 
-  /*
 #ifndef NOTCURSES_USE_MULTIMEDIA
   SUBCASE("VisualDisabled"){
     CHECK(!ncdirect_canopen_images(nc_));
@@ -172,7 +171,6 @@ TEST_CASE("Direct") {
     }
   }
 #endif
-  */
 
   CHECK(0 == ncdirect_stop(nc_));
 


### PR DESCRIPTION
Reimplement the sixel quantization algorithm with an octree-kinda approach. Provides a speedup on most images, supports more color registers (we now request 256 and then 1024), improves quality on some (also costs a slowdown on some images, and reduces quality on many, but I think I know how to fix that). Eliminates weird color divergence in #2503. Obsoletes #1452.