### PR TITLE
Mouse mode 1016 (pixel) support

### DIFF
--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1148,8 +1148,6 @@ da1_attrs_cb(inputctx* ictx){
       }
     }else if(curattr == 28){
       ictx->initdata->rectangular_edits = true;
-    }else if(curattr == 29){
-      ictx->initdata->pixelmice = true;
     }
     if(!foundsixel){
       scrub_sixel_responses(ictx->initdata);
@@ -1263,6 +1261,18 @@ kittygraph_cb(inputctx* ictx){
   loginfo("kitty graphics message");
   if(ictx->initdata){
     ictx->initdata->kitty_graphics = 1;
+  }
+  return 2;
+}
+
+static int
+decrpm_pixelmice(inputctx* ictx){
+  unsigned ps = amata_next_numeric(&ictx->amata, "\x1b[?1016;", '$');
+  loginfo("received decrpm 1016 %u", ps);
+  if(ps == 2){
+    if(ictx->initdata){
+      ictx->initdata->pixelmice = 1;
+    }
   }
   return 2;
 }
@@ -1545,6 +1555,7 @@ build_cflow_automaton(inputctx* ictx){
     { "[1;\\N:\\NF", kitty_cb_end, },
     { "[1;\\N:\\NH", kitty_cb_home, },
     { "[?\\Nu", kitty_keyboard_cb, },
+    { "[?1016;\\N$y", decrpm_pixelmice, },
     { "[?2026;\\N$y", decrpm_asu_cb, },
     { "[\\N;\\NR", cursor_location_cb, },
     { "[?1;1S", NULL, }, // negative cregs XTSMGRAPHICS

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -524,9 +524,14 @@ load_ncinput(inputctx* ictx, ncinput *tni, int synthsig){
 
 static void
 pixelmouse_click(inputctx* ictx, ncinput* ni, long y, long x){
-  // FIXME change over to pixels!
-  x -= (1 + ictx->lmargin);
-  y -= (1 + ictx->tmargin);
+  --x;
+  --y;
+  ni->ypx = y % ictx->ti->cellpxy;
+  ni->xpx = x % ictx->ti->cellpxx;
+  y /= ictx->ti->cellpxy;
+  x /= ictx->ti->cellpxx;
+  x -= ictx->lmargin;
+  y -= ictx->tmargin;
   // convert from 1- to 0-indexing, and account for margins
   if(x < 0 || y < 0){ // click was in margins, drop it
     logwarn("dropping click in margins %ld/%ld", y, x);
@@ -540,7 +545,8 @@ pixelmouse_click(inputctx* ictx, ncinput* ni, long y, long x){
     logwarn("dropping click in margins %ld/%ld", y, x);
     return;
   }
-  // FIXME set y, x, ypx, xpx
+  ni->y = y;
+  ni->x = x;
   load_ncinput(ictx, ni, 0);
 }
 
@@ -583,6 +589,9 @@ mouse_click(inputctx* ictx, unsigned release, char follow){
     }
   }
   if(ictx->ti->pixelmice){
+    if(ictx->ti->cellpxx == 0){
+      logerror("pixelmouse but no pixel info");
+    }
     return pixelmouse_click(ictx, &tni, y, x);
   }
   x -= (1 + ictx->lmargin);

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -521,6 +521,9 @@ init_terminfo_esc(tinfo* ti, const char* name, escape_e idx,
 // least Konsole and Terminal.app fail to consume it =[.
 #define SUMQUERY "\x1b[?2026$p"
 
+// check for mouse mode 1016, pixel-based reports
+#define PIXELMOUSEQUERY "\x1b[?1016$p"
+
 // XTSMGRAPHICS query for the number of color registers.
 #define CREGSXTSM "\x1b[?2;1;0S"
 
@@ -538,6 +541,7 @@ init_terminfo_esc(tinfo* ti, const char* name, escape_e idx,
                    DEFBGQ \
                    KKBDQUERY \
                    SUMQUERY \
+                   PIXELMOUSEQUERY \
                    "\x1b[?1;3;256S" /* try to set 256 cregs */ \
                    "\x1b[?1;3;1024S" /* try to set 1024 cregs */ \
                    KITTYQUERY \


### PR DESCRIPTION
Detect pixelmice via DECRQM 1016 instead of DA1[29]. This rectifies breakage on mlterm by not using the 1016 protocol, and uses the protocol on XTerm, where it's supported. Looks good! Closes #2326.