### PR TITLE
Improved overflow checker code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,12 +584,6 @@ target_compile_definitions(notcurses++-static
     ${NCPP_COMPILE_DEFINITIONS_PUBLIC}
 )
 
-file(GLOB NOTCURSES_HEADERS
-  CONFIGURE_DEPENDS
-  LIST_DIRECTORIES false
-  ${PROJECT_SOURCE_DIR}/include/notcurses/*.h
-  ${CMAKE_CURRENT_BINARY_DIR}/include/version.h)
-
 file(GLOB NCPP_HEADERS
   CONFIGURE_DEPENDS
   LIST_DIRECTORIES false
@@ -599,13 +593,19 @@ file(GLOB NCPP_INTERNAL_HEADERS
   CONFIGURE_DEPENDS
   LIST_DIRECTORIES false
   ${PROJECT_SOURCE_DIR}/include/ncpp/internal/*.hh)
+
+install(FILES ${NCPP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ncpp)
+install(FILES ${NCPP_INTERNAL_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ncpp/internal)
 endif()
 
 export(PACKAGE notcurses)
 
+file(GLOB NOTCURSES_HEADERS
+  CONFIGURE_DEPENDS
+  LIST_DIRECTORIES false
+  ${PROJECT_SOURCE_DIR}/include/notcurses/*.h
+  ${CMAKE_CURRENT_BINARY_DIR}/include/version.h)
 install(FILES ${NOTCURSES_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/notcurses)
-install(FILES ${NCPP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ncpp)
-install(FILES ${NCPP_INTERNAL_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ncpp/internal)
 
 # tiny proofs of concept, one binary per source file
 if(USE_POC)
@@ -1021,11 +1021,12 @@ configure_file(tools/notcurses-ffi.pc.in
   @ONLY
 )
 endif()
-configure_file(tools/notcurses++.pc.in
+if(${USE_CXX})
+   configure_file(tools/notcurses++.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/notcurses++.pc
   @ONLY
 )
-
+endif()
 include(CMakePackageConfigHelpers)
 configure_file(tools/version.h.in include/version.h)
 configure_file(tools/builddef.h.in include/builddef.h)
@@ -1050,6 +1051,7 @@ write_basic_package_version_file(
   COMPATIBILITY SameMajorVersion
 )
 
+if(${USE_CXX})
 configure_package_config_file(tools/Notcurses++Config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/Notcurses++Config.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses++
@@ -1059,6 +1061,7 @@ write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/Notcurses++ConfigVersion.cmake
   COMPATIBILITY SameMajorVersion
 )
+endif()
 
 # Installation
 install(FILES
@@ -1073,11 +1076,13 @@ install(FILES
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses"
 )
 
+if(${USE_CXX})
 install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/Notcurses++Config.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/Notcurses++ConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses++"
 )
+endif()
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/notcurses-core.pc
@@ -1096,10 +1101,12 @@ install(FILES
 )
 endif()
 
+if(${USE_CXX})
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/notcurses++.pc
   DESTINATION ${PKGCONFIG_DIR}
 )
+endif()
 
 if(NOT ${USE_MULTIMEDIA} STREQUAL "none")
 file(GLOB TESTDATA CONFIGURE_DEPENDS data/*)

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -533,29 +533,15 @@ make_ncpile(notcurses* nc, ncplane* n){
 }
 
 
-static inline size_t  ncplane_sizeof_cellarray( unsigned rows, unsigned cols)
+static inline size_t  ncplane_sizeof_cellarray( size_t rows, size_t cols)
 {
-  size_t fbsize;
-  size_t size;
-
-  // (nat) This protects against size_t overflow and also checks
-  // that dimensions are not zero en-passant. Why ?
-  // Assume: size_t is 16 bit, unsigned is 8 bit (UINT_MAX: 0xFF)
-  // nccell is sizeof( *p->fb): 0x10 (128 bit)
-  //
-  // 0xFF * 0xFF * 0x10 = 0xFE010, but overflows so: 0xE010
-  // 0x3F * 0x3F * 0x10 = 0xf810 is the biggest square possible
-
-  size = (size_t) cols * (size_t) rows;
-  if( size < (size_t) cols || size < (size_t) rows)
+  // check if multiplication would overflow
+  // calloc will deal with overflow due to sizeof(nccell)
+  if( ! rows || (cols > SIZE_MAX / rows)) 
     return 0;
-
-  fbsize = sizeof( struct nccell) * size;
-  if( fbsize <= size)
-    return 0;
-
-  return fbsize;
+  return rows * cols;
 }
+
 // create a new ncplane at the specified location (relative to the true screen,
 // having origin at 0,0), having the specified size, and put it at the top of
 // the planestack. its cursor starts at its origin; its style starts as null.
@@ -615,8 +601,8 @@ ncplane* ncplane_new_internal(notcurses* nc, ncplane* n,
     p->lenx = nopts->cols;
   }
 
-  size_t fbsize = ncplane_sizeof_cellarray( p->leny, p->lenx);
-  if( ! fbsize || (p->fb = calloc(1,fbsize)) == NULL){
+  size_t fbsize = ncplane_sizeof_cellarray(p->leny, p->lenx);
+  if(!fbsize || (p->fb = calloc(sizeof(struct nccell),fbsize)) == NULL){
     logerror("error allocating cellmatrix (r=%u, c=%u)",
              p->leny, p->lenx);
     free(p);


### PR DESCRIPTION
I think you will like this much better. The other code was more or less a mitigation but this should be a better overflow checker. The multiplication does the zero check and the comparison checks that the multiplication doesn't overflow. `calloc` will then do the other overflow check.