### PR TITLE
[macos] export PKG_CONFIG_PATH for cmake

### DIFF
--- a/.github/workflows/macos_test.yml
+++ b/.github/workflows/macos_test.yml
@@ -34,6 +34,7 @@ jobs:
       - name: cmake
         run: |
           mkdir build && cd build
+          env PKG_CONFIG_PATH="/opt/homebrew/opt/ncurses/lib/pkgconfig" \
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
             -DUSE_PANDOC=off

--- a/src/lib/tree.c
+++ b/src/lib/tree.c
@@ -165,7 +165,6 @@ static int
 nctree_add_internal(nctree* n, nctree_int_item* nii, const unsigned* spec,
                     const struct nctree_item* add){
   const unsigned* p = spec;
-  unsigned depth = 0;
   while(p[1] != UINT_MAX){ // we know p[0] isn't UINT_MAX
     if(*p >= nii->subcount){
       logerror("invalid path element (%u >= %u)", *p, nii->subcount);
@@ -173,7 +172,6 @@ nctree_add_internal(nctree* n, nctree_int_item* nii, const unsigned* spec,
     }
     nii = &nii->subs[*p];
     ++p;
-    ++depth;
   }
   // we're at the node into which |add| ought be inserted
   // this last one can be equal to subcount; we're placing it at the end


### PR DESCRIPTION
The macos build is blowing up due to not being able to find ncurses.