### PR TITLE
Request hpa via XTGETTCAP #2541

### DIFF
--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1567,14 +1567,14 @@ tcap_cb(inputctx* ictx){
   while(*s && (s = gettcap(s, &val, &key)) ){
     if(strcmp(val, "TN") == 0){
       if(ictx->initdata->qterm == TERMINAL_UNKNOWN){
-        if(strcasecmp(key, "xterm") == 0){
-          ictx->initdata->qterm = TERMINAL_XTERM; // "xterm"
-        }else if(strcasecmp(key, "mlterm") == 0){
+        if(strcmp(key, "xterm") == 0){
+          ictx->initdata->qterm = TERMINAL_XTERM;
+        }else if(strcmp(key, "mlterm") == 0){
           ictx->initdata->qterm = TERMINAL_MLTERM;
-        }else if(strcasecmp(key, "xterm-kitty") == 0){
-          ictx->initdata->qterm = TERMINAL_KITTY; // "xterm-kitty"
-        }else if(strcasecmp(key, "xterm-256color") == 0){
-          ictx->initdata->qterm = TERMINAL_XTERM; // "xterm-256color"
+        }else if(strcmp(key, "xterm-kitty") == 0){
+          ictx->initdata->qterm = TERMINAL_KITTY;
+        }else if(strcmp(key, "xterm-256color") == 0){
+          ictx->initdata->qterm = TERMINAL_XTERM;
         }else{
           logdebug("unknown terminal name %s", key);
         }

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1591,6 +1591,9 @@ tcap_cb(inputctx* ictx){
     }
     free(val);
     free(key);
+    if(*s == ';'){
+      ++s;
+    }
   }
   if(*s){
     free(str);

--- a/src/lib/in.h
+++ b/src/lib/in.h
@@ -82,6 +82,7 @@ struct initial_responses {
   ncpalette palette;           // palette entries
   int maxpaletteread;          // maximum palette index read
   bool pixelmice;              // have we pixel-based mice events?
+  char* hpa;                   // control sequence for hpa via XTGETTCAP
 };
 
 // Blocking call. Waits until the input thread has processed all responses to

--- a/src/lib/logging.h
+++ b/src/lib/logging.h
@@ -8,6 +8,9 @@ extern "C" {
 // logging
 extern ncloglevel_e loglevel;
 
+static inline void nclog(const char* fmt, ...)
+__attribute__ ((format (printf, 1, 2)));
+
 static inline void
 nclog(const char* fmt, ...){
   va_list va;


### PR DESCRIPTION
Kitty on FreeBSD has some terminfo snafu that keeps us from recognizing `hpa` there. `hpa` is pretty important, so request it via `XTGETTCAP` first, and if defined there, don't bother with terminfo. Closes #2541, with implications for #2144.