### PR TITLE
add meta modifier handling #2522

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ rearrangements of Notcurses.
 * 3.0.4 (not yet released)
   * We now use level 2 of `XTMODKEYS`, providing better differentiation
     of keyboard modifiers.
+  * Added `ncinput_shift_p()`, `ncinput_alt_p()`, `ncinput_ctrl_p()`,
+    and `ncinput_meta_p()` to test for various modifiers in `ncinput`s.
 
 * 3.0.3 (2022-01-02)
   * No user-visible changes to the API, but Sixel quantization has been

--- a/doc/man/man1/notcurses-input.1.md
+++ b/doc/man/man1/notcurses-input.1.md
@@ -21,6 +21,7 @@ of modifier indicators:
 * 'A'/'a': Alt was or was not pressed.
 * 'C'/'c': Ctrl was or was not pressed.
 * 'S'/'s': Shift was or was not pressed.
+* 'M'/'m': Meta was or was not pressed.
 * 'L'/'R'/'P'/'u': Key was a release, repeat, press, or of unknown type.
 
 # OPTIONS

--- a/doc/man/man3/notcurses_input.3.md
+++ b/doc/man/man3/notcurses_input.3.md
@@ -29,6 +29,7 @@ typedef struct ncinput {
     EVTYPE_RELEASE,
   } evtype;
   int ypx, xpx;    // pixel offsets within cell, -1 for undefined
+  unsigned modifiers;
 } ncinput;
 
 #define NCMICE_NO_EVENTS     0
@@ -61,6 +62,14 @@ typedef struct ncinput {
 **int notcurses_linesigs_disable(struct notcurses* ***n***);**
 
 **int notcurses_linesigs_enable(struct notcurses* ***n***);**
+
+**bool ncinput_shift_p(const struct ncinput* ***n***);**
+
+**bool ncinput_ctrl_p(const struct ncinput* ***n***);**
+
+**bool ncinput_alt_p(const struct ncinput* ***n***);**
+
+**bool ncinput_meta_p(const struct ncinput* ***n***);**
 
 # DESCRIPTION
 
@@ -99,6 +108,10 @@ input (though not necessarily the same input event).
 **SUSP**, and **DSUSP** into **SIGINT**, **SIGQUIT**, and **SIGTSTP**. These
 conversions are enabled by default. **notcurses_linesigs_enable** undoes this
 action, but signals in the interim are permanently lost.
+
+**ncinput_shift_p**, **ncinput_ctrl_p**, **ncinput_alt_p**, and
+**ncinput_meta_p** test ***n*** to see if the relevant modifier is set.
+This is preferably to directly accessing the struct members.
 
 ## Mice
 
@@ -188,10 +201,14 @@ for input readiness. Instead, use the file descriptor returned by
 Notcurses (it is possible that future versions will process input in their own
 contexts).
 
+The full list of synthesized events is available in **<notcurses/nckeys.h>**.
+
+In API4, the various **bool** modifier fields will go away, and these statuses
+will be merged into the ***modifiers*** bitmask. You are encouraged to use
+**ncinput_shift_p** and friends to future-proof your code.
+
 When support is detected, the Kitty keyboard disambiguation protocol will be
 requested. This eliminates most of the **BUGS** mentioned below.
-
-The full list of synthesized events is available in **<notcurses/nckeys.h>**.
 
 # BUGS
 

--- a/include/notcurses/nckeys.h
+++ b/include/notcurses/nckeys.h
@@ -216,6 +216,12 @@ nckey_supppuab_p(uint32_t w){
   return w >= 0x100000 && w <= 0x10fffd; // 65,534 codepoints
 }
 
+// modifiers bitmask
+#define NCKEY_MOD_SHIFT 1
+#define NCKEY_MOD_CTRL  2
+#define NCKEY_MOD_ALT   4
+#define NCKEY_MOD_META  8
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1133,6 +1133,7 @@ nckey_mouse_p(uint32_t r){
 // An input event. Cell coordinates are currently defined only for mouse
 // events. It is not guaranteed that we can set the modifiers for a given
 // ncinput. We encompass single Unicode codepoints, not complete EGCs.
+// FIXME for abi4, combine the bools into |modifiers|
 typedef struct ncinput {
   uint32_t id;       // Unicode codepoint or synthesized NCKEY event
   int y, x;          // y/x cell coordinate of event, -1 for undefined
@@ -1147,8 +1148,29 @@ typedef struct ncinput {
     NCTYPE_REPEAT,
     NCTYPE_RELEASE,
   } evtype;
+  unsigned modifiers;// bitmask over NCMOD_META
   int ypx, xpx;      // pixel offsets within cell, -1 for undefined
 } ncinput;
+
+static inline bool
+ncinput_shift_p(const ncinput* n){
+  return (n->modifiers & NCKEY_MOD_SHIFT);
+}
+
+static inline bool
+ncinput_ctrl_p(const ncinput* n){
+  return (n->modifiers & NCKEY_MOD_CTRL);
+}
+
+static inline bool
+ncinput_alt_p(const ncinput* n){
+  return (n->modifiers & NCKEY_MOD_ALT);
+}
+
+static inline bool
+ncinput_meta_p(const ncinput* n){
+  return (n->modifiers & NCKEY_MOD_META);
+}
 
 // compare two ncinput structs for data equality.
 static inline bool

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -328,8 +328,12 @@ int input_demo(ncpp::NotCurses* nc) {
       break;
     }
     n->set_fg_rgb8(0xd0, 0xd0, 0xd0);
-    n->printf("%c%c%c%c ", ni.alt ? 'A' : 'a', ni.ctrl ? 'C' : 'c',
-              ni.shift ? 'S' : 's', evtype_to_char(&ni));
+    n->printf("%c%c%c%c%c ",
+              ncinput_alt_p(&ni) ? 'A' : 'a',
+              ncinput_ctrl_p(&ni) ? 'C' : 'c',
+              ncinput_shift_p(&ni) ? 'S' : 's',
+              ncinput_meta_p(&ni) ? 'M' : 'm',
+              evtype_to_char(&ni));
     if(r < 0x80){
       n->set_fg_rgb8(128, 250, 64);
       if(n->printf("ASCII: [0x%02x (%03d)] '%lc'", r, r,

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -501,7 +501,6 @@ int inputctx_add_cflow(automaton* a, const char* seq, triefunc fxn){
 
 // multiple input escapes might map to the same input
 int inputctx_add_input_escape(automaton* a, const char* esc, uint32_t special,
-                              unsigned shift, unsigned ctrl, unsigned alt,
                               unsigned modifiers){
   if(esc[0] != NCKEY_ESC || strlen(esc) < 2){ // assume ESC prefix + content
     logerror("not an escape (0x%x)", special);
@@ -519,9 +518,9 @@ int inputctx_add_input_escape(automaton* a, const char* esc, uint32_t special,
     }
   }else{
     eptr->ni.id = special;
-    eptr->ni.shift = shift;
-    eptr->ni.ctrl = ctrl;
-    eptr->ni.alt = alt;
+    eptr->ni.shift = modifiers & NCKEY_MOD_SHIFT;
+    eptr->ni.ctrl = modifiers & NCKEY_MOD_CTRL;
+    eptr->ni.alt = modifiers & NCKEY_MOD_ALT;
     eptr->ni.y = 0;
     eptr->ni.x = 0;
     eptr->ni.modifiers = modifiers;

--- a/src/lib/automaton.c
+++ b/src/lib/automaton.c
@@ -501,7 +501,8 @@ int inputctx_add_cflow(automaton* a, const char* seq, triefunc fxn){
 
 // multiple input escapes might map to the same input
 int inputctx_add_input_escape(automaton* a, const char* esc, uint32_t special,
-                              unsigned shift, unsigned ctrl, unsigned alt){
+                              unsigned shift, unsigned ctrl, unsigned alt,
+                              unsigned modifiers){
   if(esc[0] != NCKEY_ESC || strlen(esc) < 2){ // assume ESC prefix + content
     logerror("not an escape (0x%x)", special);
     return -1;
@@ -523,6 +524,7 @@ int inputctx_add_input_escape(automaton* a, const char* esc, uint32_t special,
     eptr->ni.alt = alt;
     eptr->ni.y = 0;
     eptr->ni.x = 0;
+    eptr->ni.modifiers = modifiers;
     logdebug("added 0x%08x to %u", special, esctrie_idx(a, eptr));
   }
   return 0;

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -35,7 +35,8 @@ void input_free_esctrie(automaton *a);
 
 int inputctx_add_input_escape(automaton* a, const char* esc,
                               uint32_t special, unsigned shift,
-                              unsigned ctrl, unsigned alt);
+                              unsigned ctrl, unsigned alt,
+                              unsigned modifiers);
 
 int inputctx_add_cflow(automaton* a, const char* csi, triefunc fxn)
   __attribute__ ((nonnull (1, 2)));

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -34,9 +34,7 @@ typedef struct automaton {
 void input_free_esctrie(automaton *a);
 
 int inputctx_add_input_escape(automaton* a, const char* esc,
-                              uint32_t special, unsigned shift,
-                              unsigned ctrl, unsigned alt,
-                              unsigned modifiers);
+                              uint32_t special, unsigned modifiers);
 
 int inputctx_add_cflow(automaton* a, const char* csi, triefunc fxn)
   __attribute__ ((nonnull (1, 2)));

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -166,7 +166,6 @@ prep_xtmodkeys(inputctx* ictx){
   }, *k;
   for(k = keys ; k->esc ; ++k){
     if(inputctx_add_input_escape(&ictx->amata, k->esc, k->key,
-                                 k->shift, k->ctrl, k->alt,
                                  k->modifiers)){
       return -1;
     }
@@ -355,7 +354,7 @@ prep_special_keys(inputctx* ictx){
     unsigned modifiers = (k->shift ? NCKEY_MOD_SHIFT : 0)
                        | (k->alt ? NCKEY_MOD_ALT : 0)
                        | (k->ctrl ? NCKEY_MOD_CTRL : 0);
-    if(inputctx_add_input_escape(&ictx->amata, seq, k->key, k->shift, k->ctrl, k->alt, modifiers)){
+    if(inputctx_add_input_escape(&ictx->amata, seq, k->key, modifiers)){
       return -1;
     }
     logdebug("support for terminfo's %s: %s", k->tinfo, seq);
@@ -365,7 +364,7 @@ prep_special_keys(inputctx* ictx){
     logwarn("no backspace key was defined");
   }else{
     if(bs[0] == NCKEY_ESC){
-      if(inputctx_add_input_escape(&ictx->amata, bs, NCKEY_BACKSPACE, 0, 0, 0, 0)){
+      if(inputctx_add_input_escape(&ictx->amata, bs, NCKEY_BACKSPACE, 0)){
         return -1;
       }
     }else{
@@ -1753,24 +1752,22 @@ prep_kitty_special_keys(inputctx* ictx){
   static const struct {
     const char* esc;
     uint32_t key;
-    bool shift, ctrl, alt;
     unsigned modifiers;
   } keys[] = {
     { .esc = "\x1b[P", .key = NCKEY_F01, },
     { .esc = "\x1b[Q", .key = NCKEY_F02, },
     { .esc = "\x1b[R", .key = NCKEY_F03, },
     { .esc = "\x1b[S", .key = NCKEY_F04, },
-    { .esc = "\x1b[127;2u", .key = NCKEY_BACKSPACE, .shift = 1,
+    { .esc = "\x1b[127;2u", .key = NCKEY_BACKSPACE,
       .modifiers = NCKEY_MOD_SHIFT, },
-    { .esc = "\x1b[127;3u", .key = NCKEY_BACKSPACE, .alt = 1,
+    { .esc = "\x1b[127;3u", .key = NCKEY_BACKSPACE,
       .modifiers = NCKEY_MOD_ALT, },
-    { .esc = "\x1b[127;5u", .key = NCKEY_BACKSPACE, .ctrl = 1,
+    { .esc = "\x1b[127;5u", .key = NCKEY_BACKSPACE,
       .modifiers = NCKEY_MOD_CTRL, },
     { .esc = NULL, .key = 0, },
   }, *k;
   for(k = keys ; k->esc ; ++k){
-    if(inputctx_add_input_escape(&ictx->amata, k->esc, k->key,
-                                 k->shift, k->ctrl, k->alt, k->modifiers)){
+    if(inputctx_add_input_escape(&ictx->amata, k->esc, k->key, k->modifiers)){
       return -1;
     }
   }
@@ -1788,20 +1785,19 @@ prep_windows_special_keys(inputctx* ictx){
   static const struct {
     const char* esc;
     uint32_t key;
-    bool shift, ctrl, alt;
     unsigned modifiers;
   } keys[] = {
     { .esc = "\x1b[A", .key = NCKEY_UP, },
     { .esc = "\x1b[B", .key = NCKEY_DOWN, },
     { .esc = "\x1b[C", .key = NCKEY_RIGHT, },
     { .esc = "\x1b[D", .key = NCKEY_LEFT, },
-    { .esc = "\x1b[1;5A", .key = NCKEY_UP, .ctrl = 1,
+    { .esc = "\x1b[1;5A", .key = NCKEY_UP,
       .modifiers = NCKEY_MOD_CTRL, },
-    { .esc = "\x1b[1;5B", .key = NCKEY_DOWN, .ctrl = 1,
+    { .esc = "\x1b[1;5B", .key = NCKEY_DOWN,
       .modifiers = NCKEY_MOD_CTRL, },
-    { .esc = "\x1b[1;5C", .key = NCKEY_RIGHT, .ctrl = 1,
+    { .esc = "\x1b[1;5C", .key = NCKEY_RIGHT,
       .modifiers = NCKEY_MOD_CTRL, },
-    { .esc = "\x1b[1;5D", .key = NCKEY_LEFT, .ctrl = 1,
+    { .esc = "\x1b[1;5D", .key = NCKEY_LEFT,
       .modifiers = NCKEY_MOD_CTRL, },
     { .esc = "\x1b[H", .key = NCKEY_HOME, },
     { .esc = "\x1b[F", .key = NCKEY_END, },
@@ -1824,9 +1820,7 @@ prep_windows_special_keys(inputctx* ictx){
     { .esc = NULL, .key = 0, },
   }, *k;
   for(k = keys ; k->esc ; ++k){
-    if(inputctx_add_input_escape(&ictx->amata, k->esc, k->key,
-                                 k->shift, k->ctrl, k->alt,
-                                 k->modifiers)){
+    if(inputctx_add_input_escape(&ictx->amata, k->esc, k->key, k->modifiers)){
       return -1;
     }
     logdebug("added %s %u", k->esc, k->key);


### PR DESCRIPTION
Handle Meta modifier in Kitty and XTMODKEYS. Add Meta indicator to notcurses-input. Update man page. Add
`NCKEY_META_{SHIFT, CTRL, ALT, META}` constants. Add "modifiers" field to ncinput struct. Add inline functions for testing modifiers. Remove special-casing in Kitty protocol that capitalized all lowercase ASCII when ctrl was pressed; we don't do this for XTMODKEYS. Closes #2522.