### PR TITLE
Allow mouse coordinate updates outside of terminal window

### DIFF
--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -567,19 +567,6 @@ pixelmouse_click(inputctx* ictx, ncinput* ni, long y, long x){
   x /= ictx->ti->cellpxx;
   x -= ictx->lmargin;
   y -= ictx->tmargin;
-  // convert from 1- to 0-indexing, and account for margins
-  if(x < 0 || y < 0){ // click was in margins, drop it
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
-  if((unsigned)x >= ictx->ti->dimx - (ictx->rmargin + ictx->lmargin)){
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
-  if((unsigned)y >= ictx->ti->dimy - (ictx->bmargin + ictx->tmargin)){
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
   ni->y = y;
   ni->x = x;
   load_ncinput(ictx, ni);
@@ -631,19 +618,6 @@ mouse_click(inputctx* ictx, unsigned release, char follow){
   }
   x -= (1 + ictx->lmargin);
   y -= (1 + ictx->tmargin);
-  // convert from 1- to 0-indexing, and account for margins
-  if(x < 0 || y < 0){ // click was in margins, drop it
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
-  if((unsigned)x >= ictx->ti->dimx - (ictx->rmargin + ictx->lmargin)){
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
-  if((unsigned)y >= ictx->ti->dimy - (ictx->bmargin + ictx->tmargin)){
-    logwarn("dropping click in margins %ld/%ld", y, x);
-    return;
-  }
   tni.x = x;
   tni.y = y;
   tni.ypx = -1;

--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1768,6 +1768,12 @@ build_cflow_automaton(inputctx* ictx){
     { "[E", simple_cb_begin, },
     { "[<\\N;\\N;\\NM", mouse_press_cb, },
     { "[<\\N;\\N;\\Nm", mouse_release_cb, },
+    { "[<\\N;-\\N;\\NM", mouse_press_cb, },
+    { "[<\\N;-\\N;\\Nm", mouse_release_cb, },
+    { "[<\\N;\\N;-\\NM", mouse_press_cb, },
+    { "[<\\N;\\N;-\\Nm", mouse_release_cb, },
+    { "[<\\N;-\\N;-\\NM", mouse_press_cb, },
+    { "[<\\N;-\\N;-\\Nm", mouse_release_cb, },
     // technically these must begin with "4" or "8"; enforce in callbacks
     { "[\\N;\\N;\\Nt", geom_cb, },
     { "[\\Nu", kitty_cb_simple, },


### PR DESCRIPTION
Most terminals send mouse updates even when the cursor is outside of the terminal window if a button is pressed. This makes dragging operations potentially much easier for the user because they are not required keep the mouse cursor precisely inside the window while dragging.

For example, when dragging a scrollbar it may be easy click intially, but quite difficult to drag without touching the edge of the terminal window.

These two commit fix related issues in notcurses.

Comments very welcome.