### PR TITLE
Handle begy/begx and leny/lenx

### DIFF
--- a/include/notcurses/notcurses.h
+++ b/include/notcurses/notcurses.h
@@ -3476,7 +3476,7 @@ ncvisualplane_create(struct notcurses* nc, const struct ncplane_options* opts,
                      struct ncvisual* ncv, struct ncvisual_options* vopts){
   struct ncplane* newn;
   if(vopts && vopts->n){
-    if(vopts->flags & NCVISUAL_OPTION_CHILDPLANE){
+    if(!(vopts->flags & NCVISUAL_OPTION_CHILDPLANE)){
       return NULL; // the whole point is to create a new plane
     }
     newn = ncplane_create(vopts->n, opts);


### PR DESCRIPTION
Currently using begy/begx or leny/lenx results in wrong behavior or segmentation faults. 

I tested it on kitty and foot:
- asking notcurses to allocate a plane always results in the whole image being rendered
- supplying a properly sized plane results in SIGSEGV on foot and only the top of the image being rendered on kitty

The reason for this behavour is missing handling of these fields' values. I see two possible solutions to fix this behavior: 
1. crop the image in functions like ncvisual_blit and leave everything else as it is
2. fix all functions, so that they check the values of corresponding fields 

I would say, that the variant (1) is less intrusive, so I implemented it. No tests ever used non-zero values for begx/begy, so the tests weren't broken. 