### PR TITLE
ncplane_put: don't run tabs over the end of plane

### DIFF
--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -1969,7 +1969,10 @@ ncplane_put(ncplane* n, int y, int x, const char* egc, int cols,
           return -1;
         }
       }
-      ++n->x;
+      // don't do any further expansion of the plane here; just break
+      if(++n->x >= n->lenx){
+        break;
+      }
     }
   }
   if(scrolled){


### PR DESCRIPTION
as reported by @kmarius in #2870, we coredumped if the plane was not a multiple of the tab stop, and we ended the plane with a tab character. check for the plane's x boundary while expanding a tab, and break out of the expansion loop if we hit it. potential autogrowth of the plane has already been handled above.