### PR TITLE
qrcode: force 2x1 blitter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 This document attempts to list user-visible changes and any major internal
 rearrangements of Notcurses.
 
+* 3.0.12 (not yet released)
+  * Fixed a bug when rendering QR codes into a small area. QR codes now
+    require NCBLIT_2x1, as that is the only blitter which can generate a
+    proper aspect ratio. It thus no longer works in an ASCII environment.
+
 * 3.0.11 (2024-10-02)
   * We now normalize the return of `nl_langinfo()` according to the behavior
     of glibc's `_nl_normalize_charset()`, supporting some atypical synonyms

--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -4591,6 +4591,8 @@ API int ncsubproc_destroy(struct ncsubproc* n);
 // returned. Otherwise, the QR code "version" (size) is returned. The QR code
 // is (version * 4 + 17) columns wide, and ⌈version * 4 + 17⌉ rows tall (the
 // properly-scaled values are written back to '*ymax' and '*xmax').
+// NCBLIT_2x1 is always used, and the call will fail if it is not available,
+// as only this blitter can generate a proper aspect ratio.
 API int ncplane_qrcode(struct ncplane* n, unsigned* ymax, unsigned* xmax,
                        const void* data, size_t len)
   __attribute__ ((nonnull (1, 4)));

--- a/src/lib/fill.c
+++ b/src/lib/fill.c
@@ -619,9 +619,12 @@ int ncplane_qrcode(ncplane* n, unsigned* ymax, unsigned* xmax, const void* data,
       free(rgba);
       if(ncv){
         ret = square;
+        // we don't allow degredation because 2x1 is the only blitter which
+        // can generate a qrcode with proper aspect ratio. ascii is thus out.
         struct ncvisual_options vopts = {
           .n = n,
           .blitter = blitfxn,
+          .flags = NCVISUAL_OPTION_NODEGRADE,
         };
         if(ncvisual_blit(ncplane_notcurses(n), ncv, &vopts) == n){
           ret = square;


### PR DESCRIPTION
only the 2x1 blitter can generate the proper aspect ratio needed for qrcodes, so force its use with
NCVISUAL_OPTION_NODEGRADE. see PR #2806.