### PR TITLE
some Python input functionality

### DIFF
--- a/python/examples/006-input-tester.py
+++ b/python/examples/006-input-tester.py
@@ -14,27 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from notcurses import Notcurses
 
-from notcurses import get_std_plane
-
-std_plane = get_std_plane()
+nc = Notcurses()
+std_plane = nc.stdplane()
 std_plane.putstr("Enter string!")
 
-std_plane.context.render()
-std_plane.context.enable_cursor()
-std_plane.context.enable_mouse()
+nc.render()
+nc.mice_enable()
 
 while True:
     # Get an input event and print its properties
-    p = std_plane.context.get_input_blocking()
+    inp = nc.get_blocking()
     std_plane.erase()
-    std_plane.putstr(f"Code point: {repr(p.code)}",
-                     y_pos=0, x_pos=0)
-    std_plane.putstr(f"Y pos: {p.y_pos}", y_pos=1, x_pos=0)
-    std_plane.putstr(f"X pos: {p.x_pos}", y_pos=2, x_pos=0)
-    std_plane.putstr(f"Is alt: {p.is_alt}", y_pos=3, x_pos=0)
-    std_plane.putstr(f"Is shift: {p.is_shift}", y_pos=4, x_pos=0)
-    std_plane.putstr(f"Is ctrl: {p.is_ctrl}", y_pos=5, x_pos=0)
-    std_plane.putstr("Press CTRL+C to exit.", y_pos=7, x_pos=0)
+    std_plane.putstr_yx(1, 4, f"Code point: {hex(inp.id)}")
+    std_plane.putstr_yx(2, 4, f"Y pos: {inp.y}")
+    std_plane.putstr_yx(3, 4, f"X pos: {inp.x}")
+    std_plane.putstr_yx(4, 4, f"UTF-8: {inp.utf8!r}")
+    std_plane.putstr_yx(5, 4, f"Event type: {inp.evtype}")
+    std_plane.putstr_yx(6, 4, f"Modifiers: {bin(inp.modifiers)}")
+    std_plane.putstr_yx(7, 4, f"Y pixel offset: {inp.ypx}")
+    std_plane.putstr_yx(8, 4, f"X pixel offset: {inp.xpx}")
+    std_plane.putstr_yx(10, 4, "Press CTRL+C to exit.")
 
-    std_plane.context.render()
+    nc.render()

--- a/python/notcurses/__init__.py
+++ b/python/notcurses/__init__.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 from .notcurses import (
-    NcPlane, Notcurses, ncchannel_alpha, ncchannel_b, ncchannel_default_p,
+    NcPlane, Notcurses, NcInput,
+    ncchannel_alpha, ncchannel_b, ncchannel_default_p,
     ncchannel_g, ncchannel_palindex, ncchannel_palindex_p, ncchannel_r,
     ncchannel_rgb8, ncchannel_rgb_initializer, ncchannel_set,
     ncchannel_set_alpha, ncchannel_set_default, ncchannel_set_palindex,

--- a/python/notcurses/context.c
+++ b/python/notcurses/context.c
@@ -211,7 +211,7 @@ build_NcInput(ncinput const *ni)
 }
 
 static PyObject *
-Notcurses_get_nblock(NotcursesObject *self)
+Notcurses_get_nblock(NotcursesObject *self, PyObject *Py_UNUSED(args))
 {
     ncinput ni;
     uint32_t id = notcurses_get_nblock(self->notcurses_ptr, &ni);
@@ -228,7 +228,7 @@ Notcurses_get_nblock(NotcursesObject *self)
 }
 
 static PyObject *
-Notcurses_get_blocking(NotcursesObject *self)
+Notcurses_get_blocking(NotcursesObject *self, PyObject *Py_UNUSED(args))
 {
     ncinput ni;
     if (notcurses_get_blocking(self->notcurses_ptr, &ni) == (uint32_t)-1)

--- a/python/notcurses/main.c
+++ b/python/notcurses/main.c
@@ -36,6 +36,28 @@ static struct PyModuleDef NotcursesMiscModule = {
     .m_free = (freefunc)Notcurses_module_free,
 };
 
+static PyStructSequence_Field NcInput_fields[] = {
+    {"id", "Unicode codepoint or synthesized NCKEY event"},
+    {"y", "y cell coordinate of event, -1 for undefined"},
+    {"x", "x cell coordinate of event, -1 for undefined"},
+    {"utf8", "utf8 representation, if one exists"},
+    // Note: alt, shift, ctrl fields deprecated in C API are omitted.
+    {"evtype", NULL},
+    {"modifiers", "bitmask over NCKEY_MOD_*"},
+    {"ypx", "y pixel offset within cell, -1 for undefined"},
+    {"xpx", "x pixel offset within cell, -1 for undefined"},
+    {NULL, NULL},
+};
+
+static struct PyStructSequence_Desc NcInput_desc = {
+    .name = "NcInput",
+    .doc = "Notcurses input event",
+    .fields = NcInput_fields,
+    .n_in_sequence = 8,
+};
+
+PyTypeObject *NcInput_Type;
+
 PyMODINIT_FUNC
 PyInit_notcurses(void)
 {
@@ -52,6 +74,11 @@ PyInit_notcurses(void)
     // Add objects
     GNU_PY_MODULE_ADD_OBJECT(py_module, (PyObject *)&Notcurses_Type, "Notcurses");
     GNU_PY_MODULE_ADD_OBJECT(py_module, (PyObject *)&NcPlane_Type, "NcPlane");
+
+    NcInput_Type = PyStructSequence_NewType(&NcInput_desc);
+    if (NcInput_Type == NULL)
+        return NULL;
+    GNU_PY_MODULE_ADD_OBJECT(py_module, (PyObject *)NcInput_Type, "NcInput");
 
     // background cannot be highcontrast, only foreground
     GNU_PY_CHECK_INT(PyModule_AddIntMacro(py_module, NCALPHA_HIGHCONTRAST));

--- a/python/notcurses/notcurses-python.h
+++ b/python/notcurses/notcurses-python.h
@@ -125,12 +125,6 @@ typedef struct
 typedef struct
 {
     PyObject_HEAD;
-    struct ncinput ncinput;
-} NcInputObject;
-
-typedef struct
-{
-    PyObject_HEAD;
     struct ncstats ncstats;
 } NcStatsObject;
 
@@ -139,6 +133,8 @@ typedef struct
     PyObject_HEAD;
     struct ncpalette ncpalette;
 } Palette256Object;
+
+extern PyTypeObject *NcInput_Type;
 
 // Imports
 


### PR DESCRIPTION
Adds a simple `NcInput` type and implements the `get_nblock()` and `get_blocking()` methods.  Then fix up the input test example script.  Haven't implemented `get()` yet.
