### PR TITLE
first attempt at issue #2756, input-limited putnstr functions

### DIFF
--- a/src/lib/egcpool.h
+++ b/src/lib/egcpool.h
@@ -93,15 +93,17 @@ utf8_codepoint_length(unsigned char c){
   }
 }
 
-// Eat an EGC from the UTF-8 string input, counting bytes and columns. We use
-// libunistring's uc_is_grapheme_break() to segment EGCs. Writes the number of
-// columns to '*colcount'. Returns the number of bytes consumed, not including
-// any NUL terminator. Neither the number of bytes nor columns is necessarily
-// equal to the number of decoded code points. Such are the ways of Unicode.
-// uc_is_grapheme_break() wants UTF-32, which is fine, because we need wchar_t
-// to use wcwidth() anyway FIXME except this doesn't work with 16-bit wchar_t!
+
+// Eat an EGC from the UTF-8 string input (examining at most 'maxbytes' bytes),
+// counting bytes and columns. We use libunistring's uc_is_grapheme_break() to
+// segment EGCs. Writes the number of columns to '*colcount'. Returns the number
+// of bytes consumed, not including any NUL terminator. Neither the number of
+// bytes nor columns is necessarily equal to the number of decoded code points.
+// Such are the ways of Unicode. uc_is_grapheme_break() wants UTF-32, which is
+// fine, because we need wchar_t to use wcwidth() anyway FIXME except this doesn't
+// work with 16-bit wchar_t!
 static inline int
-utf8_egc_len(const char* gcluster, int* colcount){
+utf8_egcn_len(const char* gcluster, size_t maxbytes, int* colcount){
   size_t ret = 0;
   *colcount = 0;
   int r;
@@ -110,7 +112,7 @@ utf8_egc_len(const char* gcluster, int* colcount){
   wchar_t wc, prevw = 0;
   bool injoin = false;
   do{
-    r = mbrtowc(&wc, gcluster, MB_LEN_MAX, &mbt);
+    r = mbrtowc(&wc, gcluster, maxbytes, &mbt);
     if(r < 0){
       // FIXME probably ought escape this somehow
       logerror("invalid UTF8: %s", gcluster);
@@ -152,6 +154,15 @@ utf8_egc_len(const char* gcluster, int* colcount){
   }while(r);
   // FIXME what if injoin is set? incomplete EGC!
   return ret;
+}
+
+
+// Same as utf8_egcn_len, except the input UTF8 string should contain only
+// valid UTF-8 for at least MB_LEN_MAX bytes, because that is how many bytes
+// mbrtowc will examine.
+static inline int
+utf8_egc_len(const char* gcluster, int* colcount){
+  return utf8_egcn_len(gcluster, MB_LEN_MAX, colcount);
 }
 
 // stash away the provided UTF8, NUL-terminated grapheme cluster. the cluster

--- a/src/lib/notcurses.c
+++ b/src/lib/notcurses.c
@@ -540,7 +540,7 @@ static inline size_t  ncplane_sizeof_cellarray( size_t rows, size_t cols)
 {
   // check if multiplication would overflow
   // calloc will deal with overflow due to sizeof(nccell)
-  if( ! rows || (cols > SIZE_MAX / rows)) 
+  if( ! rows || (cols > SIZE_MAX / rows))
     return 0;
   return rows * cols;
 }
@@ -2010,6 +2010,20 @@ int ncplane_putegc_yx(ncplane* n, int y, int x, const char* gclust, size_t* sbyt
 //fprintf(stderr, "glust: %s cols: %d wcs: %d\n", gclust, cols, bytes);
   return ncplane_put(n, y, x, gclust, cols, n->stylemask, n->channels, bytes);
 }
+
+int ncplane_putegcn_yx(ncplane* n, int y, int x, const char* gclust, size_t maxbytes, size_t* sbytes){
+  int cols;
+  int bytes = utf8_egcn_len(gclust, maxbytes, &cols);
+  if(bytes < 0){
+    return -1;
+  }
+  if(sbytes){
+    *sbytes = bytes;
+  }
+//fprintf(stderr, "glust: %s cols: %d wcs: %d\n", gclust, cols, bytes);
+  return ncplane_put(n, y, x, gclust, cols, n->stylemask, n->channels, bytes);
+}
+
 
 int ncplane_putchar_stained(ncplane* n, char c){
   uint64_t channels = n->channels;


### PR DESCRIPTION
Totally fell off the earth there, put the project I was doing on hiatus oops.

This is a first attempt implementing #2756; ofc the names are not final, I've just put another `n` to get `putnstrn` and `egcn` etc.

Some thoughts:

1. There's other functions that end up calling `ncplane_putegc`, so we should probably also see if we want similar things for that family of functions.
2. `ncplane_putegc` actually already takes a `size_t*` as an out-parameter; if we didn't care about API breakage we could specify that it is *also* an input parameter that specifies the length of the input string. not the best idea though.
3. small amount of code duplication, not sure how to fix that