### PR TITLE
Add missing inttypes.h

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -35,6 +35,9 @@ extern "C" {
 #include <wctype.h>
 #include <pthread.h>
 #include <stdbool.h>
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 #include <unictype.h>
 #ifndef __MINGW32__


### PR DESCRIPTION
This fixes the build with GCC on macOS, and potentially on some other configurations.