### PR TITLE
Detect pixel mouse support from DA1 #2326

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -76,7 +76,7 @@ name: alpine-edge
 
 steps:
 - name: alpine-edge
-  image: dankamongmen/edge_builder:2021-11-28a
+  image: dankamongmen/edge_builder:2022-01-07a
   commands:
     - export LANG=en_US.UTF-8
     - export TERM=vt100

--- a/src/lib/mice.c
+++ b/src/lib/mice.c
@@ -40,7 +40,14 @@ int mouse_setup(tinfo* ti, unsigned eventmask){
 // Sets the shift-escape option, allowing shift+mouse to override the standard
 // mouse protocol (mainly so copy-and-paste can still be performed).
 #define XTSHIFTESCAPE "\x1b[>1s"
-  char mousecmd[] = XTSHIFTESCAPE "\x1b[?100x;" SET_SGR_MOUSE_PROT "x";
+  char* mousecmd;
+  if(ti->pixelmice){
+    static char m[] = XTSHIFTESCAPE "\x1b[?100x;" SET_PIXEL_MOUSE_PROT "x";
+    mousecmd = m;
+  }else{
+    static char m[] = XTSHIFTESCAPE "\x1b[?100x;" SET_SGR_MOUSE_PROT "x";
+    mousecmd = m;
+  }
   mousecmd[11] = ti->mouseproto;
   mousecmd[17] = command;
   if(command == 'l'){

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -192,7 +192,7 @@ typedef struct tinfo {
   pthread_t gpmthread;       // thread handle for GPM watcher
   int gpmfd;                 // connection to GPM daemon
   char mouseproto;           // DECSET level (100x, '0', '2', '3')
-  bool pixelmice;            // we support pixel-accuracy for mice
+  bool pixelmice;            // do we support pixel-precision mice?
 #ifdef __linux__
   int linux_fb_fd;           // linux framebuffer device fd
   char* linux_fb_dev;        // device corresponding to linux_fb_dev


### PR DESCRIPTION
Check the DA1 response for item 29. If it's present, mark pixelmice support high. Report pixelmice support in `notcurses-info` as `pmouse`. Update man page. #2326