### PR TITLE
cmake: export targets in config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ file(GLOB COMPATSRC CONFIGURE_DEPENDS src/compat/*.c)
 # libnotcurses-core (core shared library, core static library)
 file(GLOB NCCORESRCS CONFIGURE_DEPENDS src/lib/*.c)
 add_library(notcurses-core SHARED ${NCCORESRCS} ${COMPATSRC})
+add_library(Notcurses::NotcursesCore ALIAS notcurses-core)
 if(${USE_STATIC})
 add_library(notcurses-core-static STATIC ${NCCORESRCS} ${COMPATSRC})
 else()
@@ -243,6 +244,7 @@ endif()
 set_target_properties(notcurses-core PROPERTIES
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR}
+  EXPORT_NAME NotcursesCore
 )
 set_target_properties(notcurses-core-static PROPERTIES
   VERSION ${PROJECT_VERSION}
@@ -250,6 +252,8 @@ set_target_properties(notcurses-core-static PROPERTIES
 )
 target_include_directories(notcurses-core
   BEFORE
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
   PRIVATE
     include
     src
@@ -314,6 +318,7 @@ endif()
 # libnotcurses (multimedia shared library+static library)
 file(GLOB NCSRCS CONFIGURE_DEPENDS src/media/*.c src/media/*.cpp)
 add_library(notcurses SHARED ${NCSRCS} ${COMPATSRC})
+add_library(Notcurses::Notcurses ALIAS notcurses)
 if(${USE_STATIC})
 add_library(notcurses-static STATIC ${NCSRCS} ${COMPATSRC})
 else()
@@ -322,6 +327,7 @@ endif()
 set_target_properties(notcurses PROPERTIES
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR}
+  EXPORT_NAME Notcurses
 )
 set_target_properties(notcurses-static PROPERTIES
   VERSION ${PROJECT_VERSION}
@@ -329,6 +335,8 @@ set_target_properties(notcurses-static PROPERTIES
 )
 target_include_directories(notcurses
   BEFORE
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
   PRIVATE
     include
     src
@@ -492,6 +500,7 @@ set(NCPP_SOURCES
   )
 
 add_library(notcurses++ SHARED ${NCPP_SOURCES})
+add_library(Notcurses::Notcurses++ ALIAS notcurses++)
 if(${USE_STATIC})
 add_library(notcurses++-static STATIC ${NCPP_SOURCES})
 else()
@@ -506,7 +515,9 @@ set_target_properties(
   notcurses++ PROPERTIES
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR}
-  OUTPUT_NAME "notcurses++")
+  OUTPUT_NAME "notcurses++"
+  EXPORT_NAME Notcurses++
+)
 
 set(NCPP_INCLUDE_DIRS
     "include"
@@ -517,6 +528,8 @@ set(NCPP_INCLUDE_DIRS
 
 target_include_directories(notcurses++
   BEFORE
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
   PRIVATE ${NCPP_INCLUDE_DIRS}
   )
 
@@ -600,8 +613,6 @@ file(GLOB NCPP_INTERNAL_HEADERS
   CONFIGURE_DEPENDS
   LIST_DIRECTORIES false
   ${PROJECT_SOURCE_DIR}/include/ncpp/internal/*.hh)
-
-export(PACKAGE notcurses)
 
 install(FILES ${NOTCURSES_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/notcurses)
 install(FILES ${NCPP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ncpp)
@@ -1029,33 +1040,19 @@ configure_file(tools/notcurses++.pc.in
   @ONLY
 )
 
-include(CMakePackageConfigHelpers)
 configure_file(tools/version.h.in include/version.h)
 configure_file(tools/builddef.h.in include/builddef.h)
 
-configure_package_config_file(tools/NotcursesConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfig.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses
-)
+include(CMakePackageConfigHelpers)
 
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/NotcursesCoreConfigVersion.cmake
   COMPATIBILITY SameMajorVersion
 )
 
-configure_package_config_file(tools/NotcursesCoreConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/NotcursesCoreConfig.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/NotcursesCore
-)
-
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfigVersion.cmake
   COMPATIBILITY SameMajorVersion
-)
-
-configure_package_config_file(tools/Notcurses++Config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/Notcurses++Config.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses++
 )
 
 write_basic_package_version_file(
@@ -1065,19 +1062,19 @@ write_basic_package_version_file(
 
 # Installation
 install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/NotcursesCoreConfig.cmake"
+  tools/NotcursesCoreConfig.cmake
   "${CMAKE_CURRENT_BINARY_DIR}/NotcursesCoreConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/NotcursesCore"
 )
 
 install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfig.cmake"
+  tools/NotcursesConfig.cmake
   "${CMAKE_CURRENT_BINARY_DIR}/NotcursesConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses"
 )
 
 install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/Notcurses++Config.cmake"
+  tools/Notcurses++Config.cmake
   "${CMAKE_CURRENT_BINARY_DIR}/Notcurses++ConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses++"
 )
@@ -1136,24 +1133,68 @@ endif()
 endif() # BUILD_EXECUTABLES
 
 if(${BUILD_FFI_LIBRARY})
-LIST(APPEND INSTLIBS notcurses-ffi)
-endif()
-LIST(APPEND INSTLIBS notcurses-core notcurses)
-if(${USE_STATIC})
-LIST(APPEND INSTLIBS notcurses-core-static notcurses-static)
-endif()
-if(${USE_CXX})
-LIST(APPEND INSTLIBS notcurses++)
-if(${USE_STATIC})
-LIST(APPEND INSTLIBS notcurses++-static)
-endif()
+  install(TARGETS notcurses-ffi
+    LIBRARY
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      COMPONENT Libraries
+      NAMELINK_COMPONENT Development
+  )
 endif()
 
-install(TARGETS ${INSTLIBS}
-  LIBRARY
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT Libraries
-    NAMELINK_COMPONENT Development
+if(${USE_STATIC})
+  install(TARGETS notcurses-core-static notcurses-static
+    LIBRARY
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      COMPONENT Libraries
+      NAMELINK_COMPONENT Development
+  )
+  if(${USE_CXX})
+	  install(TARGETS notcurses++-static
+      LIBRARY
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT Libraries
+        NAMELINK_COMPONENT Development
+    )
+  endif()
+endif()
+
+install(TARGETS notcurses-core
+	EXPORT NotcursesCoreExport
+	LIBRARY
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		COMPONENT Libraries
+		NAMELINK_COMPONENT Development
+)
+install(EXPORT NotcursesCoreExport
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/NotcursesCore
+	NAMESPACE Notcurses::
+	FILE NotcursesCoreTargets.cmake
+)
+
+install(TARGETS notcurses
+	EXPORT NotcursesExport
+	LIBRARY
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		COMPONENT Libraries
+		NAMELINK_COMPONENT Development
+)
+install(EXPORT NotcursesExport
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses
+	NAMESPACE Notcurses::
+	FILE NotcursesTargets.cmake
+)
+
+install(TARGETS notcurses++
+	EXPORT Notcurses++Export
+	LIBRARY
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		COMPONENT Libraries
+		NAMELINK_COMPONENT Development
+)
+install(EXPORT Notcurses++Export
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Notcurses++
+	NAMESPACE Notcurses::
+	FILE Notcurses++Targets.cmake
 )
 
 option(DUMMY_PYTHON "Build dummy python module used for compile check and Clangd" OFF)

--- a/tools/Notcurses++Config.cmake
+++ b/tools/Notcurses++Config.cmake
@@ -1,0 +1,8 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Notcurses)
+
+include("${CMAKE_CURRENT_LIST_DIR}/Notcurses++Targets.cmake")
+
+set(Notcurses_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../../include")
+set(Notcurses_LIBRARY_DIRS "")
+set(Notcurses_LIBRARIES Notcurses::Notcurses++)

--- a/tools/Notcurses++Config.cmake.in
+++ b/tools/Notcurses++Config.cmake.in
@@ -1,9 +1,0 @@
-@PACKAGE_INIT@
-set(Notcurses++_DIR "@PACKAGE_SOME_INSTALL_DIR@")
-
-# Compute paths
-get_filename_component(Notcurses_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(Notcurses++_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
-set(Notcurses++_LIBRARY_DIRS "@CONF_LIBRARY_DIRS@")
-
-set(Notcurses++_LIBRARIES -lnotcurses -lnotcurses++)

--- a/tools/NotcursesConfig.cmake
+++ b/tools/NotcursesConfig.cmake
@@ -1,0 +1,8 @@
+include(CMakeFindDependencyMacro)
+find_dependency(NotcursesCore)
+
+include("${CMAKE_CURRENT_LIST_DIR}/NotcursesTargets.cmake")
+
+set(Notcurses_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../../include")
+set(Notcurses_LIBRARY_DIRS "")
+set(Notcurses_LIBRARIES Notcurses::Notcurses)

--- a/tools/NotcursesConfig.cmake.in
+++ b/tools/NotcursesConfig.cmake.in
@@ -1,9 +1,0 @@
-@PACKAGE_INIT@
-set(Notcurses_DIR "@PACKAGE_SOME_INSTALL_DIR@")
-
-# Compute paths
-get_filename_component(Notcurses_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(Notcurses_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
-set(Notcurses_LIBRARY_DIRS "@CONF_LIBRARY_DIRS@")
-
-set(Notcurses_LIBRARIES -lnotcurses-core -lnotcurses)

--- a/tools/NotcursesCoreConfig.cmake
+++ b/tools/NotcursesCoreConfig.cmake
@@ -1,0 +1,8 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/NotcursesCoreTargets.cmake")
+
+set(NotcursesCore_INCLUDE_DIRS "")
+set(NotcursesCore_LIBRARY_DIRS "")
+set(NotcursesCore_LIBRARIES Notcurses::NotcursesCore)

--- a/tools/NotcursesCoreConfig.cmake.in
+++ b/tools/NotcursesCoreConfig.cmake.in
@@ -1,9 +1,0 @@
-@PACKAGE_INIT@
-set(Notcurses_DIR "@PACKAGE_SOME_INSTALL_DIR@")
-
-# Compute paths
-get_filename_component(Notcurses_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(Notcurses_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
-set(Notcurses_LIBRARY_DIRS "@CONF_LIBRARY_DIRS@")
-
-set(Notcurses_LIBRARIES -lnotcurses-core)


### PR DESCRIPTION
This PR reworks Notcurses' CMake package configuration to provide logical targets (`Notcurses::NotcursesCore`, `Notcurses::Notcurses`, `Notcurses::Notcurses++`), following modern CMake conventions, while retaining the previously exported variables for compatibility.

The names of these targets match the proposed Conan recipe targets (conan-io/conan-center-index#4036), allowing developers to use the same target names when the Conan recipe is eventually resolved.
Alias targets have also been added to allow superbuilds (using Notcurses as a git submodule) with the same target names. 

Looking into the git history, I can see that Notcurses did at one point export logical targets (#1146), which was later reverted (#1149), since it broke compatibility by not defining variables like before.
This PR fixes that by splitting the logical targets generated by CMake into `Notcurses*Targets.cmake` files, with the `Notcurses*Config.cmake` files importing those and also providing the original variables for compatibility.

I've tested these changes both using find_package and config files, and using add_subdirectory and a git submodule. Please verify on your end and let me know if any adjustments are needed.