### PR TITLE
Handle EOF on stdin better

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,9 @@ steps:
     - cd build
     - cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_STATIC=off -DUSE_GPM=on -DUSE_QRCODEGEN=on -DDFSG_BUILD=on
     - make -j2
+    - ./notcurses-input < /dev/null
     - env NOTCURSES_LOGLEVEL=7 ./notcurses-input < notcurses-input
+    - ./notcurses-input < notcurses-input
       #- ./notcurses-info
       #- ctest --output-on-failure
       #- make install

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,14 +13,15 @@ steps:
     - cd build
     - cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_STATIC=off -DUSE_GPM=on -DUSE_QRCODEGEN=on -DDFSG_BUILD=on
     - make -j2
-    - ./notcurses-info
-    - ctest --output-on-failure
-    - make install
-    - ldconfig
-    - cd ../cffi
-    - LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
-    - env LD_LIBRARY_PATH=/usr/local/lib ./notcurses-pydemo > /dev/null
-    - env LD_LIBRARY_PATH=/usr/local/lib ./ncdirect-pydemo > /dev/null
+    - env NOTCURSES_LOGLEVEL=7 ./notcurses-input < notcurses-input
+      #- ./notcurses-info
+      #- ctest --output-on-failure
+      #- make install
+      #- ldconfig
+      #- cd ../cffi
+      #- LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
+      #- env LD_LIBRARY_PATH=/usr/local/lib ./notcurses-pydemo > /dev/null
+      #- env LD_LIBRARY_PATH=/usr/local/lib ./ncdirect-pydemo > /dev/null
 ---
 kind: pipeline
 type: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,17 +13,14 @@ steps:
     - cd build
     - cmake .. -DCMAKE_BUILD_TYPE=Release -DUSE_STATIC=off -DUSE_GPM=on -DUSE_QRCODEGEN=on -DDFSG_BUILD=on
     - make -j2
-    - ./notcurses-input < /dev/null
-    - env NOTCURSES_LOGLEVEL=7 ./notcurses-input < notcurses-input
-    - ./notcurses-input < notcurses-input
-      #- ./notcurses-info
-      #- ctest --output-on-failure
-      #- make install
-      #- ldconfig
-      #- cd ../cffi
-      #- LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
-      #- env LD_LIBRARY_PATH=/usr/local/lib ./notcurses-pydemo > /dev/null
-      #- env LD_LIBRARY_PATH=/usr/local/lib ./ncdirect-pydemo > /dev/null
+    - ./notcurses-info
+    - ctest --output-on-failure
+    - make install
+    - ldconfig
+    - cd ../cffi
+    - LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include python3 setup.py sdist build install
+    - env LD_LIBRARY_PATH=/usr/local/lib ./notcurses-pydemo > /dev/null
+    - env LD_LIBRARY_PATH=/usr/local/lib ./ncdirect-pydemo > /dev/null
 ---
 kind: pipeline
 type: docker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -874,12 +874,12 @@ add_test(
 # provide an empty source
 add_test(
   NAME input-devnull
-  COMMAND sh -c "./notcurses-input < /dev/null"
+  COMMAND sh -c "./notcurses-input -v < /dev/null"
 )
 # provide a binary file
 add_test(
   NAME input-binary
-  COMMAND sh -c "./notcurses-input < notcurses-input"
+  COMMAND sh -c "./notcurses-input -v < notcurses-input"
 )
 # provide an ASCII file
 add_test(

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -2381,9 +2381,7 @@ internal_get(inputctx* ictx, const struct timespec* ts, ncinput* ni){
     return (uint32_t)-1;
   }
   pthread_mutex_lock(&ictx->ilock);
-fprintf(stderr, "IVALID: %u EOF: %u IREAD: %u\n", ictx->ivalid, ictx->stdineof, ictx->iread);
   while(!ictx->ivalid){
-fprintf(stderr, "WHILE IVALID: %u EOF: %u IREAD: %u\n", ictx->ivalid, ictx->stdineof, ictx->iread);
     if(ictx->stdineof){
       pthread_mutex_unlock(&ictx->ilock);
       logwarn("read eof on stdin");
@@ -2394,9 +2392,7 @@ fprintf(stderr, "WHILE IVALID: %u EOF: %u IREAD: %u\n", ictx->ivalid, ictx->stdi
       return NCKEY_EOF;
     }
     if(ts == NULL){
-fprintf(stderr, "WAITING\n");
       pthread_cond_wait(&ictx->icond, &ictx->ilock);
-fprintf(stderr, "DONE WAITING\n");
     }else{
       int r = pthread_cond_timedwait(&ictx->icond, &ictx->ilock, ts);
       if(r == ETIMEDOUT){
@@ -2416,7 +2412,6 @@ fprintf(stderr, "DONE WAITING\n");
     }
   }
   id = ictx->inputs[ictx->iread].id;
-fprintf(stderr, "GOT ID 0x%08x IREAD: %u\n", id, ictx->iread);
   if(ni){
     memcpy(ni, &ictx->inputs[ictx->iread], sizeof(*ni));
     if(notcurses_ucs32_to_utf8(&ni->id, 1, (unsigned char*)ni->utf8, sizeof(ni->utf8)) < 0){

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -479,7 +479,7 @@ mark_pipe_ready(ipipe pipes[static 2]){
 static void
 load_ncinput(inputctx* ictx, const ncinput *tni, int synthsig){
   inc_input_events(ictx);
-  if(ictx->drain){
+  if(ictx->drain || ictx->stdineof){
     send_synth_signal(synthsig);
     return;
   }

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -252,6 +252,7 @@ typedef struct ncdirect {
   uint16_t stylemask;        // current styles
   uint64_t flags;            // copied in ncdirect_init() from param
   ncsharedstats stats;       // stats! not as broadly used as in notcurses
+  unsigned eof;              // have we seen EOF on stdin?
 } ncdirect;
 
 // Extracellular state for a cell during the render process. There is one

--- a/src/poc/cli1.c
+++ b/src/poc/cli1.c
@@ -32,7 +32,7 @@ int main(void){
 #endif
       notcurses_get_blocking(nc, &ni);
     }while(ni.evtype == NCTYPE_RELEASE);
-  }while(ni.id != 'q');
+  }while(ni.id != 'q' && ni.id != NCKEY_EOF);
   if(notcurses_render(nc)){
     goto err;
   }


### PR DESCRIPTION
Once we've received EOF on stdin, stop adding new input to the user queue. This input could come from e.g. a keyboard attached to the terminal when input is redirected from some file. After seeing `NCKEY_EOF`, the user ought see no new input.

Account for the EOF event by posting to the readiness file descriptor provided to the user. Closes #2525.

Don't use `sigaltstack()` when built with ASAN stupport; they're incompatible. Closes #2529.

Track EOF in `ncdirect` and interpret Ctrl+'d' as EOF. Closes #2521.