### PR TITLE
Fixes DECSDM interpretation for Contour.

### DIFF
--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -846,7 +846,7 @@ apply_contour_heuristics(tinfo* ti, size_t* tablelen, size_t* tableused,
   ti->caps.sextants = true;
   ti->caps.rgb = true;
   *forcesdm = true;
-  *invertsixel = true;
+  *invertsixel = false;
   return "Contour";
 }
 


### PR DESCRIPTION
We have that fixed since https://github.com/contour-terminal/contour/pull/431 (October 2021) - I don't see why we should `if`-guard here, either. So simply flipping the bit.