### PR TITLE
Add 'effective utf8' field to ncinput struct.

### DIFF
--- a/doc/man/man3/notcurses_input.3.md
+++ b/doc/man/man3/notcurses_input.3.md
@@ -37,6 +37,7 @@ typedef struct ncinput {
   ncintype_e evtype;
   unsigned modifiers;// bitmask over NCKEY_MOD_*
   int ypx, xpx;      // pixel offsets within cell, -1 for undefined
+  char utf8_eff[5];  // Effective utf8 representation, taking modifier keys into account
 } ncinput;
 
 
@@ -241,6 +242,12 @@ When the Kitty keyboard disambiguation protocol is used, most of these
 issues are resolved. You can determine whether the protocol is in use
 by examining the output of **notcurses-info(1)**. If the **kbd** property
 is indicated, you're using the Kitty protocol.
+
+Note that utf_eff will always return the effective text value of the key,
+taking into account any meta keys pressed. (So shift-a will always return
+'A' in this field, regardless of if the Kitty keyboard disambiguation
+protocol is used.) This field generally only can be trusted on
+**NCTYPE_PRESS** and **NCTYPE_REPEAT** events, however.
 
 Mouse events in the left margins will never be delivered to the
 application (as is intended), but mouse events in the bottom and right margins

--- a/doc/man/man3/notcurses_input.3.md
+++ b/doc/man/man3/notcurses_input.3.md
@@ -37,7 +37,9 @@ typedef struct ncinput {
   ncintype_e evtype;
   unsigned modifiers;// bitmask over NCKEY_MOD_*
   int ypx, xpx;      // pixel offsets within cell, -1 for undefined
-  char utf8_eff[5];  // Effective utf8 representation, taking modifier keys into account
+  uint32_t eff_text[5];  // Effective utf32 representation, taking 
+                     // modifier keys into account. This can be multiple
+                     // codepoints. Array is zero-terminated.
 } ncinput;
 
 
@@ -243,11 +245,12 @@ issues are resolved. You can determine whether the protocol is in use
 by examining the output of **notcurses-info(1)**. If the **kbd** property
 is indicated, you're using the Kitty protocol.
 
-Note that utf_eff will always return the effective text value of the key,
+Note that eff_text will always return the effective text value of the key,
 taking into account any meta keys pressed. (So shift-a will always return
 'A' in this field, regardless of if the Kitty keyboard disambiguation
 protocol is used.) This field generally only can be trusted on
-**NCTYPE_PRESS** and **NCTYPE_REPEAT** events, however.
+**NCTYPE_PRESS** and **NCTYPE_REPEAT** events, however. Also note that 
+this is a (zero-terminated) array as it can return multiple codepoints.
 
 Mouse events in the left margins will never be delivered to the
 application (as is intended), but mouse events in the bottom and right margins

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1198,6 +1198,11 @@ typedef enum {
   NCTYPE_RELEASE,
 } ncintype_e;
 
+
+//Note: changing this also means adding kitty_cb_atxt functions in
+//in.c otherwise extra codepoints won't be picked up.
+#define NCINPUT_MAX_EFF_TEXT_CODEPOINTS 4
+
 // An input event. Cell coordinates are currently defined only for mouse
 // events. It is not guaranteed that we can set the modifiers for a given
 // ncinput. We encompass single Unicode codepoints, not complete EGCs.
@@ -1214,8 +1219,9 @@ typedef struct ncinput {
   ncintype_e evtype;
   unsigned modifiers;// bitmask over NCKEY_MOD_*
   int ypx, xpx;      // pixel offsets within cell, -1 for undefined
-  uint32_t eff_text[5];  // Effective utf32 representation, taking 
-                     // modifier keys into account. This can be multiple
+  uint32_t eff_text[NCINPUT_MAX_EFF_TEXT_CODEPOINTS];  // Effective 
+                     // utf32 representation, taking modifier 
+                     // keys into account. This can be multiple
                      // codepoints. Array is zero-terminated.
 } ncinput;
 

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1214,6 +1214,7 @@ typedef struct ncinput {
   ncintype_e evtype;
   unsigned modifiers;// bitmask over NCKEY_MOD_*
   int ypx, xpx;      // pixel offsets within cell, -1 for undefined
+  char utf8_eff[5];  // Effective utf8 representation, taking modifier keys into account
 } ncinput;
 
 static inline bool

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -1214,7 +1214,9 @@ typedef struct ncinput {
   ncintype_e evtype;
   unsigned modifiers;// bitmask over NCKEY_MOD_*
   int ypx, xpx;      // pixel offsets within cell, -1 for undefined
-  char utf8_eff[5];  // Effective utf8 representation, taking modifier keys into account
+  uint32_t eff_text[5];  // Effective utf32 representation, taking 
+                     // modifier keys into account. This can be multiple
+                     // codepoints. Array is zero-terminated.
 } ncinput;
 
 static inline bool

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -832,7 +832,7 @@ kitty_kbd_txt(inputctx* ictx, int val, int mods, uint32_t *txt, int evtype){
   }
   //note: if we don't set eff_text here, it will be set to .id later.
   if(txt && txt[0]!=0){
-    for(int i=0 ; i<4 ; i++){
+    for(int i=0 ; i<NCINPUT_MAX_EFF_TEXT_CODEPOINTS ; i++){
       tni.eff_text[i] = txt[i];
     }
   }

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -401,7 +401,12 @@ bool ncreader_offer_input(ncreader* n, const ncinput* ni){
     return false;
   }
 
-  ncreader_write_egc(n, ni->utf8_eff);
+  for (int c=0; ni->eff_text[c]!=0; c++){
+    unsigned char egc[5]={0};
+    if(notcurses_ucs32_to_utf8(&ni->eff_text[c], 1, egc, 4)>=0){
+      ncreader_write_egc(n, (char*)egc);
+    }
+  }
   return true;
 }
 

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -400,12 +400,8 @@ bool ncreader_offer_input(ncreader* n, const ncinput* ni){
   }else if(nckey_synthesized_p(ni->id)){
     return false;
   }
-  // FIXME need to collect full EGCs
-  char wbuf[WCHAR_MAX_UTF8BYTES + 1];
-  // FIXME breaks for wint_t < 32bits
-  if(snprintf(wbuf, sizeof(wbuf), "%lc", (wint_t)ni->id) < (int)sizeof(wbuf)){
-    ncreader_write_egc(n, wbuf);
-  }
+
+  ncreader_write_egc(n, ni->utf8_eff);
   return true;
 }
 

--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -351,9 +351,9 @@ init_terminfo_esc(tinfo* ti, const char* name, escape_e idx,
 #define KITTYQUERY
 #endif
 
-// request kitty keyboard protocol features 1, 2, and 8, first pushing current.
+// request kitty keyboard protocol features 1, 2, 8 and 16, first pushing current.
 // see https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement
-#define KKBDSUPPORT "\x1b[=11u"
+#define KKBDSUPPORT "\x1b[=27u"
 
 // the kitty keyboard protocol allows unambiguous, complete identification of
 // input events. this queries for the level of support. we want to do this


### PR DESCRIPTION
Proposed fix for https://github.com/dankamongmen/notcurses/issues/2695 . This code adds an utf8_eff field to the ncinput struct; it gets filled with the 'effective' keypress value, that is, the UTF8 that the keypress generates with all the meta keys taken into consideration.

Looking at the 'reader' widget, it uses the the ncinput.utf8 for this, and for non-Kitty-keyboard-disambiguation terminals, it effectively acts like this. However, the docs imply that this is non-intentional and simply a result of other terminals not returning the 'base' key, so notcurses cannot know what that was. 

As such, I decided to add an extra member to the ncinput struct rather than re-using the ncinput.utf8 field. The extra advantage is that this is backwards compatible with any other program as the meaning of existing fields stays the same.