### PR TITLE
docs: remove references to ncplane_growtext

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1521,15 +1521,6 @@ of [Unicode Annex #14](http://www.unicode.org/reports/tr14/tr14-34.html).
 int ncplane_puttext(struct ncplane* n, int y, ncalign_e align,
                     const char* text, size_t* bytes);
 
-// Like ncplane_puttext(), we're going for an orderly presentation of (possibly
-// bulk) text. Unlike ncplane_puttext(), we're going to grow the plane as
-// necessary to present it. If the plane is scrolling, we'll grow the bottom
-// out; we'll otherwise grow out to the right. Either way, no actual scrolling
-// will occur.
-int ncplane_growtext(struct ncplane* n, int y, ncalign_e align,
-                     const char* text, size_t* bytes);
-```
-
 Lines and boxes can be drawn, interpolating their colors between their two
 endpoints. For a line of a single color, be sure to specify the same channels
 on both sides. Boxes allow fairly detailed specification of how they're drawn.

--- a/doc/man/man3/notcurses_output.3.md
+++ b/doc/man/man3/notcurses_output.3.md
@@ -76,8 +76,6 @@ notcurses_output - output to ncplanes
 
 **int ncplane_puttext(struct ncplane* ***n***, int ***y***, ncalign_e ***align***, const char* ***text***, size_t* ***bytes***);**
 
-**int ncplane_growtext(struct ncplane* ***n***, int ***y***, ncalign_e ***align***, const char* ***text***, size_t* ***bytes***);**
-
 # DESCRIPTION
 
 These functions write EGCs (Extended Grapheme Clusters) to the specified
@@ -93,7 +91,6 @@ These functions write EGCs (Extended Grapheme Clusters) to the specified
 * **ncplane_vprintf()**: formatted output using **va_list**
 * **ncplane_printf()**: formatted output using variadic arguments
 * **ncplane_puttext()**: multi-line, line-broken, aligned text
-* **ncplane_growtext()**: **ncplane_growtext()** with an autogrowing plane
 
 All of these use the **ncplane**'s active styling, save **notcurses_putc()**,
 which uses the **nccell**'s styling. Functions accepting a single EGC expect a series


### PR DESCRIPTION
According to https://github.com/dankamongmen/notcurses/issues/2440#issuecomment-988341648, `ncplane_growtext` was killed off before being introduced into any version of notcurses. However, references to it snuck into some of the documentation. This just removes the two references to it I saw in the docs to prevent confusion.