### PR TITLE
ncvisual_blit_internal: honor begy/begx/leny/lenx on every blit path

### DIFF
--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -370,8 +370,6 @@ typedef struct notcurses {
 } notcurses;
 
 typedef struct blitterargs {
-  // FIXME begy/begx are really only of interest to scaling; they ought be
-  // consumed there, and blitters ought always work with the scaled output.
   int begy;            // upper left start within visual
   int begx;
   int leny;            // number of source pixels to use

--- a/src/lib/visual.c
+++ b/src/lib/visual.c
@@ -81,29 +81,71 @@ ncplane* ncvisual_subtitle_plane(ncplane* parent, const ncvisual* ncv){
   return visual_implementation->visual_subtitle(parent, ncv);
 }
 
+// Forward decl; definition needs pad_for_image in scope (below).
+static ncvisual* ncvisual_subregion_internal(const ncvisual* src,
+                                             unsigned begy, unsigned begx,
+                                             unsigned leny, unsigned lenx);
+
 int ncvisual_blit_internal(const ncvisual* ncv, int rows, int cols, ncplane* n,
                            const struct blitset* bset, const blitterargs* barg){
+  // Pre-crop the source once here so every backend sees "full source"
+  // semantics. leny/lenx==0 fall back to full extent for direct callers.
+  unsigned crop_begy = barg->begy;
+  unsigned crop_begx = barg->begx;
+  unsigned crop_leny = barg->leny ? barg->leny
+                                  : (unsigned)((int)ncv->pixy - (int)crop_begy);
+  unsigned crop_lenx = barg->lenx ? barg->lenx
+                                  : (unsigned)((int)ncv->pixx - (int)crop_begx);
+  const bool needs_crop = (crop_begy != 0) || (crop_begx != 0)
+                       || (crop_leny != (unsigned)ncv->pixy)
+                       || (crop_lenx != (unsigned)ncv->pixx);
+  ncvisual* tmp = NULL;
+  const ncvisual* src = ncv;
+  if(needs_crop){
+    tmp = ncvisual_subregion_internal(ncv, crop_begy, crop_begx,
+                                      crop_leny, crop_lenx);
+    if(tmp == NULL){
+      return -1;
+    }
+    src = tmp;
+  }
+  // Zero offsets in a local copy so backends don't crop again. Original
+  // barg is preserved for callers.
+  blitterargs local_bargs = *barg;
+  local_bargs.begy = 0;
+  local_bargs.begx = 0;
+  local_bargs.leny = (unsigned)src->pixy;
+  local_bargs.lenx = (unsigned)src->pixx;
+
+  int ret = -1;
   if(!(barg->flags & NCVISUAL_OPTION_NOINTERPOLATE)){
     if(visual_implementation->visual_blit){
-      if(visual_implementation->visual_blit(ncv, rows, cols, n, bset, barg) < 0){
-        return -1;
+      if(visual_implementation->visual_blit(src, rows, cols, n, bset,
+                                            &local_bargs) >= 0){
+        ret = 0;
       }
-      return 0;
+      goto done;
     }
   }
   // generic implementation
-  int stride = 4 * cols;
-  uint32_t* data = resize_bitmap(ncv->data, ncv->pixy, ncv->pixx,
-                                 ncv->rowstride, rows, cols, stride);
-  if(data == NULL){
-    return -1;
+  {
+    int stride = 4 * cols;
+    uint32_t* data = resize_bitmap(src->data, src->pixy, src->pixx,
+                                   src->rowstride, rows, cols, stride);
+    if(data == NULL){
+      goto done;
+    }
+    if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, &local_bargs) >= 0){
+      ret = 0;
+    }
+    if(data != src->data){
+      free(data);
+    }
   }
-  int ret = -1;
-  if(rgba_blit_dispatch(n, bset, stride, data, rows, cols, barg) >= 0){
-    ret = 0;
-  }
-  if(data != ncv->data){
-    free(data);
+
+done:
+  if(tmp){
+    ncvisual_destroy(tmp);
   }
   return ret;
 }
@@ -774,6 +816,59 @@ pad_for_image(size_t stride, int cols){
   }
   return (stride + visual_implementation->rowalign) /
           visual_implementation->rowalign * visual_implementation->rowalign;
+}
+
+// Copy a pixel-space rectangle out of |src| into a fresh ncvisual,
+// seeded via ncvisual_details_seed so any backend (FFmpeg/OIIO) gets
+// a properly-typed details->ibuf for the cropped buffer.
+static ncvisual* ncvisual_subregion_internal(const ncvisual* src,
+                                             unsigned begy, unsigned begx,
+                                             unsigned leny, unsigned lenx){
+  if(src == NULL || src->data == NULL){
+    return NULL;
+  }
+  if(leny == 0 || lenx == 0){
+    return NULL;
+  }
+  // Unsigned-subtract on the safe side: `begy + leny > pixy` would wrap
+  // for huge unsigned inputs (e.g. negative int cast) and silently accept.
+  if(begy > (unsigned)src->pixy || leny > (unsigned)src->pixy - begy){
+    return NULL;
+  }
+  if(begx > (unsigned)src->pixx || lenx > (unsigned)src->pixx - begx){
+    return NULL;
+  }
+  // Every public ncvisual ctor produces rowstride % 4 == 0; guard so
+  // src_stride_px below stays an integer multiple of uint32_t.
+  if(src->rowstride % 4 != 0){
+    logerror("source rowstride %u not a multiple of 4", src->rowstride);
+    return NULL;
+  }
+  ncvisual* sub = ncvisual_create();
+  if(sub == NULL){
+    return NULL;
+  }
+  size_t dstride = pad_for_image((size_t)lenx * 4, (int)lenx);
+  size_t buf_size = dstride * leny;
+  uint32_t* buf = (uint32_t*)malloc(buf_size);
+  if(buf == NULL){
+    ncvisual_destroy(sub);
+    return NULL;
+  }
+  size_t src_stride_px = src->rowstride / sizeof(uint32_t);
+  size_t dst_stride_px = dstride / sizeof(uint32_t);
+  const size_t row_bytes = (size_t)lenx * 4;
+  for(unsigned y = 0; y < leny; ++y){
+    memcpy(buf + y * dst_stride_px,
+           src->data + (size_t)(begy + y) * src_stride_px + begx,
+           row_bytes);
+  }
+  ncvisual_set_data(sub, buf, true);
+  sub->pixx = lenx;
+  sub->pixy = leny;
+  sub->rowstride = (unsigned)dstride;
+  ncvisual_details_seed(sub);
+  return sub;
 }
 
 ncvisual* ncvisual_from_rgba(const void* rgba, int rows, int rowstride, int cols){

--- a/src/media/oiio.cpp
+++ b/src/media/oiio.cpp
@@ -152,7 +152,6 @@ int oiio_blit(const ncvisual* ncv, unsigned rows, unsigned cols,
   int stride;
   auto ibuf = std::make_unique<OIIO::ImageBuf>();
   if(ncv->details->ibuf && (ncv->pixx != cols || ncv->pixy != rows)){ // scale it
-    // FIXME need to honor leny/lenx and begy/begx
     OIIO::ROI roi(0, cols, 0, rows, 0, 1, 0, 4);
     if(!OIIO::ImageBufAlgo::resize(*ibuf, *ncv->details->ibuf, "", 0, roi)){
       return -1;

--- a/src/tests/visual.cpp
+++ b/src/tests/visual.cpp
@@ -301,6 +301,64 @@ TEST_CASE("Visual") {
     CHECK(0 == ncplane_destroy(n));
   }
 
+  // begy/begx must select a sub-region, not the top-left corner.
+  SUBCASE("BlitSubregionOffset") {
+    constexpr int dim = 8;
+    constexpr int half = dim / 2;
+    // const, not constexpr: glibc htole isn't constexpr-clean.
+    const uint32_t RED   = htole(0xffff0000u);
+    const uint32_t GREEN = htole(0xff00ff00u);
+    const uint32_t BLUE  = htole(0xff0000ffu);
+    const uint32_t WHITE = htole(0xffffffffu);
+    std::vector<uint32_t> src(dim * dim);
+    for(int y = 0 ; y < dim ; ++y){
+      for(int x = 0 ; x < dim ; ++x){
+        uint32_t c;
+        if(y < half && x < half)      c = RED;
+        else if(y < half)             c = GREEN;
+        else if(x < half)             c = BLUE;
+        else                          c = WHITE;
+        src[y * dim + x] = c;
+      }
+    }
+    auto ncv = ncvisual_from_rgba(src.data(), dim,
+                                  dim * sizeof(decltype(src)::value_type),
+                                  dim);
+    REQUIRE(nullptr != ncv);
+    struct ncvisual_options vopts = {
+      .n = n_,
+      .scaling = NCSCALE_NONE,
+      .y = 0, .x = 0,
+      .begy = static_cast<unsigned>(half),
+      .begx = static_cast<unsigned>(half),
+      .leny = static_cast<unsigned>(half),
+      .lenx = static_cast<unsigned>(half),
+      .blitter = NCBLIT_1x1,
+      .flags = NCVISUAL_OPTION_CHILDPLANE,
+      .transcolor = 0,
+      .pxoffy = 0, .pxoffx = 0,
+    };
+    auto n = ncvisual_blit(nc_, ncv, &vopts);
+    REQUIRE(nullptr != n);
+    CHECK(static_cast<unsigned>(half) == ncplane_dim_y(n));
+    CHECK(static_cast<unsigned>(half) == ncplane_dim_x(n));
+    for(int y = 0 ; y < half ; ++y){
+      for(int x = 0 ; x < half ; ++x){
+        uint16_t stylemask;
+        uint64_t channels;
+        auto egc = ncplane_at_yx(n, y, x, &stylemask, &channels);
+        REQUIRE(nullptr != egc);
+        free(egc);
+        uint32_t rgb = htole(ncchannels_bg_rgb(channels));
+        CHECK(0xff == ncpixel_r(rgb));
+        CHECK(0xff == ncpixel_g(rgb));
+        CHECK(0xff == ncpixel_b(rgb));
+      }
+    }
+    ncvisual_destroy(ncv);
+    CHECK(0 == ncplane_destroy(n));
+  }
+
   // ensure that NCSCALE_STRETCH gives us a full plane, and that we write
   // everywhere within that plane
   SUBCASE("Stretch") {


### PR DESCRIPTION
## Resolves

- Issue #2892 
- `// FIXME begy/begx are really only of interest to scaling…` (src/lib/internal.h:blitterargs)
- `// FIXME need to honor leny/lenx and begy/begx` (src/media/oiio.cpp)

## Overview

I found this issue while doing some work in [Selkie::Widget::ViewportedCardList](https://github.com/m-doughty/Selkie/blob/master/lib/Selkie/Widget/ViewportedCardList.rakumod) then realised it was already marked by `FIXME`s and an issue upstream, so I decided it'd be better to fix it at source instead of in a local shim.

`ncvisual_blit_internal` takes `begx`, `begy`, `lenx` and `leny` (the source subregion in pixel space) but most downstream backends disregard them.

- **Sprixel blitters** take only `data`, `lenx` and `leny` and consume from `data[0]` so any crop with `begx` or `begy` > 0 renders the top left instead of the required region.
- **Cell blitters** reference `begx` and `begy` but index the resized buffer within the input-space offset -- latent out of bounds read for `begy` > 0 whenever the resize ratio shrinks rows.
- **OIIO blit** had an explicit `// FIXME need to honor leny/lenx and begy/begx`

## Fix Summary

- Crops the requested sub-region once at the entry of `ncvisual_blit_internal` then zeroes `begx`, `begy`, `lenx`, `leny` in a local `blitterargs` copy before dispatching to backends (backends now uniformly get the pre-cropped source).
- Adds a static helper to `src/lib/visual.c` called `ncvisual_blit_internal` which:
  - Allocates a fresh `ncvisual` and row-loop `memcpy`s the requested region honoring source `rowstride` padding
  - Re-pads the destination via `pad_for_image`
  - Calls `ncvisual_details_seed` so the cropped visual feeds through the same FFmpeg/OIIO pipeline
  - Preserves the original `barg` for callers, only the local copy sent to backends is zeroed
- Skipped when no crop is needed via quick short-circuit for the common full-source case

## Testing

Added `Visual::BlitSubregionOffset` (src/tests/visual.cpp):

- Builds an 8x8 RGBA source with four 4x4 quadrants in distinct colors
- Blits with `begx = 4`, `begy = 4` and asserts that every cell is returned white (bottom right quadrant)
- This test was red-green tested, failed on `master` and `v3.0.17` with 48/73 assertions reporting red

Full `notcurses-tester` suite green on both bases (MacOS aarch64, ffmpeg backend).