### PR TITLE
Add dependency on libavdevice

### DIFF
--- a/.github/workflows/macos_test.yml
+++ b/.github/workflows/macos_test.yml
@@ -26,7 +26,8 @@ jobs:
             ffmpeg \
             libdeflate \
             libunistring \
-            ncurses
+            ncurses \
+            pkg-config
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ubuntu_test.yml
+++ b/.github/workflows/ubuntu_test.yml
@@ -28,6 +28,7 @@ jobs:
             ffmpeg \
             libavcodec-dev \
             libavformat-dev \
+            libavdevice-dev \
             libavutil-dev \
             libdeflate-dev \
             libncurses-dev \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ set_package_properties(terminfo PROPERTIES TYPE REQUIRED)
 set(PKGCONF_REQ_PRIV "${TERMINFO_LIBRARIES}")
 if(${USE_FFMPEG})
 pkg_check_modules(AVCODEC REQUIRED libavcodec>=57.0)
+pkg_check_modules(AVDEVICE REQUIRED libavdevice>=57.0)
 pkg_check_modules(AVFORMAT REQUIRED libavformat>=57.0)
 pkg_check_modules(AVUTIL REQUIRED libavutil>=56.0)
 pkg_check_modules(SWSCALE REQUIRED libswscale>=5.0)
@@ -362,6 +363,7 @@ if(${USE_FFMPEG})
 target_include_directories(notcurses
   PRIVATE
     "${AVCODEC_INCLUDE_DIRS}"
+    "${AVDEVICE_INCLUDE_DIRS}"
     "${AVFORMAT_INCLUDE_DIRS}"
     "${AVUTIL_INCLUDE_DIRS}"
     "${SWSCALE_INCLUDE_DIRS}"
@@ -369,6 +371,7 @@ target_include_directories(notcurses
 target_include_directories(notcurses-static
   PRIVATE
     "${AVCODEC_STATIC_INCLUDE_DIRS}"
+    "${AVDEVICE_STATIC_INCLUDE_DIRS}"
     "${AVFORMAT_STATIC_INCLUDE_DIRS}"
     "${AVUTIL_STATIC_INCLUDE_DIRS}"
     "${SWSCALE_STATIC_INCLUDE_DIRS}"
@@ -376,6 +379,7 @@ target_include_directories(notcurses-static
 target_link_libraries(notcurses
   PRIVATE
     "${AVCODEC_LIBRARIES}"
+    "${AVDEVICE_LIBRARIES}"
     "${AVFORMAT_LIBRARIES}"
     "${SWSCALE_LIBRARIES}"
     "${AVUTIL_LIBRARIES}"
@@ -383,6 +387,7 @@ target_link_libraries(notcurses
 target_link_libraries(notcurses-static
   PRIVATE
     "${AVCODEC_STATIC_LIBRARIES}"
+    "${AVDEVICE_STATIC_LIBRARIES}"
     "${AVFORMAT_STATIC_LIBRARIES}"
     "${SWSCALE_STATIC_LIBRARIES}"
     "${AVUTIL_STATIC_LIBRARIES}"
@@ -390,6 +395,7 @@ target_link_libraries(notcurses-static
 target_link_directories(notcurses
   PRIVATE
     "${AVCODEC_LIBRARY_DIRS}"
+    "${AVDEVICE_LIBRARY_DIRS}"
     "${AVFORMAT_LIBRARY_DIRS}"
     "${SWSCALE_LIBRARY_DIRS}"
     "${AVUTIL_LIBRARY_DIRS}"
@@ -397,6 +403,7 @@ target_link_directories(notcurses
 target_link_directories(notcurses-static
   PRIVATE
     "${AVCODEC_STATIC_LIBRARY_DIRS}"
+    "${AVDEVICE_STATIC_LIBRARY_DIRS}"
     "${AVFORMAT_STATIC_LIBRARY_DIRS}"
     "${SWSCALE_STATIC_LIBRARY_DIRS}"
     "${AVUTIL_STATIC_LIBRARY_DIRS}"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,13 +16,13 @@ There are no submodules. Dependencies are fairly minimal.
 
 Install build dependencies:
 
-`apt-get install build-essential cmake doctest-dev libavformat-dev libavutil-dev libdeflate-dev libgpm-dev libncurses-dev libqrcodegen-dev libswscale-dev libunistring-dev pandoc pkg-config`
+`apt-get install build-essential cmake doctest-dev libavformat-dev libavdevice-dev libavutil-dev libdeflate-dev libgpm-dev libncurses-dev libqrcodegen-dev libswscale-dev libunistring-dev pandoc pkg-config`
 
-If you only intend to build core Notcurses (without multimedia support), you
-can omit `libavformat-dev`, `libavutil-dev`, and `libswscale-dev` from this
-list. `zlib1g-dev` can be substituted for `libdeflate-dev`; build with
-`-DUSE_DEFLATE=off` in this case. If you don't want to generate QR codes, you can
-omit 'libqrcodegen-dev'.
+If you only intend to build core Notcurses (without multimedia support), you can
+omit `libavformat-dev`, `libavdevice-dev`, `libavutil-dev`, and `libswscale-dev`
+from this list. `zlib1g-dev` can be substituted for `libdeflate-dev`; build with
+`-DUSE_DEFLATE=off` in this case. If you don't want to generate QR codes, you
+can omit 'libqrcodegen-dev'.
 
 If you want to build the Python wrappers, you'll also need:
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ may well be possible to use still older versions. Let me know of any successes!
 * (build+runtime) GNU [libunistring](https://www.gnu.org/software/libunistring/) 0.9.10+
 * (OPTIONAL) (build+runtime) [libgpm](https://www.nico.schottelius.org/software/gpm/) 1.20+
 * (OPTIONAL) (build+runtime) From QR-Code-generator: [libqrcodegen](https://github.com/nayuki/QR-Code-generator) 1.5.0+
-* (OPTIONAL) (build+runtime) From [FFmpeg](https://www.ffmpeg.org/): libswscale 5.0+, libavformat 57.0+, libavutil 56.0+
+* (OPTIONAL) (build+runtime) From [FFmpeg](https://www.ffmpeg.org/): libswscale 5.0+, libavformat 57.0+, libavutil 56.0+, libavdevice 57.0+
 * (OPTIONAL) (build+runtime) [OpenImageIO](https://github.com/OpenImageIO/oiio) 2.15.0+, requires C++
 * (OPTIONAL) (testing) [Doctest](https://github.com/onqtam/doctest) 2.3.5+
 * (OPTIONAL) (documentation) [pandoc](https://pandoc.org/index.html) 1.19.2+

--- a/doc/man/man3/notcurses_visual.3.md
+++ b/doc/man/man3/notcurses_visual.3.md
@@ -132,6 +132,8 @@ If Notcurses was built against a multimedia engine (FFMpeg or OpenImageIO),
 image and video files can be loaded into visuals using
 **ncvisual_from_file**. **ncvisual_from_file** discovers the container
 and codecs, but does not verify that the entire file is well-formed.
+If Notcurses was built against FFMpeg, **ncvisual_from_file** can also handle
+multimedia devices such as webcams.
 **ncvisual_decode** ought be invoked to recover subsequent frames, once
 per frame. **ncvisual_decode_loop** will return to the first frame,
 as if **ncvisual_decode** had never been called.

--- a/src/media/ffmpeg.c
+++ b/src/media/ffmpeg.c
@@ -9,6 +9,7 @@
 #include <libavutil/rational.h>
 #include <libswscale/swscale.h>
 #include <libswscale/version.h>
+#include <libavdevice/avdevice.h>
 #include <libavformat/version.h>
 #include <libavformat/avformat.h>
 #include "lib/visual-details.h"
@@ -691,17 +692,19 @@ ffmpeg_log_level(int level){
 static int
 ffmpeg_init(int logl){
   av_log_set_level(ffmpeg_log_level(logl));
+  avdevice_register_all();
   // FIXME could also use av_log_set_callback() and capture the message...
   return 0;
 }
 
 static void
 ffmpeg_printbanner(fbuf* f){
-  fbuf_printf(f, "avformat %u.%u.%u avutil %u.%u.%u swscale %u.%u.%u avcodec %u.%u.%u" NL,
+  fbuf_printf(f, "avformat %u.%u.%u avutil %u.%u.%u swscale %u.%u.%u avcodec %u.%u.%u avdevice %u.%u.%u" NL,
               LIBAVFORMAT_VERSION_MAJOR, LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO,
               LIBAVUTIL_VERSION_MAJOR, LIBAVUTIL_VERSION_MINOR, LIBAVUTIL_VERSION_MICRO,
               LIBSWSCALE_VERSION_MAJOR, LIBSWSCALE_VERSION_MINOR, LIBSWSCALE_VERSION_MICRO,
-              LIBAVCODEC_VERSION_MAJOR, LIBAVCODEC_VERSION_MINOR, LIBAVCODEC_VERSION_MICRO);
+              LIBAVCODEC_VERSION_MAJOR, LIBAVCODEC_VERSION_MINOR, LIBAVCODEC_VERSION_MICRO,
+              LIBAVDEVICE_VERSION_MAJOR, LIBAVDEVICE_VERSION_MINOR, LIBAVDEVICE_VERSION_MICRO);
 }
 
 static void


### PR DESCRIPTION
Thanks to adding a call to `avdevice_register_all()`, ncvisuals for e.g. v4l2 device "/dev/video0" allow me to have my ugly mug looking right back at me from my terminal; that is to say, this adds webcam support to notcurses visuals.

If you'd rather not add another dependency to notcurses when building with multimedia support, then a note for anybody else who wishes to use a webcam: merely calling libavdevice's `avdevice_register_all()` once in your program, sometime before creating the ncvisual, will still allow this to work.

Pro: webcam support
Con: banner line now awkwardly longer than other lines in notcurses-info.