### PR TITLE
Correct progbar options in documentation

### DIFF
--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -16,7 +16,7 @@ jobs:
       COLORTERM: truecolor
       TERM: xterm
     name: 🏁 build, test, & install
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -2830,10 +2830,10 @@ struct ncprogbar* ncprogbar_create(struct ncplane* n, const ncprogbar_options* o
 #define NCPROGBAR_OPTION_RETROGRADE        0x0001u // proceed left/down
 
 typedef struct ncprogbar_options {
-  // channels for the maximum and minimum points. linear interpolation will be
-  // applied across the domain between these two.
-  uint64_t maxchannels;
-  uint64_t minchannels;
+  uint32_t ulchannel; // upper-left channel. in the context of a progress bar,
+  uint32_t urchannel; // "up" is the direction we are progressing towards, and
+  uint32_t blchannel; // "bottom" is the direction of origin. for monochromatic
+  uint32_t brchannel; // bar, all four channels ought be the same.
   uint64_t flags;
 } ncprogbar_options;
 

--- a/doc/man/man3/notcurses_progbar.3.md
+++ b/doc/man/man3/notcurses_progbar.3.md
@@ -16,8 +16,10 @@ struct ncprogbar;
 #define NCPROGBAR_OPTION_RETROGRADE        0x0001u // proceed left/down
 
 typedef struct ncprogbar_options {
-  uint64_t maxchannels;
-  uint64_t minchannels;
+  uint32_t ulchannel; // upper-left channel. in the context of a progress bar,
+  uint32_t urchannel; // "up" is the direction we are progressing towards, and
+  uint32_t blchannel; // "bottom" is the direction of origin. for monochromatic
+  uint32_t brchannel; // bar, all four channels ought be the same.
   uint64_t flags;
 } ncprogbar_options;
 ```


### PR DESCRIPTION
Both `USAGE.md` and `notcurses_progbar.3` had incorrect definitions of `ncprogbar_options`. Update them. Closes #2639