### PR TITLE
Enable detecting SyncTERM DA1 response.

### DIFF
--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1842,7 +1842,7 @@ build_cflow_automaton(inputctx* ictx){
     { "[?2;0;\\N;\\NS", xtsmgraphics_sixel_cb, },
     { "[>83;\\N;0c", da2_screen_cb, },
     { "[>\\N;\\N;\\Nc", da2_cb, },
-    { "[=\\N;\\Dc", da1_syncterm_cb, }, // CSI da1 form as issued by SyncTERM
+    { "[=67;84;101;114;109;\\Dc", da1_syncterm_cb, }, // CSI da1 form as issued by SyncTERM
     // DCS (\eP...ST)
     { "P0+\\S", NULL, }, // negative XTGETTCAP
     { "P1+r\\S", tcap_cb, }, // positive XTGETTCAP


### PR DESCRIPTION
SyncTERM sends CSI = Pn c not CSI ? Pn c like VT terminals. This results in notcurses hanging in init.

This required WezTerm da3 support to be removed, because the SyncTERM and WezTerm responses could not both exist in the automaton.  As it turns out, a dig through the WezTerm git history shows that it never actually sent CSI = ... ST in response to DA3, and notcurses took no actions in response to it, so it should be safe to remove this feature.