### PR TITLE
fix(input): handle DA1 responses with extended attributes from modern terminals

### DIFF
--- a/src/lib/in.c
+++ b/src/lib/in.c
@@ -1846,15 +1846,11 @@ build_cflow_automaton(inputctx* ictx){
     { "[?1;0c", da1_cb, }, // CSI ? 1 ; 0 c ("VT101 with No Options")
     { "[?1;2c", da1_cb, }, // CSI ? 1 ; 2 c ("VT100 with Advanced Video Option")
     { "[?4;6c", da1_cb, }, // CSI ? 4 ; 6 c ("VT132 with Advanced Video and Graphics")
-    { "[?1;2;4c", da1_attrs_cb, }, // CSI ? 1 ; 2 ; 4 c (tmux 3.4+ with sixel support)
-    // CSI ? 1 2 ; Ps c ("VT125")
-    // CSI ? 6 0 ; Ps c (kmscon)
-    // CSI ? 6 2 ; Ps c ("VT220")
-    // CSI ? 6 3 ; Ps c ("VT320")
-    // CSI ? 6 4 ; Ps c ("VT420")
-    // CSI ? 6 5 ; Ps c (WezTerm, VT5xx?)
-    { "[?\\N;\\N;\\Dc", da1_attrs_cb, }, // DA1 with 3+ parameters (multiplexers, extended responses)
-    { "[?\\N;\\Dc", da1_attrs_cb, },
+    { "[?1;2;\\Dc", da1_attrs_cb, }, // CSI ? 1 ; 2 ; Ps... c (VT100 with extended attrs, e.g. tmux sixel)
+    { "[?62;\\Dc", da1_attrs_cb, },  // CSI ? 6 2 ; Ps c ("VT220", Ghostty)
+    { "[?63;\\Dc", da1_attrs_cb, },  // CSI ? 6 3 ; Ps c ("VT320")
+    { "[?64;\\Dc", da1_attrs_cb, },  // CSI ? 6 4 ; Ps c ("VT420", iTerm2)
+    { "[?65;\\Dc", da1_attrs_cb, },  // CSI ? 6 5 ; Ps c ("VT520", WezTerm)
     { "[?1;0;\\NS", xtsmgraphics_cregs_cb, },
     { "[?2;0;\\N;\\NS", xtsmgraphics_sixel_cb, },
     { "[>83;\\N;0c", da2_screen_cb, },


### PR DESCRIPTION
## Summary

Fixes #2736

tmux 3.4+ with sixel support sends DA1 response `CSI ? 1 ; 2 ; 4 c` which notcurses couldn't parse, causing applications to hang during initialization.

## Solution

Add specific patterns for DA1 responses with extended attributes:

- `[?1;2;\Dc` - VT100 with extended attrs (tmux 3.4+ with sixel)
- `[?62;\Dc` - VT220 (Ghostty, Kitty)
- `[?63;\Dc` - VT320
- `[?64;\Dc` - VT420 (iTerm2)
- `[?65;\Dc` - VT520 (WezTerm)

Generic patterns like `[?\N;\N;\Dc` conflicted with XTSMGRAPHICS patterns (`[?1;0;\NS`) in the automaton FSM, causing build failures. Specific patterns avoid these conflicts while covering all major terminals.

## Testing

Tested successfully on:
- Ghostty
- iTerm2
- Kitty
- Alacritty
- macOS Terminal.app
- tmux
- screen

All terminals now initialize correctly without hanging.