### PR TITLE
Workaround kitty F3 issue

### DIFF
--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -592,6 +592,17 @@ ncchannels_set_bg_default(uint64_t* channels){
 // 0x0--0x10ffff can be UTF-8-encoded with only 4 bytes
 #define WCHAR_MAX_UTF8BYTES 4
 
+// Calculate the length and width of the next EGC in the UTF-8 string input.
+// We use libunistring's uc_is_grapheme_break() to segment EGCs. Writes the
+// number of columns to '*colcount'. Returns the number of bytes consumed,
+// not including any NUL terminator. Neither the number of bytes nor columns
+// is necessarily equal to the number of decoded code points. Such are the
+// ways of Unicode. uc_is_grapheme_break() wants UTF-32, which is fine, because
+// we need wchar_t to use wcwidth() anyway FIXME except this doesn't work with
+// 16-bit wchar_t!
+API int ncegc_len(const char* gcluster, int* colcount)
+  __attribute__ ((nonnull (1)));
+
 // Returns the number of columns occupied by the longest valid prefix of a
 // multibyte (UTF-8) string. If an invalid character is encountered, -1 will be
 // returned, and the number of valid bytes and columns will be written into

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -567,19 +567,6 @@ pixelmouse_click(inputctx* ictx, ncinput* ni, long y, long x){
   x /= ictx->ti->cellpxx;
   x -= ictx->lmargin;
   y -= ictx->tmargin;
-  // convert from 1- to 0-indexing, and account for margins
-  if(x < 0 || y < 0){ // click was in margins, drop it
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
-  if((unsigned)x >= ictx->ti->dimx - (ictx->rmargin + ictx->lmargin)){
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
-  if((unsigned)y >= ictx->ti->dimy - (ictx->bmargin + ictx->tmargin)){
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
   ni->y = y;
   ni->x = x;
   load_ncinput(ictx, ni);
@@ -631,19 +618,6 @@ mouse_click(inputctx* ictx, unsigned release, char follow){
   }
   x -= (1 + ictx->lmargin);
   y -= (1 + ictx->tmargin);
-  // convert from 1- to 0-indexing, and account for margins
-  if(x < 0 || y < 0){ // click was in margins, drop it
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
-  if((unsigned)x >= ictx->ti->dimx - (ictx->rmargin + ictx->lmargin)){
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
-  if((unsigned)y >= ictx->ti->dimy - (ictx->bmargin + ictx->tmargin)){
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
   tni.x = x;
   tni.y = y;
   tni.ypx = -1;

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -956,6 +956,10 @@ kitty_cb_functional(inputctx* ictx){
   unsigned val = amata_next_numeric(&ictx->amata, "\x1b[", ';');
   unsigned mods = amata_next_numeric(&ictx->amata, "", ':');
   unsigned ev = amata_next_numeric(&ictx->amata, "", '~');
+  if(val == 13) {
+    kitty_kbd(ictx, NCKEY_F03, mods, ev);
+    return 23;
+  }
   uint32_t kval = kitty_functional(val);
   if(kval == val){
     kval = legacy_functional(val);
@@ -1015,6 +1019,13 @@ kitty_cb_f3(inputctx* ictx){
   unsigned mods = amata_next_numeric(&ictx->amata, "\x1b[1;", ':');
   unsigned ev = amata_next_numeric(&ictx->amata, "", 'R');
   kitty_kbd(ictx, NCKEY_F03, mods, ev);
+  return 2;
+}
+
+static int
+kitty_cb_f3_alternate(inputctx* ictx){
+  amata_next_numeric(&ictx->amata, "\x1b[", '~');
+  kitty_kbd(ictx, NCKEY_F03, 1, 0);
   return 2;
 }
 
@@ -1771,6 +1782,7 @@ build_cflow_automaton(inputctx* ictx){
     // technically these must begin with "4" or "8"; enforce in callbacks
     { "[\\N;\\N;\\Nt", geom_cb, },
     { "[\\Nu", kitty_cb_simple, },
+    { "[13~", kitty_cb_f3_alternate, },
     { "[\\N;\\N~", wezterm_cb, },
     { "[\\N;\\Nu", kitty_cb, },
     { "[\\N;\\N;\\Nu", kitty_cb_atxt1, },
@@ -2052,6 +2064,7 @@ prep_kitty_special_keys(inputctx* ictx){
     { .esc = "\x1b[P", .key = NCKEY_F01, },
     { .esc = "\x1b[Q", .key = NCKEY_F02, },
     { .esc = "\x1b[R", .key = NCKEY_F03, },
+    { .esc = "\x1b[13~", .key = NCKEY_F03, },
     { .esc = "\x1b[S", .key = NCKEY_F04, },
     { .esc = "\x1b[127;2u", .key = NCKEY_BACKSPACE,
       .modifiers = NCKEY_MOD_SHIFT, },

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1779,6 +1779,12 @@ build_cflow_automaton(inputctx* ictx){
     { "[E", simple_cb_begin, },
     { "[<\\N;\\N;\\NM", mouse_press_cb, },
     { "[<\\N;\\N;\\Nm", mouse_release_cb, },
+    { "[<\\N;-\\N;\\NM", mouse_press_cb, },
+    { "[<\\N;-\\N;\\Nm", mouse_release_cb, },
+    { "[<\\N;\\N;-\\NM", mouse_press_cb, },
+    { "[<\\N;\\N;-\\Nm", mouse_release_cb, },
+    { "[<\\N;-\\N;-\\NM", mouse_press_cb, },
+    { "[<\\N;-\\N;-\\Nm", mouse_release_cb, },
     // technically these must begin with "4" or "8"; enforce in callbacks
     { "[\\N;\\N;\\Nt", geom_cb, },
     { "[\\Nu", kitty_cb_simple, },

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -3269,6 +3269,10 @@ int ncplane_putwstr_stained(ncplane* n, const wchar_t* gclustarr){
   return r;
 }
 
+int ncegc_len(const char* gcluster, int* colcount){
+  return utf8_egc_len(gcluster, colcount);
+}
+
 int notcurses_ucs32_to_utf8(const uint32_t* ucs32, unsigned ucs32count,
                             unsigned char* resultbuf, size_t buflen){
   if(u32_to_u8(ucs32, ucs32count, resultbuf, &buflen) == NULL){

--- a/src/lib/render.c
+++ b/src/lib/render.c
@@ -713,15 +713,15 @@ term_bg_rgb8(const tinfo* ti, fbuf* f, unsigned r, unsigned g, unsigned b){
   // we're also in that case working with hopefully more robust terminals.
   // If it doesn't work, eh, it doesn't work. Fuck the world; save yourself.
   if(ti->caps.rgb){
-    if((ti->bg_collides_default & 0xff000000) == 0x01000000){
-      if((r == ncchannel_r(ti->bg_collides_default)) &&
-         (g == ncchannel_g(ti->bg_collides_default)) &&
-         (b == ncchannel_b(ti->bg_collides_default))){
-        // the human eye has fewer blue cones than red or green. toggle
-        // the last bit in the blue component to avoid a collision.
-        b ^= 0x00000001;
-      }
-    }
+  //if((ti->bg_collides_default & 0xff000000) == 0x01000000){
+  //  if((r == ncchannel_r(ti->bg_collides_default)) &&
+  //     (g == ncchannel_g(ti->bg_collides_default)) &&
+  //     (b == ncchannel_b(ti->bg_collides_default))){
+  //    // the human eye has fewer blue cones than red or green. toggle
+  //    // the last bit in the blue component to avoid a collision.
+  //    b ^= 0x00000001;
+  //  }
+  //}
     return term_esc_rgb(f, false, r, g, b);
   }else{
     const char* setab = get_escape(ti, ESCAPE_SETAB);


### PR DESCRIPTION
Notcurses does not recognize the F3 key correctly in kitty (and ghostty, maybe others?).

These are some workarounds I've had lying around in my local tree for a few months that resolve the issue for me. Really, really not sure about the quality and/or correctness of these fixes though. I have not spent too much time looking at the inner workings of the notcurses input layer and these changes are just enough to get it working for me.

Comments are very welcome.