### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/demo/fission.c
+++ b/src/demo/fission.c
@@ -13,7 +13,7 @@ drop_bricks(struct notcurses* nc, struct ncplane** arr, int arrcount){
   // 5 * demodelay total
   ns_to_timespec(timespec_to_ns(&demodelay) / arrcount / 2, &iterdelay);
   // we've got a range of up to 10% total blocks falling at any given time. they
-  // accelerate as they fall. [ranges, reange) covers the active range.
+  // accelerate as they fall. [ranges, range) covers the active range.
   int ranges = 0;
   int rangee = 0;
   const int FALLINGMAX = arrcount < 10 ? 1 : arrcount / 10;

--- a/src/tests/wide.cpp
+++ b/src/tests/wide.cpp
@@ -284,7 +284,7 @@ TEST_CASE("Wide") {
   }
 
   // If an ncplane is moved atop the right half of a wide glyph, the entire
-  // glyph should be oblitrated.
+  // glyph should be obliterated.
   SUBCASE("PlaneStompsWideGlyph"){
     nccell c = NCCELL_TRIVIAL_INITIALIZER;
     char* egc;


### PR DESCRIPTION
There are small typos in:
- src/demo/fission.c
- src/tests/wide.cpp

Fixes:
- Should read `obliterated` rather than `oblitrated`.
- Should read `range` rather than `reange`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md