### PR TITLE
fix incorrect state reset after carriage return command

### DIFF
--- a/src/lib/sixel.h
+++ b/src/lib/sixel.h
@@ -153,7 +153,7 @@ uint32_t* ncsixel_as_rgba(const char *sx, unsigned leny, unsigned lenx){
         --sx;
       }else if(*sx == '$'){
         x = 0;
-        state = STATE_WANT_HASH;
+        state = STATE_WANT_DATA;
       }else if(*sx == '-'){
         x = 0;
         y += 6;


### PR DESCRIPTION
i ran into an issue with `ncsixel_as_rgba` where it always failed with sixel images exceeding 13 pixels in height

the cause of the issue seems to be

```
}else if(*sx == '$'){
  x = 0;
  state = STATE_WANT_HASH;
```

this prevents sixel images from being correctly parsed -- i haven't investigated what the sixel standard says about this, but `img2sixel` outputs don't follow carriage returns with a hash, just more data

changing `STATE_WANT_HASH` to `STATE_WANT_DATA` resolved the issue

in any case, i don't think this change is likely to break anything:

```
if(state == STATE_WANT_DATA){
  if(*sx == '#'){
    state = STATE_WANT_HASH;
    --sx;
```

as if a hash is encountered, it will just decrement the pointer and set the state to `STATE_WANT_HASH`