### PR TITLE
Fast relaxation

### DIFF
--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -672,6 +672,7 @@ xtmodkey(inputctx* ictx, int val, int mods){
   if(mods >= 9 && mods <= 16){
     tni.modifiers |= NCKEY_MOD_META;
   }
+  // FIXME 9..16 indicate Meta
   load_ncinput(ictx, &tni, 0);
 }
 

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -672,7 +672,6 @@ xtmodkey(inputctx* ictx, int val, int mods){
   if(mods >= 9 && mods <= 16){
     tni.modifiers |= NCKEY_MOD_META;
   }
-  // FIXME 9..16 indicate Meta
   load_ncinput(ictx, &tni, 0);
 }
 

--- a/src/lib/sixel.c
+++ b/src/lib/sixel.c
@@ -140,6 +140,9 @@ insert_color(qstate* qs, uint32_t pixel, uint32_t* colors){
   onode* o;
   // it's not a fractured node, but it's been used. check to see if we
   // match the secondary key of what's here.
+if(key == 3172){
+  fprintf(stderr, "DAMNIT 3172 %u %u %p\n", q->qlink, q->q.pop, q);
+}
   if(q->qlink == 0){
     unsigned skeynat = secondary_key(q->q.comps[0], ss(q->q.comps[1]), ss(q->q.comps[2]));
     if(skey == skeynat){
@@ -151,6 +154,7 @@ insert_color(qstate* qs, uint32_t pixel, uint32_t* colors){
     // open an onode just to fail to insert our current lookup; that's fine;
     // it's a symmetry between creation and extension.
     if(qs->dynnodes_free == 0 || qs->onodes_free == 0){
+//fprintf(stderr, "NO FREE ONES %u\n", key);
       ++q->q.pop; // not a great match, but we're already scattered
       return;
     }
@@ -178,6 +182,7 @@ insert_color(qstate* qs, uint32_t pixel, uint32_t* colors){
   }
   // we try otherwise to insert ourselves into o. this requires a free dynnode.
   if(qs->dynnodes_free == 0){
+//fprintf(stderr, "NO DYNFREE %u\n", key);
     // whoops! no room in the inn, mother mary. throw this sample away.
     return;
   }
@@ -192,6 +197,9 @@ insert_color(qstate* qs, uint32_t pixel, uint32_t* colors){
   o->q[skey]->cidx = 0;
   ++*colors;
 //fprintf(stderr, "INSERTED[%u]: %u %u %u\n", key, q->q.comps[0], q->q.comps[1], q->q.comps[2]);
+if(key == 3172){
+  fprintf(stderr, "END 3172 %u %u %p\n", q->qlink, q->q.pop, q);
+}
 }
 
 // resolve the input color to a color table index following any postprocessing
@@ -203,6 +211,14 @@ find_color(const qstate* qs, uint32_t pixel){
   const unsigned b = ncpixel_b(pixel);
   const unsigned key = color_key(r, g, b);
   const qnode* q = &qs->qnodes[key];
+  if(q->qlink && q->q.pop == 0){
+    unsigned skey = secondary_key(r, g, b);
+    if(qs->onodes[q->qlink].q[skey]){
+      q = qs->onodes[q->qlink].q[skey];
+    }else{
+      fprintf(stderr, "OH NOOOOOOOOOO\n"); // FIXME find one
+    }
+  }
   while(!chosen_p(q)){
     const qnode* newq = &qs->qnodes[qidx(q)];
     if(newq == q){


### PR DESCRIPTION
Use a dynamic octree method to extend the existing qnodes via the method of "fractures". Improves quality substantially at very low cost.

## freebsd.png

### old

```
analyzing ../data/freebsd.png...
 source pixels: 651x600 rendered: 651x600 1562400B
 control sequence: 86652 bytes (5.546%)
 00390600 pixels analyzed Δr 296015 Δg 244794 Δb 137021
 Colors: 1548 vs 91
 390600px Δr 296015 (0.758) Δg 244794 (0.627) Δb 137021 (0.351)
 avg diff per pixel: 1.74
done with ../data/freebsd.png in 123.114ms.
```

### fast-relaxation

```
analyzing ../data/freebsd.png...
 source pixels: 651x600 rendered: 651x600 1562400B
 control sequence: 91009 bytes (5.825%)
 00390600 pixels analyzed Δr 109376 Δg 68246 Δb 12733
 Colors: 1548 vs 90
 390600px Δr 109376 (0.28) Δg 68246 (0.175) Δb 12733 (0.0326)
 avg diff per pixel: 0.487
done with ../data/freebsd.png in 131.920ms.
```

## natasha-blur.png

### old
```
analyzing ../data/natasha-blur.png...
 source pixels: 515x300 rendered: 515x300 618000B
 control sequence: 75025 bytes (12.14%)
 00154500 pixels analyzed Δr 220130 Δg 201919 Δb 348638
 Colors: 9421 vs 98
 154500px Δr 220130 (1.42) Δg 201919 (1.31) Δb 348638 (2.26)
 avg diff per pixel: 4.99
done with ../data/natasha-blur.png in 89.103ms.
```

### fast-relaxation
```
analyzing ../data/natasha-blur.png...
 source pixels: 515x300 rendered: 515x300 618000B
 control sequence: 81152 bytes (13.13%)
 00154500 pixels analyzed Δr 181133 Δg 151075 Δb 203295
 Colors: 9421 vs 97
 154500px Δr 181133 (1.17) Δg 151075 (0.978) Δb 203295 (1.32)
 avg diff per pixel: 3.47
done with ../data/natasha-blur.png in 97.181ms.
```

## lamepatents.jpg

### old
```
analyzing ../data/lamepatents.jpg...
 source pixels: 433x577 rendered: 433x577 999364B
 control sequence: 278338 bytes (27.85%)
 00249841 pixels analyzed Δr 1372892 Δg 885475 Δb 1560546
 Colors: 73829 vs 597
 249841px Δr 1372892 (5.5) Δg 885475 (3.54) Δb 1560546 (6.25)
 avg diff per pixel: 15.3
done with ../data/lamepatents.jpg in 112.221ms.
```

### fast-relaxation
```
analyzing ../data/lamepatents.jpg...
 source pixels: 433x577 rendered: 433x577 999364B
 control sequence: 281724 bytes (28.19%)
 00249841 pixels analyzed Δr 1218779 Δg 604912 Δb 1430187
 Colors: 73829 vs 392
 249841px Δr 1218779 (4.88) Δg 604912 (2.42) Δb 1430187 (5.72)
 avg diff per pixel: 13
done with ../data/lamepatents.jpg in 133.546ms.
```

closes #2515 

The one thing I want to figure out before I commit this, though, is why would we have a drop in total output color number?