### PR TITLE
Don't `#include` within an `extern "C"` block

### DIFF
--- a/include/notcurses/ncport.h
+++ b/include/notcurses/ncport.h
@@ -1,10 +1,6 @@
 #ifndef NOTCURSES_NCPORT
 #define NOTCURSES_NCPORT
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // Platform-dependent preprocessor material (includes and definitions) needed
 // to compile against Notcurses. A critical definition is htole(), which forces
 // 32-bit values to little-endian (as used in the nccell gcluster field). This
@@ -34,10 +30,6 @@ extern "C" {
 #else                                             // BSDs
 #include <sys/endian.h>
 #define htole(x) (bswap32(htonl(x)))
-#endif
-
-#ifdef __cplusplus
-} // extern "C"
 #endif
 
 #endif

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -1,10 +1,6 @@
 #ifndef NOTCURSES_COMPAT
 #define NOTCURSES_COMPAT
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -75,6 +71,10 @@ path_separator(void){
 #include <sys/time.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 // get the default data directory (heap-allocated). on unix, this is compiled

--- a/src/lib/automaton.h
+++ b/src/lib/automaton.h
@@ -1,11 +1,11 @@
 #ifndef NOTCURSES_AUTOMATON
 #define NOTCURSES_AUTOMATON
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 struct ncinput;
 struct esctrie;

--- a/src/lib/blitset.h
+++ b/src/lib/blitset.h
@@ -1,11 +1,11 @@
 #ifndef NOTCURSES_BLITSET
 #define NOTCURSES_BLITSET
 
+#include "blit.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "blit.h"
 
 // number of pixels that map to a single cell, height-wise
 static inline int

--- a/src/lib/fbuf.h
+++ b/src/lib/fbuf.h
@@ -1,10 +1,6 @@
 #ifndef NOTCURSES_FBUF
 #define NOTCURSES_FBUF
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <errno.h>
 #include <assert.h>
 #include <string.h>
@@ -13,6 +9,10 @@ extern "C" {
 #include <inttypes.h>
 #include "compat/compat.h"
 #include "logging.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // a growable buffer into which one can perform formatted i/o, like the
 // ten thousand that came before it, and the ten trillion which shall

--- a/src/lib/in.h
+++ b/src/lib/in.h
@@ -1,13 +1,13 @@
 #ifndef NOTCURSES_IN
 #define NOTCURSES_IN
 
+#include <stdio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 // internal header, not installed
-
-#include <stdio.h>
 
 struct tinfo;
 struct inputctx;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -1,10 +1,6 @@
 #ifndef NOTCURSES_INTERNAL
 #define NOTCURSES_INTERNAL
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "version.h"
 #include "builddef.h"
 #include "compat/compat.h"
@@ -413,6 +409,10 @@ struct blitset {
 };
 
 #include "blitset.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 void reset_stats(ncstats* stats);
 void summarize_stats(notcurses* nc);

--- a/src/lib/linux.h
+++ b/src/lib/linux.h
@@ -1,12 +1,12 @@
 #ifndef NOTCURSES_LINUX
 #define NOTCURSES_LINUX
 
+#include <stddef.h>
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stddef.h>
-#include <stdbool.h>
 
 struct tinfo;
 

--- a/src/lib/render.h
+++ b/src/lib/render.h
@@ -1,11 +1,11 @@
 #ifndef NOTCURSES_RENDER
 #define NOTCURSES_RENDER
 
+#include <signal.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <signal.h>
 
 extern sig_atomic_t sigcont_seen_for_render;
 

--- a/src/lib/sixel.h
+++ b/src/lib/sixel.h
@@ -1,13 +1,13 @@
 #ifndef NOTCURSES_LIB_SIXEL
 #define NOTCURSES_LIB_SIXEL
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <ctype.h>
 #include <stdlib.h>
 #include "logging.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 uint32_t* ncsixel_as_rgba(const char *sx, unsigned leny, unsigned lenx){
   if(!leny || !lenx){

--- a/src/lib/sprite.h
+++ b/src/lib/sprite.h
@@ -1,13 +1,13 @@
 #ifndef NOTCURSES_SPRITE
 #define NOTCURSES_SPRITE
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stdbool.h>
 #include "fbuf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define SIXEL_MAX_REGISTERS 65534 // 65535 is used for transparent
 

--- a/src/lib/termdesc.h
+++ b/src/lib/termdesc.h
@@ -1,10 +1,6 @@
 #ifndef NOTCURSES_TERMDESC
 #define NOTCURSES_TERMDESC
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // internal header, not installed
 
 #include "version.h"
@@ -17,6 +13,10 @@ extern "C" {
 #include "blit.h"
 #include "fbuf.h"
 #include "in.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // kitty keyboard protocol pop, used at end when kitty is verified.
 #define KKEYBOARD_POP  "\x1b[<u"

--- a/src/lib/unixsig.h
+++ b/src/lib/unixsig.h
@@ -1,11 +1,11 @@
 #ifndef NOTCURSES_UNIXSIG
 #define NOTCURSES_UNIXSIG
 
+#include <signal.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <signal.h>
 
 int setup_signals(void* nc, bool no_quit_sigs, bool no_winch_sig,
                   int(*handler)(void*, void**, int));

--- a/src/lib/visual-details.h
+++ b/src/lib/visual-details.h
@@ -1,15 +1,15 @@
 #ifndef NOTCURSES_VISUAL_DETAILS
 #define NOTCURSES_VISUAL_DETAILS
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include "builddef.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct blitset;
 struct ncplane;

--- a/src/man/parse.h
+++ b/src/man/parse.h
@@ -1,10 +1,6 @@
 #ifndef NOTCURSES_MAN_PARSE
 #define NOTCURSES_MAN_PARSE
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdio.h>
 #include <stdint.h>
 
@@ -63,6 +59,10 @@ typedef struct pagedom {
   char* header;
   struct docstructure* ds;
 } pagedom;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline const char*
 dom_get_title(const pagedom* dom){

--- a/src/media/oiio.h
+++ b/src/media/oiio.h
@@ -1,11 +1,11 @@
 #ifndef MEDIA_OIIO
 #define MEDIA_OIIO
 
+#include "lib/internal.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "lib/internal.h"
 
 int oiio_decode(ncvisual* nc);
 struct ncvisual_details* oiio_details_init(void);


### PR DESCRIPTION
Using `#include` within an `extern "C"` block can break the header being included. For example, build fails when using libunistring >= 1.4.

[libunistring 1.4 has a separate `extern "C"` bug](https://savannah.gnu.org/bugs/index.php?67576) to be fixed in 1.4.1. But once that's fixed, notcurses still fails with:

```
In file included from /opt/local/var/macports/build/notcurses-0a839c9e/work/notcurses-3.0.9/src/tests/Exceptions.cpp:2:
In file included from /opt/local/var/macports/build/notcurses-0a839c9e/work/notcurses-3.0.9/src/tests/main.h:13:
In file included from /opt/local/var/macports/build/notcurses-0a839c9e/work/notcurses-3.0.9/src/lib/internal.h:47:
In file included from /opt/local/var/macports/build/notcurses-0a839c9e/work/notcurses-3.0.9/src/lib/egcpool.h:13:
/opt/local/include/unigbrk.h:121:1: error: templates must have C++ linkage
template <typename T>
^~~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/notcurses-0a839c9e/work/notcurses-3.0.9/src/lib/internal.h:5:1: note: extern "C" language linkage specification begins here
extern "C" {
^
```

Fixing just src/lib/internal.h so that the `#include` statements aren't inside the `extern "C"` block fixes this build failure for me, but in this PR for good measure I've changed all of the files that did this.