### PR TITLE
Speed up startup that got slow since #2696

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -361,6 +361,16 @@ int input_demo(ncpp::NotCurses* nc) {
         n->printf("Unicode: [0x%08x] '%s'", r, ni.utf8);
       }
     }
+    if(ni.eff_text[0] != ni.id || ni.eff_text[1] != 0){
+      n->printf(" effective text '");
+      for (int c=0; ni.eff_text[c]!=0; c++){
+        unsigned char egc[5]={0};
+        if(notcurses_ucs32_to_utf8(&ni.eff_text[c], 1, egc, 4)>=0){
+          n->printf("%s", egc);
+        }
+      }
+      n->printf("'");
+    }
     unsigned x;
     n->get_cursor_yx(nullptr, &x);
     for(unsigned i = x ; i < n->get_dim_x() ; ++i){


### PR DESCRIPTION
#2696 added a bunch of numeric fields to the input automaton, greatly slowing down startup times of any notcurses program. This is mostly because numeric fields aren't handled optimally in the automaton: on creation, a lot of links are created from one trie node via the digits 0-9 to another one. When appending more patterns, the automaton creation logic takes each of these digit links as an individual path that should be followed recursively, which greatly increases processing time. This patch makes the logic recognize this and skips following a path if it is the same as the path followed before.

To illustrate, the times on my laptop to run notcurses-info are as following:
Master, before #2696: 0m0.031s                                                                                 
Master, after #2696: 0m1.001s                                                                                      
After this patch: 0m0.034s  

Closes #2697