### PR TITLE
Update 001-init-notcurses.py

### DIFF
--- a/python/examples/001-init-notcurses.py
+++ b/python/examples/001-init-notcurses.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 from time import sleep
 
-from notcurses import Notcurses
+from notcurses.notcurses import Notcurses
 
 Notcurses()
 


### PR DESCRIPTION
Fix import call 

[Import call](https://github.com/dankamongmen/notcurses/blob/bc8acc661d653566dc73786eaac52cf0fe87f415/python/examples/001-init-notcurses.py#L18) was attempting to import non-existent 'Notcurses' from base package instead of the notcurses module.