### PR TITLE
qrcode: fix vertical space check

### DIFF
--- a/src/lib/fill.c
+++ b/src/lib/fill.c
@@ -572,7 +572,7 @@ int ncplane_qrcode(ncplane* n, unsigned* ymax, unsigned* xmax, const void* data,
   if(*ymax > n->leny - starty){
     return -1;
   }
-  if(*ymax < qrcode_rows(1)){
+  if(*ymax * 2 < qrcode_rows(1)){
     return -1;
   }
   if(*xmax < qrcode_cols(1)){


### PR DESCRIPTION
This PR fixes an if check in Notcurses' QR code rendering function.

This particular if statement is responsible for ensuring atleast 21 rows of space is available, the height for the smallest (version 1) QR code.

However, since the QR code is drawn with the 2x1 blitter (which maps two visual rows to a single terminal row), the effective minimum height becomes 10.5 (well, 11) rows.

Hence, QR codes that can fit in less than 21 rows (versions 1 to 5) are unnecessarily blocked by the current check.

---

Video demonstrating the current behaviour:
https://github.com/user-attachments/assets/e65fbed3-3f75-4150-bee6-aa4bb48d8165

Video demonstrating the fixed behaviour:
https://github.com/user-attachments/assets/55a3374c-a372-4216-b01d-1cabc31bd19b

Sample code used for the above demos:  
```cpp
#include <unistd.h>
#include <locale.h>

#include <notcurses/notcurses.h>

int main()
{
    setlocale(LC_ALL, "");

    notcurses_options opts{};
    notcurses* nc = notcurses_core_init(&opts, stdout);
    ncplane* stdplane = notcurses_stdplane(nc);

    char32_t key;
    do
    {
        ncplane_erase(stdplane);

        unsigned int height, width;
        ncplane_dim_yx(stdplane, &height, &width);
        
        unsigned int y = height, x = width;
        const char* text = "1234567890";
        int ver = ncplane_qrcode(stdplane, &y, &x, text, strlen(text));

        ncplane_printf_yx(stdplane, 0, 40, "VERSION: %d", ver);
        ncplane_printf_yx(stdplane, 1, 40, "SIZE: %d x %d", x, y);
        ncplane_printf_yx(stdplane, 2, 40, "PLANE: %d x %d", width, height);

    	notcurses_render(nc);
    }
    while ((key = notcurses_get_nblock(nc, nullptr)) != (char32_t)-1);

    return 0;
}
```