### PR TITLE
termdesc: foot has octants since 1.20.0

### DIFF
--- a/src/lib/termdesc.c
+++ b/src/lib/termdesc.c
@@ -806,6 +806,9 @@ apply_foot_heuristics(tinfo* ti, size_t *tablelen, size_t *tableused,
       return NULL;
     }
   }
+  if(compare_versions(ti->termversion, "1.20.0") >= 0){
+    ti->caps.octants = true;
+  }
   return "foot";
 }
 


### PR DESCRIPTION
References:

* https://codeberg.org/dnkl/foot/src/branch/master/CHANGELOG.md#1-20-0
* https://codeberg.org/dnkl/foot/pulls/1880

I realize this will create a merge conflict with https://github.com/dankamongmen/notcurses/pull/2845, sorry about that, be happy to rebase either PR myself :)